### PR TITLE
Add Claude Code documentation suite

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,207 @@
+# Backlog
+
+Items where the codebase doesn't yet satisfy [ENTERPRISE.md](ENTERPRISE.md) and the gap requires real refactor work, not just documentation. Items here are not current rules — `CLAUDE.md` describes what the project *does today*, this file describes what it *should grow into*.
+
+Each item references the ENTERPRISE.md section that motivates it. Scope estimates are rough order of magnitude (S = days, M = a week, L = multiple weeks).
+
+## Top three by impact
+
+1. **External-adapter testing.** Six external clients, zero tests today. Highest blast radius if any provider's contract drifts. *(External API and Messaging Tests)*
+2. **Real-dependency database tests.** Production runs SQL Server; migrations, transactions, and provider-specific queries are unverified before deploy. *(Database Testing Rules)*
+3. **Test taxonomy / dependency-realism labels.** No tagging convention exists; the test suite can't be sliced for fast/slow CI runs or for category-specific gates. *(Test Taxonomy, Dependency Realism Labels)*
+
+---
+
+## Test infrastructure
+
+### Real-dependency database tests — *L*
+
+ENTERPRISE: *Real-Dependency Integration Test*, *Database Testing Rules*
+
+- [ ] Pick a Testcontainers strategy (Testcontainers.MsSql is the obvious option; LocalDB is a fallback for Windows-only CI).
+- [ ] Add a base test class that spins up a container per test class (or per fixture), applies migrations, and tears down.
+- [ ] Establish seed/cleanup convention: per-test transactions that roll back, or per-test `Respawn`-style truncation.
+- [ ] Cover migrations: a smoke test that applies all 165 migrations from empty.
+- [ ] Cover the highest-traffic repositories first: `EFUserRepository`, `EFChartRepository`, `EFPhoenixRecordsRepository`, `EFTournamentRepository`.
+- [ ] CI: gate this suite separately from PR fast tests; tag with `integration-real`.
+- [ ] Update CI runner to support Docker (Azure Pipelines `windows-latest` may need adjustment or a Linux pool for the container).
+
+Depends on: tagging convention (below).
+
+### External-adapter / consumer tests — *M*
+
+ENTERPRISE: *External API and Messaging Tests*
+
+Six external clients have zero coverage. Recommended order, lowest-risk first:
+
+- [ ] `PiuGameApi` (HTTP, typed `HttpClient`) — fake `HttpMessageHandler` returning canned HTML/JSON; assert request shape and response parsing.
+- [ ] `OfficialSiteClient`, `PiuTrackerClient` — same pattern.
+- [ ] `SendGridAdminNotificationClient` — fake the SendGrid client.
+- [ ] `AzureBlobFileUploadClient` — Azurite emulator (real-dep) or interface-level test.
+- [ ] `DiscordBotClient` — interface-level test against `IBotClient`; full Discord flow is out of scope.
+- [ ] Tag fake-server tests as `component`; emulator-backed tests as `integration-real`.
+
+Where possible, capture the contract: real responses go in test fixtures, not hand-written.
+
+### MassTransit message-flow tests — *S*
+
+ENTERPRISE: *External API and Messaging Tests*
+
+- [ ] One end-to-end test per recurring scheduled message (`UpdateBountiesEvent`, `CalculateScoringDifficultyEvent`, etc.) — start the in-memory bus, publish, assert the consumer side effects via mocked Domain ports.
+- [ ] Tests classify as `component` (the in-memory transport is production-real, but ports are mocked).
+- [ ] Reference: `RecurringJobHostedService` is the publisher; saga classes are the consumers.
+
+### Test taxonomy / dependency-realism labels — *S*
+
+ENTERPRISE: *Dependency Realism Labels*, *Test Taxonomy*
+
+- [ ] Decide convention: xUnit `[Trait("category", "<label>")]` is the most flexible; folder names are more discoverable. Recommend `[Trait]` so multiple labels can attach to one test class.
+- [ ] Apply labels across all 57 existing tests: `unit` for `DomainTests/`, `component` for `ApplicationTests/`.
+- [ ] Add `dotnet test --filter Category=unit` examples to `CLAUDE.md`'s Commands section.
+- [ ] Add a CI fast-PR job that runs only `unit + component`.
+
+Blocks: real-dependency DB tests, external-adapter tests (both need labels to gate independently).
+
+### Property-based tests on value types — *S*
+
+ENTERPRISE: *Property-Based Test*
+
+- [ ] Add `FsCheck.Xunit` or `CsCheck` to `ScoreTracker.Tests`.
+- [ ] Cover `PhoenixScore`, `XXScore`, `DifficultyLevel`, `Bpm`, `Name` with invariant tests (round-trip serialization, ordering, validation boundaries).
+- [ ] Use deterministic seeds; report failing seed in output.
+
+### Characterization tests as a workflow — *S* (recurring)
+
+ENTERPRISE: *Characterization Test*, *Refactoring Rules*
+
+- [ ] Pick one upcoming legacy refactor and add characterization tests around the existing behavior first.
+- [ ] Establish naming: `<Type>CharacterizationTests.cs` or a `[Trait("category", "characterization")]` tag.
+- [ ] Document the workflow as a PR-template checkbox: "Did this PR change legacy behavior? If yes, characterization tests added before behavior change?"
+
+### Mutation testing on Domain — *S* (low priority)
+
+ENTERPRISE: *Mutation Test* (marked "if applicable")
+
+- [ ] Add Stryker.NET configured to mutate `ScoreTracker.Domain.ValueTypes` and `Domain.Services` only.
+- [ ] Run on a schedule, not per-PR.
+- [ ] Use the score as a signal, not a gate.
+
+### E2E / acceptance tests — *L* (only if needed)
+
+ENTERPRISE: *End-to-End / Acceptance Test*
+
+Currently skipped — no critical user-visible flow is regressed often enough to justify the maintenance cost. Revisit when:
+- A second deployment environment exists, or
+- A regression escapes to production that component/slice tests would have caught.
+
+Likely tooling: bUnit for Blazor Server components, Playwright for full browser flows.
+
+### Contract tests — *M* (only if a consumer appears)
+
+ENTERPRISE: *Contract Test*
+
+Currently skipped — the codebase consumes external APIs but exposes only a thin MVC surface; there are no known external consumers of this app's API. Revisit if:
+- A second service starts consuming this app's API, or
+- A breaking change in `PiuGameApi` causes a production incident that contract verification would have caught.
+
+---
+
+## Architecture cleanups
+
+### Remove `Data → Application` reference — *M*
+
+ENTERPRISE: *Architecture Priorities*. Also flagged in [ARCHITECTURE.md](ARCHITECTURE.md) under known divergences.
+
+- [ ] Audit the six `Data/` files that import `ScoreTracker.Application` (`EFTournamentRepository`, `EFRandomizerRepository`, `EFPlayerStatsRepository`, `EFPlayerHistoryRepository`, `EFPhoenixRecordsRepository`, `OfficialSiteClient`).
+- [ ] For each, identify what's being pulled from Application. Likely candidates: command/query types being constructed, MediatR types, helper utilities.
+- [ ] Move shared types to Domain or duplicate where appropriate.
+- [ ] Drop the project reference in `ScoreTracker.Data.csproj`.
+
+Risk: low — known divergence, no business impact.
+
+### Move command-shaped messages out of `Domain/Events/` — *S*
+
+ENTERPRISE: *DDD Policy*. Also flagged in [ARCHITECTURE.md](ARCHITECTURE.md).
+
+- [ ] Move `ProcessPassTierListCommand` and `ProcessScoresTiersListCommand` to `Application/Commands/` (or a new `Application/Messages/` if they remain MassTransit-shaped).
+- [ ] Update consumers and publishers (likely just `RecurringJobHostedService` and the saga consumers).
+- [ ] Verify scheduled messages still fire after the move.
+
+### MediatR-in-Domain decision — *M* (or zero, if accepted as carve-out)
+
+ENTERPRISE: *Architecture Priorities*
+
+Two paths:
+- **Option A (status quo)**: keep the carve-out documented in `CLAUDE.md`. Zero work.
+- **Option B (full compliance)**: move `IRequest`/`INotification` types out of Domain. Domain `Records/` and `Events/` types currently used as MediatR messages would need to move to Application. Larger refactor; check whether any are referenced by Domain-internal code.
+
+No urgency. Revisit only if multiple projects on the team adopt strict ENTERPRISE compliance and this becomes the odd one out.
+
+### MassTransit version skew — *S*
+
+Flagged in [ARCHITECTURE.md](ARCHITECTURE.md).
+
+- [ ] `Web` uses `MassTransit.Extensions.DependencyInjection 7.3.1`; rest uses `MassTransit 8.5.7`. Consolidate on v8 DI extensions.
+- [ ] Verify in-memory transport setup still works after the upgrade.
+
+### Automatic migration application — *S*
+
+Flagged in [ARCHITECTURE.md](ARCHITECTURE.md).
+
+- [ ] Decide policy: auto-migrate on startup (simpler) vs. require an explicit migration step in deploys (safer).
+- [ ] If auto-migrate: add `db.Database.Migrate()` to `Program.cs` startup with appropriate error handling.
+- [ ] If explicit: document the deploy-time migration command.
+
+### `PersonalProgress` vertical-slice cleanup — *M*
+
+Flagged in [ARCHITECTURE.md](ARCHITECTURE.md).
+
+- [ ] Decide: fold `PersonalProgress` back into `Application`, or formalize the vertical-slice split for other features.
+- [ ] If folding back: move `PlayerRatingSaga` and queries into `Application/`; drop the project.
+- [ ] If formalizing: document the split rule in `CLAUDE.md` and stop treating it as experimental.
+
+### ID generation seam — *S*
+
+ENTERPRISE: *Test Data Rules* ("stable IDs")
+
+- [ ] Introduce `IGuidGenerator` (or similar) port in `Domain/SecondaryPorts/`.
+- [ ] Audit Domain factories for `Guid.NewGuid()` calls (e.g. `User(...)`, `TournamentConfiguration(...)`).
+- [ ] Decide whether to thread the port through or accept that Domain construction is a controlled boundary.
+- [ ] Update test conventions: the `IGuidGenerator` mock becomes part of handler tests where ID assertions matter.
+
+Lower priority — current ID assertions in tests use `Assert.NotEqual(Guid.Empty, ...)` style which works without a seam.
+
+---
+
+## Process / docs
+
+### CI fast-PR vs. nightly split — *S*
+
+Depends on: dependency-realism labels.
+
+- [ ] Define which labels run on PR (`unit`, `component`) vs. nightly (`integration-real`, `external`, `mutation`).
+- [ ] Update `azure-pipelines.yml` to add the filter; possibly split into two pipelines.
+
+### Test running documentation — *S*
+
+ENTERPRISE: *Project CLAUDE.md Requirements*
+
+Once labels exist, expand `CLAUDE.md` Commands section with concrete filter examples:
+- [ ] `dotnet test --filter Category=unit` — fast PR check.
+- [ ] `dotnet test --filter Category=component` — handler/saga checks.
+- [ ] `dotnet test --filter Category=integration-real` — DB and emulator-backed checks (requires Docker).
+
+### Local-dev bring-up script — *S*
+
+- [ ] `scripts/dev-up.sh` (or PowerShell equivalent) that starts SQL Server in a container with a known connection string.
+- [ ] Document in `CLAUDE.md` *Local external dependencies*.
+
+---
+
+## Out of scope
+
+Not on this backlog because they're either covered elsewhere or intentionally deferred:
+
+- **Domain-vs-integration-event distinction.** Single bounded context with in-memory transport — the distinction has no current application. Revisit only when a second context appears.
+- **Snapshot / approval tests.** Limited applicability in this codebase; the "tier list" and "letter difficulty" outputs *could* benefit, but semantic assertions work fine today.
+- **MediatR pipeline behaviors for cross-cutting concerns (validation, logging, transactions).** Removed from ENTERPRISE.md; not a project gap. Add when a concrete need appears, not as policy compliance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,157 @@
+# PumpItUpScoreTracker
+
+Blazor Server + MVC API for tracking Pump It Up scores, leaderboards, tournaments, and player progression. Onion architecture: pure `Domain`, MediatR-based `Application`, EF Core `Infrastructure` (`Data`), Blazor/MVC `Presentation` (`Web`), wired through `CompositionRoot`. Async work runs on MassTransit with an in-memory transport.
+
+## Imports
+
+- `@ENTERPRISE.md` — **simulated org managed policy.** Stands in for the OS-level managed-policy CLAUDE.md that would auto-load in a real enterprise deployment. Owned by the (notional) org architecture team; treat it as read-only from this repo. Per-project carve-outs go in the *Carve-outs* section below, never in that file.
+- `@ARCHITECTURE.md` — structural source of truth: solution layout, dependency graph, eventing, data access, glossary, known divergences, open questions.
+
+@ENTERPRISE.md
+@ARCHITECTURE.md
+
+## Commands
+
+Run from the repo root (the solution lives at `ScoreTracker/ScoreTracker.sln`).
+
+- **Build**: `dotnet build ScoreTracker/ScoreTracker.sln -c Release`
+- **Typecheck**: covered by `dotnet build` (no separate step).
+- **Lint/static analysis**: none locally configured. DeepSource runs in CI (`.deepsource.toml`).
+- **Unit tests**: `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` — covers `DomainTests/` (unit) and `ApplicationTests/` (component).
+- **Component / module tests**: same command, same project.
+- **Contract tests**: not present.
+- **Real-dependency integration tests**: not present. SQL Server via Testcontainers is the intended target if/when added.
+- **E2E / Playwright tests**: not present.
+- **Mutation tests**: not present.
+
+CI: Azure Pipelines (`azure-pipelines.yml`) does NuGet restore → `VSBuild` → `VSTest` on `windows-latest`.
+
+## Architecture conventions
+
+These are the project-local realizations of the rules in `ENTERPRISE.md`. When ENTERPRISE.md says "do X," this section says "and here X looks like *this*."
+
+### Layer graph and per-layer package allowlist
+
+```
+Domain  ◄── Application ◄── Data
+  ▲           ▲              ▲
+  │           │              │
+  └── PersonalProgress ◄─────┘
+              ▲
+              │
+              └── Web ◄── CompositionRoot
+```
+
+| Project | Allowed external packages | Forbidden |
+|---|---|---|
+| `ScoreTracker.Domain` | `MediatR`, `Microsoft.Extensions.Logging.Abstractions` | Anything else. No EF, no `HttpClient`, no MassTransit, no ASP.NET, no Azure/Discord/SendGrid. |
+| `ScoreTracker.Application` | + `MassTransit.Abstractions`, `Microsoft.Extensions.Caching.Memory` | EF Core, ASP.NET, `HttpClient`, vendor SDKs. Application must never know it's behind a web server. |
+| `ScoreTracker.Data` | + `Microsoft.EntityFrameworkCore.SqlServer`, `Azure.Storage.Blobs`, `Discord.Net`, `HtmlAgilityPack`, `SendGrid` | ASP.NET. |
+| `ScoreTracker.Web` | + `MudBlazor`, OAuth providers, `Swashbuckle`, `Tesseract`, MassTransit DI | EF Core directly (must go through ports). |
+| `ScoreTracker.CompositionRoot` | DI extensions only | Business logic. |
+| `ScoreTracker.Tests` | + `xunit`, `Moq` | Other doubling libraries (see Test conventions). |
+
+Adding a package outside its allowed layer is a violation. Adding a project reference that isn't in the graph above is a violation.
+
+### Use case dispatch
+
+- Every business operation is an `IRequest<T>` (or `IRequest`) record in `Application/Commands/` or `Application/Queries/`, paired with an `IRequestHandler<,>` in `Application/Handlers/`. Async work uses `IConsumer<TEvent>` (MassTransit) in the same `Application/Handlers/` folder.
+- **Razor pages, Blazor components, and MVC controllers dispatch exclusively via `IMediator`.** No `DbContext`, repository, or `HttpClient` is injected into Web code. (Exception: `Accessors/` types in Web that *implement* Domain ports.)
+- Background work is published over `IBus.Publish(...)` with a record from `Domain/Events/`. In-process notifications use `IMediator.Publish(INotification)`.
+- Recurring scheduled work goes through `RecurringJobHostedService` + MassTransit's delayed scheduler. Do not introduce a separate scheduler library.
+
+### Ports and abstractions
+
+- All external boundaries (persistence, HTTP, blob, email, Discord) cross via Domain ports. Naming: `I*Repository`, `I*Client`, `I*Accessor`.
+- Ports live in `ScoreTracker.Domain.SecondaryPorts/`.
+- EF-backed implementations: `EF<Port>` in `ScoreTracker.Data.Repositories/` (e.g. `EFUserRepository : IUserRepository`). **One implementation per port.**
+- Non-EF integrations: concrete types in `ScoreTracker.Data.Clients/` and `ScoreTracker.Data.Apis/`.
+- DI wiring: `CompositionRoot.RegistrationExtensions.AddInfrastructure` reflects over `ScoreTracker.Data` types and binds every `Domain.SecondaryPorts.*` interface they implement as **transient by default**. `IBotClient` is the only singleton. Adding a port = no DI wiring needed if the implementation lives in `Data` and follows naming. Other lifetimes require an explicit registration.
+- Cross-cutting Web-bound ports (`HttpContextUserAccessor : ICurrentUserAccessor`, `DateTimeOffsetAccessor : IDateTimeOffsetAccessor`) live in `ScoreTracker.Web.Accessors/` because they depend on ASP.NET.
+
+### Domain models
+
+- `sealed record` is the default for entities and value-shaped types.
+- Most models are intentionally lean (e.g. `User`, `Song`, `Chart` are property bags). Rich behavior is acceptable when invariants demand it — `TournamentSession` is the project's reference example, with methods like `Approve`, `AddPhoto`, `RemovePhoto`, `SetVerificationType` enforcing approval flow.
+- **Value-type construction**: immutable structs/records with `static <Type> From(<input>)` factories that throw a domain exception on invalid input. Implicit conversions from primitives may delegate to `From`. Reference: [Name.cs](ScoreTracker/ScoreTracker.Domain/ValueTypes/Name.cs). Bypassing `From` is a violation.
+- Domain exceptions live in `Domain/Exceptions/` and inherit a domain base (e.g. `InvalidNameException`).
+
+### One DbContext
+
+- `ChartAttemptDbContext` is the only `DbContext`. Add `DbSet`s here. Adding a second context requires explicit discussion.
+- Repositories take `IDbContextFactory<ChartAttemptDbContext>` and create scoped contexts.
+- Migrations live in `ScoreTracker.Data/Migrations/` and are applied **manually** — no `Database.Migrate()` at startup.
+
+## Test conventions
+
+### Frameworks and doubles
+
+- **xUnit `2.9.3` + Moq `4.20.72`.** Do not introduce alternative double libraries (`FakeItEasy`, `NSubstitute`, `AutoFixture`) without explicit approval.
+- All tests live in `ScoreTracker.Tests/`, mirroring source by namespace.
+
+### Unit tests (`unit`)
+
+- **Location**: `ScoreTracker.Tests/DomainTests/`.
+- **Subjects**: value types, domain services, pure functions, simulators, policies, edge cases.
+- **Naming**: `<TypeName>Tests.cs`, one class per subject.
+- **Form**: xUnit `[Fact]` / `[Theory]`. Use real domain objects; mocking is the exception, not the default.
+- **No external dependencies** — no Moq usage if avoidable, no DbContext, no HTTP, no time/RNG calls (use the seams below).
+- Reference: [NameTests.cs](ScoreTracker/ScoreTracker.Tests/DomainTests/NameTests.cs).
+
+### Component tests (`component`)
+
+- **Location**: `ScoreTracker.Tests/ApplicationTests/`.
+- **Subjects**: MediatR handlers and "Sagas" (feature-grouped consumer + handler classes).
+- **Naming**: `<HandlerOrSaga>Tests.cs`.
+- **Pattern** (canonical, follow this verbatim):
+  1. Construct a `Mock<TPort>` for each Domain port the handler depends on.
+  2. Construct the real handler with `mock.Object` dependencies.
+  3. Call `handler.Handle(new TCommand(...), CancellationToken.None)`.
+  4. `Assert` on the returned value where applicable.
+  5. `Verify` side-effect calls with `It.Is<T>(predicate)` and `Times.Once` (or appropriate).
+- **Bus assertions**: mock `MassTransit.IBus` and `Verify` `Publish` calls.
+- Reference: [CreateUserHandlerTests.cs](ScoreTracker/ScoreTracker.Tests/ApplicationTests/CreateUserHandlerTests.cs).
+
+### Test data
+
+- **Builders** live in `ScoreTracker.Tests/TestData/` as `internal sealed class <Type>Builder` with `WithX(...)` methods returning `this`, a terminal `Build()`, and (optionally) an implicit conversion operator to the built type. Sensible defaults for every field. Reference: [UserBuilder.cs](ScoreTracker/ScoreTracker.Tests/TestData/UserBuilder.cs). Add a builder when you find yourself constructing the same type by hand in two tests.
+- **Clock seam**: `IDateTimeOffsetAccessor` (Domain port). In tests, use `FakeDateTime.At(<DateTimeOffset>)` from `TestHelpers/` — returns a configured `Mock<IDateTimeOffsetAccessor>`. **Never call `DateTime.Now`, `DateTimeOffset.Now`, or `*.UtcNow` from Application code or tests.**
+- **Randomness seam**: `IRandomNumberGenerator` (Domain port). Inject and mock. Do not call `Random.Shared` or `new Random()` from Application code.
+- **IDs**: there is no formal ID seam yet. Application handlers currently allow `Guid.NewGuid()` only at construction (e.g. inside a Domain factory like `User(...)`). Direct `Guid.NewGuid()` calls in handlers are forbidden by convention; if you need new IDs in a handler, introduce an `IGuidGenerator`-style port first.
+
+### Coverage exclusions
+
+- Mark new commands, queries, events, records, exceptions, view projections, and enum-helper static classes with `[ExcludeFromCodeCoverage]`. `GlobalUsings.cs` already exposes `System.Diagnostics.CodeAnalysis`.
+- Excluded folders: `Application/Commands`, `Application/Queries`, `Application/Events`, `Domain/Records`, `Domain/Events`, `Domain/Views`, `Domain/Exceptions`, `Domain/Enums` (helpers only), `PersonalProgress/Queries`.
+- **Never** exclude code in `Domain/Models`, `Domain/Services`, `Domain/ValueTypes`, or `Application/Handlers` — that's where coverage matters.
+
+### Dependency realism in this project
+
+- **MassTransit in-memory transport is the production transport.** Tests that go through `IBus`/`IConsumer<>` are exercising the real transport, not a fake. Classify any future MassTransit-flow test under `component` or `slice` based on what *else* is mocked, not as `integration-fake`.
+- **SQL Server is never replaced** with EF in-memory or SQLite. Tests either mock the repository port or wait for real-dependency integration tests.
+
+### Expected for PR-sized changes
+
+`dotnet build` + `dotnet test`. There is no fast/slow split today.
+
+### Local external dependencies
+
+SQL Server is required to *run* the app but is not exercised by the current test suite. There is no `docker-compose` or scripted local bring-up; configure a connection string via user-secrets or `appsettings.Development.json`.
+
+## Carve-outs from ENTERPRISE.md
+
+Deliberate, documented divergences. Read these before flagging a violation.
+
+- **MediatR is permitted in `ScoreTracker.Domain`.** ENTERPRISE.md forbids framework types in Domain; this codebase exempts `MediatR` and `Microsoft.Extensions.Logging.Abstractions`. Any other outside dependency in Domain is a violation.
+- **"Saga" is a feature-grouped class, not a state machine.** A `*Saga` (e.g. `BountySaga`, `TierListSaga`, `MatchSaga`, `PlayerRatingSaga`) contains one MassTransit `IConsumer<>` plus related MediatR `IRequestHandler<>` for that feature. It is **not** a `MassTransit.MassTransitStateMachine`.
+- **`Domain/Events/` mixes events and command-shaped messages** (`ProcessPassTierListCommand`, `ProcessScoresTiersListCommand`). Known divergence from ENTERPRISE's domain-events-vs-integration-events rule. Don't relocate without a planned cleanup.
+- **`ScoreTracker.Data` references `ScoreTracker.Application`.** Onion-direction divergence. Slated for removal — do not lean on it for new code.
+- **No domain-vs-integration-event distinction.** Single bounded context with an in-memory transport makes the distinction moot today. Revisit if a second bounded context appears.
+
+## Architecture authority
+
+`ARCHITECTURE.md` is the source of truth for solution layout, full dependency graph, eventing detail, data-access detail, glossary (Mix, Chart, Phoenix score, Pumbility, Tier list, Bounty, UCS, Saga), known divergences, and open questions. Update it in the same PR that changes a structural pattern.
+
+## Backlog
+
+[BACKLOG.md](BACKLOG.md) tracks the gaps between this codebase and `ENTERPRISE.md` that require real refactor work — real-dependency database tests, external-adapter coverage, dependency-realism labels, the `Data → Application` cleanup, etc. Items in `BACKLOG.md` are not current rules; consult it when picking up follow-on work, not when judging existing code.

--- a/ENTERPRISE.md
+++ b/ENTERPRISE.md
@@ -1,0 +1,288 @@
+# Organization Engineering Rules
+
+> **Role:** simulated managed-policy CLAUDE.md content. In a real org rollout this file would be deployed to the OS-level managed-policy path (`C:\Program Files\ClaudeCode\CLAUDE.md` on Windows, `/etc/claude-code/CLAUDE.md` on Linux, `/Library/Application Support/ClaudeCode/CLAUDE.md` on macOS) via MDM/GPO/Ansible and auto-load into every Claude Code session on the machine. For this testbed it is checked into the repo at `ENTERPRISE.md` and pulled in via `@import` from the project `CLAUDE.md` — same effective behavior, repo-scoped instead of machine-scoped.
+>
+> **Editing:** in production this is owned by the platform/architecture team and changes ship through the managed-policy distribution. Per-project overrides go in the project `CLAUDE.md`, never here.
+
+## Architecture Priorities
+
+- Optimize for clear boundaries, testability, maintainability, and safe AI-assisted refactoring.
+- Follow Clean/Hexagonal dependency direction:
+  - Domain depends on nothing outside domain.
+  - Application depends on domain and ports.
+  - Infrastructure implements ports.
+  - API/UI delegates to application/use cases.
+- Do not introduce framework, HTTP, ORM, database, or vendor SDK types into domain code.
+- Prefer explicit, boring, navigable code over clever indirection.
+
+## Use Cases
+
+- Put business operations behind named use cases, handlers, interactors, or application services.
+- Controllers, routes, resolvers, message consumers, and UI actions should delegate to use cases.
+- Use cases orchestrate work.
+- Domain models enforce business rules.
+- Infrastructure performs side effects.
+
+## Abstractions
+
+Introduce an interface/port only when it:
+- crosses an external boundary,
+- has multiple implementations,
+- protects domain/application from infrastructure,
+- provides a necessary test seam,
+- or represents a domain capability.
+
+Do not create interfaces only because a class exists.
+
+## DDD Policy
+
+- Use rich domain models for complex business rules.
+- Simple CRUD services may use simpler models.
+- Aggregates protect invariants.
+- Domain events are for same-bounded-context side effects.
+- Integration events are for cross-service or cross-bounded-context communication after commit.
+
+## Testing Philosophy
+
+- Tests are executable specifications, not coverage theater.
+- Prefer the smallest test that gives meaningful confidence.
+- Tests should be deterministic, isolated, and runnable by both humans and AI agents.
+- Tests should verify observable behavior, not implementation details.
+- Do not weaken, delete, or rewrite existing assertions just to make a change pass.
+- If an existing test appears incorrect, explain why and make the test change explicit.
+- Do not mix broad refactors with unrelated test rewrites.
+
+## Test Taxonomy
+
+Use these terms consistently.
+
+### Unit Test
+
+A unit test verifies one narrow behavior in isolation.
+
+Rules:
+- No real network, database, filesystem, message broker, or external service.
+- Time, randomness, IDs, and environment variables must be controlled through test seams.
+- Mock or stub ports only when needed.
+- Prefer real domain objects over excessive mocks.
+- Use for domain invariants, value objects, pure functions, validators, policies, and edge cases.
+
+### Component / Module Test
+
+A component test verifies multiple in-process modules together.
+
+Examples:
+- Use case + domain model + fake repository.
+- Handler + validator + fake ports.
+- React/Vue component mounted with test providers.
+- Frontend feature module with mocked API adapter.
+
+Rules:
+- External dependencies are fake, mocked, in-memory, or stubbed.
+- These tests may use framework rendering or dependency injection.
+- These tests are not proof that real external dependencies work.
+
+### Slice Test
+
+A slice test verifies a vertical path through part of the app.
+
+Examples:
+- HTTP route -> controller -> use case -> domain with fake persistence.
+- Message consumer -> handler -> application service with fake ports.
+- UI action -> feature service -> mocked API adapter.
+
+Rules:
+- Use slice tests to protect meaningful behavior during refactors.
+- Prefer slice tests over broad E2E tests when they provide the same confidence.
+- Clearly identify whether dependencies are fake-backed or real.
+
+### Fake-Backed Integration Test
+
+A fake-backed integration test wires multiple real app components together but replaces external dependencies.
+
+Examples:
+- API pipeline with in-memory test server.
+- Repository-like behavior using in-memory database provider.
+- Service using a fake HTTP server.
+- Message flow using an in-memory broker.
+
+Rules:
+- Name these as fake-backed, component, or slice tests.
+- Do not claim these prove compatibility with the real database, broker, or external API.
+- Use them for routing, orchestration, serialization shape, validation, and basic flow confidence.
+
+### Real-Dependency Integration Test
+
+A real-dependency integration test verifies code against the actual class of dependency used in production.
+
+Examples:
+- Repository/DAO against a real database container.
+- Migration test against a real database container.
+- Message publisher/consumer against a real broker container.
+- Storage adapter against a real local emulator or controlled test instance.
+- HTTP adapter against a verified provider sandbox when appropriate.
+
+Rules:
+- Prefer ephemeral local dependencies such as containers or official emulators.
+- Tests must control schema, data, and cleanup.
+- Tests must not depend on production systems.
+- Shared staging dependencies are allowed only when explicitly tagged non-hermetic/external.
+- Use these tests for SQL semantics, migrations, transactions, indexes, serialization, broker behavior, and provider-specific behavior.
+
+### Contract Test
+
+A contract test verifies that a consumer and provider agree on request/response or message/event shape.
+
+Rules:
+- Use consumer contracts for APIs/events this codebase consumes.
+- Providers should verify the contracts they are expected to satisfy.
+- Contract tests are preferred over broad cross-service E2E tests for microservice compatibility.
+- OpenAPI/AsyncAPI/schema checks are useful, but examples of actual consumer expectations are stronger.
+- Contract tests do not replace provider unit/component tests.
+
+### End-to-End / Acceptance Test
+
+An E2E test verifies a critical user or system workflow through the running application.
+
+Rules:
+- Keep E2E coverage focused on critical paths.
+- Do not test every business rule through E2E.
+- Prefer API/component/slice tests for permutations and edge cases.
+- E2E tests must control data and avoid uncontrolled third-party dependencies.
+- E2E tests should be tagged separately from fast PR tests.
+
+### Characterization Test
+
+A characterization test captures current behavior before changing legacy code.
+
+Rules:
+- Add characterization tests before risky refactors.
+- Preserve public behavior first; improve internals second.
+- If behavior is intentionally changed, update tests and explain the behavior change.
+
+### Property-Based Test
+
+A property-based test verifies invariants across many generated inputs.
+
+Use for:
+- Date/time rules.
+- Pricing/rating calculations.
+- Permission logic.
+- Parsers and serializers.
+- State transitions.
+- Domain invariants.
+
+Rules:
+- Use deterministic seeds when failures need reproduction.
+- Include the failing seed or minimized case in failure output when supported.
+
+### Golden Master / Approval / Snapshot Test
+
+A golden master, approval, or snapshot test compares output to an approved baseline.
+
+Use for:
+- Legacy behavior.
+- Generated documents.
+- Serialized payloads.
+- Stable UI screenshots.
+- Complex text or report output.
+
+Rules:
+- Snapshots must be reviewed as behavior, not blindly updated.
+- Do not update snapshots or visual baselines merely to make tests pass.
+- Keep snapshots focused and readable where possible.
+- Prefer semantic assertions over giant snapshots when practical.
+
+### Mutation Test
+
+A mutation test evaluates whether tests fail when production code is intentionally changed.
+
+Rules:
+- Use mutation testing for high-value domain logic where correctness matters.
+- Do not require mutation tests for every routine change unless the project explicitly does.
+- Mutation score is a signal, not an absolute goal.
+
+## Dependency Realism Labels
+
+Every test suite should make dependency realism clear.
+
+Use these labels in folders, tags, categories, or naming:
+
+- `unit`: no external dependency.
+- `component`: multiple in-process modules; external dependencies faked.
+- `slice`: vertical app path; dependency mode must be clear.
+- `contract`: consumer/provider contract verification.
+- `integration-real`: real database, broker, filesystem, emulator, or container.
+- `integration-fake`: fake-backed integration; not proof of real dependency behavior.
+- `e2e`: full workflow through running app.
+- `characterization`: legacy behavior capture.
+- `mutation`: test-suite quality check.
+- `external`: uses shared staging, sandbox, or third-party dependency and may be slower/flakier.
+
+Do not call a test `integration-real` if it uses only mocks, fake servers, or in-memory providers.
+
+## Database Testing Rules
+
+- In-memory database tests are fake-backed tests.
+- SQLite in-memory tests are relational fake-backed tests unless SQLite is the production database.
+- Real database integration tests should use the production database engine or closest supported equivalent.
+- Use real-dependency integration tests for:
+  - migrations,
+  - transaction behavior,
+  - SQL syntax,
+  - provider-specific queries,
+  - indexes and constraints,
+  - concurrency behavior,
+  - raw SQL,
+  - ORM mapping behavior.
+- Use component or slice tests with fake persistence for application orchestration and business rule permutations.
+- Each database test must control seed data and cleanup.
+- Tests must not depend on production data.
+
+## External API and Messaging Tests
+
+- Use contract tests for service-to-service HTTP, event, and message compatibility.
+- Use fake servers for consumer-side behavior tests.
+- Use provider verification to ensure the real provider satisfies consumer expectations.
+- Use real-dependency integration tests for serialization, authentication setup, retry policies, broker configuration, and adapter behavior.
+- Do not call live third-party services from normal PR test suites.
+- Tests that call shared external systems must be tagged `external`.
+
+## Test Data Rules
+
+- Prefer explicit test data builders, mothers, factories, or fixtures over large opaque shared fixtures.
+- Each test should make its important inputs and expected outcomes clear.
+- Avoid cross-test state.
+- Avoid test order dependencies.
+- Use stable clocks, IDs, random seeds, and environment configuration.
+- Failure messages should identify the behavior that broke.
+
+## Refactoring Rules
+
+- Before changing legacy behavior, add characterization tests around the current behavior unless the task is explicitly a bug fix.
+- Run the smallest relevant test first, then broader suites as needed.
+- Do not perform large structural refactors and behavior changes in the same diff unless unavoidable.
+- After changes, run relevant build, test, lint, and typecheck checks.
+- If verification cannot be run, report exactly what was not run and why.
+
+## Project CLAUDE.md Requirements
+
+Each project must define its actual commands.
+
+Required command entries:
+- Build:
+- Typecheck, if applicable:
+- Lint/static analysis:
+- Unit tests:
+- Component/module tests:
+- Contract tests, if applicable:
+- Real-dependency integration tests, if applicable:
+- E2E/Playwright tests, if applicable:
+- Mutation tests, if applicable:
+
+Each project must also document:
+- Test framework conventions.
+- Test naming/tagging conventions.
+- Whether in-memory providers are used and how they are classified.
+- How real external dependencies are started locally.
+- Which test suites are expected for normal PR-sized changes.


### PR DESCRIPTION
Introduces three new docs that work together to drive Claude Code's behavior on this repo and test-bed the doc structure for adoption across a larger set of internal codebases:

- CLAUDE.md: project-level conventions, auto-loaded by Claude Code. Imports the other two via @-syntax. Captures architecture rules (per-layer package allowlist, dispatch pattern, port naming), test conventions (unit vs. component definitions, builder pattern, clock/RNG seams, coverage exclusions), and explicit carve-outs from org policy (MediatR in Domain, "Saga" naming, Events folder mixing, Data->Application reverse reference).

- ENTERPRISE.md: simulated organizational managed-policy CLAUDE.md. Stands in for the OS-level managed-policy file that would be deployed via MDM/GPO/Ansible in a real enterprise rollout. Defines cross-codebase rules for architecture, DDD, testing taxonomy, dependency-realism labels, database/external-API testing, test data, and refactoring workflow.

- BACKLOG.md: refactor work to close gaps between this codebase and ENTERPRISE.md. Not current rules - a tracked roadmap. Top three by impact are external-adapter testing, real-dependency database tests, and applying dependency-realism labels.

ARCHITECTURE.md remains the structural source of truth and is imported into CLAUDE.md alongside ENTERPRISE.md.