### PR TITLE
Fix unclosed <data> blocks in App.en-US.resx (main is red)

### DIFF
--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -841,8 +841,10 @@
   <data name="Updated X Y" xml:space="preserve">
 	  <value>Updated {0} {1}</value>
 	  <comment>{0} = song name, {1} = difficulty string (e.g. "S17"). Snackbar after a chart save on /ChartUpdate.</comment>
+  </data>
   <data name="Community Invite" xml:space="preserve">
 	  <value>Community Invite</value>
+  </data>
   <data name="Chart Compare" xml:space="preserve">
 	  <value>Chart Compare</value>
   </data>
@@ -1005,6 +1007,7 @@
   </data>
   <data name="Team Infinitesimal, data-mine from NX2 + Prime" xml:space="preserve">
 	  <value>Team Infinitesimal, data-mine from NX2 + Prime</value>
+  </data>
   <data name="Welcome" xml:space="preserve">
 	  <value>Welcome</value>
   </data>
@@ -1062,6 +1065,7 @@
   </data>
   <data name="Show" xml:space="preserve">
 	  <value>Show</value>
+  </data>
   <data name="Unknown" xml:space="preserve">
 	  <value>Unknown</value>
   </data>
@@ -1109,6 +1113,7 @@
   </data>
   <data name="There was an unknown error while parsing the file" xml:space="preserve">
 	  <value>There was an unknown error while parsing the file</value>
+  </data>
   <data name="No Recorded Scores" xml:space="preserve">
 	  <value>No Recorded Scores</value>
   </data>
@@ -1122,6 +1127,7 @@
   <data name="Wouldn't You Like To Know" xml:space="preserve">
 	  <value>Wouldn't You Like To Know</value>
 	  <comment>Easter-egg tooltip shown for the user "CLEARALL18SORQUIT"</comment>
+  </data>
   <data name="About The Site" xml:space="preserve">
 	  <value>About The Site</value>
   </data>


### PR DESCRIPTION
## ⚠️ Main is currently broken

`dotnet build` on `main` fails with MSB3103 — MSBuild's XML reader can't parse `App.en-US.resx`. This needs to land before any further Phase 1 work.

## Cause

Each of the merged Phase 1 PRs (#59-#63) appended new `<data>` blocks before the closing `</root>`. Six of the merge resolutions dropped the closing `</data>` tag at the boundary between previously-merged content and the new block, leaving six `<data>` elements structurally unclosed.

## Locations fixed (six junctions)

Each fix is a single inserted `  </data>` line between two adjacent keys:

| After key | Before key |
|---|---|
| `Updated X Y` | `Community Invite` |
| `Community Invite` | `Chart Compare` |
| `Team Infinitesimal, data-mine from NX2 + Prime` | `Welcome` |
| `Show` | `Unknown` |
| `There was an unknown error while parsing the file` | `No Recorded Scores` |
| `Wouldn't You Like To Know` | `About The Site` |

## Verification

- [x] `<data>` opens (321) now equal `</data>` closes (321).
- [x] No duplicate key names. Real key count steady at 317.
- [x] Other locale resx files (`en-ZW`, `es-MX`, `fr-FR`, `ko-KR`, `pt-BR`) were not affected — already balanced.
- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` — **0 errors**, 197 pre-existing warnings (was 1 error before this PR).
- [x] Spot-checked recently added keys are present and unique: `Scores`, `Community Invite`, `Welcome`, `Unknown`, `About The Site`, `PIU Life Calculator`, `Updated X Y`, `Wouldn't You Like To Know`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)