### PR TITLE
Localize Experiments folder (Phase 1, PR #6)

### DIFF
--- a/ScoreTracker/ScoreTracker/Pages/Experiments/Bounties.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Experiments/Bounties.razor
@@ -6,21 +6,21 @@
 @using ScoreTracker.Domain.Models
 @using MediatR
 
-<PageTitle>Bounties</PageTitle>
+<PageTitle>@L["Bounties"]</PageTitle>
 <MudTable T="(int place,BountyLeaderboard record)" Items="_leaderboard" Breakpoint="Breakpoint.None">
     <ToolBarContent>
-        <MudText Typo="Typo.h4">Bounty Leaderboard</MudText>
+        <MudText Typo="Typo.h4">@L["Bounty Leaderboard"]</MudText>
     </ToolBarContent>
     <HeaderContent>
         <MudTh>
-            <MudTableSortLabel T="(int place,BountyLeaderboard record)" SortBy="@(e => e.place)">Place</MudTableSortLabel>
+            <MudTableSortLabel T="(int place,BountyLeaderboard record)" SortBy="@(e => e.place)">@L["Place"]</MudTableSortLabel>
         </MudTh>
         <MudTh>
-            Avatar
+            @L["Avatar"]
         </MudTh>
-        <MudTh>Player</MudTh>
-        <MudTh><MudTableSortLabel T="(int place,BountyLeaderboard record)" SortBy="@(e=>e.record.MonthlyTotal)">Monthly Total</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel T="(int place,BountyLeaderboard record)" SortBy="@(e=>e.record.Total)">Total</MudTableSortLabel></MudTh>
+        <MudTh>@L["Player"]</MudTh>
+        <MudTh><MudTableSortLabel T="(int place,BountyLeaderboard record)" SortBy="@(e=>e.record.MonthlyTotal)">@L["Monthly Total"]</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel T="(int place,BountyLeaderboard record)" SortBy="@(e=>e.record.Total)">@L["Total"]</MudTableSortLabel></MudTh>
         
     </HeaderContent>
     <RowTemplate>

--- a/ScoreTracker/ScoreTracker/Pages/Experiments/ChartLetterDifficulties.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Experiments/ChartLetterDifficulties.razor
@@ -10,7 +10,7 @@
 @using ScoreTracker.Domain.Enums
 @using ScoreTracker.Domain.ValueTypes
 @using ChartType = ScoreTracker.Domain.Enums.ChartType;
-<PageTitle>LetterDifficulties</PageTitle>
+<PageTitle>@L["LetterDifficulties"]</PageTitle>
 
 <ChartSelector ChartIdSelected="SetChart"></ChartSelector>
 @if (_isLoading)
@@ -20,11 +20,11 @@
 @if (_chartId!=null && !_isLoading)
 {
         <DifficultyBubble Chart="_charts[_chartId.Value]"></DifficultyBubble>
-        <MudText>Folder Weighted Distribution</MudText>
+        <MudText>@L["Folder Weighted Distribution"]</MudText>
 
-    
+
     <ApexChart TItem="Range"
-               Title="Letter Difficulty"
+               Title=@L["Letter Difficulty"]
                @ref=_folderChart>
         <ApexPointSeries TItem="Range"
                          Items="_ranges"
@@ -44,7 +44,7 @@
                          OrderBy="e => ParagonLevelGradeHelperMethods.GetParagonLevel((string)e.X)" />
         <ApexPointSeries TItem="Range"
                          Items="_ranges"
-                         Name="Median"
+                         Name=@L["Median"]
                          Color="#FFFFFF"
                          SeriesType="SeriesType.Line"
                          XValue="@(e => e.letter.GetName())"
@@ -69,7 +69,7 @@
 
         <ApexPointSeries TItem="Range"
                          Items="_ranges"
-                         Name="Selected Chart"
+                         Name=@L["Selected Chart"]
                          SeriesType="SeriesType.Line"
                          Color="#00FFFF"
                          XValue="@(e => e.letter.GetName())"
@@ -80,15 +80,15 @@
 
         <SongImage Song="_charts[_chartId.Value].Song"></SongImage>
         <DifficultyBubble Chart="_charts[_chartId.Value]"></DifficultyBubble>
-        <MudText>Percentile Distribution</MudText>
-    
+        <MudText>@L["Percentile Distribution"]</MudText>
+
     <ApexChart TItem="Range"
-                           Title="Letter Difficulty"
+                           Title=@L["Letter Difficulty"]
                            @ref=_percentChart
                Options="_percentOptions">
         <ApexPointSeries TItem="Range"
                          Items="_ranges"
-                         Name="Difficulty By Letter"
+                         Name=@L["Difficulty By Letter"]
                          SeriesType="SeriesType.Line"
                          XValue="@(e => e.letter.GetName())"
                          YValue="@(e => (decimal)_chartPercentiles[e.letter])"

--- a/ScoreTracker/ScoreTracker/Pages/Experiments/ChartScoringLevels.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Experiments/ChartScoringLevels.razor
@@ -11,15 +11,15 @@
 @using ScoreTracker.Domain.ValueTypes
 @using Swashbuckle.AspNetCore.SwaggerGen
 
-<PageTitle>ChartScoring</PageTitle>
+<PageTitle>@L["ChartScoring"]</PageTitle>
 @if (_isLoading)
 {
     <MudProgressLinear Indeterminate="true" Color="Color.Primary"></MudProgressLinear>
 }
 <MudGrid>
     <MudItem xs="12" sm="6">
-        
-        <MudAutocomplete Disabled="_isLoading" T="string" Value="_selected" ValueChanged="SetChart" CoerceValue="false" CoerceText="true" Label="Chart" SearchFunc="(s,c)=>SearchSongs(s)">
+
+        <MudAutocomplete Disabled="_isLoading" T="string" Value="_selected" ValueChanged="SetChart" CoerceValue="false" CoerceText="true" Label=@L["Chart"] SearchFunc="(s,c)=>SearchSongs(s)">
             <ItemTemplate>
                 <DifficultyBubble Chart="_chartNames[context]" Small="true"></DifficultyBubble> @_chartNames[context].Song.Name
             </ItemTemplate>
@@ -28,7 +28,7 @@
     @if (_selectedChart != null && !_isLoading)
     {
         <MudItem xs="12" sm="6">
-            <MudNumericField T="int" HideSpinButtons="true" Min="1" Max="DifficultyLevel.Max" Label="Target Player Level" Value="_playerLevel" ValueChanged="SetPlayerLevel"></MudNumericField>
+            <MudNumericField T="int" HideSpinButtons="true" Min="1" Max="DifficultyLevel.Max" Label=@L["Target Player Level"] Value="_playerLevel" ValueChanged="SetPlayerLevel"></MudNumericField>
         </MudItem>
     }
 </MudGrid>
@@ -38,21 +38,21 @@
 
     @if (_selectedChart.Type != ChartType.CoOp)
     {
-        <MudText Typo="Typo.h4">Player Weights</MudText>
-        <MudText Typo="Typo.subtitle1">All players with scores within the target folder are assigned weights based on how close their competitive level is to @_playerLevel.</MudText>
-        <MudText Typo="Typo.subtitle1">Highlighted players have a recorded score on the chart in question.</MudText>
+        <MudText Typo="Typo.h4">@L["Player Weights"]</MudText>
+        <MudText Typo="Typo.subtitle1">@L["All players with scores within the target folder are assigned weights based on how close their competitive level is to X.", _playerLevel]</MudText>
+        <MudText Typo="Typo.subtitle1">@L["Highlighted players have a recorded score on the chart in question."]</MudText>
         @foreach (var playerWeight in _playerWeights.OrderByDescending(kv => kv.Value[_playerLevel]))
         {
             <MudText Typo="Typo.body2" Color="_playerScores.ContainsKey(playerWeight.Key)?Color.Success:Color.Default">
-                @($"{(!_users[playerWeight.Key].IsPublic ? "Anonymous" : _users[playerWeight.Key].Name)} - {playerWeight.Value[_playerLevel]:0.000} (Competitively {_playerLevels[playerWeight.Key]:0.00}{(_playerScores.TryGetValue(playerWeight.Key, out var score) ? ", " + score : "")})")
+                @($"{(!_users[playerWeight.Key].IsPublic ? L["Anonymous"].Value : _users[playerWeight.Key].Name)} - {playerWeight.Value[_playerLevel]:0.000} ({L["Competitively"]} {_playerLevels[playerWeight.Key]:0.00}{(_playerScores.TryGetValue(playerWeight.Key, out var score) ? ", " + score : "")})")
             </MudText>
         }
         <br/>
-        <MudText Typo="Typo.h4">Folder Averages</MudText>
-        <MudText Typo="Typo.subtitle1">The target folder and the three surrounding are provided weighted average scores utilizing the player weights above.</MudText>
-        <MudText Typo="Typo.subtitle1">These averages are shifted away from the level in question by .5 of a standard deviation within their respective folder to make sure level changes are better represented by the bulk of a surrounding folder.</MudText>
+        <MudText Typo="Typo.h4">@L["Folder Averages"]</MudText>
+        <MudText Typo="Typo.subtitle1">@L["The target folder and the three surrounding are provided weighted average scores utilizing the player weights above."]</MudText>
+        <MudText Typo="Typo.subtitle1">@L["These averages are shifted away from the level in question by .5 of a standard deviation within their respective folder to make sure level changes are better represented by the bulk of a surrounding folder."]</MudText>
         <ApexChart TItem="DataPoint"
-                   Title=@($"Weighted Average Scores By Folder")
+                   Title=@L["Weighted Average Scores By Folder"]
                                                 @ref="_levelAverageGraph">
 
             <ApexPointSeries TItem="DataPoint"
@@ -64,44 +64,44 @@
 
         </ApexChart>
         <br/>
-        <MudText Typo="Typo.h4">Chart Average</MudText>
-        <MudText Typo="Typo.subtitle1">The chart in question has its weighted average score projected onto the score distributions</MudText>
+        <MudText Typo="Typo.h4">@L["Chart Average"]</MudText>
+        <MudText Typo="Typo.subtitle1">@L["The chart in question has its weighted average score projected onto the score distributions"]</MudText>
         <MudText Typo="Typo.body2">@_selectedChart.Song.Name @_selectedChart.DifficultyString - @_chartAverages[_playerLevel].ToString("N0")</MudText>
         @if (_calculatedLevels.TryGetValue(_selectedChart.Id, out var level))
         {
             @if (_lowLevel[_playerLevel] == 0 && _highLevel[_playerLevel] == 0)
             {
-                <MudText Typo="Typo.body2">There was not enough data for the targeted player level to evaluate a final difficulty. </MudText>
+                <MudText Typo="Typo.body2">@L["There was not enough data for the targeted player level to evaluate a final difficulty."] </MudText>
             }
             else if (_lowLevel[_playerLevel] == 0)
             {
 
-                <MudText Typo="Typo.body2">The weighted average for this chart is better than the average for a @_highLevel[_playerLevel].</MudText>
-                <MudText Typo="Typo.body2">In this case, the chart is determined to be below by @_percentBetween[_playerLevel].ToString("0.00") utilizing standard deviations in the @_highLevel[_playerLevel] folder.</MudText>
+                <MudText Typo="Typo.body2">@L["The weighted average for this chart is better than the average for a X.", _highLevel[_playerLevel]]</MudText>
+                <MudText Typo="Typo.body2">@L["In this case, the chart is determined to be below by X utilizing standard deviations in the Y folder.", _percentBetween[_playerLevel].ToString("0.00"), _highLevel[_playerLevel]]</MudText>
             }
             else if (_highLevel[_playerLevel] == 0)
             {
-                <MudText Typo="Typo.body2">The weighted average for this chart is worst than the average for a @_lowLevel[_playerLevel].</MudText>
-                <MudText Typo="Typo.body2">In this case, the chart is determined to be above by @_percentBetween[_playerLevel].ToString("0.00") utilizing standard deviations in the @_lowLevel[_playerLevel] folder.</MudText>
+                <MudText Typo="Typo.body2">@L["The weighted average for this chart is worst than the average for a X.", _lowLevel[_playerLevel]]</MudText>
+                <MudText Typo="Typo.body2">@L["In this case, the chart is determined to be above by X utilizing standard deviations in the Y folder.", _percentBetween[_playerLevel].ToString("0.00"), _lowLevel[_playerLevel]]</MudText>
             }
             else
             {
-                <MudText Typo="Typo.body2">Determined to be @_percentBetween[_playerLevel].ToString("0.000") between @(_lowLevel[_playerLevel] + .5) and @(_highLevel[_playerLevel] + .5)</MudText>
+                <MudText Typo="Typo.body2">@L["Determined to be X between Y and Z", _percentBetween[_playerLevel].ToString("0.000"), _lowLevel[_playerLevel] + .5, _highLevel[_playerLevel] + .5]</MudText>
             }
-            <MudText>Final Result: @level[_playerLevel].ToString("0.000")</MudText>
+            <MudText>@L["Final Result: X", level[_playerLevel].ToString("0.000")]</MudText>
         }
         else
         {
-            <MudText Typo="Typo.body2">At this point, it's identified that this chart has no players with a weight of .5 or higher (within 1 level). The chart is marked as not having a scoring level as any estimation would be based on missing data.</MudText>
+            <MudText Typo="Typo.body2">@L["At this point, it's identified that this chart has no players with a weight of .5 or higher (within 1 level). The chart is marked as not having a scoring level as any estimation would be based on missing data."]</MudText>
         }
         <br/>
-        <MudText Typo="Typo.h4">Difficulty By Player Level</MudText>
-        <MudText Typo="Typo.subtitle1">The listed scoring difficulty is calculated for players competitively playing in the officially listed folder for a chart.</MudText>
-        <MudText Typo="Typo.subtitle1">The outcome of this algorithm has drastically different results for players at different levels though</MudText>
-        <MudText Typo="Typo.subtitle1">This is intended. There are charts that are relatively easier to score to others in the folder for players just pushing into the folder, but are harder for higher level players to perfect.</MudText>
+        <MudText Typo="Typo.h4">@L["Difficulty By Player Level"]</MudText>
+        <MudText Typo="Typo.subtitle1">@L["The listed scoring difficulty is calculated for players competitively playing in the officially listed folder for a chart."]</MudText>
+        <MudText Typo="Typo.subtitle1">@L["The outcome of this algorithm has drastically different results for players at different levels though"]</MudText>
+        <MudText Typo="Typo.subtitle1">@L["This is intended. There are charts that are relatively easier to score to others in the folder for players just pushing into the folder, but are harder for higher level players to perfect."]</MudText>
         <ApexChart TItem="DataPoint"
                    Options="_scoreBoxesOptions"
-                   Title=@($"Scoring Level by Player Competitive Level")
+                   Title=@L["Scoring Level by Player Competitive Level"]
                                                                                             @ref="_playerLevelLevels">
 
             <ApexPointSeries TItem="DataPoint"
@@ -115,24 +115,24 @@
     }
     else
     {
-        <MudText Typo="Typo.h4">Player Levels</MudText>
-        <MudText Typo="Typo.subtitle1">For CoOps, scoring level is simply the lowest level player who's been able to pass the chart.</MudText>
-        <MudText Typo="Typo.subtitle1">This isn't perfect, but until I have more data other algorithms haven't been successful at projecting CoOps onto difficulty levels</MudText>
+        <MudText Typo="Typo.h4">@L["Player Levels"]</MudText>
+        <MudText Typo="Typo.subtitle1">@L["For CoOps, scoring level is simply the lowest level player who's been able to pass the chart."]</MudText>
+        <MudText Typo="Typo.subtitle1">@L["This isn't perfect, but until I have more data other algorithms haven't been successful at projecting CoOps onto difficulty levels"]</MudText>
         @foreach (var playerWeight in _playerWeights.OrderByDescending(kv => kv.Value[_playerLevel]))
         {
             <MudText Typo="Typo.body2" Color="_playerScores.ContainsKey(playerWeight.Key)?Color.Success:Color.Default">
-                @($"{(!_users[playerWeight.Key].IsPublic ? "Anonymous" : _users[playerWeight.Key].Name)} (Competitively {_playerLevels[playerWeight.Key]:0.00}{(_playerScores.TryGetValue(playerWeight.Key, out var score) ? ", " + score : "")})")
+                @($"{(!_users[playerWeight.Key].IsPublic ? L["Anonymous"].Value : _users[playerWeight.Key].Name)} ({L["Competitively"]} {_playerLevels[playerWeight.Key]:0.00}{(_playerScores.TryGetValue(playerWeight.Key, out var score) ? ", " + score : "")})")
             </MudText>
-        }        
+        }
         <br/>
         @if (!_playerWeights.Any(w => _playerScores.ContainsKey(w.Key)))
         {
-            <MudText Typo="Typo.subtitle1">No one has passed this CoOp yet so no level is assigned.</MudText>
+            <MudText Typo="Typo.subtitle1">@L["No one has passed this CoOp yet so no level is assigned."]</MudText>
         }
         else
         {
-            
-            <MudText Typo="Typo.subtitle1">This gives this chart a scoring level of: @_playerWeights.Where(w=>_playerScores.ContainsKey(w.Key)).Min(w=>_playerLevels[w.Key]).ToString("0.00")</MudText>
+
+            <MudText Typo="Typo.subtitle1">@L["This gives this chart a scoring level of: X", _playerWeights.Where(w=>_playerScores.ContainsKey(w.Key)).Min(w=>_playerLevels[w.Key]).ToString("0.00")]</MudText>
         }
     }
 }

--- a/ScoreTracker/ScoreTracker/Pages/Experiments/Distribution.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Experiments/Distribution.razor
@@ -3,8 +3,8 @@
 @using ScoreTracker.Web.Dtos
 @using ScoreTracker.Web.Pages.Tools
 
-<PageTitle>Upload Scores</PageTitle>
-<MudButton Disabled="true" Variant="Variant.Filled" Color="MudBlazor.Color.Primary" OnClick="_=>IterateThroughScores(400)">Start</MudButton>
+<PageTitle>@L["Upload Scores"]</PageTitle>
+<MudButton Disabled="true" Variant="Variant.Filled" Color="MudBlazor.Color.Primary" OnClick="_=>IterateThroughScores(400)">@L["Start"]</MudButton>
 <MudText>
     @_text
 </MudText>

--- a/ScoreTracker/ScoreTracker/Pages/Experiments/GameStats.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Experiments/GameStats.razor
@@ -10,19 +10,19 @@
 @page "/GameStats"
 <MudPaper>
     <MudToolBar>
-        <MudText Typo="Typo.h6">Game Stats</MudText>
+        <MudText Typo="Typo.h6">@L["Game Stats"]</MudText>
     </MudToolBar>
     <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
-        <MudTabPanel Text="Total Popularity Singles vs Doubles">
+        <MudTabPanel Text=@L["Total Popularity Singles vs Doubles"]>
             <ApexChart TItem="BoxPlotData"
-                       Title="Total Singles vs Doubles"
+                       Title=@L["Total Singles vs Doubles"]
                        @ref="_sdChart"
                        Options="_scoreBoxesOptions">
 
                 <ApexPointSeries TItem="BoxPlotData"
                                  Color="#FFFFFF"
                                  Items="_popularityData.Where(e=>e.Type==ChartType.SinglePerformance)"
-                                 Name="Total"
+                                 Name=@L["Total"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Level)"
                                  YValue="@(e => e.Total)"
@@ -30,7 +30,7 @@
                 <ApexPointSeries TItem="BoxPlotData"
                                  Color="#EA3F24"
                                  Items="_popularityData.Where(e=>e.Type==ChartType.Single)"
-                                 Name="Singles"
+                                 Name=@L["Singles"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Level)"
                                  YValue="@(e => e.Total)"
@@ -38,7 +38,7 @@
                 <ApexPointSeries TItem="BoxPlotData"
                                  Color="#76FA4F"
                                  Items="_popularityData.Where(e=>e.Type==ChartType.Double)"
-                                 Name="Doubles"
+                                 Name=@L["Doubles"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Level)"
                                  YValue="@(e => e.Total)"
@@ -46,7 +46,7 @@
                 <ApexPointSeries TItem="BoxPlotData"
                                  Color="#FFFF5B"
                                  Items="_popularityData.Where(e=>e.Type==ChartType.CoOp)"
-                                 Name="CoOp"
+                                 Name=@L["CoOp"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Level)"
                                  YValue="@(e => e.Total)"
@@ -55,16 +55,16 @@
             </ApexChart>
 
         </MudTabPanel>
-        <MudTabPanel Text="Chart Count By Level">
+        <MudTabPanel Text=@L["Chart Count By Level"]>
             <ApexChart TItem="BoxPlotData"
-                       Title="Total Singles vs Doubles"
+                       Title=@L["Total Singles vs Doubles"]
             @ref="_chartChart"
                        Options="_chartBoxesOptions">
 
                 <ApexPointSeries TItem="BoxPlotData"
                                  Color="#FFFFFF"
                                  Items="_chartCounts.Where(e=>e.Type==ChartType.SinglePerformance)"
-                                 Name="Total"
+                                 Name=@L["Total"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Level)"
                                  YValue="@(e => e.Total)"
@@ -72,7 +72,7 @@
                 <ApexPointSeries TItem="BoxPlotData"
                                  Color="#EA3F24"
                                  Items="_chartCounts.Where(e=>e.Type==ChartType.Single)"
-                                 Name="Singles"
+                                 Name=@L["Singles"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Level)"
                                  YValue="@(e => e.Total)"
@@ -80,7 +80,7 @@
                 <ApexPointSeries TItem="BoxPlotData"
                                  Color="#76FA4F"
                                  Items="_chartCounts.Where(e=>e.Type==ChartType.Double)"
-                                 Name="Doubles"
+                                 Name=@L["Doubles"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Level)"
                                  YValue="@(e => e.Total)"
@@ -88,7 +88,7 @@
                 <ApexPointSeries TItem="BoxPlotData"
                                  Color="#FFFF5B"
                                  Items="_chartCounts.Where(e=>e.Type==ChartType.CoOp)"
-                                 Name="CoOp"
+                                 Name=@L["CoOp"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Level)"
                                  YValue="@(e => e.Total)"

--- a/ScoreTracker/ScoreTracker/Pages/Experiments/NoteCounts.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Experiments/NoteCounts.razor
@@ -11,50 +11,50 @@
 @using ScoreTracker.Web.Components
 @using ChartType = ScoreTracker.Domain.Enums.ChartType
 
-<PageTitle>Note Counts</PageTitle>
+<PageTitle>@L["Note Counts"]</PageTitle>
 @if (!_isLoading)
 {
-    <MudSelect T="ChartType" Value="_currentChartType" ValueChanged="SetType" Label="Chart Type">
+    <MudSelect T="ChartType" Value="_currentChartType" ValueChanged="SetType" Label=@L["Chart Type"]>
         <MudSelectItem T="ChartType" Value="ChartType.Single">@ChartType.Single</MudSelectItem>
         <MudSelectItem T="ChartType" Value="ChartType.Double">@ChartType.Double</MudSelectItem>
         <MudSelectItem T="ChartType" Value="ChartType.CoOp">@ChartType.CoOp</MudSelectItem>
     </MudSelect>
     <ApexChart TItem="DataPoint"
                @ref="_graph1"
-                   Title=@($"{_currentChartType} Note counts")
+                   Title=@L["X Note counts", _currentChartType]
                    Options="_scoreBoxesOptions">
 
             <ApexPointSeries TItem="DataPoint"
                          Items="_mins[_currentChartType]"
-                             Name="Minimums"
+                             Name=@L["Minimums"]
                              SeriesType="SeriesType.Line"
                              XValue="@(e => e.X)"
                              YValue="@(e => e.Y)"
                              OrderBy="e => e.X" />
             <ApexPointSeries TItem="DataPoint"
                          Items="_standardMin[_currentChartType]"
-                             Name="Standard Low"
+                             Name=@L["Standard Low"]
                              SeriesType="SeriesType.Line"
                              XValue="@(e => e.X)"
                              YValue="@(e => e.Y)"
                              OrderBy="e => e.X" />
             <ApexPointSeries TItem="DataPoint"
                          Items="_averages[_currentChartType]"
-                             Name="Average"
+                             Name=@L["Average"]
                              SeriesType="SeriesType.Line"
                              XValue="@(e => e.X)"
                              YValue="@(e => e.Y)"
                              OrderBy="e => e.X" />
             <ApexPointSeries TItem="DataPoint"
                          Items="_standardMax[_currentChartType]"
-                             Name="Standard High"
+                             Name=@L["Standard High"]
                              SeriesType="SeriesType.Line"
                              XValue="@(e => e.X)"
                              YValue="@(e => e.Y)"
                              OrderBy="e => e.X" />
             <ApexPointSeries TItem="DataPoint"
                          Items="_maxes[_currentChartType]"
-                             Name="Maximums"
+                             Name=@L["Maximums"]
                              SeriesType="SeriesType.Line"
                              XValue="@(e => e.X)"
                              YValue="@(e => e.Y)"
@@ -63,18 +63,18 @@
         </ApexChart>
         <ApexChart TItem="DataPoint"
                    @ref="_graph2"
-               Title=@($"{_currentChartType} Progress")>
+               Title=@L["X Progress", _currentChartType]>
 
                         <ApexPointSeries TItem="DataPoint"
                          Items="_missingCount[_currentChartType]"
-                                         Name="Missing"
+                                         Name=@L["Missing"]
                                          SeriesType="SeriesType.Line"
                                          XValue="@(e => e.X)"
                                          YValue="@(e => e.Y)"
                                          OrderBy="e => e.X" />
                         <ApexPointSeries TItem="DataPoint"
                          Items="_existingCount[_currentChartType]"
-                                         Name="Existing"
+                                         Name=@L["Existing"]
                                          SeriesType="SeriesType.Line"
                                          XValue="@(e => e.X)"
                                          YValue="@(e => e.Y)"

--- a/ScoreTracker/ScoreTracker/Pages/Experiments/SimilarPlayers.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Experiments/SimilarPlayers.razor
@@ -11,19 +11,19 @@
 @using ScoreTracker.Domain.Models
 @using ScoreTracker.Domain.ValueTypes
 
-<PageTitle>User Matches</PageTitle>
+<PageTitle>@L["User Matches"]</PageTitle>
 <MudGrid>
     <MudItem xs="12" sm="6">
-        <MudSelect T="ChartType" Label="Chart Type" Value="_type" ValueChanged="t=>SetFilters(t,_level)">
-            <MudSelectItem T="ChartType" Value="ChartType.Double">Doubles</MudSelectItem>
-            <MudSelectItem T="ChartType" Value="ChartType.Single">Singles</MudSelectItem>
+        <MudSelect T="ChartType" Label=@L["Chart Type"] Value="_type" ValueChanged="t=>SetFilters(t,_level)">
+            <MudSelectItem T="ChartType" Value="ChartType.Double">@L["Doubles"]</MudSelectItem>
+            <MudSelectItem T="ChartType" Value="ChartType.Single">@L["Singles"]</MudSelectItem>
         </MudSelect>
     </MudItem>
     <MudItem xs="12" sm="6">
-        <MudNumericField T="int" Value="_level" ValueChanged="l=>SetFilters(_type,l)" HideSpinButtons="true" Label="Level"></MudNumericField>
+        <MudNumericField T="int" Value="_level" ValueChanged="l=>SetFilters(_type,l)" HideSpinButtons="true" Label=@L["Level"]></MudNumericField>
     </MudItem>
 </MudGrid>
-<MudText Typo="Typo.h4">Calculated Tier List</MudText>
+<MudText Typo="Typo.h4">@L["Calculated Tier List"]</MudText>
 @foreach (var category in Enum.GetValues<TierListCategory>().Where(c=>_tierList.ContainsKey(c)))
 {
     <br/>
@@ -36,7 +36,7 @@
     }
 }
 <br/><br/>
-<MudText Typo="Typo.h4">Similar Players</MudText>
+<MudText Typo="Typo.h4">@L["Similar Players"]</MudText>
 @foreach (var kv in _userTotals.OrderByDescending(k=>k.Value))
 {
     @if (_users[kv.Key].IsPublic)
@@ -45,7 +45,7 @@
     }
     else
     {
-        <MudText>@($"Private User - {kv.Value}")</MudText>
+        <MudText>@L["Private User - X", kv.Value]</MudText>
     }
 }
 @if (_users.ContainsKey(CurrentUser.User.Id) && _userTiersLists.ContainsKey(CurrentUser.User.Id))
@@ -53,9 +53,9 @@
 
     <MudTable T="Chart" Items="_tierList.Values.SelectMany(c=>c)" Dense="true">
         <HeaderContent>
-            <MudTh>Song</MudTh>
-            <MudTh>Difficulty</MudTh>
-            <MudTh>Final Result</MudTh>
+            <MudTh>@L["Song"]</MudTh>
+            <MudTh>@L["Difficulty"]</MudTh>
+            <MudTh>@L["Final Result"]</MudTh>
             @foreach (var userId in new[] { CurrentUser.User.Id }.Concat(_comparingUsers))
             {
                 <MudTh>@_users[userId].Name</MudTh>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -1143,4 +1143,202 @@
   <data name="Original Concept (excel score tracking) Constructed by KyleTT" xml:space="preserve">
 	  <value>Original Concept (excel score tracking) Constructed by KyleTT</value>
   </data>
+  <data name="Bounties" xml:space="preserve">
+	  <value>Bounties</value>
+  </data>
+  <data name="Bounty Leaderboard" xml:space="preserve">
+	  <value>Bounty Leaderboard</value>
+  </data>
+  <data name="Monthly Total" xml:space="preserve">
+	  <value>Monthly Total</value>
+  </data>
+  <data name="Total" xml:space="preserve">
+	  <value>Total</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+	  <value>Start</value>
+  </data>
+  <data name="Game Stats" xml:space="preserve">
+	  <value>Game Stats</value>
+  </data>
+  <data name="Total Popularity Singles vs Doubles" xml:space="preserve">
+	  <value>Total Popularity Singles vs Doubles</value>
+  </data>
+  <data name="Total Singles vs Doubles" xml:space="preserve">
+	  <value>Total Singles vs Doubles</value>
+  </data>
+  <data name="Chart Count By Level" xml:space="preserve">
+	  <value>Chart Count By Level</value>
+  </data>
+  <data name="Note Counts" xml:space="preserve">
+	  <value>Note Counts</value>
+  </data>
+  <data name="X Note counts" xml:space="preserve">
+	  <value>{0} Note counts</value>
+	  <comment>{0} = ChartType (Single/Double/CoOp). Chart title on /NoteCounts.</comment>
+  </data>
+  <data name="X Progress" xml:space="preserve">
+	  <value>{0} Progress</value>
+	  <comment>{0} = ChartType. Chart title on /NoteCounts.</comment>
+  </data>
+  <data name="Minimums" xml:space="preserve">
+	  <value>Minimums</value>
+  </data>
+  <data name="Standard Low" xml:space="preserve">
+	  <value>Standard Low</value>
+  </data>
+  <data name="Standard High" xml:space="preserve">
+	  <value>Standard High</value>
+  </data>
+  <data name="Maximums" xml:space="preserve">
+	  <value>Maximums</value>
+  </data>
+  <data name="Missing" xml:space="preserve">
+	  <value>Missing</value>
+  </data>
+  <data name="Existing" xml:space="preserve">
+	  <value>Existing</value>
+  </data>
+  <data name="LetterDifficulties" xml:space="preserve">
+	  <value>LetterDifficulties</value>
+	  <comment>Page title on /Experiments/LetterDifficulties; the source has no space between "Letter" and "Difficulties".</comment>
+  </data>
+  <data name="Folder Weighted Distribution" xml:space="preserve">
+	  <value>Folder Weighted Distribution</value>
+  </data>
+  <data name="Letter Difficulty" xml:space="preserve">
+	  <value>Letter Difficulty</value>
+  </data>
+  <data name="Median" xml:space="preserve">
+	  <value>Median</value>
+  </data>
+  <data name="Selected Chart" xml:space="preserve">
+	  <value>Selected Chart</value>
+  </data>
+  <data name="Percentile Distribution" xml:space="preserve">
+	  <value>Percentile Distribution</value>
+  </data>
+  <data name="Difficulty By Letter" xml:space="preserve">
+	  <value>Difficulty By Letter</value>
+  </data>
+  <data name="User Matches" xml:space="preserve">
+	  <value>User Matches</value>
+  </data>
+  <data name="Calculated Tier List" xml:space="preserve">
+	  <value>Calculated Tier List</value>
+  </data>
+  <data name="Similar Players" xml:space="preserve">
+	  <value>Similar Players</value>
+  </data>
+  <data name="Private User - X" xml:space="preserve">
+	  <value>Private User - {0}</value>
+	  <comment>{0} = comparison-score number. Listed for users who have set their profile private.</comment>
+  </data>
+  <data name="Final Result" xml:space="preserve">
+	  <value>Final Result</value>
+  </data>
+  <data name="ChartScoring" xml:space="preserve">
+	  <value>ChartScoring</value>
+	  <comment>Page title on /Experiments/ChartScoring; the source has no space between "Chart" and "Scoring".</comment>
+  </data>
+  <data name="Target Player Level" xml:space="preserve">
+	  <value>Target Player Level</value>
+  </data>
+  <data name="Player Weights" xml:space="preserve">
+	  <value>Player Weights</value>
+  </data>
+  <data name="All players with scores within the target folder are assigned weights based on how close their competitive level is to X." xml:space="preserve">
+	  <value>All players with scores within the target folder are assigned weights based on how close their competitive level is to {0}.</value>
+	  <comment>{0} = target player level (integer).</comment>
+  </data>
+  <data name="Highlighted players have a recorded score on the chart in question." xml:space="preserve">
+	  <value>Highlighted players have a recorded score on the chart in question.</value>
+  </data>
+  <data name="Anonymous" xml:space="preserve">
+	  <value>Anonymous</value>
+	  <comment>Display name shown for users who have set their profile private.</comment>
+  </data>
+  <data name="Competitively" xml:space="preserve">
+	  <value>Competitively</value>
+	  <comment>Word used in player-weight rows on /Experiments/ChartScoring (e.g. "(Competitively 12.34)").</comment>
+  </data>
+  <data name="Folder Averages" xml:space="preserve">
+	  <value>Folder Averages</value>
+  </data>
+  <data name="The target folder and the three surrounding are provided weighted average scores utilizing the player weights above." xml:space="preserve">
+	  <value>The target folder and the three surrounding are provided weighted average scores utilizing the player weights above.</value>
+  </data>
+  <data name="These averages are shifted away from the level in question by .5 of a standard deviation within their respective folder to make sure level changes are better represented by the bulk of a surrounding folder." xml:space="preserve">
+	  <value>These averages are shifted away from the level in question by .5 of a standard deviation within their respective folder to make sure level changes are better represented by the bulk of a surrounding folder.</value>
+  </data>
+  <data name="Weighted Average Scores By Folder" xml:space="preserve">
+	  <value>Weighted Average Scores By Folder</value>
+  </data>
+  <data name="Chart Average" xml:space="preserve">
+	  <value>Chart Average</value>
+  </data>
+  <data name="The chart in question has its weighted average score projected onto the score distributions" xml:space="preserve">
+	  <value>The chart in question has its weighted average score projected onto the score distributions</value>
+  </data>
+  <data name="There was not enough data for the targeted player level to evaluate a final difficulty." xml:space="preserve">
+	  <value>There was not enough data for the targeted player level to evaluate a final difficulty.</value>
+  </data>
+  <data name="The weighted average for this chart is better than the average for a X." xml:space="preserve">
+	  <value>The weighted average for this chart is better than the average for a {0}.</value>
+	  <comment>{0} = high-level integer.</comment>
+  </data>
+  <data name="In this case, the chart is determined to be below by X utilizing standard deviations in the Y folder." xml:space="preserve">
+	  <value>In this case, the chart is determined to be below by {0} utilizing standard deviations in the {1} folder.</value>
+	  <comment>{0} = percent-between value, {1} = high-level integer.</comment>
+  </data>
+  <data name="The weighted average for this chart is worst than the average for a X." xml:space="preserve">
+	  <value>The weighted average for this chart is worst than the average for a {0}.</value>
+	  <comment>Source spelling preserved verbatim ("worst" rather than "worse"). {0} = low-level integer.</comment>
+  </data>
+  <data name="In this case, the chart is determined to be above by X utilizing standard deviations in the Y folder." xml:space="preserve">
+	  <value>In this case, the chart is determined to be above by {0} utilizing standard deviations in the {1} folder.</value>
+	  <comment>{0} = percent-between value, {1} = low-level integer.</comment>
+  </data>
+  <data name="Determined to be X between Y and Z" xml:space="preserve">
+	  <value>Determined to be {0} between {1} and {2}</value>
+	  <comment>{0} = percent-between (3 decimals), {1} = low+0.5, {2} = high+0.5.</comment>
+  </data>
+  <data name="Final Result: X" xml:space="preserve">
+	  <value>Final Result: {0}</value>
+	  <comment>{0} = computed level (3 decimals).</comment>
+  </data>
+  <data name="At this point, it's identified that this chart has no players with a weight of .5 or higher (within 1 level). The chart is marked as not having a scoring level as any estimation would be based on missing data." xml:space="preserve">
+	  <value>At this point, it's identified that this chart has no players with a weight of .5 or higher (within 1 level). The chart is marked as not having a scoring level as any estimation would be based on missing data.</value>
+  </data>
+  <data name="Difficulty By Player Level" xml:space="preserve">
+	  <value>Difficulty By Player Level</value>
+  </data>
+  <data name="The listed scoring difficulty is calculated for players competitively playing in the officially listed folder for a chart." xml:space="preserve">
+	  <value>The listed scoring difficulty is calculated for players competitively playing in the officially listed folder for a chart.</value>
+  </data>
+  <data name="The outcome of this algorithm has drastically different results for players at different levels though" xml:space="preserve">
+	  <value>The outcome of this algorithm has drastically different results for players at different levels though</value>
+  </data>
+  <data name="This is intended. There are charts that are relatively easier to score to others in the folder for players just pushing into the folder, but are harder for higher level players to perfect." xml:space="preserve">
+	  <value>This is intended. There are charts that are relatively easier to score to others in the folder for players just pushing into the folder, but are harder for higher level players to perfect.</value>
+  </data>
+  <data name="Scoring Level by Player Competitive Level" xml:space="preserve">
+	  <value>Scoring Level by Player Competitive Level</value>
+  </data>
+  <data name="Player Levels" xml:space="preserve">
+	  <value>Player Levels</value>
+  </data>
+  <data name="For CoOps, scoring level is simply the lowest level player who's been able to pass the chart." xml:space="preserve">
+	  <value>For CoOps, scoring level is simply the lowest level player who's been able to pass the chart.</value>
+  </data>
+  <data name="This isn't perfect, but until I have more data other algorithms haven't been successful at projecting CoOps onto difficulty levels" xml:space="preserve">
+	  <value>This isn't perfect, but until I have more data other algorithms haven't been successful at projecting CoOps onto difficulty levels</value>
+  </data>
+  <data name="No one has passed this CoOp yet so no level is assigned." xml:space="preserve">
+	  <value>No one has passed this CoOp yet so no level is assigned.</value>
+  </data>
+  <data name="This gives this chart a scoring level of: X" xml:space="preserve">
+	  <value>This gives this chart a scoring level of: {0}</value>
+	  <comment>{0} = lowest passing player's competitive level (2 decimals).</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary

Phase 1 PR #6 — `Pages/Experiments/`. Largest folder so far: 7 files, ~60 new keys, ~17 reused. 287+/89- diff. Build clean.

## Files changed

| File | Notes |
|---|---|
| [Bounties.razor](ScoreTracker/ScoreTracker/Pages/Experiments/Bounties.razor) | Page title + leaderboard table headers. |
| [Distribution.razor](ScoreTracker/ScoreTracker/Pages/Experiments/Distribution.razor) | Just the `Start` button (page title `Upload Scores` reused — the page is a research tool that shares the upload page's title). |
| [GameStats.razor](ScoreTracker/ScoreTracker/Pages/Experiments/GameStats.razor) | Tab titles, chart title, series names. Shared `Total Singles vs Doubles` chart title used for both tabs. |
| [NoteCounts.razor](ScoreTracker/ScoreTracker/Pages/Experiments/NoteCounts.razor) | Page title, Chart Type label, two ChartType-parameterized chart titles (`X Note counts`, `X Progress`), six series names. Enum-display dropdown items left as data. |
| [ChartLetterDifficulties.razor](ScoreTracker/ScoreTracker/Pages/Experiments/ChartLetterDifficulties.razor) | Page title (verbatim `LetterDifficulties` with no space — flagged in resx), two section headers, shared chart title, series names. `5%` / `Q1` / `Q3` / `95%` left hardcoded as universal statistical-quartile/percentile labels. |
| [SimilarPlayers.razor](ScoreTracker/ScoreTracker/Pages/Experiments/SimilarPlayers.razor) | Page title, filter labels, section headers, private-user format `Private User - X`, table headers. |
| [ChartScoringLevels.razor](ScoreTracker/ScoreTracker/Pages/Experiments/ChartScoringLevels.razor) | Page title (verbatim `ChartScoring`), labels, and the bulk documentation prose. The player-row format string composition stays in C#, with `Anonymous` and `Competitively` extracted as reusable word-level keys. |
| [Resources/App.en-US.resx](ScoreTracker/ScoreTracker/Resources/App.en-US.resx) | ~60 new keys. |

## New keys (highlights)

Section headers / page titles: `Bounties`, `Bounty Leaderboard`, `Game Stats`, `Note Counts`, `LetterDifficulties`, `User Matches`, `ChartScoring`, `Player Weights`, `Folder Averages`, `Chart Average`, `Difficulty By Player Level`, `Player Levels`, `Calculated Tier List`, `Similar Players`, `Final Result`

Format keys: `X Note counts`, `X Progress`, `Private User - X`, `All players with scores within the target folder are assigned weights based on how close their competitive level is to X.`, `The weighted average for this chart is better than the average for a X.`, `In this case, the chart is determined to be below by X utilizing standard deviations in the Y folder.`, `Determined to be X between Y and Z`, `Final Result: X`, `This gives this chart a scoring level of: X`

Word-level: `Total`, `Start`, `Monthly Total`, `Median`, `Selected Chart`, `Difficulty By Letter`, `Folder Weighted Distribution`, `Percentile Distribution`, `Letter Difficulty`, `Anonymous`, `Competitively`, `Target Player Level`

Series names (charts): `Minimums`, `Standard Low`, `Standard High`, `Maximums`, `Missing`, `Existing`

Long prose lines (one key per line) for the Chart Scoring algorithm explanation paragraphs.

## Reused

`Place`, `Avatar`, `Player`, `Upload Scores`, `Total` (within file), `Singles`, `Doubles`, `CoOp`, `Average`, `Chart Type`, `Chart`, `Difficulty`, `Song`, `Level`

## Notable judgment calls

- **Source verbatim quirks preserved** with explanatory comments in the resx:
  - Page title `ChartScoring` (no space between "Chart" and "Scoring") on `/Experiments/ChartScoring`.
  - Page title `LetterDifficulties` (no space) on `/Experiments/LetterDifficulties`.
  - `"The weighted average for this chart is worst than the average for a X."` — preserves `worst` rather than `worse`.
- **Player-row format string in `ChartScoringLevels.razor`** (e.g. `"{name} - {weight} (Competitively {level}, {score})"`) intentionally kept as C# string interpolation rather than collapsed into one resx key. The conditional pieces (anonymous-vs-named, score-or-no-score) make a single unified format key fragile; instead, `Anonymous` and `Competitively` are extracted as single-word keys and translators handle the rest of the punctuation/spacing structurally.
- **Statistical-quartile/percentile labels** (`5%`, `Q1`, `Q3`, `95%`) on `ChartLetterDifficulties.razor` left hardcoded — universally recognized.

## Verification

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` — 0 errors, 197 pre-existing warnings.
- [ ] Render the seven Experiments pages: `/Bounties`, `/Distribution`, `/GameStats`, `/NoteCounts`, `/Experiments/LetterDifficulties`, `/Experiments/SimilarPlayers`, `/Experiments/ChartScoring`. Confirm page titles, chart titles/series, table headers, and the Chart Scoring documentation prose all render in English. The `/Experiments/ChartScoring` page exercises the most prose — pick a chart and a player level to make the conditional explanation lines render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)