### PR TITLE
Add Tier 2 tests for 37 simple Application handlers

### DIFF
--- a/ScoreTracker/ScoreTracker.Application/Handlers/GetUserByDiscordIdHandler.cs
+++ b/ScoreTracker/ScoreTracker.Application/Handlers/GetUserByDiscordIdHandler.cs
@@ -5,7 +5,7 @@ using ScoreTracker.Domain.SecondaryPorts;
 
 namespace ScoreTracker.Application.Handlers;
 
-internal class GetUserByDiscordIdHandler : IRequestHandler<GetUserByExternalLoginQuery, User?>
+public sealed class GetUserByDiscordIdHandler : IRequestHandler<GetUserByExternalLoginQuery, User?>
 {
     private readonly IUserRepository _user;
 

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/ApiTokenHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/ApiTokenHandlerTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class ApiTokenHandlerTests
+{
+    [Fact]
+    public async Task GetUserApiTokenReturnsTokenForCurrentUser()
+    {
+        var user = new UserBuilder().Build();
+        var token = Guid.NewGuid();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUserApiToken(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync(token);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new ApiTokenHandler(users.Object, currentUser.Object);
+        var result = await handler.Handle(new GetUserApiTokenQuery(), CancellationToken.None);
+
+        Assert.Equal(token, result);
+    }
+
+    [Fact]
+    public async Task GetUserByApiTokenDelegatesToRepository()
+    {
+        var user = new UserBuilder().Build();
+        var token = Guid.NewGuid();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUserByApiToken(token, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var handler = new ApiTokenHandler(users.Object, new Mock<ICurrentUserAccessor>().Object);
+        var result = await handler.Handle(new GetUserByApiTokenQuery(token), CancellationToken.None);
+
+        Assert.Equal(user, result);
+    }
+
+    [Fact]
+    public async Task SetApiTokenWritesNewGuidForCurrentUserAndReturnsIt()
+    {
+        var user = new UserBuilder().Build();
+        var users = new Mock<IUserRepository>();
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new ApiTokenHandler(users.Object, currentUser.Object);
+        var result = await handler.Handle(new SetApiTokenCommand(), CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result);
+        users.Verify(u => u.SetUserApiToken(user.Id, result, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CreateExternalLoginHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CreateExternalLoginHandlerTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class CreateExternalLoginHandlerTests
+{
+    [Fact]
+    public async Task CreatesLoginWhenNoneExists()
+    {
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUserByExternalLogin("Discord", "ext-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Models.User?)null);
+
+        var handler = new CreateExternalLoginHandler(users.Object);
+        var userId = Guid.NewGuid();
+        await handler.Handle(new CreateExternalLoginCommand(userId, "ext-1", "Discord"), CancellationToken.None);
+
+        users.Verify(u => u.CreateExternalLogin(userId, "Discord", "ext-1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ThrowsWhenLoginAlreadyExists()
+    {
+        var existing = new UserBuilder().Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUserByExternalLogin("Discord", "ext-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var handler = new CreateExternalLoginHandler(users.Object);
+
+        await Assert.ThrowsAsync<Exception>(() =>
+            handler.Handle(new CreateExternalLoginCommand(Guid.NewGuid(), "ext-1", "Discord"), CancellationToken.None));
+
+        users.Verify(u => u.CreateExternalLogin(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetAllChartScoreAggregatesHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetAllChartScoreAggregatesHandlerTests.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetAllChartScoreAggregatesHandlerTests
+{
+    [Fact]
+    public async Task ReturnsAggregatesFromRepository()
+    {
+        var aggregates = new List<ChartScoreAggregate>();
+        var records = new Mock<IPhoenixRecordRepository>();
+        records.Setup(r => r.GetAllChartScoreAggregates(It.IsAny<CancellationToken>())).ReturnsAsync(aggregates);
+
+        var handler = new GetAllChartScoreAggregatesHandler(records.Object);
+        var result = await handler.Handle(new GetAllChartScoreAggregatesQuery(), CancellationToken.None);
+
+        Assert.Same(aggregates, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartHandlerTests.cs
@@ -1,0 +1,50 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetChartHandlerTests
+{
+    [Fact]
+    public async Task ReturnsChartMatchingTypeAndLevel()
+    {
+        var matching = new ChartBuilder().WithType(ChartType.Single).WithLevel(15).Build();
+        var wrongLevel = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var wrongType = new ChartBuilder().WithType(ChartType.Double).WithLevel(15).Build();
+
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChartsForSong(MixEnum.Phoenix, It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { wrongLevel, matching, wrongType });
+
+        var handler = new GetChartHandler(charts.Object);
+        var result = await handler.Handle(
+            new GetChartQuery(MixEnum.Phoenix, Name.From("song"), DifficultyLevel.From(15), ChartType.Single),
+            CancellationToken.None);
+
+        Assert.Equal(matching, result);
+    }
+
+    [Fact]
+    public async Task ReturnsNullWhenNoChartMatches()
+    {
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChartsForSong(It.IsAny<MixEnum>(), It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new ChartBuilder().WithType(ChartType.Double).WithLevel(20).Build() });
+
+        var handler = new GetChartHandler(charts.Object);
+        var result = await handler.Handle(
+            new GetChartQuery(MixEnum.Phoenix, Name.From("song"), DifficultyLevel.From(15), ChartType.Single),
+            CancellationToken.None);
+
+        Assert.Null(result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartRatingHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartRatingHandlerTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetChartRatingHandlerTests
+{
+    [Fact]
+    public async Task ReturnsBaseRatingWhenAnonymous()
+    {
+        var chartId = Guid.NewGuid();
+        var record = new ChartDifficultyRatingRecord(chartId, 15.5, 10, 0.5);
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetChartRatedDifficulty(MixEnum.Phoenix, chartId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(record);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.IsLoggedIn).Returns(false);
+
+        var handler = new GetChartRatingHandler(ratings.Object, currentUser.Object);
+        var result = await handler.Handle(new GetChartRatingQuery(MixEnum.Phoenix, chartId), CancellationToken.None);
+
+        Assert.Equal(record, result);
+        Assert.Null(result!.MyRating);
+        ratings.Verify(r => r.GetRating(It.IsAny<MixEnum>(), It.IsAny<Guid>(), It.IsAny<Guid>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReturnsNullWhenChartNotRated()
+    {
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r =>
+                r.GetChartRatedDifficulty(It.IsAny<MixEnum>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ChartDifficultyRatingRecord?)null);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.IsLoggedIn).Returns(true);
+
+        var handler = new GetChartRatingHandler(ratings.Object, currentUser.Object);
+        var result = await handler.Handle(new GetChartRatingQuery(MixEnum.Phoenix, Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task PopulatesMyRatingForLoggedInUser()
+    {
+        var chartId = Guid.NewGuid();
+        var record = new ChartDifficultyRatingRecord(chartId, 15.5, 10, 0.5);
+        var user = new UserBuilder().Build();
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetChartRatedDifficulty(MixEnum.Phoenix, chartId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(record);
+        ratings.Setup(r => r.GetRating(MixEnum.Phoenix, chartId, user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DifficultyAdjustment.Easy);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.IsLoggedIn).Returns(true);
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new GetChartRatingHandler(ratings.Object, currentUser.Object);
+        var result = await handler.Handle(new GetChartRatingQuery(MixEnum.Phoenix, chartId), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(DifficultyAdjustment.Easy, result!.MyRating);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartRatingsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartRatingsHandlerTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetChartRatingsHandlerTests
+{
+    [Fact]
+    public async Task ReturnsAllRatingsForAnonymousUser()
+    {
+        var record = new ChartDifficultyRatingRecord(Guid.NewGuid(), 20.0, 5, 0.3);
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetAllChartRatedDifficulties(MixEnum.Phoenix, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { record });
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.IsLoggedIn).Returns(false);
+
+        var handler = new GetChartRatingsHandler(ratings.Object, currentUser.Object,
+            new Mock<IChartRepository>().Object);
+        var result = (await handler.Handle(new GetChartRatingsQuery(MixEnum.Phoenix), CancellationToken.None))
+            .ToArray();
+
+        Assert.Single(result);
+        Assert.Null(result[0].MyRating);
+    }
+
+    [Fact]
+    public async Task FiltersByLevelAndType()
+    {
+        var matchingId = Guid.NewGuid();
+        var nonMatchingId = Guid.NewGuid();
+        var matching = new ChartDifficultyRatingRecord(matchingId, 20.0, 5, 0.3);
+        var nonMatching = new ChartDifficultyRatingRecord(nonMatchingId, 10.0, 1, 0.0);
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetAllChartRatedDifficulties(MixEnum.Phoenix, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { matching, nonMatching });
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetCharts(MixEnum.Phoenix, It.IsAny<DifficultyLevel?>(), It.IsAny<ChartType?>(),
+                It.IsAny<System.Collections.Generic.IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new ChartBuilder().WithId(matchingId).Build() });
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.IsLoggedIn).Returns(false);
+
+        var handler = new GetChartRatingsHandler(ratings.Object, currentUser.Object, charts.Object);
+        var result = (await handler.Handle(
+                new GetChartRatingsQuery(MixEnum.Phoenix, DifficultyLevel.From(20), ChartType.Single),
+                CancellationToken.None))
+            .ToArray();
+
+        Assert.Single(result);
+        Assert.Equal(matchingId, result[0].ChartId);
+    }
+
+    [Fact]
+    public async Task PopulatesMyRatingForLoggedInUser()
+    {
+        var chartId = Guid.NewGuid();
+        var record = new ChartDifficultyRatingRecord(chartId, 20.0, 5, 0.3);
+        var user = new UserBuilder().Build();
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetAllChartRatedDifficulties(MixEnum.Phoenix, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { record });
+        ratings.Setup(r => r.GetRatingsByUser(MixEnum.Phoenix, user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { (chartId, DifficultyAdjustment.Hard) });
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.IsLoggedIn).Returns(true);
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new GetChartRatingsHandler(ratings.Object, currentUser.Object,
+            new Mock<IChartRepository>().Object);
+        var result = (await handler.Handle(new GetChartRatingsQuery(MixEnum.Phoenix), CancellationToken.None))
+            .ToArray();
+
+        Assert.Single(result);
+        Assert.Equal(DifficultyAdjustment.Hard, result[0].MyRating);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartVideosHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartVideosHandlerTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetChartVideosHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepository()
+    {
+        var ids = new[] { Guid.NewGuid() };
+        var expected = new List<ChartVideoInformation>();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChartVideoInformation(ids, It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+
+        var handler = new GetChartVideosHandler(charts.Object);
+        var result = await handler.Handle(new GetChartVideosQuery(ids), CancellationToken.None);
+
+        Assert.Same(expected, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartsBySongHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartsBySongHandlerTests.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetChartsBySongHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepository()
+    {
+        var songName = Name.From("Test Song");
+        var expected = new[] { new ChartBuilder().Build() };
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChartsForSong(MixEnum.Phoenix, songName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var handler = new GetChartsBySongHandler(charts.Object);
+        var result = await handler.Handle(new GetChartsBySongQuery(MixEnum.Phoenix, songName), CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartsHandlerTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetChartsHandlerTests
+{
+    [Fact]
+    public async Task DelegatesAllFiltersToRepository()
+    {
+        var expected = new[] { new ChartBuilder().Build() };
+        var ids = new[] { Guid.NewGuid() };
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetCharts(MixEnum.Phoenix, DifficultyLevel.From(20), ChartType.Single,
+                It.Is<IEnumerable<Guid>>(g => g != null), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var handler = new GetChartsHandler(charts.Object);
+        var result = await handler.Handle(
+            new GetChartsQuery(MixEnum.Phoenix, DifficultyLevel.From(20), ChartType.Single, ids),
+            CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task PassesNullFiltersThroughWhenUnspecified()
+    {
+        var expected = new[] { new ChartBuilder().Build() };
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetCharts(MixEnum.Phoenix, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var handler = new GetChartsHandler(charts.Object);
+        var result = await handler.Handle(new GetChartsQuery(MixEnum.Phoenix), CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetCoOpBestAttemptsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetCoOpBestAttemptsHandlerTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetCoOpBestAttemptsHandlerTests
+{
+    [Fact]
+    public async Task FetchesCoOpChartsThenBestAttemptsForCurrentUser()
+    {
+        var user = new UserBuilder().Build();
+        var coOpCharts = new[] { new ChartBuilder().WithType(ChartType.CoOp).WithLevel(3).Build() };
+        var attempts = new List<BestXXChartAttempt>();
+
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetCoOpCharts(MixEnum.XX, It.IsAny<CancellationToken>())).ReturnsAsync(coOpCharts);
+        var attemptRepo = new Mock<IXXChartAttemptRepository>();
+        attemptRepo.Setup(a => a.GetBestAttempts(user.Id, coOpCharts, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(attempts);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new GetCoOpBestAttemptsHandler(attemptRepo.Object, charts.Object, currentUser.Object);
+        var result = await handler.Handle(new GetXXCoOpBestAttemptsQuery(), CancellationToken.None);
+
+        Assert.Same(attempts, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetCoOpRatingHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetCoOpRatingHandlerTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetCoOpRatingHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepository()
+    {
+        var chartId = Guid.NewGuid();
+        var rating = new CoOpRating(chartId, 1, new Dictionary<int, DifficultyLevel> { { 1, DifficultyLevel.From(20) } });
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetCoOpRating(chartId, It.IsAny<CancellationToken>())).ReturnsAsync(rating);
+
+        var handler = new GetCoOpRatingHandler(ratings.Object);
+        var result = await handler.Handle(new GetCoOpRatingQuery(chartId), CancellationToken.None);
+
+        Assert.Equal(rating, result);
+    }
+
+    [Fact]
+    public async Task ReturnsNullWhenRepositoryReturnsNull()
+    {
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetCoOpRating(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CoOpRating?)null);
+
+        var handler = new GetCoOpRatingHandler(ratings.Object);
+        var result = await handler.Handle(new GetCoOpRatingQuery(Guid.NewGuid()), CancellationToken.None);
+
+        Assert.Null(result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetCoOpRatingsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetCoOpRatingsHandlerTests.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetCoOpRatingsHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepository()
+    {
+        var ratingsList = new List<CoOpRating>();
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetAllCoOpRatings(It.IsAny<CancellationToken>())).ReturnsAsync(ratingsList);
+
+        var handler = new GetCoOpRatingsHandler(ratings.Object);
+        var result = await handler.Handle(new GetCoOpRatingsQuery(), CancellationToken.None);
+
+        Assert.Same(ratingsList, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetMyCoOpRatingHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetMyCoOpRatingHandlerTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetMyCoOpRatingHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepositoryWithCurrentUserId()
+    {
+        var user = new UserBuilder().Build();
+        var chartId = Guid.NewGuid();
+        var rating = new Dictionary<int, DifficultyLevel>
+        {
+            { 1, DifficultyLevel.From(20) }, { 2, DifficultyLevel.From(22) }
+        };
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetMyCoOpRating(user.Id, chartId, It.IsAny<CancellationToken>())).ReturnsAsync(rating);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new GetMyCoOpRatingHandler(ratings.Object, currentUser.Object);
+        var result = await handler.Handle(new GetMyCoOpRatingQuery(chartId), CancellationToken.None);
+
+        Assert.Same(rating, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixRecordHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixRecordHandlerTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetPhoenixRecordHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepositoryForCurrentUser()
+    {
+        var user = new UserBuilder().Build();
+        var chartId = Guid.NewGuid();
+        var score = new RecordedPhoenixScore(chartId, 995010, PhoenixPlate.MarvelousGame, false,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var records = new Mock<IPhoenixRecordRepository>();
+        records.Setup(r => r.GetRecordedScore(user.Id, chartId, It.IsAny<CancellationToken>())).ReturnsAsync(score);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new GetPhoenixRecordHandler(currentUser.Object, records.Object);
+        var result = await handler.Handle(new GetPhoenixRecordQuery(chartId), CancellationToken.None);
+
+        Assert.Equal(score, result);
+    }
+
+    [Fact]
+    public async Task ReturnsNullWhenNoRecordExists()
+    {
+        var user = new UserBuilder().Build();
+        var records = new Mock<IPhoenixRecordRepository>();
+        records.Setup(r => r.GetRecordedScore(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RecordedPhoenixScore?)null);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new GetPhoenixRecordHandler(currentUser.Object, records.Object);
+        var result = await handler.Handle(new GetPhoenixRecordQuery(Guid.NewGuid()), CancellationToken.None);
+
+        Assert.Null(result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixRecordsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixRecordsHandlerTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.Services.Contracts;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetPhoenixRecordsHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepositoryForRequestedUser()
+    {
+        var userId = Guid.NewGuid();
+        var scores = new List<RecordedPhoenixScore>();
+        var records = new Mock<IPhoenixRecordRepository>();
+        records.Setup(r => r.GetRecordedScores(userId, It.IsAny<CancellationToken>())).ReturnsAsync(scores);
+
+        var handler = new GetPhoenixRecordsHandler(new Mock<IUserAccessService>().Object, records.Object);
+        var result = await handler.Handle(new GetPhoenixRecordsQuery(userId), CancellationToken.None);
+
+        Assert.Same(scores, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixScoresForChartHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixScoresForChartHandlerTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetPhoenixScoresForChartHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepository()
+    {
+        var chartId = Guid.NewGuid();
+        var scores = new List<UserPhoenixScore>();
+        var records = new Mock<IPhoenixRecordRepository>();
+        records.Setup(r => r.GetRecordedUserScores(chartId, It.IsAny<CancellationToken>())).ReturnsAsync(scores);
+
+        var handler = new GetPhoenixScoresForChartHandler(records.Object);
+        var result = await handler.Handle(new GetPhoenixScoresForChartQuery(chartId), CancellationToken.None);
+
+        Assert.Same(scores, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetSavedChartsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetSavedChartsHandlerTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetSavedChartsHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepositoryForCurrentUser()
+    {
+        var user = new UserBuilder().Build();
+        var saved = new List<SavedChartRecord>();
+        var lists = new Mock<IChartListRepository>();
+        lists.Setup(l => l.GetSavedChartsByUser(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync(saved);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new GetSavedChartsHandler(currentUser.Object, lists.Object);
+        var result = await handler.Handle(new GetSavedChartsQuery(), CancellationToken.None);
+
+        Assert.Same(saved, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetSongNamesHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetSongNamesHandlerTests.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetSongNamesHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepository()
+    {
+        var names = new[] { Name.From("song-a"), Name.From("song-b") };
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetSongNames(MixEnum.Phoenix, It.IsAny<CancellationToken>())).ReturnsAsync(names);
+
+        var handler = new GetSongNamesHandler(charts.Object);
+        var result = await handler.Handle(new GetSongNamesQuery(MixEnum.Phoenix), CancellationToken.None);
+
+        Assert.Equal(names, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetTierListHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetTierListHandlerTests.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetTierListHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepository()
+    {
+        var entries = new List<SongTierListEntry>();
+        var name = Name.From("Difficulty");
+        var tierLists = new Mock<ITierListRepository>();
+        tierLists.Setup(t => t.GetAllEntries(name, It.IsAny<CancellationToken>())).ReturnsAsync(entries);
+
+        var handler = new GetTierListHandler(tierLists.Object);
+        var result = await handler.Handle(new GetTierListQuery(name), CancellationToken.None);
+
+        Assert.Same(entries, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetUserByDiscordIdHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetUserByDiscordIdHandlerTests.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetUserByDiscordIdHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepository()
+    {
+        var user = new UserBuilder().Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUserByExternalLogin("Discord", "abc123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        var handler = new GetUserByDiscordIdHandler(users.Object);
+        var result = await handler.Handle(new GetUserByExternalLoginQuery("abc123", "Discord"), CancellationToken.None);
+
+        Assert.Equal(user, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetUserByIdHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetUserByIdHandlerTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetUserByIdHandlerTests
+{
+    [Fact]
+    public async Task DelegatesToRepository()
+    {
+        var userId = Guid.NewGuid();
+        var user = new UserBuilder().WithId(userId).Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var handler = new GetUserByIdHandler(users.Object);
+        var result = await handler.Handle(new GetUserByIdQuery(userId), CancellationToken.None);
+
+        Assert.Equal(user, result);
+    }
+
+    [Fact]
+    public async Task ReturnsNullWhenUserDoesNotExist()
+    {
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync((User?)null);
+
+        var handler = new GetUserByIdHandler(users.Object);
+        var result = await handler.Handle(new GetUserByIdQuery(Guid.NewGuid()), CancellationToken.None);
+
+        Assert.Null(result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetUserUiSettingsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetUserUiSettingsHandlerTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetUserUiSettingsHandlerTests
+{
+    [Fact]
+    public async Task UsesCurrentUserWhenQueryUserIdIsNull()
+    {
+        var user = new UserBuilder().Build();
+        var settings = new Dictionary<string, string> { { "theme", "dark" } };
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUserUiSettings(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync(settings);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new GetUserUiSettingsHandler(users.Object, currentUser.Object);
+        var result = await handler.Handle(new GetUserUiSettingsQuery(), CancellationToken.None);
+
+        Assert.Same(settings, result);
+    }
+
+    [Fact]
+    public async Task UsesQueryUserIdWhenProvided()
+    {
+        var overrideId = Guid.NewGuid();
+        var settings = new Dictionary<string, string>();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUserUiSettings(overrideId, It.IsAny<CancellationToken>())).ReturnsAsync(settings);
+
+        var handler = new GetUserUiSettingsHandler(users.Object, new Mock<ICurrentUserAccessor>().Object);
+        var result = await handler.Handle(new GetUserUiSettingsQuery(overrideId), CancellationToken.None);
+
+        Assert.Same(settings, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetXXBestChartAttemptHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetXXBestChartAttemptHandlerTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetXXBestChartAttemptHandlerTests
+{
+    [Fact]
+    public async Task ReturnsChartAndAttempt()
+    {
+        var user = new UserBuilder().Build();
+        var chartId = Guid.NewGuid();
+        var chart = new ChartBuilder().WithId(chartId).Build();
+        var attempt = new XXChartAttempt(XXLetterGrade.S, false, 100_000_000,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.XX, chartId, It.IsAny<CancellationToken>())).ReturnsAsync(chart);
+        var attempts = new Mock<IXXChartAttemptRepository>();
+        attempts.Setup(a => a.GetBestAttempt(user.Id, chart, It.IsAny<CancellationToken>())).ReturnsAsync(attempt);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new GetXXBestChartAttemptHandler(currentUser.Object, attempts.Object, charts.Object);
+        var result = await handler.Handle(new GetXXBestChartAttemptQuery(chartId), CancellationToken.None);
+
+        Assert.Equal(chart, result.Chart);
+        Assert.Equal(attempt, result.BestAttempt);
+    }
+
+    [Fact]
+    public async Task ReturnsChartWithNullAttemptWhenNoneExists()
+    {
+        var user = new UserBuilder().Build();
+        var chart = new ChartBuilder().Build();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.XX, chart.Id, It.IsAny<CancellationToken>())).ReturnsAsync(chart);
+        var attempts = new Mock<IXXChartAttemptRepository>();
+        attempts.Setup(a => a.GetBestAttempt(user.Id, chart, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((XXChartAttempt?)null);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new GetXXBestChartAttemptHandler(currentUser.Object, attempts.Object, charts.Object);
+        var result = await handler.Handle(new GetXXBestChartAttemptQuery(chart.Id), CancellationToken.None);
+
+        Assert.Null(result.BestAttempt);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetXXBestChartAttemptsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetXXBestChartAttemptsHandlerTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.Services.Contracts;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class GetXXBestChartAttemptsHandlerTests
+{
+    [Fact]
+    public async Task ReturnsEmptyWhenAccessIsDenied()
+    {
+        var userId = Guid.NewGuid();
+        var access = new Mock<IUserAccessService>();
+        access.Setup(a => a.HasAccessTo(userId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        var attempts = new Mock<IXXChartAttemptRepository>();
+
+        var handler = new GetXXBestChartAttemptsHandler(attempts.Object, access.Object);
+        var result = await handler.Handle(new GetXXBestChartAttemptsQuery(userId), CancellationToken.None);
+
+        Assert.Empty(result);
+        attempts.Verify(a => a.GetBestAttempts(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReturnsAttemptsWhenAccessGranted()
+    {
+        var userId = Guid.NewGuid();
+        var attemptList = new List<BestXXChartAttempt>();
+        var access = new Mock<IUserAccessService>();
+        access.Setup(a => a.HasAccessTo(userId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        var attempts = new Mock<IXXChartAttemptRepository>();
+        attempts.Setup(a => a.GetBestAttempts(userId, It.IsAny<CancellationToken>())).ReturnsAsync(attemptList);
+
+        var handler = new GetXXBestChartAttemptsHandler(attempts.Object, access.Object);
+        var result = await handler.Handle(new GetXXBestChartAttemptsQuery(userId), CancellationToken.None);
+
+        Assert.Same(attemptList, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PreferenceRatingHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PreferenceRatingHandlerTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class PreferenceRatingHandlerTests
+{
+    [Fact]
+    public async Task UpdateSavesRatingThenWritesAverage()
+    {
+        var user = new UserBuilder().Build();
+        var chartId = Guid.NewGuid();
+        var preferences = new Mock<IChartPreferenceRepository>();
+        preferences.Setup(p => p.GetRatingsForChart(MixEnum.Phoenix, chartId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { PreferenceRating.From(4m), PreferenceRating.From(2m) });
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new PreferenceRatingHandler(preferences.Object, currentUser.Object);
+        var result = await handler.Handle(
+            new UpdatePreferenceRatingCommand(MixEnum.Phoenix, chartId, PreferenceRating.From(4m)),
+            CancellationToken.None);
+
+        preferences.Verify(p => p.SaveRating(MixEnum.Phoenix, user.Id, chartId, PreferenceRating.From(4m),
+            It.IsAny<CancellationToken>()), Times.Once);
+        preferences.Verify(p => p.SetAverageRating(MixEnum.Phoenix, chartId, PreferenceRating.From(3m), 2,
+            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(PreferenceRating.From(3m), result.Rating);
+    }
+
+    [Fact]
+    public async Task GetAllDelegatesToRepository()
+    {
+        var ratings = new List<ChartPreferenceRatingRecord>();
+        var preferences = new Mock<IChartPreferenceRepository>();
+        preferences.Setup(p => p.GetPreferenceRatings(MixEnum.Phoenix, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ratings);
+
+        var handler = new PreferenceRatingHandler(preferences.Object, new Mock<ICurrentUserAccessor>().Object);
+        var result = await handler.Handle(new GetAllPreferenceRatingsQuery(MixEnum.Phoenix), CancellationToken.None);
+
+        Assert.Same(ratings, result);
+    }
+
+    [Fact]
+    public async Task GetUserUsesCurrentUserId()
+    {
+        var user = new UserBuilder().Build();
+        var ratings = new List<UserRatingsRecord>();
+        var preferences = new Mock<IChartPreferenceRepository>();
+        preferences.Setup(p => p.GetUserRatings(MixEnum.Phoenix, user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ratings);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new PreferenceRatingHandler(preferences.Object, currentUser.Object);
+        var result = await handler.Handle(new GetUserPreferenceRatingsQuery(MixEnum.Phoenix), CancellationToken.None);
+
+        Assert.Same(ratings, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RateChartDifficultyHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RateChartDifficultyHandlerTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class RateChartDifficultyHandlerTests
+{
+    [Fact]
+    public async Task PersistsRatingAndChainsRecalculate()
+    {
+        var user = new UserBuilder().Build();
+        var chartId = Guid.NewGuid();
+        var resultRecord = new ChartDifficultyRatingRecord(chartId, 16.0, 3, 0.2);
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.Is<ReCalculateChartRatingCommand>(c => c.ChartId == chartId),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resultRecord);
+
+        var handler = new RateChartDifficultyHandler(ratings.Object, currentUser.Object, mediator.Object);
+        var result = await handler.Handle(
+            new RateChartDifficultyCommand(MixEnum.Phoenix, chartId, DifficultyAdjustment.Hard),
+            CancellationToken.None);
+
+        ratings.Verify(r => r.RateChart(MixEnum.Phoenix, chartId, user.Id, DifficultyAdjustment.Hard,
+            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Equal(resultRecord, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RateCoOpDifficultyHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RateCoOpDifficultyHandlerTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class RateCoOpDifficultyHandlerTests
+{
+    [Fact]
+    public async Task ThrowsWhenChartIsNotCoOp()
+    {
+        var chart = new ChartBuilder().WithType(ChartType.Single).Build();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.Phoenix, chart.Id, It.IsAny<CancellationToken>())).ReturnsAsync(chart);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(new UserBuilder().Build());
+
+        var handler = new RateCoOpDifficultyHandler(charts.Object,
+            new Mock<IChartDifficultyRatingRepository>().Object, currentUser.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => handler.Handle(
+            new RateCoOpDifficultyCommand(MixEnum.Phoenix, chart.Id,
+                new Dictionary<int, DifficultyLevel> { { 1, DifficultyLevel.From(20) } }),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ThrowsWhenPlayerCountMismatch()
+    {
+        var chart = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(3).Build();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.Phoenix, chart.Id, It.IsAny<CancellationToken>())).ReturnsAsync(chart);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(new UserBuilder().Build());
+
+        var handler = new RateCoOpDifficultyHandler(charts.Object,
+            new Mock<IChartDifficultyRatingRepository>().Object, currentUser.Object);
+
+        // Chart says 3 players but only 2 ratings supplied
+        await Assert.ThrowsAsync<ArgumentException>(() => handler.Handle(
+            new RateCoOpDifficultyCommand(MixEnum.Phoenix, chart.Id,
+                new Dictionary<int, DifficultyLevel>
+                {
+                    { 1, DifficultyLevel.From(20) }, { 2, DifficultyLevel.From(20) }
+                }),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ClearsRatingWhenNoOtherRatersExist()
+    {
+        var chart = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(3).Build();
+        var user = new UserBuilder().Build();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.Phoenix, chart.Id, It.IsAny<CancellationToken>())).ReturnsAsync(chart);
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetCoOpRatings(chart.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, IEnumerable<DifficultyLevel>>());
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new RateCoOpDifficultyHandler(charts.Object, ratings.Object, currentUser.Object);
+        var result = await handler.Handle(
+            new RateCoOpDifficultyCommand(MixEnum.Phoenix, chart.Id, Ratings: null),
+            CancellationToken.None);
+
+        Assert.Null(result);
+        ratings.Verify(r => r.ClearCoOpRating(chart.Id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PersistsAveragedRatingWhenRatingsExist()
+    {
+        var chart = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(3).Build();
+        var user = new UserBuilder().Build();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.Phoenix, chart.Id, It.IsAny<CancellationToken>())).ReturnsAsync(chart);
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetCoOpRatings(chart.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, IEnumerable<DifficultyLevel>>
+            {
+                { 1, new[] { DifficultyLevel.From(20), DifficultyLevel.From(22) } },
+                { 2, new[] { DifficultyLevel.From(18), DifficultyLevel.From(20) } },
+                { 3, new[] { DifficultyLevel.From(20), DifficultyLevel.From(20) } }
+            });
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new RateCoOpDifficultyHandler(charts.Object, ratings.Object, currentUser.Object);
+        var result = await handler.Handle(
+            new RateCoOpDifficultyCommand(MixEnum.Phoenix, chart.Id,
+                new Dictionary<int, DifficultyLevel>
+                {
+                    { 1, DifficultyLevel.From(22) },
+                    { 2, DifficultyLevel.From(20) },
+                    { 3, DifficultyLevel.From(20) }
+                }),
+            CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(chart.Id, result!.ChartId);
+        ratings.Verify(r => r.SaveCoOpRating(It.IsAny<CoOpRating>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/ReCalculateChartRatingHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/ReCalculateChartRatingHandlerTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class ReCalculateChartRatingHandlerTests
+{
+    [Fact]
+    public async Task ClearsAdjustmentAndReturnsBaseWhenNoRatings()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.Phoenix, chart.Id, It.IsAny<CancellationToken>())).ReturnsAsync(chart);
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetRatings(MixEnum.Phoenix, chart.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<DifficultyAdjustment>());
+        var bus = new Mock<IBus>();
+
+        var handler = new ReCalculateChartRatingHandler(ratings.Object, charts.Object, bus.Object);
+        var result = await handler.Handle(new ReCalculateChartRatingCommand(MixEnum.Phoenix, chart.Id),
+            CancellationToken.None);
+
+        Assert.Equal(chart.Id, result.ChartId);
+        Assert.Equal(20.5, result.Difficulty);
+        Assert.Equal(0, result.RatingCount);
+        ratings.Verify(r => r.ClearAdjustedDifficulty(MixEnum.Phoenix, chart.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+        bus.Verify(b => b.Publish(It.IsAny<ChartDifficultyUpdatedEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PersistsAdjustedDifficultyAndPublishesEventWhenRatingsExist()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.Phoenix, chart.Id, It.IsAny<CancellationToken>())).ReturnsAsync(chart);
+        var ratings = new Mock<IChartDifficultyRatingRepository>();
+        ratings.Setup(r => r.GetRatings(MixEnum.Phoenix, chart.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { DifficultyAdjustment.Hard, DifficultyAdjustment.VeryHard, DifficultyAdjustment.Hard });
+        var bus = new Mock<IBus>();
+
+        var handler = new ReCalculateChartRatingHandler(ratings.Object, charts.Object, bus.Object);
+        var result = await handler.Handle(new ReCalculateChartRatingCommand(MixEnum.Phoenix, chart.Id),
+            CancellationToken.None);
+
+        Assert.Equal(3, result.RatingCount);
+        ratings.Verify(r => r.SetAdjustedDifficulty(MixEnum.Phoenix, chart.Id, It.IsAny<double>(), 3,
+            It.IsAny<double>(), It.IsAny<CancellationToken>()), Times.Once);
+        bus.Verify(b => b.Publish(
+            It.Is<ChartDifficultyUpdatedEvent>(e => e.ChartType == chart.Type && e.Level == (int)chart.Level),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RemoveChartFromListHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RemoveChartFromListHandlerTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class RemoveChartFromListHandlerTests
+{
+    [Fact]
+    public async Task RemovesChartForCurrentUser()
+    {
+        var user = new UserBuilder().Build();
+        var chartId = Guid.NewGuid();
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+        var lists = new Mock<IChartListRepository>();
+
+        var handler = new RemoveChartFromListHandler(currentUser.Object, lists.Object);
+        await handler.Handle(new RemoveChartFromListCommand(ChartListType.Favorite, chartId), CancellationToken.None);
+
+        lists.Verify(l => l.RemoveChart(user.Id, ChartListType.Favorite, chartId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SaveChartToListHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SaveChartToListHandlerTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class SaveChartToListHandlerTests
+{
+    [Fact]
+    public async Task SavesChartForCurrentUser()
+    {
+        var user = new UserBuilder().Build();
+        var chartId = Guid.NewGuid();
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+        var lists = new Mock<IChartListRepository>();
+
+        var handler = new SaveChartToListHandler(currentUser.Object, lists.Object);
+        await handler.Handle(new SaveChartToListCommand(ChartListType.ToDo, chartId), CancellationToken.None);
+
+        lists.Verify(l => l.SaveChart(user.Id, ChartListType.ToDo, chartId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SaveUserUiSettingHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SaveUserUiSettingHandlerTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class SaveUserUiSettingHandlerTests
+{
+    [Fact]
+    public async Task PersistsNewValueAlongsideExistingSettings()
+    {
+        var user = new UserBuilder().Build();
+        var existing = new Dictionary<string, string> { { "theme", "dark" } };
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUserUiSettings(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new SaveUserUiSettingHandler(users.Object, currentUser.Object);
+        await handler.Handle(new SaveUserUiSettingCommand("language", "en-US"), CancellationToken.None);
+
+        users.Verify(u => u.SaveUserUiSettings(user.Id,
+            It.Is<IDictionary<string, string>>(s => s["theme"] == "dark" && s["language"] == "en-US"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task OverwritesExistingValueForSameKey()
+    {
+        var user = new UserBuilder().Build();
+        var existing = new Dictionary<string, string> { { "theme", "dark" } };
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUserUiSettings(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new SaveUserUiSettingHandler(users.Object, currentUser.Object);
+        await handler.Handle(new SaveUserUiSettingCommand("theme", "light"), CancellationToken.None);
+
+        users.Verify(u => u.SaveUserUiSettings(user.Id,
+            It.Is<IDictionary<string, string>>(s => s["theme"] == "light" && s.Count == 1),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SearchForUsersHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SearchForUsersHandlerTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class SearchForUsersHandlerTests
+{
+    [Fact]
+    public async Task ReturnsPublicUsersMatchingByName()
+    {
+        var publicUser = new UserBuilder().WithName("Alice").WithIsPublic(true).Build();
+        var privateUser = new UserBuilder().WithName("Alicia").WithIsPublic(false).Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.SearchForUsersByName("Ali", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { publicUser, privateUser });
+
+        var handler = new SearchForUsersHandler(users.Object);
+        var result = await handler.Handle(new SearchForUsersQuery("Ali", 1, 10), CancellationToken.None);
+
+        Assert.Single(result.Results);
+        Assert.Contains(publicUser, result.Results);
+    }
+
+    [Fact]
+    public async Task IncludesPublicUserMatchedByGuidWhenSearchTextIsGuid()
+    {
+        var matchingId = Guid.NewGuid();
+        var matchingUser = new UserBuilder().WithId(matchingId).WithIsPublic(true).Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(matchingId, It.IsAny<CancellationToken>())).ReturnsAsync(matchingUser);
+        users.Setup(u => u.SearchForUsersByName(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<User>());
+
+        var handler = new SearchForUsersHandler(users.Object);
+        var result = await handler.Handle(new SearchForUsersQuery(matchingId.ToString(), 1, 10),
+            CancellationToken.None);
+
+        Assert.Contains(matchingUser, result.Results);
+    }
+
+    [Fact]
+    public async Task ExcludesPrivateUserMatchedByGuid()
+    {
+        var matchingId = Guid.NewGuid();
+        var privateUser = new UserBuilder().WithId(matchingId).WithIsPublic(false).Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(matchingId, It.IsAny<CancellationToken>())).ReturnsAsync(privateUser);
+        users.Setup(u => u.SearchForUsersByName(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<User>());
+
+        var handler = new SearchForUsersHandler(users.Object);
+        var result = await handler.Handle(new SearchForUsersQuery(matchingId.ToString(), 1, 10),
+            CancellationToken.None);
+
+        Assert.Empty(result.Results);
+    }
+
+    [Fact]
+    public async Task PaginatesResults()
+    {
+        var page1User = new UserBuilder().WithName("Alice").WithIsPublic(true).Build();
+        var page2User = new UserBuilder().WithName("Alicia").WithIsPublic(true).Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.SearchForUsersByName(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { page1User, page2User });
+
+        var handler = new SearchForUsersHandler(users.Object);
+        var page2 = await handler.Handle(new SearchForUsersQuery("Ali", Page: 2, Count: 1), CancellationToken.None);
+
+        Assert.Single(page2.Results);
+        Assert.Equal(page2User, page2.Results.First());
+        Assert.Equal(2, page2.Total);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TournamentHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TournamentHandlerTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class TournamentHandlerTests
+{
+    [Fact]
+    public async Task SaveDelegatesToRepository()
+    {
+        var tournament = new TournamentConfiguration(new ScoringConfiguration());
+        var tournaments = new Mock<ITournamentRepository>();
+
+        var handler = new TournamentHandler(tournaments.Object);
+        await handler.Handle(new SaveTournamentCommand(tournament), CancellationToken.None);
+
+        tournaments.Verify(t => t.CreateOrSaveTournament(tournament, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllDelegatesToRepository()
+    {
+        var records = new List<TournamentRecord>();
+        var tournaments = new Mock<ITournamentRepository>();
+        tournaments.Setup(t => t.GetAllTournaments(It.IsAny<CancellationToken>())).ReturnsAsync(records);
+
+        var handler = new TournamentHandler(tournaments.Object);
+        var result = await handler.Handle(new GetAllTournamentsQuery(), CancellationToken.None);
+
+        Assert.Same(records, result);
+    }
+
+    [Fact]
+    public async Task GetSingleDelegatesToRepository()
+    {
+        var id = Guid.NewGuid();
+        var tournament = new TournamentConfiguration(new ScoringConfiguration());
+        var tournaments = new Mock<ITournamentRepository>();
+        tournaments.Setup(t => t.GetTournament(id, It.IsAny<CancellationToken>())).ReturnsAsync(tournament);
+
+        var handler = new TournamentHandler(tournaments.Object);
+        var result = await handler.Handle(new GetTournamentQuery(id), CancellationToken.None);
+
+        Assert.Equal(tournament, result);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdateUserHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdateUserHandlerTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class UpdateUserHandlerTests
+{
+    [Fact]
+    public async Task SavesNewUserAndPublishesUpdatedEvent()
+    {
+        var existingUser = new UserBuilder()
+            .WithName("Original")
+            .WithGameTag("GAMETAG")
+            .WithCountry("US")
+            .Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(existingUser.Id, It.IsAny<CancellationToken>())).ReturnsAsync(existingUser);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(existingUser);
+        var bus = new Mock<IBus>();
+
+        var handler = new UpdateUserHandler(users.Object, currentUser.Object, bus.Object);
+        await handler.Handle(new UpdateUserCommand(Name.From("NewName"), false, Name.From("CA")),
+            CancellationToken.None);
+
+        users.Verify(u => u.SaveUser(
+            It.Is<User>(saved => saved.Id == existingUser.Id
+                                 && saved.Name == Name.From("NewName")
+                                 && saved.IsPublic == false
+                                 && saved.Country == Name.From("CA")
+                                 && saved.GameTag == existingUser.GameTag),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        bus.Verify(b => b.Publish(It.Is<UserUpdatedEvent>(e => e.UserId == existingUser.Id),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UsesDefaultProfileImageWhenExistingUserHasNone()
+    {
+        var current = new UserBuilder().Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync((User?)null);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(current);
+        var bus = new Mock<IBus>();
+
+        var handler = new UpdateUserHandler(users.Object, currentUser.Object, bus.Object);
+        await handler.Handle(new UpdateUserCommand(Name.From("Name"), true, Name.From("US")),
+            CancellationToken.None);
+
+        users.Verify(u => u.SaveUser(It.Is<User>(saved => saved.ProfileImage != null), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdateXXBestAttemptHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdateXXBestAttemptHandlerTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class UpdateXXBestAttemptHandlerTests
+{
+    [Fact]
+    public async Task PersistsAttemptStampedWithCurrentTime()
+    {
+        var user = new UserBuilder().Build();
+        var chart = new ChartBuilder().Build();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.XX, chart.Id, It.IsAny<CancellationToken>())).ReturnsAsync(chart);
+        var attempts = new Mock<IXXChartAttemptRepository>();
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+        var now = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+        var clock = FakeDateTime.At(now);
+
+        var handler = new UpdateXXBestAttemptHandler(attempts.Object, currentUser.Object, clock.Object,
+            charts.Object);
+        await handler.Handle(
+            new UpdateXXBestAttemptCommand(chart.Id, XXLetterGrade.S, false, 100_000_000),
+            CancellationToken.None);
+
+        attempts.Verify(a => a.SetBestAttempt(user.Id, chart,
+            It.Is<XXChartAttempt>(x => x.RecordedOn == now && x.LetterGrade == XXLetterGrade.S),
+            now, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RemovesAttemptWhenLetterGradeIsNull()
+    {
+        var user = new UserBuilder().Build();
+        var chart = new ChartBuilder().Build();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.XX, chart.Id, It.IsAny<CancellationToken>())).ReturnsAsync(chart);
+        var attempts = new Mock<IXXChartAttemptRepository>();
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var handler = new UpdateXXBestAttemptHandler(attempts.Object, currentUser.Object,
+            FakeDateTime.At(2026, 1, 1).Object, charts.Object);
+        await handler.Handle(
+            new UpdateXXBestAttemptCommand(chart.Id, null, false, null),
+            CancellationToken.None);
+
+        attempts.Verify(a => a.RemoveBestAttempt(user.Id, chart, It.IsAny<CancellationToken>()), Times.Once);
+        attempts.Verify(a => a.SetBestAttempt(It.IsAny<Guid>(), It.IsAny<Chart>(), It.IsAny<XXChartAttempt>(),
+            It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}


### PR DESCRIPTION
Covers all single-purpose IRequestHandler classes excluding the saga
group. Tests follow the established mocked-port pattern: Mock<I*Repo>
the Domain ports, construct the real handler with mock.Object deps, verify side effects with It.Is<T>(...) predicates. Uses the existing UserBuilder/ChartBuilder/FakeDateTime helpers added in #48 to keep Arrange blocks small.

Coverage:
- 17 trivial handlers (1-2 mocks, no branching) — pass-through query/command handlers that delegate straight to a single repo
- 20 small handlers (2-4 mocks, real branching) — including IDateTimeOffsetAccessor (UpdateXXBestAttemptHandler), IBus.Publish (UpdateUserHandler, ReCalculateChartRatingHandler), IMediator.Send chaining (RateChartDifficultyHandler), IUserAccessService gating (GetXXBestChartAttemptsHandler), and multi-Handle classes (PreferenceRatingHandler, TournamentHandler).

Drive-by: GetUserByDiscordIdHandler was internal (the only handler in the project that wasn't public). Promoted to public sealed for consistency and to make it directly testable without [InternalsVisibleTo].

Deferred to Tier 3 (need fixture-heavy ScoringConfiguration / QualifiersConfiguration / TournamentSession setup):
- AutoBuildSessionHandler
- SaveQualifiersHandler

Total tests: 269 (was 205, +64).