### PR TITLE
Fix remaining phoenix rounding issues

### DIFF
--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixDifficultyTitle.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixDifficultyTitle.cs
@@ -1,5 +1,6 @@
 ﻿using ScoreTracker.Domain.Enums;
 using ScoreTracker.Domain.ValueTypes;
+using System;
 
 namespace ScoreTracker.Domain.Models.Titles.Phoenix;
 
@@ -18,6 +19,6 @@ public sealed class PhoenixDifficultyTitle : PhoenixTitle
     public override int CompletionProgress(Chart chart, RecordedPhoenixScore attempt)
     {
         if (chart.Level != Level || attempt.IsBroken || attempt.Score == null) return 0;
-        return (int)(chart.Level.BaseRating * attempt.Score.Value.LetterGrade.GetModifier());
+        return (int)Math.Round(chart.Level.BaseRating * attempt.Score.Value.LetterGrade.GetModifier());
     }
 }

--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixDifficultyTitle.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixDifficultyTitle.cs
@@ -15,9 +15,9 @@ public sealed class PhoenixDifficultyTitle : PhoenixTitle
     public DifficultyLevel Level { get; }
     public int RequiredRating { get; }
 
-    public override double CompletionProgress(Chart chart, RecordedPhoenixScore attempt)
+    public override int CompletionProgress(Chart chart, RecordedPhoenixScore attempt)
     {
         if (chart.Level != Level || attempt.IsBroken || attempt.Score == null) return 0;
-        return chart.Level.BaseRating * attempt.Score.Value.LetterGrade.GetModifier();
+        return (int)(chart.Level.BaseRating * attempt.Score.Value.LetterGrade.GetModifier());
     }
 }

--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixTitle.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixTitle.cs
@@ -13,7 +13,7 @@ public abstract class PhoenixTitle : Title
     {
     }
 
-    public virtual double CompletionProgress(Chart chart, RecordedPhoenixScore attempt)
+    public virtual int CompletionProgress(Chart chart, RecordedPhoenixScore attempt)
     {
         return 0;
     }

--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixTitleProgress.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixTitleProgress.cs
@@ -11,7 +11,7 @@ public sealed class PhoenixTitleProgress : TitleProgress
 
     public PhoenixTitle PhoenixTitle { get; }
 
-    public override double CompletionCount { get; protected set; }
+    public override int CompletionCount { get; protected set; }
 
     public override string AdditionalNote
     {

--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/TitleProgress.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/TitleProgress.cs
@@ -9,6 +9,6 @@ public abstract class TitleProgress
 
     public Title Title { get; }
 
-    public abstract double CompletionCount { get; protected set; }
+    public abstract int CompletionCount { get; protected set; }
     public virtual string AdditionalNote => string.Empty;
 }

--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/XX/XXTitleProgress.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/XX/XXTitleProgress.cs
@@ -9,7 +9,7 @@ public sealed class XXTitleProgress : TitleProgress
 
     public XXTitle XXTitle { get; }
 
-    public override double CompletionCount { get; protected set; }
+    public override int CompletionCount { get; protected set; }
 
     public void ApplyAttempt(BestXXChartAttempt attempt)
     {

--- a/ScoreTracker/ScoreTracker/Dtos/TitleProgressDto.cs
+++ b/ScoreTracker/ScoreTracker/Dtos/TitleProgressDto.cs
@@ -18,7 +18,7 @@ public sealed class TitleProgressDto
     {
         return new TitleProgressDto
         {
-            CompletionCount = (int)progress.CompletionCount,
+            CompletionCount = progress.CompletionCount,
             RequiredCount = progress.Title.CompletionRequired,
             TitleCategory = progress.Title.Category,
             TitleDescription = progress.Title.Description,


### PR DESCRIPTION
This method seems to work for all levels now and looks correct according to the site.  Some imports didn't process for 20s and I didn't feel like finding which ones failed so only including the output for 21+.

I don't have compiler working yet; please test this locally and review changes carefully before accepting the PR.  Feel free to add anything I missed.

![21s - 48921](https://github.com/DrMurloc/PumpItUpScoreTracker/assets/2644839/9f133fc7-62cd-4fdb-ba20-8dede38a4339)
![22s - 70620](https://github.com/DrMurloc/PumpItUpScoreTracker/assets/2644839/50692efa-f3e5-42d9-994c-2e6daa31a011)
![23s - 18539](https://github.com/DrMurloc/PumpItUpScoreTracker/assets/2644839/c89046ad-f5de-4fcf-a770-f40027cb9821)
![24s - 1035](https://github.com/DrMurloc/PumpItUpScoreTracker/assets/2644839/3f5e697f-2536-4aca-9ad3-f5fcb7425556)
```
Level: 21
Count: 60
----
A+ 684.0 (rounded: 684)
AA 760 (rounded: 760)
AA+ 798.0 (rounded: 798)
AAA 836.0000000000001 (rounded: 836)
AAA+ 873.9999999999999 (rounded: 874)
S 912.0 (rounded: 912)
S+ 957.6 (rounded: 958)
SS 1003.2 (rounded: 1003)
SS+ 1048.8 (rounded: 1049)
SSS 1094.3999999999999 (rounded: 1094)
SSS+ 1140.0 (rounded: 1140)
Rating: 48921
Level: 22
Count: 77
----
A+ 792.0 (rounded: 792)
AA 880 (rounded: 880)
AA+ 924.0 (rounded: 924)
AAA 968.0000000000001 (rounded: 968)
AAA+ 1011.9999999999999 (rounded: 1012)
S 1056.0 (rounded: 1056)
S+ 1108.8 (rounded: 1109)
SS 1161.6000000000001 (rounded: 1162)
SS+ 1214.3999999999999 (rounded: 1214)
SSS 1267.2 (rounded: 1267)
SSS+ 1320.0 (rounded: 1320)
Rating: 70620
Level: 23
Count: 18
----
A+ 909.0 (rounded: 909)
AA 1010 (rounded: 1010)
AA+ 1060.5 (rounded: 1061)
AAA 1111.0 (rounded: 1111)
AAA+ 1161.5 (rounded: 1162)
S 1212.0 (rounded: 1212)
S+ 1272.6 (rounded: 1273)
SS 1333.2 (rounded: 1333)
SS+ 1393.8 (rounded: 1394)
SSS 1454.3999999999999 (rounded: 1454)
SSS+ 1515.0 (rounded: 1515)
Rating: 18539
Level: 24
Count: 1
----
A+ 1035.0 (rounded: 1035)
AA 1150 (rounded: 1150)
AA+ 1207.5 (rounded: 1208)
AAA 1265.0 (rounded: 1265)
AAA+ 1322.5 (rounded: 1323)
S 1380.0 (rounded: 1380)
S+ 1449.0 (rounded: 1449)
SS 1518.0 (rounded: 1518)
SS+ 1586.9999999999998 (rounded: 1587)
SSS 1656.0 (rounded: 1656)
SSS+ 1725.0 (rounded: 1725)
Rating: 1035
```