### PR TITLE
Localize Progress folder (Phase 1, PR #7)

### DIFF
--- a/ScoreTracker/ScoreTracker/Pages/Progress/PhoenixProgress.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/PhoenixProgress.razor
@@ -12,12 +12,12 @@
 @page "/Phoenix/Progress"
 <MudPaper>
     <MudToolBar>
-        <MudText Typo="Typo.h6">Progress</MudText>
+        <MudText Typo="Typo.h6">@L["Progress"]</MudText>
         <MudSpacer></MudSpacer>
 
         @if (CurrentUser.IsLoggedIn && CurrentUser.User.IsPublic && CurrentUser.User.Id == RequestedUserId)
         {
-            <MudTooltip Text="Share Your Progress Page" Inline="true">
+            <MudTooltip Text=@L["Share Your Progress Page"] Inline="true">
                 <MudIconButton Icon="@Icons.Material.Filled.Share" OnClick="() => _showShareDialog = true"></MudIconButton>
             </MudTooltip>
         }
@@ -25,16 +25,16 @@
 
     </MudToolBar>
     <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6" @ref="_tabs">
-        <MudTabPanel Text="Difficulty Progress">
+        <MudTabPanel Text=@L["Difficulty Progress"]>
             <MudTable T="DifficultyEntry" Items="_difficultyEntries" Breakpoint="Breakpoint.None">
                 <HeaderContent>
-                    <MudTh>Level</MudTh>
-                    <MudTh>Passes</MudTh>
-                    <MudTh>Rating</MudTh>
-                    <MudTh>Min Score</MudTh>
-                    <MudTh>Avg Score</MudTh>
-                    <MudTh>Max Score</MudTh>
-                    <MudTh>Avg Plate</MudTh>
+                    <MudTh>@L["Level"]</MudTh>
+                    <MudTh>@L["Passes"]</MudTh>
+                    <MudTh>@L["Rating"]</MudTh>
+                    <MudTh>@L["Min Score"]</MudTh>
+                    <MudTh>@L["Avg Score"]</MudTh>
+                    <MudTh>@L["Max Score"]</MudTh>
+                    <MudTh>@L["Avg Plate"]</MudTh>
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd>@context.Level</MudTd>
@@ -86,33 +86,33 @@
 
 
         </MudTabPanel>
-        <MudTabPanel Text="Passes By Level">
+        <MudTabPanel Text=@L["Passes By Level"]>
             <ApexChart TItem="LevelPass"
-                       Title="Passes By Level">
+                       Title=@L["Passes By Level"]>
                 <ApexPointSeries TItem="LevelPass"
                                  Items="_passBars"
                                  SeriesType="SeriesType.Bar"
-                                 Name="Passes"
+                                 Name=@L["Passes"]
                                  XValue="@(e => e.Level)"
                                  YAggregate="@(e => e.Sum(z => z.Passed))"
                                  OrderBy="e => e.Y"/>
                 <ApexPointSeries TItem="LevelPass"
                                  Items="_passBars"
                                  SeriesType="SeriesType.Bar"
-                                 Name="Remaining"
+                                 Name=@L["Remaining"]
                                  XValue="@(e => e.Level)"
                                  YAggregate="@(e => e.Sum(z => z.Remaining))"
                                  OrderBy="e => e.Y"/>
             </ApexChart>
         </MudTabPanel>
-        <MudTabPanel Text="Score Distribution Lines">
+        <MudTabPanel Text=@L["Score Distribution Lines"]>
             <ApexChart TItem="BoxPlotData"
-                       Title="Score Distribution"
+                       Title=@L["Score Distribution"]
                        @ref="_scoreDistLines"
                        Options="_scoreBoxesOptions">
                 <ApexPointSeries TItem="BoxPlotData"
                                  Items="BoxPlotData.From(_filteredScores.Where(s => s.Score != null).ToArray(), s => _charts[s.ChartId].Level).ToArray()"
-                                 Name="Min"
+                                 Name=@L["Min"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Label)"
                                  YValue="@(e => e.Min)"
@@ -126,7 +126,7 @@
                                  OrderBy="e => e.X"/>
                 <ApexPointSeries TItem="BoxPlotData"
                                  Items="BoxPlotData.From(_filteredScores.Where(s => s.Score != null).ToArray(), s => _charts[s.ChartId].Level).ToArray()"
-                                 Name="Median"
+                                 Name=@L["Median"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Label)"
                                  YValue="@(e => e.Median)"
@@ -141,22 +141,22 @@
 
                 <ApexPointSeries TItem="BoxPlotData"
                                  Items="BoxPlotData.From(_filteredScores.Where(s => s.Score != null).ToArray(), s => _charts[s.ChartId].Level).ToArray()"
-                                 Name="Max"
+                                 Name=@L["Max"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Label)"
                                  YValue="@(e => e.Max)"
                                  OrderBy="e => e.X"/>
             </ApexChart>
         </MudTabPanel>
-        <MudTabPanel Text="Singles vs Doubles">
+        <MudTabPanel Text=@L["Singles vs Doubles"]>
             <ApexChart TItem="BoxPlotData"
-                       Title="Singles vs Doubles"
+                       Title=@L["Singles vs Doubles"]
                        @ref="_sdChart"
                        Options="_scoreBoxesOptions">
                 <ApexPointSeries TItem="BoxPlotData"
                                  Color="#EA3F24"
                                  Items="BoxPlotData.From(_scores.Where(s => s is { Score: not null,IsBroken: false } && _charts[s.ChartId].Type == ChartType.Single).ToArray(), s => _charts[s.ChartId].Level).ToArray()"
-                                 Name="Singles"
+                                 Name=@L["Singles"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Label)"
                                  YValue="@(e => e.Average)"
@@ -164,7 +164,7 @@
                 <ApexPointSeries TItem="BoxPlotData"
                                  Color="#76FA4F"
                                  Items="BoxPlotData.From(_scores.Where(s => s is { Score: not null,IsBroken: false } && _charts[s.ChartId].Type == ChartType.Double).ToArray(), s => _charts[s.ChartId].Level).ToArray()"
-                                 Name="Doubles"
+                                 Name=@L["Doubles"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.Label)"
                                  YValue="@(e => e.Average)"
@@ -177,14 +177,14 @@
 
     <MudDialog @bind-Visible="_showShareDialog">
         <DialogContent>
-            <MudText>Use this link to share your chart list to other players.</MudText>
+            <MudText>@L["Chart List Share Description"]</MudText>
             <br/>
-            <MudTextField Value="@ShareUrl" Label="Share Url" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="true"/>
+            <MudTextField Value="@ShareUrl" Label=@L["Share Url"] Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="true"/>
         </DialogContent>
         <DialogActions>
             <MudSpacer></MudSpacer>
-            <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="CopyShareLink">Copy To Clipboard</MudButton>
-            <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Close" OnClick="() => _showShareDialog = false">Close</MudButton>
+            <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="CopyShareLink">@L["Copy to Clipboard"]</MudButton>
+            <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Close" OnClick="() => _showShareDialog = false">@L["Close"]</MudButton>
         </DialogActions>
     </MudDialog>
 </MudPaper>
@@ -234,7 +234,7 @@
     private async Task CopyShareLink()
     {
         await Javascript.InvokeVoidAsync("navigator.clipboard.writeText", ShareUrl);
-        Snackbar.Add("Copied to clipboard!", Severity.Success);
+        Snackbar.Add(L["Copied to clipboard!"].Value, Severity.Success);
     }
 
     private string ShareUrl => CurrentUser.IsLoggedIn ? $"{NavManager.BaseUri}{CurrentUser.User.Id}/Phoenix/Progress" : string.Empty;
@@ -330,7 +330,7 @@
         var coOpAvgPlate = coOpPlates.Any() ? coOpPlates.Average(p => (int)p) : 0;
         var coOpPlate1 = coOpPlates.Any() ? (PhoenixPlate?)Math.Floor(coOpAvgPlate) : null;
         var coOpPlate2 = coOpPlates.Any() ? (PhoenixPlate?)Math.Ceiling(coOpAvgPlate) : null;
-        entries.Add(new DifficultyEntry("CoOp", coOpPassed, coOpRemaining, (int)coOpTotalRating, (int)coOpRatingRemainnig, coOpMinScore, coOpAvgScore, coOpMaxScore, coOpPlate1, coOpPlate2));
+        entries.Add(new DifficultyEntry(L["CoOp"].Value, coOpPassed, coOpRemaining, (int)coOpTotalRating, (int)coOpRatingRemainnig, coOpMinScore, coOpAvgScore, coOpMaxScore, coOpPlate1, coOpPlate2));
 
         var totalPassed = entries.Sum(e=>e.Passed);
         var totalRemaining = entries.Sum(e=>e.Remaining);
@@ -343,7 +343,7 @@
         var totalAvgPlate = totalPlates.Any() ? totalPlates.Average(p => (int)p) : 0;
         var totalPlate1 = totalPlates.Any() ? (PhoenixPlate?)Math.Floor(totalAvgPlate) : null;
         var totalPlate2 = totalPlates.Any()?(PhoenixPlate?)Math.Ceiling(totalAvgPlate):null;
-        entries.Add(new DifficultyEntry("Total", totalPassed, totalRemaining, (int)totalRanking, (int)totalRemainingRanking, totalMinScore, totalAvgScore, totalMaxScore, totalPlate1, totalPlate2));
+        entries.Add(new DifficultyEntry(L["Total"].Value, totalPassed, totalRemaining, (int)totalRanking, (int)totalRemainingRanking, totalMinScore, totalAvgScore, totalMaxScore, totalPlate1, totalPlate2));
 
         _passBars = DifficultyLevel.All.Select(l => new LevelPass(l, _scores.Count(s => !s.IsBroken && _charts[s.ChartId].Level == l && _charts[s.ChartId].Type!=ChartType.CoOp), _charts.Values.Count(c => c.Level == l && c.Type!=ChartType.CoOp)))
         .ToArray();

--- a/ScoreTracker/ScoreTracker/Pages/Progress/Progress.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/Progress.razor
@@ -3,7 +3,7 @@
 @using ScoreTracker.Domain.Enums
 @using ScoreTracker.Domain.SecondaryPorts
 @using ScoreTracker.Web.Services.Contracts
-<PageTitle>Best Attempts</PageTitle>
+<PageTitle>@L["Best Attempts"]</PageTitle>
 @using MediatR
 @using ScoreTracker.Application.Queries
 @using ScoreTracker.Domain.ValueTypes
@@ -13,17 +13,17 @@
 
 <MudPaper>
 <MudToolBar>
-    <MudText Typo="Typo.h6">XX Progress</MudText>
+    <MudText Typo="Typo.h6">@L["XX Progress"]</MudText>
     <MudSpacer></MudSpacer>
 
-    <MudSelect T="SelectedChartsEnum" Label="Chart Type" Value="_selectedCharts" ValueChanged="ChangeSelectedCharts" FullWidth="false" Style="padding-left: 30px;">
+    <MudSelect T="SelectedChartsEnum" Label=@L["Chart Type"] Value="_selectedCharts" ValueChanged="ChangeSelectedCharts" FullWidth="false" Style="padding-left: 30px;">
         <MudSelectItem T="SelectedChartsEnum" Value="SelectedChartsEnum.All"></MudSelectItem>
         <MudSelectItem T="SelectedChartsEnum" Value="SelectedChartsEnum.Singles"></MudSelectItem>
         <MudSelectItem T="SelectedChartsEnum" Value="SelectedChartsEnum.Doubles"></MudSelectItem>
     </MudSelect>
     @if (CurrentUser.IsLoggedIn && CurrentUser.User.IsPublic && CurrentUser.User.Id == RequestedUserId)
     {
-        <MudTooltip Text="Share Your Progress Page" Inline="true">
+        <MudTooltip Text=@L["Share Your Progress Page"] Inline="true">
             <MudIconButton Icon="@Icons.Material.Filled.Share" OnClick="() => _showShareDialog = true"></MudIconButton>
         </MudTooltip>
     }
@@ -31,33 +31,33 @@
 
 </MudToolBar>
 <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
-    <MudTabPanel Text="Overview">
+    <MudTabPanel Text=@L["Overview"]>
         <MudDataGrid T="DifficultyOverviewDto" ReadOnly="true" Items="_difficultyOverviews" Height="500px" FixedHeader="true" Striped="true" Loading="@_isLoading">
             <ToolBarContent>
             </ToolBarContent>
             <Columns>
-                <PropertyColumn Property="t=>t.Difficulty" Title="Difficulty">
-                    <FooterTemplate>Total</FooterTemplate>
+                <PropertyColumn Property="t=>t.Difficulty" Title=@L["Difficulty"]>
+                    <FooterTemplate>@L["Total"]</FooterTemplate>
                 </PropertyColumn>
-                <PropertyColumn Property="t=>t.ACount" Title="As" AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
-                <PropertyColumn Property="t=>t.SCount" Title="Ss" AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
-                <PropertyColumn Property="t=>t.SSCount" Title="SSs" AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
-                <PropertyColumn Property="t=>t.SSSCount" Title="SSSs" AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
-                <PropertyColumn Property="t=>t.PassedCount" Title="Passed" AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
-                <PropertyColumn Property="t=>t.UnpassedCount" Title="Unpassed" AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
+                <PropertyColumn Property="t=>t.ACount" Title=@L["As"] AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
+                <PropertyColumn Property="t=>t.SCount" Title=@L["Ss"] AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
+                <PropertyColumn Property="t=>t.SSCount" Title=@L["SSs"] AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
+                <PropertyColumn Property="t=>t.SSSCount" Title=@L["SSSs"] AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
+                <PropertyColumn Property="t=>t.PassedCount" Title=@L["Passed"] AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
+                <PropertyColumn Property="t=>t.UnpassedCount" Title=@L["Unpassed"] AggregateDefinition="@(new AggregateDefinition<DifficultyOverviewDto> { Type = AggregateType.Sum, DisplayFormat = "{value}" })"></PropertyColumn>
             </Columns>
         </MudDataGrid>
     </MudTabPanel>
-    <MudTabPanel Text="Overall Letters">
+    <MudTabPanel Text=@L["Overall Letters"]>
         <MudChart ChartType="ChartType.Pie" InputData="@_letterCounts.ToArray()" InputLabels="@_letterLabels.ToArray()" Width="40%" />
     </MudTabPanel>
-    <MudTabPanel Text="Overall Passes">
+    <MudTabPanel Text=@L["Overall Passes"]>
         <MudChart ChartType="ChartType.Pie" InputData="@_passCounts.ToArray()" InputLabels="@_passLabels.ToArray()" Width="40%" />
     </MudTabPanel>
-    <MudTabPanel Text="Difficulty Letters">
+    <MudTabPanel Text=@L["Difficulty Letters"]>
         <MudChart ChartType="ChartType.Bar" ChartSeries="@_letterBreakdown" XAxisLabels="@_difficulties" Width="100%" Height="350px"></MudChart>
     </MudTabPanel>
-    <MudTabPanel Text="Difficulty Passes">
+    <MudTabPanel Text=@L["Difficulty Passes"]>
         <MudChart ChartType="ChartType.Bar" ChartSeries="@_passBreakdown" XAxisLabels="@_difficulties" Width="100%" Height="350px"></MudChart>
     </MudTabPanel>
 </MudTabs>
@@ -65,14 +65,14 @@
 
 <MudDialog @bind-Visible="_showShareDialog">
     <DialogContent>
-        <MudText>Use this link to share your chart list to other players.</MudText>
+        <MudText>@L["Chart List Share Description"]</MudText>
         <br />
-        <MudTextField Value="@ShareUrl" Label="Share Url" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="true" />
+        <MudTextField Value="@ShareUrl" Label=@L["Share Url"] Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="true" />
     </DialogContent>
     <DialogActions>
         <MudSpacer></MudSpacer>
-        <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="CopyShareLink">Copy To Clipboard</MudButton>
-        <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Close" OnClick="()=>_showShareDialog=false">Close</MudButton>
+        <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="CopyShareLink">@L["Copy to Clipboard"]</MudButton>
+        <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Close" OnClick="()=>_showShareDialog=false">@L["Close"]</MudButton>
     </DialogActions>
 </MudDialog>
 </MudPaper>
@@ -104,7 +104,7 @@
     private async Task CopyShareLink()
     {
         await Javascript.InvokeVoidAsync("navigator.clipboard.writeText", ShareUrl);
-        Snackbar.Add("Copied to clipboard!", Severity.Success);
+        Snackbar.Add(L["Copied to clipboard!"].Value, Severity.Success);
     }
 
     private async Task ChangeSelectedCharts(SelectedChartsEnum newType)
@@ -231,12 +231,12 @@
 
         if (ungradedSeries.Any(v => v > 0))
         {
-            letterLabels.Add("Ungraded");
+            letterLabels.Add(L["Ungraded"].Value);
             letterCounts.Add(ungradedSeries.Sum());
             _letterBreakdown.Add(
                 new ChartSeries()
                     {
-                        Name = "Ungraded",
+                        Name = L["Ungraded"].Value,
                         Data = ungradedSeries.ToArray()
                     });
         }
@@ -274,19 +274,19 @@
                     Data = lessThanA
                 });
         }
-        passLabels.Add("Unpassed");
+        passLabels.Add(L["Unpassed"].Value);
         passCounts.Add(passSeries[false].Sum());
-        passLabels.Add("Passed");
+        passLabels.Add(L["Passed"].Value);
         passCounts.Add(passSeries[true].Sum());
         _passBreakdown = new List<ChartSeries>()
         {
             new ChartSeries()
             {
-                Name = "Pass", Data = passSeries[true].ToArray()
+                Name = L["Pass"].Value, Data = passSeries[true].ToArray()
             },
             new ChartSeries()
             {
-                Name = "Unpassed", Data = passSeries[false].ToArray()
+                Name = L["Unpassed"].Value, Data = passSeries[false].ToArray()
             }
         };
         _passLabels = passLabels.ToArray();

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -1341,4 +1341,101 @@
 	  <value>This gives this chart a scoring level of: {0}</value>
 	  <comment>{0} = lowest passing player's competitive level (2 decimals).</comment>
   </data>
+  <data name="Best Attempts" xml:space="preserve">
+	  <value>Best Attempts</value>
+  </data>
+  <data name="XX Progress" xml:space="preserve">
+	  <value>XX Progress</value>
+  </data>
+  <data name="Share Your Progress Page" xml:space="preserve">
+	  <value>Share Your Progress Page</value>
+  </data>
+  <data name="Overview" xml:space="preserve">
+	  <value>Overview</value>
+  </data>
+  <data name="As" xml:space="preserve">
+	  <value>As</value>
+	  <comment>Plural of letter grade A — column header counting A grades.</comment>
+  </data>
+  <data name="Ss" xml:space="preserve">
+	  <value>Ss</value>
+	  <comment>Plural of letter grade S.</comment>
+  </data>
+  <data name="SSs" xml:space="preserve">
+	  <value>SSs</value>
+	  <comment>Plural of letter grade SS.</comment>
+  </data>
+  <data name="SSSs" xml:space="preserve">
+	  <value>SSSs</value>
+	  <comment>Plural of letter grade SSS.</comment>
+  </data>
+  <data name="Passed" xml:space="preserve">
+	  <value>Passed</value>
+  </data>
+  <data name="Unpassed" xml:space="preserve">
+	  <value>Unpassed</value>
+  </data>
+  <data name="Overall Letters" xml:space="preserve">
+	  <value>Overall Letters</value>
+  </data>
+  <data name="Overall Passes" xml:space="preserve">
+	  <value>Overall Passes</value>
+  </data>
+  <data name="Difficulty Letters" xml:space="preserve">
+	  <value>Difficulty Letters</value>
+  </data>
+  <data name="Difficulty Passes" xml:space="preserve">
+	  <value>Difficulty Passes</value>
+  </data>
+  <data name="Share Url" xml:space="preserve">
+	  <value>Share Url</value>
+  </data>
+  <data name="Copied to clipboard!" xml:space="preserve">
+	  <value>Copied to clipboard!</value>
+  </data>
+  <data name="Ungraded" xml:space="preserve">
+	  <value>Ungraded</value>
+  </data>
+  <data name="Pass" xml:space="preserve">
+	  <value>Pass</value>
+  </data>
+  <data name="Difficulty Progress" xml:space="preserve">
+	  <value>Difficulty Progress</value>
+  </data>
+  <data name="Passes" xml:space="preserve">
+	  <value>Passes</value>
+  </data>
+  <data name="Min Score" xml:space="preserve">
+	  <value>Min Score</value>
+  </data>
+  <data name="Avg Score" xml:space="preserve">
+	  <value>Avg Score</value>
+  </data>
+  <data name="Max Score" xml:space="preserve">
+	  <value>Max Score</value>
+  </data>
+  <data name="Avg Plate" xml:space="preserve">
+	  <value>Avg Plate</value>
+  </data>
+  <data name="Passes By Level" xml:space="preserve">
+	  <value>Passes By Level</value>
+  </data>
+  <data name="Remaining" xml:space="preserve">
+	  <value>Remaining</value>
+  </data>
+  <data name="Score Distribution Lines" xml:space="preserve">
+	  <value>Score Distribution Lines</value>
+  </data>
+  <data name="Score Distribution" xml:space="preserve">
+	  <value>Score Distribution</value>
+  </data>
+  <data name="Min" xml:space="preserve">
+	  <value>Min</value>
+  </data>
+  <data name="Max" xml:space="preserve">
+	  <value>Max</value>
+  </data>
+  <data name="Singles vs Doubles" xml:space="preserve">
+	  <value>Singles vs Doubles</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary

Phase 1 PR #7 — `Pages/Progress/`. 2 files, 31 new keys, 13 reused. 155+/58- diff. Build clean.

## Files changed

| File | Notes |
|---|---|
| [Pages/Progress/Progress.razor](ScoreTracker/ScoreTracker/Pages/Progress/Progress.razor) | XX-mix progress page. Page title, header, Chart Type filter, share tooltip, five tab titles, seven Overview-grid column headers, share dialog, snackbar, chart-series labels in code. |
| [Pages/Progress/PhoenixProgress.razor](ScoreTracker/ScoreTracker/Pages/Progress/PhoenixProgress.razor) | Phoenix-mix progress page. Header, share dialog (matching keys shared with Progress.razor), Difficulty Progress tab + 7 table headers, three other tab titles, chart titles, series names, snackbar, and two C#-constructed DifficultyEntry level labels. |

## New keys (31)

Page chrome: `Best Attempts`, `XX Progress`, `Share Your Progress Page`, `Overview`, `Difficulty Progress`, `Passes By Level`, `Score Distribution Lines`, `Singles vs Doubles`, `Score Distribution`, `Overall Letters`, `Overall Passes`, `Difficulty Letters`, `Difficulty Passes`

Column headers / labels: `As`, `Ss`, `SSs`, `SSSs` (letter-grade plurals — explanatory resx comments), `Passed`, `Unpassed`, `Passes`, `Min Score`, `Avg Score`, `Max Score`, `Avg Plate`, `Share Url`

Series / data labels: `Ungraded`, `Pass`, `Remaining`, `Min`, `Max`

Snackbar: `Copied to clipboard!`

## Reused

`Chart Type`, `Difficulty`, `Total`, `Chart List Share Description`, `Copy to Clipboard`, `Close`, `Progress`, `Level`, `Rating`, `Singles`, `Doubles`, `Median`, `CoOp`

## Notable judgment calls

- **Cosmetic source-code casing reconciled at extraction time**: the MudButton text `"Copy To Clipboard"` (capital T) maps to the existing key `"Copy to Clipboard"` (lowercase t) rather than minting a near-duplicate. Translators get one key. This is the only place I deviated from strict English-as-key-verbatim and it was to dedupe.
- **`"B,C,D,F"`** aggregate-series label in `Progress.razor` left hardcoded — letter-grade abbreviations read the same in any language.
- **`Q1` / `Q3`** chart series labels in `PhoenixProgress.razor` left hardcoded — universal stats notation, consistent with the call made in PR #6.
- **`"CoOp"` and `"Total"`** strings in `PhoenixProgress.razor`'s `DifficultyEntry(...)` constructor calls localized via `L["..."].Value` so the Level column on the Difficulty Progress tab renders translated. These are existing keys.

## Verification

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` — 0 errors.
- [ ] Render `/Progress` (XX mix) and `/Phoenix/Progress` while logged in. Click each tab on both pages and verify titles + table/chart labels render in English. Open the share dialog to confirm the dialog text + buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)