### PR TITLE
Tier 1 tests: Domain value types, pure models, and saga static helpers

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TierListSagaStaticsTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TierListSagaStaticsTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class TierListSagaStaticsTests
+{
+    [Fact]
+    public void ProcessIntoTierListReturnsEmptyForEmptyInput()
+    {
+        var result = TierListSaga.ProcessIntoTierList("Bounties", new Dictionary<Guid, int>());
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ProcessIntoTierListAssignsTierListNameToEveryEntry()
+    {
+        var weights = MakeWeights(20, _ => 1);
+        var entries = TierListSaga.ProcessIntoTierList("Bounties", weights).ToArray();
+        Assert.All(entries, e => Assert.Equal("Bounties", (string)e.TierListName));
+    }
+
+    [Fact]
+    public void ProcessIntoTierListAssignsContiguousAscendingOrder()
+    {
+        var weights = MakeWeights(20, i => i);
+        var entries = TierListSaga.ProcessIntoTierList("Bounties", weights)
+            .OrderBy(e => e.Order)
+            .ToArray();
+
+        Assert.Equal(weights.Count, entries.Length);
+        for (var i = 0; i < entries.Length; i++)
+            Assert.Equal(i, entries[i].Order);
+    }
+
+    [Fact]
+    public void ZeroWeightedChartIsCategorisedAsUnrecorded()
+    {
+        var weights = MakeWeights(20, i => i + 1);
+        var zeroChart = Guid.NewGuid();
+        weights[zeroChart] = 0;
+
+        var result = TierListSaga.ProcessIntoTierList("Bounties", weights).ToArray();
+        var entry = result.Single(e => e.ChartId == zeroChart);
+
+        Assert.Equal(TierListCategory.Unrecorded, entry.Category);
+    }
+
+    [Fact]
+    public void HighestNonZeroWeightFallsAtOrAboveOverrated()
+    {
+        var weights = MakeWeights(20, _ => 1);
+        var topChart = Guid.NewGuid();
+        weights[topChart] = 1_000_000;
+
+        var result = TierListSaga.ProcessIntoTierList("Bounties", weights).ToArray();
+        var entry = result.Single(e => e.ChartId == topChart);
+
+        Assert.Equal(TierListCategory.Overrated, entry.Category);
+    }
+
+    [Fact]
+    public void DistinctChartsProduceDistinctEntries()
+    {
+        var weights = MakeWeights(50, i => i);
+        var result = TierListSaga.ProcessIntoTierList("Bounties", weights).ToArray();
+
+        Assert.Equal(weights.Count, result.Length);
+        Assert.Equal(weights.Count, result.Select(r => r.ChartId).Distinct().Count());
+    }
+
+    [Theory]
+    [InlineData(new double[] { 1, 1, 1, 1 }, false, 0)]
+    [InlineData(new double[] { 1, 2, 3, 4 }, false, 1.118033988749895)]
+    public void StdDevReturnsExpectedPopulationDeviation(double[] values, bool asSample, double expected)
+    {
+        Assert.Equal(expected, TierListSaga.StdDev(values, asSample), 6);
+    }
+
+    [Fact]
+    public void StdDevAsSampleDiffersFromPopulation()
+    {
+        double[] values = { 1, 2, 3, 4, 5 };
+        var population = TierListSaga.StdDev(values, false);
+        var sample = TierListSaga.StdDev(values, true);
+        Assert.True(sample > population);
+    }
+
+    private static IDictionary<Guid, int> MakeWeights(int count, Func<int, int> weightFor)
+    {
+        var dict = new Dictionary<Guid, int>();
+        for (var i = 0; i < count; i++) dict[Guid.NewGuid()] = weightFor(i);
+        return dict;
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/WeeklyTournamentSagaStaticsTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/WeeklyTournamentSagaStaticsTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class WeeklyTournamentSagaStaticsTests
+{
+    [Fact]
+    public void ProcessIntoPlacesReturnsEmptyForNoEntries()
+    {
+        var result = WeeklyTournamentSaga.ProcessIntoPlaces(Array.Empty<WeeklyTournamentEntry>());
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ProcessIntoPlacesAssignsFirstPlaceToTopScore()
+    {
+        var chartId = Guid.NewGuid();
+        var entries = new[]
+        {
+            Entry(chartId, score: 800_000),
+            Entry(chartId, score: 950_000),
+            Entry(chartId, score: 900_000)
+        };
+
+        var result = WeeklyTournamentSaga.ProcessIntoPlaces(entries).ToArray();
+        var first = result.Single(r => r.Item2.Score == 950_000);
+
+        Assert.Equal(1, first.Item1);
+    }
+
+    [Fact]
+    public void ProcessIntoPlacesAssignsConsecutivePlacesToDistinctScores()
+    {
+        var chartId = Guid.NewGuid();
+        var entries = new[]
+        {
+            Entry(chartId, score: 800_000),
+            Entry(chartId, score: 950_000),
+            Entry(chartId, score: 900_000)
+        };
+
+        var result = WeeklyTournamentSaga.ProcessIntoPlaces(entries)
+            .OrderBy(r => r.Item1)
+            .ToArray();
+
+        Assert.Equal(new[] { 1, 2, 3 }, result.Select(r => r.Item1).ToArray());
+    }
+
+    [Fact]
+    public void ProcessIntoPlacesGivesTiedScoresTheSamePlace()
+    {
+        var chartId = Guid.NewGuid();
+        var entries = new[]
+        {
+            Entry(chartId, score: 950_000),
+            Entry(chartId, score: 950_000),
+            Entry(chartId, score: 800_000)
+        };
+
+        var result = WeeklyTournamentSaga.ProcessIntoPlaces(entries).ToArray();
+
+        var topPlaces = result.Where(r => r.Item2.Score == 950_000).Select(r => r.Item1).ToArray();
+        var bottomPlace = result.Single(r => r.Item2.Score == 800_000).Item1;
+
+        Assert.Equal(new[] { 1, 1 }, topPlaces);
+        Assert.Equal(3, bottomPlace);
+    }
+
+    [Fact]
+    public void GetSuggestedChartsAlwaysIncludesCoOp()
+    {
+        var coOp = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(3).Build();
+        var result = WeeklyTournamentSaga.GetSuggestedCharts(new[] { coOp }, doublesCompetitive: 0, singlesCompetitive: 0);
+        Assert.Contains(coOp, result);
+    }
+
+    [Fact]
+    public void GetSuggestedChartsIncludesSinglesWithinRangeOfSinglesCompetitive()
+    {
+        var inRange = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var farTooHigh = new ChartBuilder().WithType(ChartType.Single).WithLevel(25).Build();
+        var farTooLow = new ChartBuilder().WithType(ChartType.Single).WithLevel(10).Build();
+
+        var result = WeeklyTournamentSaga
+            .GetSuggestedCharts(new[] { inRange, farTooHigh, farTooLow },
+                doublesCompetitive: 0, singlesCompetitive: 21)
+            .ToHashSet();
+
+        Assert.Contains(inRange, result);
+        Assert.DoesNotContain(farTooHigh, result);
+        Assert.DoesNotContain(farTooLow, result);
+    }
+
+    [Fact]
+    public void GetSuggestedChartsIncludesDoublesWithinRangeOfDoublesCompetitive()
+    {
+        var inRange = new ChartBuilder().WithType(ChartType.Double).WithLevel(18).Build();
+        var farTooHigh = new ChartBuilder().WithType(ChartType.Double).WithLevel(25).Build();
+
+        var result = WeeklyTournamentSaga
+            .GetSuggestedCharts(new[] { inRange, farTooHigh },
+                doublesCompetitive: 19, singlesCompetitive: 0)
+            .ToHashSet();
+
+        Assert.Contains(inRange, result);
+        Assert.DoesNotContain(farTooHigh, result);
+    }
+
+    [Fact]
+    public void GetSuggestedChartsExcludesSinglesOutsideSinglesCompetitiveRange()
+    {
+        var farFromSingles = new ChartBuilder().WithType(ChartType.Single).WithLevel(25).Build();
+
+        var result = WeeklyTournamentSaga
+            .GetSuggestedCharts(new[] { farFromSingles },
+                doublesCompetitive: 25, singlesCompetitive: 10)
+            .ToArray();
+
+        Assert.DoesNotContain(farFromSingles, result);
+    }
+
+    private static WeeklyTournamentEntry Entry(Guid chartId, int score) =>
+        new(UserId: Guid.NewGuid(), ChartId: chartId, Score: score, Plate: PhoenixPlate.MarvelousGame,
+            IsBroken: false, PhotoUrl: null, CompetitiveLevel: 20);
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/BpmTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/BpmTests.cs
@@ -1,0 +1,128 @@
+using ScoreTracker.Domain.Exceptions;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class BpmTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void FromNonPositiveThrows(decimal value)
+    {
+        Assert.Throws<InvalidBpmException>(() => Bpm.From(value));
+    }
+
+    [Theory]
+    [InlineData(120)]
+    [InlineData(0.5)]
+    [InlineData(999.999)]
+    public void FromPositiveProducesEqualMinAndMax(decimal value)
+    {
+        var bpm = Bpm.From(value);
+        Assert.Equal(value, bpm.Min);
+        Assert.Equal(value, bpm.Max);
+        Assert.Equal(value, bpm.Average);
+    }
+
+    [Fact]
+    public void FromRangeAcceptsMinLessThanMax()
+    {
+        var bpm = Bpm.From(120m, 200m);
+        Assert.Equal(120m, bpm.Min);
+        Assert.Equal(200m, bpm.Max);
+        Assert.Equal(160m, bpm.Average);
+    }
+
+    [Fact]
+    public void FromRangeAcceptsEqualMinAndMax()
+    {
+        var bpm = Bpm.From(120m, 120m);
+        Assert.Equal(120m, bpm.Min);
+        Assert.Equal(120m, bpm.Max);
+    }
+
+    [Fact]
+    public void FromRangeWithMaxLessThanMinThrows()
+    {
+        Assert.Throws<InvalidBpmException>(() => Bpm.From(200m, 120m));
+    }
+
+    [Fact]
+    public void FromRangeWithNonPositiveMinThrows()
+    {
+        Assert.Throws<InvalidBpmException>(() => Bpm.From(0m, 120m));
+    }
+
+    [Fact]
+    public void FromRangeWithNonPositiveMaxThrows()
+    {
+        Assert.Throws<InvalidBpmException>(() => Bpm.From(-1m, 0m));
+    }
+
+    [Fact]
+    public void NullableFromReturnsNullWhenBothNull()
+    {
+        Assert.Null(Bpm.From(null, null));
+    }
+
+    [Fact]
+    public void NullableFromUsesMinWhenMaxIsNull()
+    {
+        var bpm = Bpm.From(120m, null);
+        Assert.NotNull(bpm);
+        Assert.Equal(120m, bpm!.Value.Min);
+        Assert.Equal(120m, bpm.Value.Max);
+    }
+
+    [Fact]
+    public void NullableFromUsesMaxWhenMinIsNull()
+    {
+        var bpm = Bpm.From(null, 200m);
+        Assert.NotNull(bpm);
+        Assert.Equal(200m, bpm!.Value.Min);
+        Assert.Equal(200m, bpm.Value.Max);
+    }
+
+    [Fact]
+    public void EqualBpmsAreEqual()
+    {
+        Assert.True(Bpm.From(120m) == Bpm.From(120m));
+        Assert.False(Bpm.From(120m) != Bpm.From(120m));
+    }
+
+    [Fact]
+    public void DifferentBpmsAreNotEqual()
+    {
+        Assert.False(Bpm.From(120m) == Bpm.From(140m));
+        Assert.True(Bpm.From(120m) != Bpm.From(140m));
+    }
+
+    [Theory]
+    [InlineData("120", 120)]
+    [InlineData("99.5", 99.5)]
+    public void TryParseReadsSingleValue(string input, decimal expected)
+    {
+        Assert.True(Bpm.TryParse(input, out var result));
+        Assert.Equal(expected, result.Min);
+        Assert.Equal(expected, result.Max);
+    }
+
+    [Fact]
+    public void TryParseReadsRange()
+    {
+        Assert.True(Bpm.TryParse("120 ~ 200", out var result));
+        Assert.Equal(120m, result.Min);
+        Assert.Equal(200m, result.Max);
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("120 - 200")]
+    [InlineData("")]
+    public void TryParseRejectsInvalidInput(string input)
+    {
+        Assert.False(Bpm.TryParse(input, out _));
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/LevelBucketTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/LevelBucketTests.cs
@@ -1,0 +1,103 @@
+using System.Linq;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Exceptions;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class LevelBucketTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("    ")]
+    public void FromBlankThrows(string value)
+    {
+        Assert.Throws<InvalidNameException>(() => LevelBucket.From(value));
+    }
+
+    [Fact]
+    public void FromTrimsWhitespace()
+    {
+        var bucket = LevelBucket.From("  S15  ");
+        Assert.Equal("S15", (string)bucket);
+    }
+
+    [Fact]
+    public void EqualityIsCaseInsensitive()
+    {
+        Assert.Equal(LevelBucket.From("S15"), LevelBucket.From("s15"));
+        Assert.True(LevelBucket.From("S15") == LevelBucket.From("s15"));
+    }
+
+    [Fact]
+    public void DifferentBucketsAreNotEqual()
+    {
+        Assert.NotEqual(LevelBucket.From("S15"), LevelBucket.From("S16"));
+        Assert.True(LevelBucket.From("S15") != LevelBucket.From("S16"));
+    }
+
+    [Fact]
+    public void GetDifficultiesParsesSinglePrefix()
+    {
+        var difficulties = LevelBucket.From("S15").GetDifficulties();
+        Assert.Single(difficulties);
+        Assert.Contains((ChartType.Single, DifficultyLevel.From(15)), difficulties);
+    }
+
+    [Fact]
+    public void GetDifficultiesParsesDoublePrefix()
+    {
+        var difficulties = LevelBucket.From("D20").GetDifficulties();
+        Assert.Single(difficulties);
+        Assert.Contains((ChartType.Double, DifficultyLevel.From(20)), difficulties);
+    }
+
+    [Fact]
+    public void GetDifficultiesParsesCoOpPrefix()
+    {
+        var difficulties = LevelBucket.From("C3").GetDifficulties();
+        Assert.Single(difficulties);
+        Assert.Contains((ChartType.CoOp, DifficultyLevel.From(3)), difficulties);
+    }
+
+    [Fact]
+    public void GetDifficultiesWithoutPrefixIncludesSingleAndDouble()
+    {
+        var difficulties = LevelBucket.From("17").GetDifficulties().ToHashSet();
+        Assert.Contains((ChartType.Single, DifficultyLevel.From(17)), difficulties);
+        Assert.Contains((ChartType.Double, DifficultyLevel.From(17)), difficulties);
+    }
+
+    [Fact]
+    public void GetDifficultiesParsesCommaSeparatedSections()
+    {
+        var difficulties = LevelBucket.From("S15,D20").GetDifficulties().ToHashSet();
+        Assert.Contains((ChartType.Single, DifficultyLevel.From(15)), difficulties);
+        Assert.Contains((ChartType.Double, DifficultyLevel.From(20)), difficulties);
+    }
+
+    [Fact]
+    public void TryParseReturnsTrueForValid()
+    {
+        Assert.True(LevelBucket.TryParse("S15", out var result));
+        Assert.Equal("S15", (string)result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryParseReturnsFalseForBlank(string input)
+    {
+        Assert.False(LevelBucket.TryParse(input, out _));
+    }
+
+    [Fact]
+    public void ContainsIsCaseInsensitive()
+    {
+        var bucket = LevelBucket.From("S15");
+        Assert.True(bucket.Contains("s"));
+        Assert.True(bucket.Contains("15"));
+        Assert.False(bucket.Contains("D"));
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/LifebarSimulatorTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/LifebarSimulatorTests.cs
@@ -1,0 +1,96 @@
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class LifebarSimulatorTests
+{
+    [Theory]
+    [InlineData(15, 1675)]   // 1000 + 15*15*3
+    [InlineData(20, 2200)]   // 1000 + 20*20*3
+    [InlineData(29, 3523)]   // 1000 + 29*29*3
+    public void MaxLifeFollowsLevelFormula(int level, int expectedMax)
+    {
+        var sim = new LifebarSimulator(DifficultyLevel.From(level));
+        Assert.Equal(expectedMax, sim.MaxLife);
+    }
+
+    [Fact]
+    public void StartAtHalfByDefault()
+    {
+        var sim = new LifebarSimulator(DifficultyLevel.From(20));
+        Assert.Equal(500, sim.CurrentLife);
+    }
+
+    [Fact]
+    public void StartAtFullWhenRequested()
+    {
+        var sim = new LifebarSimulator(DifficultyLevel.From(20), startAtFull: true);
+        Assert.Equal(sim.MaxLife, sim.CurrentLife);
+    }
+
+    [Fact]
+    public void GoodDoesNotChangeLife()
+    {
+        var sim = new LifebarSimulator(DifficultyLevel.From(20));
+        var before = sim.CurrentLife;
+        sim.ApplyJudgment(Judgment.Good);
+        Assert.Equal(before, sim.CurrentLife);
+    }
+
+    [Fact]
+    public void BadReducesLifeByFifty()
+    {
+        var sim = new LifebarSimulator(DifficultyLevel.From(20));
+        sim.ApplyJudgment(Judgment.Bad);
+        Assert.Equal(450, sim.CurrentLife);
+    }
+
+    [Fact]
+    public void RepeatedBadsClampAtZero()
+    {
+        var sim = new LifebarSimulator(DifficultyLevel.From(20));
+        for (var i = 0; i < 100; i++) sim.ApplyJudgment(Judgment.Bad);
+        Assert.Equal(0, sim.CurrentLife);
+    }
+
+    [Fact]
+    public void MissReducesLifeMoreThanBad()
+    {
+        var missSim = new LifebarSimulator(DifficultyLevel.From(20));
+        missSim.ApplyJudgment(Judgment.Miss);
+
+        var badSim = new LifebarSimulator(DifficultyLevel.From(20));
+        badSim.ApplyJudgment(Judgment.Bad);
+
+        Assert.True(missSim.CurrentLife < badSim.CurrentLife);
+    }
+
+    [Fact]
+    public void PerfectIncreasesLife()
+    {
+        var sim = new LifebarSimulator(DifficultyLevel.From(20));
+        var before = sim.CurrentLife;
+        sim.ApplyJudgment(Judgment.Perfect);
+        Assert.True(sim.CurrentLife >= before);
+    }
+
+    [Fact]
+    public void RepeatedPerfectsClampAtMaxLife()
+    {
+        var sim = new LifebarSimulator(DifficultyLevel.From(20));
+        for (var i = 0; i < 10000; i++) sim.ApplyJudgment(Judgment.Perfect);
+        Assert.Equal(sim.MaxLife, sim.CurrentLife);
+    }
+
+    [Fact]
+    public void MissesAfterBadsStillReduceLifeAtZero()
+    {
+        var sim = new LifebarSimulator(DifficultyLevel.From(20));
+        for (var i = 0; i < 100; i++) sim.ApplyJudgment(Judgment.Bad);
+        sim.ApplyJudgment(Judgment.Miss);
+        Assert.Equal(0, sim.CurrentLife);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixScoreTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixScoreTests.cs
@@ -1,0 +1,131 @@
+using ScoreTracker.Domain.Exceptions;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class PhoenixScoreTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(995010)]
+    [InlineData(1000000)]
+    public void FromInRangeSucceeds(int value)
+    {
+        var score = PhoenixScore.From(value);
+        Assert.Equal(value, (int)score);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(1000001)]
+    public void FromOutOfRangeThrows(int value)
+    {
+        Assert.Throws<InvalidScoreException>(() => PhoenixScore.From(value));
+    }
+
+    [Fact]
+    public void IsValidIsTrueForBoundaryValues()
+    {
+        Assert.True(PhoenixScore.IsValid(0));
+        Assert.True(PhoenixScore.IsValid(1000000));
+    }
+
+    [Fact]
+    public void IsValidIsFalseOutsideBoundaries()
+    {
+        Assert.False(PhoenixScore.IsValid(-1));
+        Assert.False(PhoenixScore.IsValid(1000001));
+    }
+
+    [Theory]
+    [InlineData(995010, 4, 1000000)]
+    [InlineData(995010, 3, 995000)]
+    [InlineData(994499, 3, 994000)]
+    [InlineData(0, 4, 0)]
+    public void RoundUsesPowerOfTen(int score, int zeros, int expected)
+    {
+        var rounded = PhoenixScore.From(score).Round(zeros);
+        Assert.Equal(expected, (int)rounded);
+    }
+
+    [Theory]
+    [InlineData(995000, 990000, true)]
+    [InlineData(990000, 995000, false)]
+    [InlineData(995000, 995000, false)]
+    public void GreaterThanComparesUnderlyingScore(int left, int right, bool expected)
+    {
+        Assert.Equal(expected, PhoenixScore.From(left) > PhoenixScore.From(right));
+    }
+
+    [Theory]
+    [InlineData(990000, 995000, true)]
+    [InlineData(995000, 990000, false)]
+    [InlineData(995000, 995000, false)]
+    public void LessThanComparesUnderlyingScore(int left, int right, bool expected)
+    {
+        Assert.Equal(expected, PhoenixScore.From(left) < PhoenixScore.From(right));
+    }
+
+    [Fact]
+    public void EqualScoresAreEqual()
+    {
+        Assert.True(PhoenixScore.From(995010) == PhoenixScore.From(995010));
+        Assert.False(PhoenixScore.From(995010) != PhoenixScore.From(995010));
+    }
+
+    [Fact]
+    public void DifferentScoresAreNotEqual()
+    {
+        Assert.False(PhoenixScore.From(995010) == PhoenixScore.From(995011));
+        Assert.True(PhoenixScore.From(995010) != PhoenixScore.From(995011));
+    }
+
+    [Fact]
+    public void CompareToOrdersByUnderlyingScore()
+    {
+        Assert.Equal(0, PhoenixScore.From(995010).CompareTo(PhoenixScore.From(995010)));
+        Assert.True(PhoenixScore.From(1000000).CompareTo(PhoenixScore.From(0)) > 0);
+        Assert.True(PhoenixScore.From(0).CompareTo(PhoenixScore.From(1000000)) < 0);
+    }
+
+    [Fact]
+    public void CompareToWithIntComparesUnderlyingValue()
+    {
+        Assert.Equal(0, PhoenixScore.From(995010).CompareTo(995010));
+        Assert.True(PhoenixScore.From(995010).CompareTo(995009) > 0);
+    }
+
+    [Fact]
+    public void ImplicitFromIntCallsFrom()
+    {
+        PhoenixScore s = 995010;
+        Assert.Equal(995010, (int)s);
+    }
+
+    [Theory]
+    [InlineData("995010", true)]
+    [InlineData("0", true)]
+    [InlineData("1000001", false)]
+    [InlineData("-1", false)]
+    [InlineData("abc", false)]
+    public void TryParseFromStringHonorsValidity(string input, bool expected)
+    {
+        Assert.Equal(expected, PhoenixScore.TryParse(input, out PhoenixScore _));
+    }
+
+    [Fact]
+    public void NullableTryParseReturnsNullForBlank()
+    {
+        Assert.True(PhoenixScore.TryParse("   ", out PhoenixScore? result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ToStringContainsAllDigits()
+    {
+        var rendered = PhoenixScore.From(995010).ToString();
+        Assert.Contains("995", rendered);
+        Assert.Contains("010", rendered);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/PreferenceRatingTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/PreferenceRatingTests.cs
@@ -1,0 +1,88 @@
+using ScoreTracker.Domain.Exceptions;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class PreferenceRatingTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2.5)]
+    [InlineData(5)]
+    public void FromInRangeSucceeds(decimal value)
+    {
+        var rating = PreferenceRating.From(value);
+        Assert.Equal(value, (decimal)rating);
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(-1)]
+    [InlineData(5.01)]
+    [InlineData(100)]
+    public void FromOutOfRangeThrows(decimal value)
+    {
+        Assert.Throws<InvalidDifficultyLevelException>(() => PreferenceRating.From(value));
+    }
+
+    [Fact]
+    public void ImplicitFromIntCallsFrom()
+    {
+        PreferenceRating r = 3;
+        Assert.Equal(3m, (decimal)r);
+    }
+
+    [Fact]
+    public void ImplicitToIntTruncates()
+    {
+        var r = PreferenceRating.From(3.7m);
+        int v = r;
+        Assert.Equal(3, v);
+    }
+
+    [Theory]
+    [InlineData(2, 1, true)]
+    [InlineData(1, 2, false)]
+    [InlineData(2, 2, false)]
+    public void GreaterThanComparesUnderlyingValue(decimal left, decimal right, bool expected)
+    {
+        Assert.Equal(expected, PreferenceRating.From(left) > PreferenceRating.From(right));
+    }
+
+    [Theory]
+    [InlineData(2, 2, true)]
+    [InlineData(2, 3, true)]
+    [InlineData(3, 2, false)]
+    public void LessOrEqualComparesUnderlyingValue(decimal left, decimal right, bool expected)
+    {
+        Assert.Equal(expected, PreferenceRating.From(left) <= PreferenceRating.From(right));
+    }
+
+    [Fact]
+    public void EqualRatingsAreEqual()
+    {
+        Assert.True(PreferenceRating.From(2.5m) == PreferenceRating.From(2.5m));
+    }
+
+    [Fact]
+    public void CompareToReturnsDifferenceSign()
+    {
+        Assert.Equal(0, PreferenceRating.From(2m).CompareTo(PreferenceRating.From(2m)));
+        Assert.True(PreferenceRating.From(3m).CompareTo(PreferenceRating.From(2m)) > 0);
+        Assert.True(PreferenceRating.From(1m).CompareTo(PreferenceRating.From(2m)) < 0);
+    }
+
+    [Theory]
+    [InlineData("3", true)]
+    [InlineData("3.5", true)]
+    [InlineData("0", true)]
+    [InlineData("5", true)]
+    [InlineData("6", false)]
+    [InlineData("-1", false)]
+    [InlineData("abc", false)]
+    public void TryParseHonorsValidity(string input, bool expected)
+    {
+        Assert.Equal(expected, PreferenceRating.TryParse(input, out _));
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/RandomSettingsTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/RandomSettingsTests.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class RandomSettingsTests
+{
+    [Fact]
+    public void DefaultLevelWeightsCoverAllDifficulties()
+    {
+        var settings = new RandomSettings();
+        foreach (var level in DifficultyLevel.All)
+            Assert.Equal(0, settings.LevelWeights[(int)level]);
+    }
+
+    [Fact]
+    public void DefaultDoubleLevelWeightsCoverAllDifficulties()
+    {
+        var settings = new RandomSettings();
+        foreach (var level in DifficultyLevel.All)
+            Assert.Equal(0, settings.DoubleLevelWeights[(int)level]);
+    }
+
+    [Fact]
+    public void DefaultPlayerCountWeightsCoverTwoThroughFive()
+    {
+        var settings = new RandomSettings();
+        Assert.Equal(new[] { 2, 3, 4, 5 }, settings.PlayerCountWeights.Keys.OrderBy(k => k));
+        Assert.All(settings.PlayerCountWeights.Values, v => Assert.Equal(0, v));
+    }
+
+    [Fact]
+    public void DefaultHasWeightedSettingIsFalse()
+    {
+        Assert.False(new RandomSettings().HasWeightedSetting);
+    }
+
+    [Fact]
+    public void HasWeightedSettingIsTrueWhenLevelWeightExceedsOne()
+    {
+        var settings = new RandomSettings();
+        var firstLevel = DifficultyLevel.All.First();
+        settings.LevelWeights[(int)firstLevel] = 2;
+        Assert.True(settings.HasWeightedSetting);
+    }
+
+    [Fact]
+    public void HasWeightedSettingIsFalseWhenAllWeightsAreOneOrLess()
+    {
+        var settings = new RandomSettings();
+        foreach (var level in DifficultyLevel.All)
+            settings.LevelWeights[(int)level] = 1;
+        Assert.False(settings.HasWeightedSetting);
+    }
+
+    [Fact]
+    public void HasWeightedSettingIsTrueWhenSongTypeWeightExceedsOne()
+    {
+        var settings = new RandomSettings();
+        settings.SongTypeWeights[SongType.Arcade] = 5;
+        Assert.True(settings.HasWeightedSetting);
+    }
+
+    [Fact]
+    public void ClearLevelWeightsZerosLevelWeightsAndDoublesAndPlayerCounts()
+    {
+        var settings = new RandomSettings();
+        var firstLevel = DifficultyLevel.All.First();
+        settings.LevelWeights[(int)firstLevel] = 5;
+        settings.DoubleLevelWeights[(int)firstLevel] = 7;
+        settings.PlayerCountWeights[2] = 9;
+
+        settings.ClearLevelWeights();
+
+        Assert.All(settings.LevelWeights.Values, v => Assert.Equal(0, v));
+        Assert.All(settings.DoubleLevelWeights.Values, v => Assert.Equal(0, v));
+        Assert.All(settings.PlayerCountWeights.Values, v => Assert.Equal(0, v));
+    }
+
+    [Fact]
+    public void ClearLevelWeightsLeavesSongTypeWeightsAlone()
+    {
+        var settings = new RandomSettings();
+        settings.SongTypeWeights[SongType.Arcade] = 3;
+
+        settings.ClearLevelWeights();
+
+        Assert.Equal(3, settings.SongTypeWeights[SongType.Arcade]);
+    }
+
+    [Fact]
+    public void ClearChartTypeMinimumsResetsToNullForEachKnownType()
+    {
+        var settings = new RandomSettings();
+        settings.ChartTypeMinimums[ChartType.Single] = 5;
+        settings.ChartTypeMinimums[ChartType.Double] = 10;
+
+        settings.ClearChartTypeMinimums();
+
+        Assert.Equal(3, settings.ChartTypeMinimums.Count);
+        Assert.All(settings.ChartTypeMinimums.Values, v => Assert.Null(v));
+    }
+
+    [Fact]
+    public void ClearLevelMinimumsResetsAllDifficultyKeysToNull()
+    {
+        var settings = new RandomSettings();
+        var firstLevel = DifficultyLevel.All.First();
+        settings.LevelMinimums[(int)firstLevel] = 1;
+
+        settings.ClearLevelMinimums();
+
+        Assert.All(settings.LevelMinimums.Values, v => Assert.Null(v));
+    }
+
+    [Fact]
+    public void ClearCustomMinimumsRemovesAllEntries()
+    {
+        var settings = new RandomSettings();
+        settings.CustomMinimums["foo"] = 1;
+        settings.CustomMinimums["bar"] = 2;
+
+        settings.ClearCustomMinimums();
+
+        Assert.Empty(settings.CustomMinimums);
+    }
+
+    [Fact]
+    public void CustomMinimumsKeysAreCaseInsensitive()
+    {
+        var settings = new RandomSettings();
+        settings.CustomMinimums["Foo"] = 1;
+
+        Assert.True(settings.CustomMinimums.ContainsKey("foo"));
+        Assert.True(settings.CustomMinimums.ContainsKey("FOO"));
+    }
+
+    [Fact]
+    public void DefaultOrderingIsRandomized()
+    {
+        Assert.Equal(RandomSettings.ResultsOrdering.Randomized, new RandomSettings().Ordering);
+    }
+
+    [Fact]
+    public void DefaultCountIsThree()
+    {
+        Assert.Equal(3, new RandomSettings().Count);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/RatingTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/RatingTests.cs
@@ -1,0 +1,96 @@
+using ScoreTracker.Domain.Exceptions;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class RatingTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(int.MaxValue)]
+    public void FromNonNegativeSucceeds(int value)
+    {
+        var rating = Rating.From(value);
+        Assert.Equal(value, (int)rating);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void FromNegativeThrows(int value)
+    {
+        Assert.Throws<InvalidScoreException>(() => Rating.From(value));
+    }
+
+    [Fact]
+    public void IsValidIsTrueForZero()
+    {
+        Assert.True(Rating.IsValid(0));
+    }
+
+    [Fact]
+    public void IsValidIsFalseForNegative()
+    {
+        Assert.False(Rating.IsValid(-1));
+    }
+
+    [Theory]
+    [InlineData(20, 10, true)]
+    [InlineData(10, 20, false)]
+    [InlineData(10, 10, false)]
+    public void GreaterThanComparesUnderlyingScore(int left, int right, bool expected)
+    {
+        Assert.Equal(expected, Rating.From(left) > Rating.From(right));
+    }
+
+    [Theory]
+    [InlineData(10, 20, true)]
+    [InlineData(20, 10, false)]
+    [InlineData(10, 10, false)]
+    public void LessThanComparesUnderlyingScore(int left, int right, bool expected)
+    {
+        Assert.Equal(expected, Rating.From(left) < Rating.From(right));
+    }
+
+    [Fact]
+    public void EqualRatingsAreEqual()
+    {
+        Assert.True(Rating.From(50) == Rating.From(50));
+        Assert.False(Rating.From(50) != Rating.From(50));
+    }
+
+    [Fact]
+    public void CompareToReturnsDifference()
+    {
+        Assert.Equal(0, Rating.From(50).CompareTo(Rating.From(50)));
+        Assert.True(Rating.From(50).CompareTo(Rating.From(40)) > 0);
+        Assert.True(Rating.From(50).CompareTo(Rating.From(60)) < 0);
+    }
+
+    [Theory]
+    [InlineData("100", true)]
+    [InlineData("0", true)]
+    [InlineData("-1", false)]
+    [InlineData("abc", false)]
+    public void TryParseFromStringHonorsValidity(string input, bool expectedSuccess)
+    {
+        Assert.Equal(expectedSuccess, Rating.TryParse(input, out Rating _));
+    }
+
+    [Fact]
+    public void NullableTryParseReturnsNullForBlankString()
+    {
+        Assert.True(Rating.TryParse("   ", out Rating? result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void NullableTryParseReturnsValueForValidNumber()
+    {
+        Assert.True(Rating.TryParse("100", out Rating? result));
+        Assert.NotNull(result);
+        Assert.Equal(100, (int)result!.Value);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/StepCountTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/StepCountTests.cs
@@ -1,0 +1,79 @@
+using ScoreTracker.Domain.Exceptions;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class StepCountTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(5000)]
+    public void FromNonNegativeIntSucceeds(int value)
+    {
+        var count = StepCount.From(value);
+        Assert.Equal(value, (int)count);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void FromNegativeIntThrows(int value)
+    {
+        Assert.Throws<InvalidStepCountException>(() => StepCount.From(value));
+    }
+
+    [Fact]
+    public void ImplicitFromIntCallsFrom()
+    {
+        StepCount count = 42;
+        Assert.Equal(42, (int)count);
+    }
+
+    [Fact]
+    public void ImplicitToIntReturnsUnderlying()
+    {
+        var count = StepCount.From(42);
+        int value = count;
+        Assert.Equal(42, value);
+    }
+
+    [Fact]
+    public void EqualCountsAreEqual()
+    {
+        Assert.True(StepCount.From(5) == StepCount.From(5));
+        Assert.False(StepCount.From(5) != StepCount.From(5));
+    }
+
+    [Fact]
+    public void DifferentCountsAreNotEqual()
+    {
+        Assert.False(StepCount.From(5) == StepCount.From(6));
+        Assert.True(StepCount.From(5) != StepCount.From(6));
+    }
+
+    [Theory]
+    [InlineData("100", true)]
+    [InlineData("0", true)]
+    [InlineData("-1", false)]
+    [InlineData("abc", false)]
+    [InlineData("", false)]
+    public void TryParseFromStringHonorsValidity(string input, bool expectedSuccess)
+    {
+        Assert.Equal(expectedSuccess, StepCount.TryParse(input, out _));
+    }
+
+    [Fact]
+    public void TryParseFromIntReturnsTrueForValid()
+    {
+        Assert.True(StepCount.TryParse(100, out var result));
+        Assert.Equal(100, (int)result);
+    }
+
+    [Fact]
+    public void TryParseFromIntReturnsFalseForNegative()
+    {
+        Assert.False(StepCount.TryParse(-1, out _));
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/UserAccessServiceTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/UserAccessServiceTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.Services;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class UserAccessServiceTests
+{
+    [Fact]
+    public async Task LoggedInUserHasAccessToOwnProfile()
+    {
+        var userId = Guid.NewGuid();
+        var currentUser = new UserBuilder().WithId(userId).Build();
+        var currentUserAccessor = new Mock<ICurrentUserAccessor>();
+        currentUserAccessor.SetupGet(c => c.IsLoggedIn).Returns(true);
+        currentUserAccessor.SetupGet(c => c.User).Returns(currentUser);
+        var users = new Mock<IUserRepository>();
+
+        var service = new UserAccessService(currentUserAccessor.Object, users.Object);
+
+        Assert.True(await service.HasAccessTo(userId));
+        users.Verify(u => u.GetUser(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task LoggedInUserHasAccessToPublicProfile()
+    {
+        var currentUser = new UserBuilder().Build();
+        var currentUserAccessor = new Mock<ICurrentUserAccessor>();
+        currentUserAccessor.SetupGet(c => c.IsLoggedIn).Returns(true);
+        currentUserAccessor.SetupGet(c => c.User).Returns(currentUser);
+
+        var targetId = Guid.NewGuid();
+        var target = new UserBuilder().WithId(targetId).WithIsPublic(true).Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(targetId, It.IsAny<CancellationToken>())).ReturnsAsync(target);
+
+        var service = new UserAccessService(currentUserAccessor.Object, users.Object);
+
+        Assert.True(await service.HasAccessTo(targetId));
+    }
+
+    [Fact]
+    public async Task LoggedInUserDeniedFromPrivateProfile()
+    {
+        var currentUser = new UserBuilder().Build();
+        var currentUserAccessor = new Mock<ICurrentUserAccessor>();
+        currentUserAccessor.SetupGet(c => c.IsLoggedIn).Returns(true);
+        currentUserAccessor.SetupGet(c => c.User).Returns(currentUser);
+
+        var targetId = Guid.NewGuid();
+        var target = new UserBuilder().WithId(targetId).WithIsPublic(false).Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(targetId, It.IsAny<CancellationToken>())).ReturnsAsync(target);
+
+        var service = new UserAccessService(currentUserAccessor.Object, users.Object);
+
+        Assert.False(await service.HasAccessTo(targetId));
+    }
+
+    [Fact]
+    public async Task AnonymousUserHasAccessToPublicProfile()
+    {
+        var currentUserAccessor = new Mock<ICurrentUserAccessor>();
+        currentUserAccessor.SetupGet(c => c.IsLoggedIn).Returns(false);
+
+        var targetId = Guid.NewGuid();
+        var target = new UserBuilder().WithId(targetId).WithIsPublic(true).Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(targetId, It.IsAny<CancellationToken>())).ReturnsAsync(target);
+
+        var service = new UserAccessService(currentUserAccessor.Object, users.Object);
+
+        Assert.True(await service.HasAccessTo(targetId));
+    }
+
+    [Fact]
+    public async Task AnonymousUserDeniedFromPrivateProfile()
+    {
+        var currentUserAccessor = new Mock<ICurrentUserAccessor>();
+        currentUserAccessor.SetupGet(c => c.IsLoggedIn).Returns(false);
+
+        var targetId = Guid.NewGuid();
+        var target = new UserBuilder().WithId(targetId).WithIsPublic(false).Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(targetId, It.IsAny<CancellationToken>())).ReturnsAsync(target);
+
+        var service = new UserAccessService(currentUserAccessor.Object, users.Object);
+
+        Assert.False(await service.HasAccessTo(targetId));
+    }
+
+    [Fact]
+    public async Task DeniedWhenTargetUserDoesNotExist()
+    {
+        var currentUserAccessor = new Mock<ICurrentUserAccessor>();
+        currentUserAccessor.SetupGet(c => c.IsLoggedIn).Returns(false);
+
+        var targetId = Guid.NewGuid();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(targetId, It.IsAny<CancellationToken>())).ReturnsAsync((User?)null);
+
+        var service = new UserAccessService(currentUserAccessor.Object, users.Object);
+
+        Assert.False(await service.HasAccessTo(targetId));
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/XXScoreTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/XXScoreTests.cs
@@ -1,0 +1,82 @@
+using ScoreTracker.Domain.Exceptions;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class XXScoreTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(995010)]
+    [InlineData(200000000)]
+    public void FromInRangeSucceeds(int value)
+    {
+        var score = XXScore.From(value);
+        Assert.Equal(value, (int)score);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(200000001)]
+    public void FromOutOfRangeThrows(int value)
+    {
+        Assert.Throws<InvalidScoreException>(() => XXScore.From(value));
+    }
+
+    [Fact]
+    public void ImplicitFromIntCallsFrom()
+    {
+        XXScore s = 1000;
+        Assert.Equal(1000, (int)s);
+    }
+
+    [Fact]
+    public void ImplicitToIntReturnsUnderlying()
+    {
+        int v = XXScore.From(1000);
+        Assert.Equal(1000, v);
+    }
+
+    [Theory]
+    [InlineData(100, 50, true)]
+    [InlineData(50, 100, false)]
+    [InlineData(50, 50, false)]
+    public void GreaterThanComparesUnderlyingScore(int left, int right, bool expected)
+    {
+        Assert.Equal(expected, XXScore.From(left) > XXScore.From(right));
+    }
+
+    [Theory]
+    [InlineData(50, 100, true)]
+    [InlineData(100, 50, false)]
+    [InlineData(50, 50, false)]
+    public void LessThanComparesUnderlyingScore(int left, int right, bool expected)
+    {
+        Assert.Equal(expected, XXScore.From(left) < XXScore.From(right));
+    }
+
+    [Fact]
+    public void EqualScoresAreEqual()
+    {
+        Assert.True(XXScore.From(1000) == XXScore.From(1000));
+        Assert.False(XXScore.From(1000) != XXScore.From(1000));
+    }
+
+    [Theory]
+    [InlineData("100", true)]
+    [InlineData("0", true)]
+    [InlineData("-1", false)]
+    [InlineData("abc", false)]
+    public void TryParseFromStringHonorsValidity(string input, bool expected)
+    {
+        Assert.Equal(expected, XXScore.TryParse(input, out XXScore _));
+    }
+
+    [Fact]
+    public void NullableTryParseReturnsNullForBlank()
+    {
+        Assert.True(XXScore.TryParse("   ", out XXScore? result));
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
## Summary
Adds 194 new unit tests (11 → 205 total) covering pure-logic Domain code and
public static helpers that were testable without further refactor. All tests
are no-mock or single-mock, use the test helpers added in #48
(FakeDateTime / UserBuilder / ChartBuilder), and follow the xUnit + Moq
conventions in ARCHITECTURE.md.
### Coverage added
- **Domain value types** (7 files): Bpm, LevelBucket, PhoenixScore,
  PreferenceRating, Rating, StepCount, XXScore — boundaries, comparison
  operators, parsing, equality.
- **Pure-logic Domain models** (2 files): LifebarSimulator (MaxLife formula,
  judgment effects, life clamping) and RandomSettings (defaults, Clear*
  methods, HasWeightedSetting branches).
- **Domain service** (1 file): UserAccessService — own-profile, public,
  private, and anonymous access paths.
- **Application static helpers** (2 files): TierListSaga.ProcessIntoTierList
  (empty input, ordering, zero-weight → Unrecorded, top-weight → Overrated)
  and StdDev; WeeklyTournamentSaga.ProcessIntoPlaces (tie handling) and
  GetSuggestedCharts (CoOp inclusion, level-range filtering).
### Notes for reviewer
- Caught one pre-existing copy-paste bug in the `Rating > Rating` test data
  rows during the run — fixed before commit.
- UserQualifiers and the title-progression models were *not* covered. Both
  drag in ScoringConfiguration (the heavy DataTable + reflection model),
  which I've marked as a Tier-3 golden-master target.
## Test plan
- [x] `dotnet test` — 205 / 205 passing, 0 failures