### PR TITLE
Tier 3 Bucket 1 + 2.1 + 2.2: easy saga tests, IRandomNumberGenerator, IPlayerScoreBatchAccumulator

### DIFF
--- a/ScoreTracker/ScoreTracker.Application/Handlers/RandomizerSaga.cs
+++ b/ScoreTracker/ScoreTracker.Application/Handlers/RandomizerSaga.cs
@@ -13,12 +13,8 @@ namespace ScoreTracker.Application.Handlers
         IRequestHandler<SaveUserRandomSettingsCommand>,
         IRequestHandler<DeleteRandomSettingsCommand>
     {
-        private readonly Random _random = new(DateTimeOffset.Now.Year + DateTimeOffset.Now.Month +
-                                              DateTimeOffset.Now.Day + DateTimeOffset.Now.Hour +
-                                              DateTimeOffset.Now.Minute + DateTimeOffset.Now.Second +
-                                              DateTimeOffset.Now.Millisecond);
-
-        private IChartRepository _charts;
+        private readonly IRandomNumberGenerator _random;
+        private readonly IChartRepository _charts;
         private readonly IRandomizerRepository _repo;
         private readonly ICurrentUserAccessor _currentUser;
         private readonly IPhoenixRecordRepository _phoenixRecords;
@@ -26,12 +22,14 @@ namespace ScoreTracker.Application.Handlers
         public RandomizerSaga(IChartRepository charts,
             IRandomizerRepository repo,
             ICurrentUserAccessor currentUser,
-            IPhoenixRecordRepository phoenixRecords)
+            IPhoenixRecordRepository phoenixRecords,
+            IRandomNumberGenerator random)
         {
             _charts = charts;
             _repo = repo;
             _currentUser = currentUser;
             _phoenixRecords = phoenixRecords;
+            _random = random;
         }
 
         private Guid NextRandomGuid(IEnumerable<KeyValuePair<Guid, int>> weights)

--- a/ScoreTracker/ScoreTracker.Application/Handlers/UpdatePhoenixRecordHandler.cs
+++ b/ScoreTracker/ScoreTracker.Application/Handlers/UpdatePhoenixRecordHandler.cs
@@ -1,11 +1,9 @@
-﻿using System.Collections.Concurrent;
 using MassTransit;
 using MediatR;
 using ScoreTracker.Application.Commands;
 using ScoreTracker.Domain.Events;
 using ScoreTracker.Domain.Models;
 using ScoreTracker.Domain.SecondaryPorts;
-using ScoreTracker.Domain.ValueTypes;
 
 namespace ScoreTracker.Application.Handlers;
 
@@ -13,7 +11,8 @@ public sealed class UpdatePhoenixRecordHandler(IPhoenixRecordRepository records,
         ICurrentUserAccessor user,
         IDateTimeOffsetAccessor dateTimeOffset,
         IBus bus,
-        IMessageScheduler scheduler)
+        IMessageScheduler scheduler,
+        IPlayerScoreBatchAccumulator batches)
     : IRequestHandler<UpdatePhoenixBestAttemptCommand>,
         IConsumer<UpdatePhoenixRecordHandler.TryFireScoreMessage>
 {
@@ -38,59 +37,40 @@ public sealed class UpdatePhoenixRecordHandler(IPhoenixRecordRepository records,
         var isNewScore = (existing?.IsBroken ?? true) && !request.IsBroken;
         var isUpscore = existing?.Score != null && request.Score != null && existing.Score < request.Score;
         if (!isNewScore && !isUpscore) return;
-        //995010
+
         //Batches up score posts to reduce noise
         var fireAt = dateTimeOffset.Now.UtcDateTime + TimeSpan.FromMinutes(2);
-        if (!_fireAt.ContainsKey(user.User.Id))
+        if (batches.RegisterFireAt(user.User.Id, fireAt))
         {
-            _newCharts[user.User.Id] = new HashSet<Guid>();
-            _upscoreCharts[user.User.Id] = new ConcurrentDictionary<Guid, PhoenixScore>();
             await scheduler.SchedulePublish(fireAt + TimeSpan.FromSeconds(5),
                 new TryFireScoreMessage(user.User.Id),
                 cancellationToken);
         }
 
-        _fireAt[user.User.Id] = fireAt;
+        if (isNewScore) batches.RecordNewChart(user.User.Id, request.ChartId);
 
-        if (isNewScore) _newCharts[user.User.Id].Add(request.ChartId);
-
-        if (isUpscore && !_newCharts[user.User.Id].Contains(request.ChartId))
-            _upscoreCharts[user.User.Id][request.ChartId] = existing!.Score!.Value;
+        if (isUpscore)
+            batches.RecordUpscoreIfNotNew(user.User.Id, request.ChartId, existing!.Score!.Value);
     }
 
     public sealed record ScheduleScoreMessage(Guid UserId, Guid[] ChartIds);
 
     public sealed record TryFireScoreMessage(Guid UserId);
 
-    private static readonly ConcurrentDictionary<Guid, IDictionary<Guid, PhoenixScore>> _upscoreCharts = new();
-    private static readonly ConcurrentDictionary<Guid, ISet<Guid>> _newCharts = new();
-
-    private static readonly ConcurrentDictionary<Guid, DateTime> _fireAt = new();
-
     public async Task Consume(ConsumeContext<TryFireScoreMessage> context)
     {
-        if (dateTimeOffset.Now.UtcDateTime < _fireAt[context.Message.UserId])
+        var fireAt = batches.GetFireAt(context.Message.UserId);
+        if (dateTimeOffset.Now.UtcDateTime < fireAt)
         {
-            await scheduler.SchedulePublish(_fireAt[context.Message.UserId] + TimeSpan.FromMinutes(2),
+            await scheduler.SchedulePublish(fireAt + TimeSpan.FromMinutes(2),
                 new TryFireScoreMessage(context.Message.UserId),
                 context.CancellationToken);
             return;
         }
 
-        var newChartIds = _newCharts.TryGetValue(context.Message.UserId, out var newChart)
-            ? newChart.ToArray()
-            : Array.Empty<Guid>();
-
-        var upscoredChartIds = _upscoreCharts.TryGetValue(context.Message.UserId, out var chart)
-            ? chart
-                .ToDictionary(kv => kv.Key, kv => (int)kv.Value)
-            : new Dictionary<Guid, int>();
-
+        var batch = batches.TakeBatch(context.Message.UserId);
         await bus.Publish(
-            new PlayerScoreUpdatedEvent(context.Message.UserId, newChartIds, upscoredChartIds),
+            new PlayerScoreUpdatedEvent(context.Message.UserId, batch.NewChartIds, batch.UpscoredChartIds),
             context.CancellationToken);
-        _fireAt.TryRemove(context.Message.UserId, out _);
-        _upscoreCharts.TryRemove(context.Message.UserId, out _);
-        _newCharts.TryRemove(context.Message.UserId, out _);
     }
 }

--- a/ScoreTracker/ScoreTracker.Domain/Records/PendingScoreBatch.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Records/PendingScoreBatch.cs
@@ -1,0 +1,6 @@
+namespace ScoreTracker.Domain.Records;
+
+[ExcludeFromCodeCoverage]
+public sealed record PendingScoreBatch(Guid[] NewChartIds, IDictionary<Guid, int> UpscoredChartIds)
+{
+}

--- a/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPlayerScoreBatchAccumulator.cs
+++ b/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPlayerScoreBatchAccumulator.cs
@@ -1,0 +1,34 @@
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.ValueTypes;
+
+namespace ScoreTracker.Domain.SecondaryPorts;
+
+/// <summary>
+/// Per-user score-update debouncer. UpdatePhoenixRecordHandler accumulates
+/// new clears and upscores into a batch and schedules a single
+/// PlayerScoreUpdatedEvent once the user has stopped recording for a while.
+/// Implementation must be a singleton so state survives across handler instances.
+/// </summary>
+public interface IPlayerScoreBatchAccumulator
+{
+    /// <summary>
+    /// Sets the fire-at time for this user. Returns true if no batch existed yet
+    /// (caller should schedule the fire message); false if a batch was already active
+    /// (its fire time has just been pushed forward).
+    /// </summary>
+    bool RegisterFireAt(Guid userId, DateTime fireAt);
+
+    void RecordNewChart(Guid userId, Guid chartId);
+
+    /// <summary>
+    /// Records an upscore against the user's batch UNLESS the chart is already
+    /// being tracked as a new clear (a new clear with a higher score takes precedence).
+    /// </summary>
+    void RecordUpscoreIfNotNew(Guid userId, Guid chartId, PhoenixScore previousScore);
+
+    /// <summary>Returns the scheduled fire-at time. Throws if no batch is active for the user.</summary>
+    DateTime GetFireAt(Guid userId);
+
+    /// <summary>Atomically removes and returns the user's pending batch.</summary>
+    PendingScoreBatch TakeBatch(Guid userId);
+}

--- a/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IRandomNumberGenerator.cs
+++ b/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IRandomNumberGenerator.cs
@@ -1,0 +1,7 @@
+namespace ScoreTracker.Domain.SecondaryPorts;
+
+public interface IRandomNumberGenerator
+{
+    int Next(int maxValue);
+    double NextDouble();
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/BountySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/BountySagaTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class BountySagaTests
+{
+    [Fact]
+    public async Task ConsumeUpdateBountiesClearsMonthlyBoardOnFirstOfMonth()
+    {
+        var bounties = new Mock<IChartBountyRepository>();
+        var saga = BuildSaga(bounties: bounties, dateTime: FakeDateTime.At(2026, 5, 1));
+
+        await saga.Consume(BuildContext(new UpdateBountiesEvent()));
+
+        bounties.Verify(b => b.ClearMonthlyBoard(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumeUpdateBountiesDoesNotClearBoardOnOtherDays()
+    {
+        var bounties = new Mock<IChartBountyRepository>();
+        var saga = BuildSaga(bounties: bounties, dateTime: FakeDateTime.At(2026, 5, 15));
+
+        await saga.Consume(BuildContext(new UpdateBountiesEvent()));
+
+        bounties.Verify(b => b.ClearMonthlyBoard(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConsumeUpdateBountiesAssignsTopBountyToChartsWithoutScores()
+    {
+        var bounties = new Mock<IChartBountyRepository>();
+        var charts = new Mock<IChartRepository>();
+        var unscoredChartId = Guid.NewGuid();
+        // Return one unscored chart for Single+lowest level; everything else empty.
+        charts.Setup(c => c.GetCharts(MixEnum.Phoenix, DifficultyLevel.From(1), ChartType.Single,
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new Chart(unscoredChartId, MixEnum.Phoenix,
+                new Song(Name.From("s"), SongType.Arcade,
+                    new Uri("https://example.invalid"), TimeSpan.FromMinutes(2), Name.From("a"), Bpm: null),
+                ChartType.Single, DifficultyLevel.From(1), MixEnum.Phoenix, null, null, null,
+                new HashSet<Skill>()) });
+
+        var saga = BuildSaga(charts: charts, bounties: bounties, dateTime: FakeDateTime.At(2026, 5, 15));
+
+        await saga.Consume(BuildContext(new UpdateBountiesEvent()));
+
+        // Unscored charts always get bounty 10 (top reward).
+        bounties.Verify(b => b.SetChartBounty(unscoredChartId, 10, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumePlayerScoreUpdatedRedeemsZeroWhenNoBountiesMatch()
+    {
+        var bounties = new Mock<IChartBountyRepository>();
+        var stats = new Mock<IPlayerStatsRepository>();
+        stats.Setup(s => s.GetStats(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PlayerStatsRecord(Guid.NewGuid(), TotalRating: 0, HighestLevel: 1,
+                ClearCount: 0, CoOpRating: 0, CoOpScore: 0, SkillRating: 0, SkillScore: 0, SkillLevel: 0,
+                SinglesRating: 0, SinglesScore: 0, SinglesLevel: 0, DoublesRating: 0, DoublesScore: 0,
+                DoublesLevel: 0, CompetitiveLevel: 15.0, SinglesCompetitiveLevel: 15.0,
+                DoublesCompetitiveLevel: 15.0));
+        var saga = BuildSaga(bounties: bounties, stats: stats);
+
+        var userId = Guid.NewGuid();
+        await saga.Consume(BuildContext(new PlayerScoreUpdatedEvent(userId,
+            NewChartIds: new[] { Guid.NewGuid() },
+            UpscoredChartIds: new Dictionary<Guid, int>())));
+
+        bounties.Verify(b => b.RedeemBounty(userId, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumePlayerScoreUpdatedSumsBountyWorthForMatchingCharts()
+    {
+        var bountyChartId = Guid.NewGuid();
+        var bounties = new Mock<IChartBountyRepository>();
+        // Default empty for any combination, then specific return for the single Single+15 call.
+        bounties.Setup(b => b.GetChartBounties(It.IsAny<ChartType>(), It.IsAny<DifficultyLevel>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ChartBounty>());
+        bounties.Setup(b => b.GetChartBounties(ChartType.Single, DifficultyLevel.From(15),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new ChartBounty(bountyChartId, Worth: 5) });
+        var stats = new Mock<IPlayerStatsRepository>();
+        stats.Setup(s => s.GetStats(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PlayerStatsRecord(Guid.NewGuid(), TotalRating: 0, HighestLevel: 1,
+                ClearCount: 0, CoOpRating: 0, CoOpScore: 0, SkillRating: 0, SkillScore: 0, SkillLevel: 0,
+                SinglesRating: 0, SinglesScore: 0, SinglesLevel: 0, DoublesRating: 0, DoublesScore: 0,
+                DoublesLevel: 0, CompetitiveLevel: 15.0, SinglesCompetitiveLevel: 15.0,
+                DoublesCompetitiveLevel: 15.0));
+        var saga = BuildSaga(bounties: bounties, stats: stats);
+
+        var userId = Guid.NewGuid();
+        await saga.Consume(BuildContext(new PlayerScoreUpdatedEvent(userId,
+            NewChartIds: new[] { bountyChartId },
+            UpscoredChartIds: new Dictionary<Guid, int>())));
+
+        bounties.Verify(b => b.RedeemBounty(userId, 5, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static BountySaga BuildSaga(
+        Mock<IPhoenixRecordRepository>? scores = null,
+        Mock<IChartRepository>? charts = null,
+        Mock<IChartBountyRepository>? bounties = null,
+        Mock<IPlayerStatsRepository>? stats = null,
+        Mock<ICurrentUserAccessor>? currentUser = null,
+        Mock<IDateTimeOffsetAccessor>? dateTime = null)
+    {
+        scores ??= EmptyScoresMock();
+        charts ??= EmptyChartsMock();
+        bounties ??= new Mock<IChartBountyRepository>();
+        stats ??= new Mock<IPlayerStatsRepository>();
+        currentUser ??= new Mock<ICurrentUserAccessor>();
+        dateTime ??= FakeDateTime.At(2026, 5, 15);
+        return new BountySaga(scores.Object, charts.Object, bounties.Object, stats.Object,
+            currentUser.Object, dateTime.Object);
+    }
+
+    private static Mock<IPhoenixRecordRepository> EmptyScoresMock()
+    {
+        var m = new Mock<IPhoenixRecordRepository>();
+        m.Setup(s => s.GetMeaningfulScoresCount(It.IsAny<ChartType>(), It.IsAny<DifficultyLevel>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ChartScoreAggregate>());
+        m.Setup(s => s.GetRecordedScores(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RecordedPhoenixScore>());
+        return m;
+    }
+
+    private static Mock<IChartRepository> EmptyChartsMock()
+    {
+        var m = new Mock<IChartRepository>();
+        m.Setup(c => c.GetCharts(It.IsAny<MixEnum>(), It.IsAny<DifficultyLevel?>(), It.IsAny<ChartType?>(),
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Chart>());
+        return m;
+    }
+
+    private static ConsumeContext<T> BuildContext<T>(T message) where T : class
+    {
+        var ctx = new Mock<ConsumeContext<T>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerHistorySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerHistorySagaTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class PlayerHistorySagaTests
+{
+    [Fact]
+    public async Task ConsumePersistsHistoryRecordStampedWithCurrentTime()
+    {
+        var userId = Guid.NewGuid();
+        var now = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+        var history = new Mock<IPlayerHistoryRepository>();
+
+        var saga = new PlayerHistorySaga(history.Object, FakeDateTime.At(now).Object);
+        var message = new PlayerRatingsImprovedEvent(userId,
+            OldTop50: 0, OldSinglesTop50: 0, OldDoublesTop50: 0,
+            NewTop50: 100, NewSinglesTop50: 50, NewDoublesTop50: 60,
+            OldCompetitive: 0, NewCompetitive: 17.5,
+            OldSinglesCompetitive: 0, NewSinglesCompetitive: 17.0,
+            OldDoublesCompetitive: 0, NewDoublesCompetitive: 18.0,
+            CoOpRating: 200, PassCount: 42);
+        var ctx = new Mock<ConsumeContext<PlayerRatingsImprovedEvent>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+
+        await saga.Consume(ctx.Object);
+
+        history.Verify(h => h.WriteHistory(
+            It.Is<PlayerRatingRecord>(r => r.UserId == userId
+                                            && r.Date == now
+                                            && r.CompetitiveLevel == 17.5
+                                            && r.SinglesLevel == 17.0
+                                            && r.DoublesLevel == 18.0
+                                            && r.CoOpRating == 200
+                                            && r.PassCount == 42),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SkillsSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SkillsSagaTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class SkillsSagaTests
+{
+    [Fact]
+    public async Task GetChartSkillsDelegatesToRepository()
+    {
+        var skills = new List<ChartSkillsRecord>();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChartSkills(It.IsAny<CancellationToken>())).ReturnsAsync(skills);
+
+        var saga = new SkillsSaga(charts.Object);
+        var result = await saga.Handle(new GetChartSkillsQuery(), CancellationToken.None);
+
+        Assert.Same(skills, result);
+    }
+
+    [Fact]
+    public async Task UpdateChartSkillDelegatesToRepository()
+    {
+        var record = new ChartSkillsRecord(Guid.NewGuid(),
+            new[] { Skill.Twists }, new[] { Skill.Twists });
+        var charts = new Mock<IChartRepository>();
+
+        var saga = new SkillsSaga(charts.Object);
+        await saga.Handle(new UpdateChartSkillCommand(record), CancellationToken.None);
+
+        charts.Verify(c => c.SaveChartSkills(record, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UcsSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UcsSagaTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class UcsSagaTests
+{
+    [Fact]
+    public async Task RegisterUpdatesScoreThenPublishesPlacedEvent()
+    {
+        var user = new UserBuilder().Build();
+        var chartId = Guid.NewGuid();
+        var bus = new Mock<IBus>();
+        var ucs = new Mock<IUcsRepository>();
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var saga = new UcsSaga(bus.Object, ucs.Object, currentUser.Object);
+        await saga.Handle(
+            new RegisterUcsEntryCommand(chartId, PhoenixScore.From(950000), PhoenixPlate.SuperbGame, IsBroken: false,
+                VideoPath: null, ImagePath: null),
+            CancellationToken.None);
+
+        ucs.Verify(u => u.UpdateScore(chartId, user.Id, PhoenixScore.From(950000), PhoenixPlate.SuperbGame,
+            false, null, null, It.IsAny<CancellationToken>()), Times.Once);
+        bus.Verify(b => b.Publish(
+            It.Is<UcsLeaderboardPlacedEvent>(e => e.UserId == user.Id && e.ChartId == chartId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PassesVideoAndImagePathsThrough()
+    {
+        var user = new UserBuilder().Build();
+        var chartId = Guid.NewGuid();
+        var video = new Uri("https://example.invalid/v.mp4");
+        var image = new Uri("https://example.invalid/i.png");
+        var bus = new Mock<IBus>();
+        var ucs = new Mock<IUcsRepository>();
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(user);
+
+        var saga = new UcsSaga(bus.Object, ucs.Object, currentUser.Object);
+        await saga.Handle(
+            new RegisterUcsEntryCommand(chartId, PhoenixScore.From(800000), PhoenixPlate.MarvelousGame, IsBroken: true,
+                VideoPath: video, ImagePath: image),
+            CancellationToken.None);
+
+        ucs.Verify(u => u.UpdateScore(chartId, user.Id, PhoenixScore.From(800000), PhoenixPlate.MarvelousGame,
+            true, video, image, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker/Accessors/PlayerScoreBatchAccumulator.cs
+++ b/ScoreTracker/ScoreTracker/Accessors/PlayerScoreBatchAccumulator.cs
@@ -1,0 +1,52 @@
+using System.Collections.Concurrent;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+
+namespace ScoreTracker.Web.Accessors;
+
+public sealed class PlayerScoreBatchAccumulator : IPlayerScoreBatchAccumulator
+{
+    private readonly ConcurrentDictionary<Guid, DateTime> _fireAt = new();
+    private readonly ConcurrentDictionary<Guid, ISet<Guid>> _newCharts = new();
+    private readonly ConcurrentDictionary<Guid, IDictionary<Guid, PhoenixScore>> _upscoreCharts = new();
+
+    public bool RegisterFireAt(Guid userId, DateTime fireAt)
+    {
+        var isNew = !_fireAt.ContainsKey(userId);
+        if (isNew)
+        {
+            _newCharts[userId] = new HashSet<Guid>();
+            _upscoreCharts[userId] = new ConcurrentDictionary<Guid, PhoenixScore>();
+        }
+        _fireAt[userId] = fireAt;
+        return isNew;
+    }
+
+    public void RecordNewChart(Guid userId, Guid chartId)
+    {
+        _newCharts[userId].Add(chartId);
+    }
+
+    public void RecordUpscoreIfNotNew(Guid userId, Guid chartId, PhoenixScore previousScore)
+    {
+        if (!_newCharts[userId].Contains(chartId))
+            _upscoreCharts[userId][chartId] = previousScore;
+    }
+
+    public DateTime GetFireAt(Guid userId) => _fireAt[userId];
+
+    public PendingScoreBatch TakeBatch(Guid userId)
+    {
+        var newChartIds = _newCharts.TryGetValue(userId, out var newChart)
+            ? newChart.ToArray()
+            : Array.Empty<Guid>();
+        var upscoredChartIds = _upscoreCharts.TryGetValue(userId, out var chart)
+            ? chart.ToDictionary(kv => kv.Key, kv => (int)kv.Value)
+            : new Dictionary<Guid, int>();
+        _fireAt.TryRemove(userId, out _);
+        _upscoreCharts.TryRemove(userId, out _);
+        _newCharts.TryRemove(userId, out _);
+        return new PendingScoreBatch(newChartIds, upscoredChartIds);
+    }
+}

--- a/ScoreTracker/ScoreTracker/Accessors/RandomNumberGenerator.cs
+++ b/ScoreTracker/ScoreTracker/Accessors/RandomNumberGenerator.cs
@@ -1,0 +1,9 @@
+using ScoreTracker.Domain.SecondaryPorts;
+
+namespace ScoreTracker.Web.Accessors;
+
+public sealed class RandomNumberGenerator : IRandomNumberGenerator
+{
+    public int Next(int maxValue) => Random.Shared.Next(maxValue);
+    public double NextDouble() => Random.Shared.NextDouble();
+}

--- a/ScoreTracker/ScoreTracker/Program.cs
+++ b/ScoreTracker/ScoreTracker/Program.cs
@@ -145,6 +145,7 @@ builder.Services.AddBlazorApplicationInsights()
         builder.Configuration.GetSection("SQL").Get<SqlConfiguration>(),
         builder.Configuration.GetSection("Sendgrid").Get<SendGridConfiguration>())
     .AddTransient<IDateTimeOffsetAccessor, DateTimeOffsetAccessor>()
+    .AddTransient<IRandomNumberGenerator, RandomNumberGenerator>()
     .AddControllers();
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 builder.Services.AddScoped<IStringLocalizer<App>, StringLocalizer<App>>();

--- a/ScoreTracker/ScoreTracker/Program.cs
+++ b/ScoreTracker/ScoreTracker/Program.cs
@@ -146,6 +146,7 @@ builder.Services.AddBlazorApplicationInsights()
         builder.Configuration.GetSection("Sendgrid").Get<SendGridConfiguration>())
     .AddTransient<IDateTimeOffsetAccessor, DateTimeOffsetAccessor>()
     .AddTransient<IRandomNumberGenerator, RandomNumberGenerator>()
+    .AddSingleton<IPlayerScoreBatchAccumulator, PlayerScoreBatchAccumulator>()
     .AddControllers();
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 builder.Services.AddScoped<IStringLocalizer<App>, StringLocalizer<App>>();


### PR DESCRIPTION
## Summary
First slice of Tier 3. Three commits:

1. **Bucket 1 — easy saga tests** (+10 tests, 4 files)
   - `PlayerHistorySaga`, `SkillsSaga`, `UcsSaga`, `BountySaga`
   - Establishes the saga test pattern: `ConsumeContext<T>` mocked with
     `Message` + `CancellationToken` getters, `BountySaga` uses a
     `BuildSaga(...)` helper with optional named mocks (foreshadows the
     `CommunitySagaFixture` pattern called out for the bigger sagas).
   - Flagship test: `BountySaga.Day == 1` clear-monthly-board branch — now
     deterministic via `FakeDateTime.At(2026, 5, 1)`.

2. **Bucket 2.1 — IRandomNumberGenerator port** (4 files, no new tests)
   - Tiny domain port: `int Next(int maxValue)`, `double NextDouble()`.
   - Impl in `Web/Accessors/` wraps `Random.Shared` (.NET 6+ thread-safe
     singleton) — replaces `RandomizerSaga`'s in-class
     time-derived `Random()` field.
   - DI: `AddTransient` alongside the other accessors.
   - Unblocks `RandomizerSaga` tests for Bucket 8.

3. **Bucket 2.2 — IPlayerScoreBatchAccumulator port** (5 files, no new tests)
   - Five-method port encodes the actual batching operations
     (`RegisterFireAt`, `RecordNewChart`, `RecordUpscoreIfNotNew`,
     `GetFireAt`, `TakeBatch`) instead of exposing raw dictionaries.
   - `PendingScoreBatch` record in `Domain/Records/` as the `TakeBatch`
     return shape.
   - Impl in `Web/Accessors/` holds the same `ConcurrentDictionary` trio.
   - **DI: `AddSingleton`** (transient would silently break the
     debouncer — handler instances are transient, so each would get fresh
     state and scheduled fire messages would arrive to empty dicts).
   - Behaviour preserved exactly; one micro-cleanup in `Consume` reads
     `GetFireAt` once into a local instead of twice.
   - Unblocks `UpdatePhoenixRecordHandler` tests for Bucket 8.

## Reviewer notes
- The accessor impls live in `Web/Accessors/` next to `DateTimeOffsetAccessor`
  and `HttpContextUserAccessor` — consistent with the existing pattern, but
  ARCHITECTURE.md flags this as an open question if a non-Blazor host ever
  appears.
- `IPlayerScoreBatchAccumulator.GetFireAt` will throw `KeyNotFoundException`
  if a `TryFireScoreMessage` arrives after the batch was already taken
  (e.g., a stale scheduled message after a rare race). This was the
  pre-existing behaviour of `_fireAt[userId]`; preserved deliberately and
  documented in the port's XML doc. Worth a separate PR if it ever bites.
- No new tests in 2.1 or 2.2 by design — saga tests for `RandomizerSaga` and
  `UpdatePhoenixRecordHandler` come in Bucket 8 once these refactors settle.

## Test plan
- [x] `dotnet test` — 279 / 279 passing (was 269; +10 from Bucket 1)
- [x] `dotnet build ScoreTracker.sln` — 0 errors