### PR TITLE
Localize Competition folder (Phase 1, PR #8 — final)

### DIFF
--- a/ScoreTracker/ScoreTracker/Pages/Competition/MatchTournamentAdmin.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Competition/MatchTournamentAdmin.razor
@@ -7,35 +7,35 @@
 @using ScoreTracker.Domain.Enums
 @using ScoreTracker.Domain.Records
 @using System.Text.RegularExpressions
-<PageTitle>@TournamentName Brackets</PageTitle>
+<PageTitle>@L["X Brackets", TournamentName]</PageTitle>
 <MudGrid>
     <MudItem xs="12">
-        <MudText Typo="Typo.h4">Players</MudText>
+        <MudText Typo="Typo.h4">@L["Players"]</MudText>
     </MudItem>
     <MudItem xs="12">
-        <MudButton Color="Color.Primary" OnClick="SyncQualifiers" Variant="Variant.Filled" Disabled="_isLoading">Sync Qualifier Leaderboard</MudButton>
+        <MudButton Color="Color.Primary" OnClick="SyncQualifiers" Variant="Variant.Filled" Disabled="_isLoading">@L["Sync Qualifier Leaderboard"]</MudButton>
     </MudItem>
     <MudItem xs="10">
-        <MudTextField @bind-Value="_newPlayerName" Label="New Player Name"></MudTextField>
+        <MudTextField @bind-Value="_newPlayerName" Label=@L["New Player Name"]></MudTextField>
     </MudItem>
     <MudItem xs="2">
-        <MudButton Color="Color.Primary" Disabled="_isLoading || string.IsNullOrWhiteSpace(_newPlayerName) || _players.ContainsKey(_newPlayerName)" Variant="Variant.Filled" OnClick="AddPlayer">Add Player</MudButton>
+        <MudButton Color="Color.Primary" Disabled="_isLoading || string.IsNullOrWhiteSpace(_newPlayerName) || _players.ContainsKey(_newPlayerName)" Variant="Variant.Filled" OnClick="AddPlayer">@L["Add Player"]</MudButton>
     </MudItem>
     <MudItem xs="12">
         <MudTable T="MatchPlayer" Items="_players.Values">
             <HeaderContent>
-                <MudTh><MudTableSortLabel T="MatchPlayer" SortBy="c=>c.Name">Player Name</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel T="MatchPlayer" SortBy="c=>c.Seed">Seed</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel T="MatchPlayer" SortBy="c=>c.DiscordId??0">Discord Id</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel T="MatchPlayer" SortBy="c=>c.Notes">Notes</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel T="MatchPlayer" SortBy="c=>c.PotentialConflict">Potential Conflict</MudTableSortLabel></MudTh>
-                <MudTh>Delete</MudTh>
+                <MudTh><MudTableSortLabel T="MatchPlayer" SortBy="c=>c.Name">@L["Player Name"]</MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel T="MatchPlayer" SortBy="c=>c.Seed">@L["Seed"]</MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel T="MatchPlayer" SortBy="c=>c.DiscordId??0">@L["Discord Id"]</MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel T="MatchPlayer" SortBy="c=>c.Notes">@L["Notes"]</MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel T="MatchPlayer" SortBy="c=>c.PotentialConflict">@L["Potential Conflict"]</MudTableSortLabel></MudTh>
+                <MudTh>@L["Delete"]</MudTh>
             </HeaderContent>
             <RowTemplate>
                 <MudTd>@context.Name</MudTd>
-                <MudTd><MudNumericField T="int" Disabled="_isLoading" InputMode="InputMode.numeric" HideSpinButtons="true" Label="Seed" Value="context.Seed" ValueChanged="n=>SetPlayer(context with {Seed=n})"></MudNumericField></MudTd>
-                <MudTd><MudNumericField T="ulong?" Disabled="_isLoading" InputMode="InputMode.numeric" HideSpinButtons="true" Label="Discord Id" Value="context.DiscordId" ValueChanged="n=>SetPlayer(context with {DiscordId = n})" Clearable="true"></MudNumericField></MudTd>
-                <MudTd><MudTextField T="string" Disabled="_isLoading" Label="Notes" Value="context.Notes" ValueChanged="n=>SetPlayer(context with {Notes=n})"></MudTextField></MudTd>
+                <MudTd><MudNumericField T="int" Disabled="_isLoading" InputMode="InputMode.numeric" HideSpinButtons="true" Label=@L["Seed"] Value="context.Seed" ValueChanged="n=>SetPlayer(context with {Seed=n})"></MudNumericField></MudTd>
+                <MudTd><MudNumericField T="ulong?" Disabled="_isLoading" InputMode="InputMode.numeric" HideSpinButtons="true" Label=@L["Discord Id"] Value="context.DiscordId" ValueChanged="n=>SetPlayer(context with {DiscordId = n})" Clearable="true"></MudNumericField></MudTd>
+                <MudTd><MudTextField T="string" Disabled="_isLoading" Label=@L["Notes"] Value="context.Notes" ValueChanged="n=>SetPlayer(context with {Notes=n})"></MudTextField></MudTd>
                 <MudTd><MudCheckBox T="bool" Disabled="_isLoading" Value="context.PotentialConflict" ValueChanged="n=>SetPlayer(context with {PotentialConflict=n})"></MudCheckBox></MudTd>
                 <MudTd><MudIconButton Disabled="_isLoading" Color="Color.Warning" Icon="@Icons.Material.Filled.Delete" OnClick="()=>DeletePlayer(context.Name)"></MudIconButton></MudTd>
             </RowTemplate>
@@ -47,10 +47,10 @@
     <MudItem xs="12">
     </MudItem>
     <MudItem xs="12">
-        <MudText Typo="Typo.h4">Permissions</MudText>
+        <MudText Typo="Typo.h4">@L["Permissions"]</MudText>
     </MudItem>
     <MudItem xs="12">
-        <MudAutocomplete Dense="true" Disabled="_isLoading" T="string" Value="_selectedUser" ValueChanged="SelectPlayer" MaxItems="15" CoerceValue="true" CoerceText="false" Label="Players (Paste UserId from Account Page if not Public)" SearchFunc="(s,c)=>Task.FromResult(_userSearchOptions.Where(o=>string.IsNullOrWhiteSpace(s)||o.Contains(s,StringComparison.OrdinalIgnoreCase)))">
+        <MudAutocomplete Dense="true" Disabled="_isLoading" T="string" Value="_selectedUser" ValueChanged="SelectPlayer" MaxItems="15" CoerceValue="true" CoerceText="false" Label=@L["Players (Paste UserId from Account Page if not Public)"] SearchFunc="(s,c)=>Task.FromResult(_userSearchOptions.Where(o=>string.IsNullOrWhiteSpace(s)||o.Contains(s,StringComparison.OrdinalIgnoreCase)))">
         </MudAutocomplete>
     </MudItem>
     @if (_selectedUserId != null)
@@ -58,7 +58,7 @@
         <MudItem xs="12" sm="4">@_publicUsers[_selectedUserId.Value]</MudItem>
         <MudItem xs="12" sm="4">
 
-            <MudSelect T="TournamentRole" Disabled="_isLoading" @bind-Value="_newRole" Label="Tournament Role">
+            <MudSelect T="TournamentRole" Disabled="_isLoading" @bind-Value="_newRole" Label=@L["Tournament Role"]>
                 @foreach (var role in Enum.GetValues<TournamentRole>())
                 {
                     <MudSelectItem T="TournamentRole" Value="@role">@role.GetName()</MudSelectItem>
@@ -66,7 +66,7 @@
             </MudSelect>
         </MudItem>
         <MudItem xs="12" sm="4">
-            <MudButton Color="Color.Primary" Disabled="_isLoading" OnClick="()=>SetRole(_selectedUserId.Value,_newRole)">Add</MudButton>
+            <MudButton Color="Color.Primary" Disabled="_isLoading" OnClick="()=>SetRole(_selectedUserId.Value,_newRole)">@L["Add"]</MudButton>
         </MudItem>
     }
     @foreach (var role in _tournamentRoles.Where(r=>_publicUsers.ContainsKey(r.Key)))
@@ -75,7 +75,7 @@
             @_publicUsers[role.Key]
         </MudItem>
         <MudItem xs="5">
-            <MudSelect T="TournamentRole" Disabled="_isLoading" Value="role.Value" ValueChanged="r=>SetRole(role.Key,r)" Label="Tournament Role">
+            <MudSelect T="TournamentRole" Disabled="_isLoading" Value="role.Value" ValueChanged="r=>SetRole(role.Key,r)" Label=@L["Tournament Role"]>
                 @foreach (var r in Enum.GetValues<TournamentRole>())
                 {
                     <MudSelectItem T="TournamentRole" Value="@r">@r.GetName()</MudSelectItem>
@@ -88,15 +88,15 @@
     }
     <MudItem xs="12">
         <br/>
-        <MudText Typo="Typo.h4">Machines</MudText>
+        <MudText Typo="Typo.h4">@L["Machines"]</MudText>
     </MudItem>
     <MudItem xs="12">
         <MudTable T="MatchMachineRecord" Items="_machines.OrderBy(m => m.IsWarmup).ThenBy(m => m.Priority)" Breakpoint="Breakpoint.None">
             <HeaderContent>
-                <MudTh>Machine Name</MudTh>
-                <MudTh>Is Warmup</MudTh>
-                <MudTh>Priority</MudTh>
-                <MudTh>Delete</MudTh>
+                <MudTh>@L["Machine Name"]</MudTh>
+                <MudTh>@L["Is Warmup"]</MudTh>
+                <MudTh>@L["Priority"]</MudTh>
+                <MudTh>@L["Delete"]</MudTh>
             </HeaderContent>
             <RowTemplate>
                 <MudTd>@context.MachineName</MudTd>
@@ -116,16 +116,16 @@
         </MudTable>
     </MudItem>
     <MudItem xs="12" sm="4">
-        <MudTextField T="string" @bind-Value="_machineName" Label="Machine Name" MaxLength="32"></MudTextField>
+        <MudTextField T="string" @bind-Value="_machineName" Label=@L["Machine Name"] MaxLength="32"></MudTextField>
     </MudItem>
     <MudItem xs="12" sm="3">
-        <MudCheckBox T="bool" @bind-Value="_isWarmup" Label="Is Warmup"></MudCheckBox>
+        <MudCheckBox T="bool" @bind-Value="_isWarmup" Label=@L["Is Warmup"]></MudCheckBox>
     </MudItem>
     <MudItem xs="12" sm="3">
-        <MudNumericField T="int" @bind-Value="_priority" Label="Priority"></MudNumericField>
+        <MudNumericField T="int" @bind-Value="_priority" Label=@L["Priority"]></MudNumericField>
     </MudItem>
     <MudItem xs="12" sm="2">
-        <MudButton StartIcon="@Icons.Material.Filled.Add" Disabled="_isLoading || string.IsNullOrWhiteSpace(_machineName)" OnClick="AddMachine">Add</MudButton>
+        <MudButton StartIcon="@Icons.Material.Filled.Add" Disabled="_isLoading || string.IsNullOrWhiteSpace(_machineName)" OnClick="AddMachine">@L["Add"]</MudButton>
     </MudItem>
 </MudGrid>
 <br/>
@@ -194,7 +194,7 @@
         await Matches.SaveMatchPlayer(TournamentId, player, CancellationToken.None);
         _players[_newPlayerName] = player;
         _newPlayerName = string.Empty;
-        Snackbar.Add("Player added", Severity.Success);
+        Snackbar.Add(L["Player added"].Value, Severity.Success);
         _isLoading = false;
     }
     private async Task SelectPlayer(string selected)
@@ -213,7 +213,7 @@
             _isLoading = false;
             if (user == null)
             {
-                Snackbar.Add("This user does not exist. Double check the User Id", Severity.Error);
+                Snackbar.Add(L["This user does not exist. Double check the User Id"].Value, Severity.Error);
                 return;
             }
             _publicUsers[user.Id] = user.Name;
@@ -269,7 +269,7 @@
             }
             await Matches.SaveMatchPlayer(TournamentId, _players[player.UserName], CancellationToken.None);
         }
-        Snackbar.Add("Players synced", Severity.Success);
+        Snackbar.Add(L["Players synced"].Value, Severity.Success);
         _isLoading = false;
     }
     protected override async Task OnInitializedAsync()

--- a/ScoreTracker/ScoreTracker/Pages/Competition/ScoreRankings.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Competition/ScoreRankings.razor
@@ -8,12 +8,12 @@
 @using ScoreTracker.Domain.ValueTypes
 @using ChartType = ScoreTracker.Domain.Enums.ChartType
 @using ScoreTracker.Web.Components
-<PageTitle>Score Rankings</PageTitle>
+<PageTitle>@L["Score Rankings"]</PageTitle>
 
-<MudText Typo="Typo.h5">Scoring Rankings</MudText>
-<MudText>Score Rankings (the colored scores) are based on comparisons to similarly skilled players.</MudText>
+<MudText Typo="Typo.h5">@L["Scoring Rankings"]</MudText>
+<MudText>@L["Score Rankings (the colored scores) are based on comparisons to similarly skilled players."]</MudText>
 <br/>
-<MudText>The higher percent of players in your range that you perform better than, the better the color:</MudText>
+<MudText>@L["The higher percent of players in your range that you perform better than, the better the color:"]</MudText>
 <br/>
 <MudText Style="color:#BDBDBD">0% -> 10%</MudText>
 <MudText Style="color:#FAFAFA">10% -> 25%</MudText>
@@ -21,17 +21,17 @@
 <MudText Style="color:#1565C0">50% -> 75%</MudText>
 <MudText Style="color:#7E57C2">75% -> 90%</MudText>
 <MudText Style="color:#EC407A">90% -> 99%</MudText>
-<MudText Style="color:#FB8C00">100% (or everyone with a PG)</MudText>
+<MudText Style="color:#FB8C00">@L["100% (or everyone with a PG)"]</MudText>
 <br/>
-<MudText Typo="Typo.h6">Similarly skilled players to you for Singles:</MudText>
+<MudText Typo="Typo.h6">@L["Similarly skilled players to you for Singles:"]</MudText>
 <MudTable T="User" Items="_comparableUsersSingles">
     <HeaderContent>
-        <MudTh>Avatar</MudTh>
+        <MudTh>@L["Avatar"]</MudTh>
         <MudTh>
-            <MudTableSortLabel T="User" SortBy=@(u=>u.IsPublic?u.Name:"Anonymous")>Player</MudTableSortLabel>
+            <MudTableSortLabel T="User" SortBy=@(u=>u.IsPublic?u.Name:"Anonymous")>@L["Player"]</MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel T="User" SortBy="u=>_competitiveLevelSingles[u.Id]">Level</MudTableSortLabel>
+            <MudTableSortLabel T="User" SortBy="u=>_competitiveLevelSingles[u.Id]">@L["Level"]</MudTableSortLabel>
         </MudTh>
     </HeaderContent>
     <RowTemplate>
@@ -48,7 +48,7 @@
             }
             else
             {
-                <MudText>Anonymous</MudText>
+                <MudText>@L["Anonymous"]</MudText>
             }
         </MudTd>
         <MudTd>
@@ -57,18 +57,18 @@
     </RowTemplate>
 </MudTable>
 <br/>
-<MudText Typo="Typo.h6">Similarly skilled players to you for Doubles (CoOp charts use doubles competitive level):</MudText>
+<MudText Typo="Typo.h6">@L["Similarly skilled players to you for Doubles (CoOp charts use doubles competitive level):"]</MudText>
 <MudTable T="User" Items="_comparableUsersDoubles">
     <HeaderContent>
-        <MudTh>Avatar</MudTh>
+        <MudTh>@L["Avatar"]</MudTh>
         <MudTh>
-            <MudTableSortLabel T="User" SortBy=@(u=>u.IsPublic?u.Name:"Anonymous")>Player</MudTableSortLabel>
+            <MudTableSortLabel T="User" SortBy=@(u=>u.IsPublic?u.Name:"Anonymous")>@L["Player"]</MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel T="User" SortBy="u=>_competitiveLevelDoubles[u.Id]">Level</MudTableSortLabel>
+            <MudTableSortLabel T="User" SortBy="u=>_competitiveLevelDoubles[u.Id]">@L["Level"]</MudTableSortLabel>
         </MudTh>
     </HeaderContent>
-    
+
     <RowTemplate>
         <MudTd>
             @if (context.IsPublic)
@@ -83,7 +83,7 @@
             }
             else
             {
-                <MudText>Anonymous</MudText>
+                <MudText>@L["Anonymous"]</MudText>
             }
         </MudTd>
         <MudTd>

--- a/ScoreTracker/ScoreTracker/Pages/Competition/SessionBuilder.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Competition/SessionBuilder.razor
@@ -15,13 +15,13 @@
 @using System.Text.Json
 @using System.Text.Json.Serialization
 
-<PageTitle>Stamina Session Builder</PageTitle>
+<PageTitle>@L["Stamina Session Builder"]</PageTitle>
 
-<MudText Typo="Typo.h3">Tournament Settings</MudText>
+<MudText Typo="Typo.h3">@L["Tournament Settings"]</MudText>
 <MudGrid>
     <MudItem xs="12">
-        <MudSelect T="Guid?" Label="PreBuilt Tournament Configuration" Value="_currentTourney" ValueChanged="SelectTourney" Clearable>
-            <MudSelectItem T="Guid?" Value="null">Default</MudSelectItem>
+        <MudSelect T="Guid?" Label=@L["PreBuilt Tournament Configuration"] Value="_currentTourney" ValueChanged="SelectTourney" Clearable>
+            <MudSelectItem T="Guid?" Value="null">@L["Default"]</MudSelectItem>
             @foreach (var tourney in _tournaments.Where(t=>t.Type==TournamentType.Stamina).OrderByDescending(t=>t.StartDate??t.EndDate??DateTimeOffset.MinValue))
             {
                 <MudSelectItem T="Guid?" Value="@tourney.Id">@tourney.Name</MudSelectItem>
@@ -45,7 +45,7 @@
 <br/>
 <MudExpansionPanels>
 
-    <MudExpansionPanel Text="Levels">
+    <MudExpansionPanel Text=@L["Levels"]>
         <MudGrid>
             @foreach (var level in DifficultyLevel.All)
             {
@@ -55,7 +55,7 @@
             }
         </MudGrid>
     </MudExpansionPanel>
-    <MudExpansionPanel Text="Chart Types">
+    <MudExpansionPanel Text=@L["Chart Types"]>
         <MudGrid>
             @foreach (var chartType in Enum.GetValues<ChartType>())
             {
@@ -66,10 +66,10 @@
         </MudGrid>
     </MudExpansionPanel>
 
-    <MudExpansionPanel Text="Song Types">
+    <MudExpansionPanel Text=@L["Song Types"]>
         <MudGrid>
             <MudItem xs="12">
-                <MudSwitch T="bool" Color="Color.Primary" Label="Adjust Scores to Song Duration (uses 2 minutes as average chart duration)" @bind-Value="Configuration.Scoring.AdjustToTime"></MudSwitch>
+                <MudSwitch T="bool" Color="Color.Primary" Label=@L["Adjust Scores to Song Duration (uses 2 minutes as average chart duration)"] @bind-Value="Configuration.Scoring.AdjustToTime"></MudSwitch>
             </MudItem>
             @foreach (var songType in Enum.GetValues<SongType>())
             {
@@ -79,10 +79,10 @@
             }
         </MudGrid>
         </MudExpansionPanel>
-    <MudExpansionPanel Text="Letter Grades">
+    <MudExpansionPanel Text=@L["Letter Grades"]>
         <MudGrid>
             <MudItem xs="12">
-                <MudSwitch T="bool" Label="Continous Modifier Scale (modifier increments between letter grades)" Color="Color.Primary" @bind-Value="Configuration.Scoring.ContinuousLetterGradeScale"></MudSwitch>
+                <MudSwitch T="bool" Label=@L["Continous Modifier Scale (modifier increments between letter grades)"] Color="Color.Primary" @bind-Value="Configuration.Scoring.ContinuousLetterGradeScale"></MudSwitch>
             </MudItem>
             @foreach (var letterGrade in Enum.GetValues<PhoenixLetterGrade>())
             {
@@ -91,14 +91,14 @@
                 </MudItem>
             }
             <MudItem xs="12">
-                <MudNumericField T="double" Min="0" Max="100" Label="Perfect Score Modifier (Acts as a letter grade beyond SSS+)" @bind-Value="Configuration.Scoring.PgLetterGradeModifier" Clearable="true" HideSpinButtons="true"></MudNumericField>
+                <MudNumericField T="double" Min="0" Max="100" Label=@L["Perfect Score Modifier (Acts as a letter grade beyond SSS+)"] @bind-Value="Configuration.Scoring.PgLetterGradeModifier" Clearable="true" HideSpinButtons="true"></MudNumericField>
             </MudItem>
             <MudItem xs="12">
-                <MudNumericField T="int" Min="0" Max="1000000" Label="Minimum Score" @bind-Value="Configuration.Scoring.MinimumScore" HideSpinButtons="true"></MudNumericField>
+                <MudNumericField T="int" Min="0" Max="1000000" Label=@L["Minimum Score"] @bind-Value="Configuration.Scoring.MinimumScore" HideSpinButtons="true"></MudNumericField>
             </MudItem>
         </MudGrid>
     </MudExpansionPanel>
-    <MudExpansionPanel Text="Plates">
+    <MudExpansionPanel Text=@L["Plates"]>
         <MudGrid>
             @foreach (var plate in Enum.GetValues<PhoenixPlate>())
             {
@@ -110,17 +110,17 @@
     </MudExpansionPanel>
     @if (CurrentUser.IsLoggedInAsAdmin)
     {
-        
-        <MudExpansionPanel Text="Charts">
+
+        <MudExpansionPanel Text=@L["Charts"]>
             <MudGrid>
                 <MudItem xs="12">
-                    <MudTextField Lines="3" Label="Input Json" @bind-Value="ChartJson"></MudTextField>
+                    <MudTextField Lines="3" Label=@L["Input Json"] @bind-Value="ChartJson"></MudTextField>
                 </MudItem>
                 <MudItem xs="12">
                     <MudText>I.E: { "Kugutsu S25":1.25, "Leather D26":2.3 }</MudText>
                 </MudItem>
                 <MudItem xs="12">
-                    <MudButton OnClick="SetCharts" Color="Color.Primary" Variant="Variant.Filled">Set Charts</MudButton>
+                    <MudButton OnClick="SetCharts" Color="Color.Primary" Variant="Variant.Filled">@L["Set Charts"]</MudButton>
                 </MudItem>
                 <MudItem xs="12">
                     @foreach (var error in NotParsed)
@@ -131,19 +131,19 @@
             </MudGrid>
         </MudExpansionPanel>
     }
-    <MudExpansionPanel Text="Extra Settings">
+    <MudExpansionPanel Text=@L["Extra Settings"]>
         <MudGrid>
             <MudItem xs="6">
-                <MudSwitch T="bool" Label="Allow Repeats" @bind-Value="Configuration.AllowRepeats" Color="Color.Primary"></MudSwitch>
+                <MudSwitch T="bool" Label=@L["Allow Repeats"] @bind-Value="Configuration.AllowRepeats" Color="Color.Primary"></MudSwitch>
             </MudItem>
             <MudItem xs="6">
-                <MudNumericField T="double" Min="0" Max="100" Label="Stage Break Modifier" @bind-Value="Configuration.Scoring.StageBreakModifier"></MudNumericField>
+                <MudNumericField T="double" Min="0" Max="100" Label=@L["Stage Break Modifier"] @bind-Value="Configuration.Scoring.StageBreakModifier"></MudNumericField>
             </MudItem>
             <MudItem xs="6">
-                <MudNumericField T="int" Label="Session Duration (Minutes)" Value="(int)Configuration.MaxTime.TotalMinutes" ValueChanged="m => Configuration.MaxTime = TimeSpan.FromMinutes(m)"></MudNumericField>
+                <MudNumericField T="int" Label=@L["Session Duration (Minutes)"] Value="(int)Configuration.MaxTime.TotalMinutes" ValueChanged="m => Configuration.MaxTime = TimeSpan.FromMinutes(m)"></MudNumericField>
             </MudItem>
             <MudItem xs="12">
-                <MudTextField T="string" Label="Custom Scoring Formula" @bind-Value="Configuration.Scoring.CustomAlgorithm" Clearable="true"></MudTextField>
+                <MudTextField T="string" Label=@L["Custom Scoring Formula"] @bind-Value="Configuration.Scoring.CustomAlgorithm" Clearable="true"></MudTextField>
             </MudItem>
             <MudItem xs="12">
                 <MudText>
@@ -162,16 +162,16 @@
     </MudExpansionPanel>
     @if (CurrentUser.IsLoggedIn && CurrentUser.User.IsAdmin)
     {
-        <MudExpansionPanel Text="Admin Settings">
+        <MudExpansionPanel Text=@L["Admin Settings"]>
             <MudGrid>
                 <MudItem xs="12">
-                    <MudDateRangePicker Label="Tournament Dates (EST)" @bind-DateRange="_dateRange" Clearable="true" Color="Color.Primary"/>
+                    <MudDateRangePicker Label=@L["Tournament Dates (EST)"] @bind-DateRange="_dateRange" Clearable="true" Color="Color.Primary"/>
                 </MudItem>
                 <MudItem xs="12">
-                    <MudTextField T="string" Value="Configuration.Name" ValueChanged="s => Configuration.Name = s" Label="Tournament Name"></MudTextField>
+                    <MudTextField T="string" Value="Configuration.Name" ValueChanged="s => Configuration.Name = s" Label=@L["Tournament Name"]></MudTextField>
                 </MudItem>
                 <MudItem xs="12">
-                    <MudButton Color="Color.Primary" OnClick="SaveTourney" Variant="Variant.Filled">Save</MudButton>
+                    <MudButton Color="Color.Primary" OnClick="SaveTourney" Variant="Variant.Filled">@L["Save"]</MudButton>
                 </MudItem>
             </MudGrid>
         </MudExpansionPanel>
@@ -180,19 +180,19 @@
 <br/>
 
 }
-<MudText Typo="Typo.h3">Test With Player Data</MudText>
+<MudText Typo="Typo.h3">@L["Test With Player Data"]</MudText>
 <br/>
-<MudButton Href="/UploadPhoenixScores" Icon="@Icons.Material.Filled.UploadFile" Variant="Variant.Filled" Color="Color.Primary">Import Your Phoenix Scores</MudButton>
+<MudButton Href="/UploadPhoenixScores" Icon="@Icons.Material.Filled.UploadFile" Variant="Variant.Filled" Color="Color.Primary">@L["Import Your Phoenix Scores"]</MudButton>
 
 <br/>
-<MudSwitch Label="Hide Record-less Charts" @bind-Value="_hideUnRecordedCharts" Color="Color.Primary"></MudSwitch>
+<MudSwitch Label=@L["Hide Record-less Charts"] @bind-Value="_hideUnRecordedCharts" Color="Color.Primary"></MudSwitch>
 <br/>
-<MudSwitch Label="Hide Zero Scoring Charts" @bind-Value="_hideZeroScoredCharts" Color="Color.Primary"></MudSwitch>
+<MudSwitch Label=@L["Hide Zero Scoring Charts"] @bind-Value="_hideZeroScoredCharts" Color="Color.Primary"></MudSwitch>
 <br/>
 @if (CurrentUser.IsLoggedInAsAdmin)
 {
 
-    <MudSelect T="Guid?" Value="_currentUser" Clearable="true" ValueChanged="SetUser" Label="Player To Test (Must Be Set To Public)">
+    <MudSelect T="Guid?" Value="_currentUser" Clearable="true" ValueChanged="SetUser" Label=@L["Player To Test (Must Be Set To Public)"]>
         @foreach (var user in _users)
         {
             <MudSelectItem T="Guid?" Value="user.Id">@user.Name.ToString() (@user.Id)</MudSelectItem>
@@ -201,28 +201,28 @@
 }
 <MudDataGrid T="ChartSessionEffectiveness" Items="@Scores">
     <Columns>
-        <TemplateColumn T="ChartSessionEffectiveness" Title="Difficulty" Sortable="true" SortBy="x=>x.Level">
+        <TemplateColumn T="ChartSessionEffectiveness" Title=@L["Difficulty"] Sortable="true" SortBy="x=>x.Level">
             <CellTemplate>
                 <DifficultyBubble Chart="context.Item.Chart"></DifficultyBubble>
             </CellTemplate>
         </TemplateColumn>
-        <TemplateColumn T="ChartSessionEffectiveness" Title="Song" Sortable="true" SortBy="x=>x.Chart.Song.Name">
+        <TemplateColumn T="ChartSessionEffectiveness" Title=@L["Song"] Sortable="true" SortBy="x=>x.Chart.Song.Name">
             <CellTemplate>
                 <SongImage Song="context.Item.Chart.Song"></SongImage>
             </CellTemplate>
         </TemplateColumn>
-        <PropertyColumn Property="x=>x.EffectiveLevel" Title="Effective Level" Sortable="true"></PropertyColumn>
-        
-        <TemplateColumn T="ChartSessionEffectiveness" Title="Your Score" Sortable="true" SortBy="x => x.Score??0">
+        <PropertyColumn Property="x=>x.EffectiveLevel" Title=@L["Effective Level"] Sortable="true"></PropertyColumn>
+
+        <TemplateColumn T="ChartSessionEffectiveness" Title=@L["Your Score"] Sortable="true" SortBy="x => x.Score??0">
             <CellTemplate>
                 <ScoreBreakdown Score="context.Item.Score" OneLine="true"></ScoreBreakdown>
             </CellTemplate>
         </TemplateColumn>
-        <PropertyColumn Property="x => x.Seconds" Title="Seconds" Sortable="true" />
-        <PropertyColumn Property="x => x.PointsWithoutScore" Title="Points Pre-Score" Sortable="true" />
-        <PropertyColumn Property="x => x.PointsPerSecondPReScore" Title="Points Per Second Pre-Score" Sortable="true" />
-        <PropertyColumn Property="x => x.Points" Title="Your Points" Sortable="true"/>
-        <PropertyColumn Property="x => x.PointsPerSecond" Title="Your Points per Second" Sortable="true"/>
+        <PropertyColumn Property="x => x.Seconds" Title=@L["Seconds"] Sortable="true" />
+        <PropertyColumn Property="x => x.PointsWithoutScore" Title=@L["Points Pre-Score"] Sortable="true" />
+        <PropertyColumn Property="x => x.PointsPerSecondPReScore" Title=@L["Points Per Second Pre-Score"] Sortable="true" />
+        <PropertyColumn Property="x => x.Points" Title=@L["Your Points"] Sortable="true"/>
+        <PropertyColumn Property="x => x.PointsPerSecond" Title=@L["Your Points per Second"] Sortable="true"/>
     </Columns>
     <PagerContent>
         <MudDataGridPager T="ChartSessionEffectiveness" />
@@ -232,36 +232,36 @@
 <br/>
 <MudGrid>
     <MudItem xs="12">
-        <MudText Typo="Typo.h3">Example Set Builder</MudText>
+        <MudText Typo="Typo.h3">@L["Example Set Builder"]</MudText>
     </MudItem>
     <MudItem xs="6">
-        <MudNumericField Min="10" Max="300" HideSpinButtons="true" @bind-Value="_restSeconds" Label="Seconds of Rest Per Chart"></MudNumericField>
+        <MudNumericField Min="10" Max="300" HideSpinButtons="true" @bind-Value="_restSeconds" Label=@L["Seconds of Rest Per Chart"]></MudNumericField>
     </MudItem>
     <MudItem xs="6">
-        <MudButton Color="Color.Primary" OnClick="BuildSession" Variant="Variant.Filled">Build Session</MudButton>
+        <MudButton Color="Color.Primary" OnClick="BuildSession" Variant="Variant.Filled">@L["Build Session"]</MudButton>
     </MudItem>
     @if (_currentSession != null)
     {
         <MudItem xs="4">
-            <MudText>Score: @_currentSession.TotalScore</MudText>
+            <MudText>@L["Score: X", _currentSession.TotalScore]</MudText>
         </MudItem>
         <MudItem xs="4">
-            <MudText>Total Charts: @_currentSession.Entries.Count()</MudText>
+            <MudText>@L["Total Charts: X", _currentSession.Entries.Count()]</MudText>
         </MudItem>
         <MudItem xs="4">
-            <MudText>Rest Time Per Chart: @_currentSession.AverageTimeBetweenCharts.ToString(@"m\:ss")</MudText>
+            <MudText>@L["Rest Time Per Chart: X", _currentSession.AverageTimeBetweenCharts.ToString(@"m\:ss")]</MudText>
         </MudItem>
         <MudItem xs="4">
-            <MudText>Song</MudText>
+            <MudText>@L["Song"]</MudText>
         </MudItem>
         <MudItem xs="2">
-            <MudText>Duration</MudText>
+            <MudText>@L["Duration"]</MudText>
         </MudItem>
         <MudItem xs="4">
-            <MudText>Chart Score</MudText>
+            <MudText>@L["Chart Score"]</MudText>
         </MudItem>
         <MudItem xs="2">
-            <MudText>Session Score</MudText>
+            <MudText>@L["Session Score"]</MudText>
         </MudItem>
         @foreach (var entry in _currentSession.Entries)
         {
@@ -305,7 +305,7 @@
         var results = JsonSerializer.Deserialize<IDictionary<string, double>>(ChartJson);
         if (results == null)
         {
-            NotParsed.Add("Couldn't parse JSON");
+            NotParsed.Add(L["Couldn't parse JSON"].Value);
             return;
         }
         foreach (var kv in results)

--- a/ScoreTracker/ScoreTracker/Pages/Competition/StaminaTournament.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Competition/StaminaTournament.razor
@@ -5,53 +5,53 @@
 @using ScoreTracker.Domain.Enums
 @using ScoreTracker.Domain.ValueTypes
 @using ScoreTracker.Web.Components
-<PageTitle>Tournament</PageTitle>
+<PageTitle>@L["Tournament"]</PageTitle>
 @if (_isLoaded)
 {
-    
+
     <MudText Typo="Typo.h3">@_configuration.Name</MudText>
     <br/>
     <MudGrid>
         <MudItem xs="6" sm="3">
             @if (_configuration.IsActive)
             {
-                <MudButton Href=@($"/Tournament/Stamina/{TournamentId}/Record") Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Edit">Record Session</MudButton>
+                <MudButton Href=@($"/Tournament/Stamina/{TournamentId}/Record") Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Edit">@L["Record Session"]</MudButton>
             }
         </MudItem>
         <MudItem xs="6" sm="3">
-            <MudButton Href=@($"/SessionBuilder?TournamentId={TournamentId}") Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.QuestionAnswer">Test Scores</MudButton>
+            <MudButton Href=@($"/SessionBuilder?TournamentId={TournamentId}") Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.QuestionAnswer">@L["Test Scores"]</MudButton>
         </MudItem>
     </MudGrid>
     <br/>
-    <MudSwitch Label="Show Extra Info" @bind-Value="_showExtraData" Color="Color.Primary"></MudSwitch>
+    <MudSwitch Label=@L["Show Extra Info"] @bind-Value="_showExtraData" Color="Color.Primary"></MudSwitch>
     <br/>
     <MudTable T="LeaderboardRecord" Items="_leaderboard" FixedHeader="true" Striped="true">
         <HeaderContent>
-            <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.Place">Place</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.UserName">Player</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.TotalScore">Score</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.ChartsPlayed">Chart Count</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.AverageDifficulty">Difficulty Range</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.Place">@L["Place"]</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.UserName">@L["Player"]</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.TotalScore">@L["Score"]</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.ChartsPlayed">@L["Chart Count"]</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.AverageDifficulty">@L["Difficulty Range"]</MudTableSortLabel></MudTh>
             @if (_showExtraData)
             {
-                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.AverageDifficulty">Average Difficulty</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.AverageScore">Average Score</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.TotalBonusScore">Total Chart Bonus</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.PassRate">Pass Rate</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.AveragePps">Average PPS</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.TotalRestTime">Rest Time</MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.AverageDifficulty">@L["Average Difficulty"]</MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.AverageScore">@L["Average Score"]</MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.TotalBonusScore">@L["Total Chart Bonus"]</MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.PassRate">@L["Pass Rate"]</MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.AveragePps">@L["Average PPS"]</MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel T="LeaderboardRecord" SortBy="e=>e.TotalRestTime">@L["Rest Time"]</MudTableSortLabel></MudTh>
             }
-            <MudTh>Verification</MudTh>
+            <MudTh>@L["Verification"]</MudTh>
             @if (CurrentUser.IsLoggedInAsAdmin && _showExtraData)
             {
-                <MudTh>Edit</MudTh>
+                <MudTh>@L["Edit"]</MudTh>
             }
         </HeaderContent>
         <RowTemplate>
             <MudTd>@context.Place</MudTd>
             <MudTd>@context.UserName</MudTd>
             <MudTd>@context.TotalScore</MudTd>
-            <MudTd><MudButton StartIcon="@Icons.Material.Filled.ViewList" Color="Color.Primary" Variant="Variant.Outlined" Disabled="_isLoadingUser" OnClick="()=>ShowUserCharts(context.UserId)">@context.ChartsPlayed Charts</MudButton></MudTd>
+            <MudTd><MudButton StartIcon="@Icons.Material.Filled.ViewList" Color="Color.Primary" Variant="Variant.Outlined" Disabled="_isLoadingUser" OnClick="()=>ShowUserCharts(context.UserId)">@L["X Charts", context.ChartsPlayed]</MudButton></MudTd>
             <MudTd>@context.LowestLevel - @context.HighestLevel</MudTd>
             @if (_showExtraData)
             {
@@ -69,30 +69,30 @@
             <MudTd>
                 @if (context.NeedsApproval)
                 {
-                    <MudText>Pending</MudText>
-                    
+                    <MudText>@L["Pending"]</MudText>
+
                 }
                 else
                 {
                     @switch (context.VerificationType)
                     {
                         case SubmissionVerificationType.Unverified:
-                            <MudText>None</MudText>
+                            <MudText>@L["None"]</MudText>
                             break;
                         case SubmissionVerificationType.Photo:
-                            <MudButton StartIcon="@Icons.Material.Filled.PhotoLibrary" Color="Color.Primary" OnClick="()=>ShowPhotos(context.UserId)">Photos</MudButton>
+                            <MudButton StartIcon="@Icons.Material.Filled.PhotoLibrary" Color="Color.Primary" OnClick="()=>ShowPhotos(context.UserId)">@L["Photos"]</MudButton>
                             break;
                         case SubmissionVerificationType.Video:
-                            <MudButton Color="Color.Primary" StartIcon="@Icons.Material.Filled.MusicVideo" Href="@(context.VideoUrl?.ToString()??"")" Target="_blank">Video</MudButton>
+                            <MudButton Color="Color.Primary" StartIcon="@Icons.Material.Filled.MusicVideo" Href="@(context.VideoUrl?.ToString()??"")" Target="_blank">@L["Video"]</MudButton>
                             break;
                         case SubmissionVerificationType.InPerson:
                             @if (context.VideoUrl != null)
                             {
-                                <MudButton Color="Color.Primary" StartIcon="@Icons.Material.Filled.MusicVideo" Href="@(context.VideoUrl?.ToString()??"")" Target="_blank">In Person</MudButton>
+                                <MudButton Color="Color.Primary" StartIcon="@Icons.Material.Filled.MusicVideo" Href="@(context.VideoUrl?.ToString()??"")" Target="_blank">@L["In Person"]</MudButton>
                             }
                             else
                             {
-                                <MudText>In Person</MudText>
+                                <MudText>@L["In Person"]</MudText>
                             }
                             break;
                         default:
@@ -103,7 +103,7 @@
             @if (CurrentUser.IsLoggedInAsAdmin && _showExtraData)
             {
                 <MudTd>
-                    <MudButton Href="@UserSessionlink(context.UserId)" Color="Color.Primary" Variant="Variant.Filled">Edit</MudButton>
+                    <MudButton Href="@UserSessionlink(context.UserId)" Color="Color.Primary" Variant="Variant.Filled">@L["Edit"]</MudButton>
                 </MudTd>
             }
         </RowTemplate>
@@ -138,13 +138,13 @@
                                 <MudItem xs="12">
                                     <ApexChart TItem="TimelinePoint"
                                                @ref=_timelineChart
-                                               Title="Estimated Point Gain Timeline"
+                                               Title=@L["Estimated Point Gain Timeline"]
                                                XAxisType="XAxisType.Numeric"
                                                Options="_scoreBoxesOptions">
                                         <ApexPointSeries TItem="TimelinePoint"
                                                          Color="#00FFFF"
                                                          Items="_timeline"
-                                                         Name="Points Per Second"
+                                                         Name=@L["Points Per Second"]
                                                          SeriesType="SeriesType.Line"
                                                          XValue="@(e => e.MinutesIn)"
                                                          YValue="@(e => (decimal)e.PointsPerSecond)"
@@ -152,7 +152,7 @@
                                         <ApexPointSeries TItem="TimelinePoint"
                                                          Color="#FFFFFF"
                                                          Items="new []{new TimelinePoint(0,_averagePps),new TimelinePoint(_timeline.Last().MinutesIn,_averagePps)}"
-                                                         Name="Average"
+                                                         Name=@L["Average"]
                                                          SeriesType="SeriesType.Line"
                                                          XValue="@(e => e.MinutesIn)"
                                                          YValue="@(e => (decimal)e.PointsPerSecond)"
@@ -169,15 +169,15 @@
         </ChildRowContent>
     </MudTable>
     <br/>
-    <MudText Typo="Typo.h3">Chart Statistics</MudText>
+    <MudText Typo="Typo.h3">@L["Chart Statistics"]</MudText>
     <br/>
     <MudTable T="ChartStatistics" Items="_chartStats" FixedHeader="true" Striped="true">
         <HeaderContent>
-            <MudTh><MudTableSortLabel T="ChartStatistics" SortBy="e=>e.Chart.Song.Name">Song</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel T="ChartStatistics" SortBy="e=>e.Chart.Level">Difficulty</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel T="ChartStatistics" SortBy="e=>e.PlayCount">Play Count</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel T="ChartStatistics" SortBy="e=>(int)e.AverageScore">Average Score</MudTableSortLabel></MudTh>
-            <MudTh>Best Score</MudTh>
+            <MudTh><MudTableSortLabel T="ChartStatistics" SortBy="e=>e.Chart.Song.Name">@L["Song"]</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="ChartStatistics" SortBy="e=>e.Chart.Level">@L["Difficulty"]</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="ChartStatistics" SortBy="e=>e.PlayCount">@L["Play Count"]</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="ChartStatistics" SortBy="e=>(int)e.AverageScore">@L["Average Score"]</MudTableSortLabel></MudTh>
+            <MudTh>@L["Best Score"]</MudTh>
         </HeaderContent>
         <RowTemplate>
 
@@ -191,7 +191,7 @@
                 <DifficultyBubble Chart="context.Chart"></DifficultyBubble>
 
             </MudTd>
-            <MudTd><MudButton StartIcon="@Icons.Material.Filled.ViewList" Color="Color.Primary" Variant="Variant.Outlined" OnClick="()=>ToggleBoard(context.Chart.Id)">@context.PlayCount Plays</MudButton></MudTd>
+            <MudTd><MudButton StartIcon="@Icons.Material.Filled.ViewList" Color="Color.Primary" Variant="Variant.Outlined" OnClick="()=>ToggleBoard(context.Chart.Id)">@L["X Plays", context.PlayCount]</MudButton></MudTd>
             <MudTd>@context.AverageScore</MudTd>
             <MudTd>@context.Scores.First()</MudTd>
         </RowTemplate>
@@ -229,7 +229,7 @@
     </DialogContent>
     <DialogActions>
         <MudSpacer></MudSpacer>
-        <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Close" OnClick="() => _showPhotoDialog = false">Close</MudButton>
+        <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Close" OnClick="() => _showPhotoDialog = false">@L["Close"]</MudButton>
     </DialogActions>
 </MudDialog>
 @inject ITournamentRepository TournamentRepository;

--- a/ScoreTracker/ScoreTracker/Pages/Competition/Tournaments.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Competition/Tournaments.razor
@@ -5,36 +5,36 @@
 @using ScoreTracker.Domain.Enums
 @using ScoreTracker.Domain.Models
 @using ScoreTracker.Domain.Records
-<PageTitle>Tournaments</PageTitle>
+<PageTitle>@L["Tournaments"]</PageTitle>
 
 @if (_active.Any())
 {
 
-    <MudText Typo="Typo.h4">Active Tournaments</MudText>
+    <MudText Typo="Typo.h4">@L["Active Tournaments"]</MudText>
     <MudDataGrid T="TournamentRecord" Items="_active">
         <Columns>
-            <PropertyColumn T="TournamentRecord" TProperty="string" Property="x => x.Name" Title="Tournament" Sortable="false"></PropertyColumn>
-            <TemplateColumn T="TournamentRecord" Title="Start Date" Sortable="true" SortBy="x => x.StartDate ?? DateTimeOffset.MinValue">
+            <PropertyColumn T="TournamentRecord" TProperty="string" Property="x => x.Name" Title=@L["Tournament"] Sortable="false"></PropertyColumn>
+            <TemplateColumn T="TournamentRecord" Title=@L["Start Date"] Sortable="true" SortBy="x => x.StartDate ?? DateTimeOffset.MinValue">
                 <CellTemplate>
                     <MudText>@(context.Item.StartDate?.ToString("D")??"")</MudText>
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="End Date" Sortable="true" SortBy="x => x.EndDate ?? DateTimeOffset.MaxValue">
+            <TemplateColumn T="TournamentRecord" Title=@L["End Date"] Sortable="true" SortBy="x => x.EndDate ?? DateTimeOffset.MaxValue">
                 <CellTemplate>
                     <MudText>@(context.Item.EndDate?.ToString("D")??"")</MudText>
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="Type" Sortable="false">
+            <TemplateColumn T="TournamentRecord" Title=@L["Type"] Sortable="false">
                 <CellTemplate>
                     @context.Item.Type
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="Location" Sortable="false">
+            <TemplateColumn T="TournamentRecord" Title=@L["Location"] Sortable="false">
                 <CellTemplate>
                     @context.Item.Location
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="Link" Sortable="false">
+            <TemplateColumn T="TournamentRecord" Title=@L["Link"] Sortable="false">
                 <CellTemplate>
                     @if (context.Item.LinkOverride != null)
                     {
@@ -53,31 +53,31 @@
 {
     <br/>
     <br/>
-    <MudText Typo="Typo.h4">Upcoming Tournaments</MudText>
+    <MudText Typo="Typo.h4">@L["Upcoming Tournaments"]</MudText>
     <MudDataGrid T="TournamentRecord" Items="_upcoming">
         <Columns>
-            <PropertyColumn T="TournamentRecord" TProperty="string" Property="x => x.Name" Title="Tournament" Sortable="false"></PropertyColumn>
-            <TemplateColumn T="TournamentRecord" Title="Start Date" Sortable="true" SortBy="x => x.StartDate ?? DateTimeOffset.MinValue">
+            <PropertyColumn T="TournamentRecord" TProperty="string" Property="x => x.Name" Title=@L["Tournament"] Sortable="false"></PropertyColumn>
+            <TemplateColumn T="TournamentRecord" Title=@L["Start Date"] Sortable="true" SortBy="x => x.StartDate ?? DateTimeOffset.MinValue">
                 <CellTemplate>
                     <MudText>@(context.Item.StartDate?.ToString("D")??"")</MudText>
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="End Date" Sortable="true" SortBy="x => x.EndDate ?? DateTimeOffset.MaxValue">
+            <TemplateColumn T="TournamentRecord" Title=@L["End Date"] Sortable="true" SortBy="x => x.EndDate ?? DateTimeOffset.MaxValue">
                 <CellTemplate>
                     <MudText>@(context.Item.EndDate?.ToString("D")??"")</MudText>
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="Type" Sortable="false">
+            <TemplateColumn T="TournamentRecord" Title=@L["Type"] Sortable="false">
                 <CellTemplate>
                     @context.Item.Type
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="Location" Sortable="false">
+            <TemplateColumn T="TournamentRecord" Title=@L["Location"] Sortable="false">
                 <CellTemplate>
                     @context.Item.Location
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="Link" Sortable="false">
+            <TemplateColumn T="TournamentRecord" Title=@L["Link"] Sortable="false">
                 <CellTemplate>
                     @if (context.Item.LinkOverride != null)
                     {
@@ -97,31 +97,31 @@
     
     <br/>
     <br/>
-    <MudText Typo="Typo.h4">Previous Tournaments</MudText>
+    <MudText Typo="Typo.h4">@L["Previous Tournaments"]</MudText>
     <MudDataGrid T="TournamentRecord" Items="_previous">
         <Columns>
-            <PropertyColumn T="TournamentRecord" TProperty="string" Property="x => x.Name" Title="Tournament" Sortable="false"></PropertyColumn>
-            <TemplateColumn T="TournamentRecord" Title="Start Date" Sortable="true" SortBy="x => x.StartDate ?? DateTimeOffset.MinValue">
+            <PropertyColumn T="TournamentRecord" TProperty="string" Property="x => x.Name" Title=@L["Tournament"] Sortable="false"></PropertyColumn>
+            <TemplateColumn T="TournamentRecord" Title=@L["Start Date"] Sortable="true" SortBy="x => x.StartDate ?? DateTimeOffset.MinValue">
                 <CellTemplate>
                     <MudText>@(context.Item.StartDate?.ToString("D")??"")</MudText>
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="End Date" Sortable="true" SortBy="x => x.EndDate ?? DateTimeOffset.MaxValue">
+            <TemplateColumn T="TournamentRecord" Title=@L["End Date"] Sortable="true" SortBy="x => x.EndDate ?? DateTimeOffset.MaxValue">
                 <CellTemplate>
                     <MudText>@(context.Item.EndDate?.ToString("D")??"")</MudText>
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="Type" Sortable="false">
+            <TemplateColumn T="TournamentRecord" Title=@L["Type"] Sortable="false">
                 <CellTemplate>
                     @context.Item.Type
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="Location" Sortable="false">
+            <TemplateColumn T="TournamentRecord" Title=@L["Location"] Sortable="false">
                 <CellTemplate>
                     @context.Item.Location
                 </CellTemplate>
             </TemplateColumn>
-            <TemplateColumn T="TournamentRecord" Title="Link" Sortable="false">
+            <TemplateColumn T="TournamentRecord" Title=@L["Link"] Sortable="false">
                 <CellTemplate>
                     @if (context.Item.LinkOverride != null)
                     {
@@ -142,11 +142,11 @@
             <MudItem xs="12">
                 <MudText Typo="Typo.h4">@_currentConfig.Name</MudText>
             </MudItem>
-            <MudItem xs="12">Start Date: @(_currentConfig.StartDate?.ToString(@"D") ?? "Always")</MudItem>
-            <MudItem xs="12">End Date: @(_currentConfig.EndDate?.ToString(@"D") ?? "Never")</MudItem>
-            <MudItem xs="12">Players have @(_currentConfig.MaxTime.ToString(@"h\:mm")) to play charts. You are allowed to finish the song you are on when your time runs out. Your total score is total combined score of all charts you play.</MudItem>
+            <MudItem xs="12">@L["Start Date: X", _currentConfig.StartDate?.ToString(@"D") ?? L["Always"].Value]</MudItem>
+            <MudItem xs="12">@L["End Date: X", _currentConfig.EndDate?.ToString(@"D") ?? L["Never"].Value]</MudItem>
+            <MudItem xs="12">@L["Players have X to play charts. You are allowed to finish the song you are on when your time runs out. Your total score is total combined score of all charts you play.", _currentConfig.MaxTime.ToString(@"h\:mm")]</MudItem>
             <MudItem xs="6" sm="3">
-                <MudMenu Label="Base Level Scores" Variant="Variant.Filled">
+                <MudMenu Label=@L["Base Level Scores"] Variant="Variant.Filled">
                     @foreach (var kv in _currentConfig.Scoring.LevelRatings.OrderBy(l => (int)l.Key).Where(kv => kv.Value > 0))
                     {
                         <MudMenuItem>@kv.Key - @kv.Value</MudMenuItem>
@@ -154,7 +154,7 @@
                 </MudMenu>
             </MudItem>
             <MudItem xs="6" sm="3">
-                <MudMenu Label="Song Types" Variant="Variant.Filled">
+                <MudMenu Label=@L["Song Types"] Variant="Variant.Filled">
                     @foreach (var kv in _currentConfig.Scoring.SongTypeModifiers.Where(kv => kv.Value > 0))
                     {
                         <MudMenuItem>@kv.Key @(Math.Abs(kv.Value - 1) < .001?"":$"- {@kv.Value}X")</MudMenuItem>
@@ -162,7 +162,7 @@
                 </MudMenu>
             </MudItem>
             <MudItem xs="6" sm="3">
-                <MudMenu Label="Chart Types" Variant="Variant.Filled">
+                <MudMenu Label=@L["Chart Types"] Variant="Variant.Filled">
                     @foreach (var kv in _currentConfig.Scoring.ChartTypeModifiers.Where(kv => kv.Value > 0))
                     {
                         <MudMenuItem>@kv.Key @(Math.Abs(kv.Value - 1) < .001?"":$"- {@kv.Value}X")</MudMenuItem>
@@ -170,7 +170,7 @@
                 </MudMenu>
             </MudItem>
             <MudItem xs="6" sm="3">
-                <MudMenu Label="Letter Grades" Variant="Variant.Filled">
+                <MudMenu Label=@L["Letter Grades"] Variant="Variant.Filled">
                     @foreach (var kv in _currentConfig.Scoring.LetterGradeModifiers.OrderBy(kv => kv.Key).Where(kv => kv.Value > 0))
                     {
                         <MudMenuItem>@kv.Key.GetName() @(Math.Abs(kv.Value - 1) < .001?"":$"- {@kv.Value}X")</MudMenuItem>
@@ -178,7 +178,7 @@
                 </MudMenu>
             </MudItem>
             <MudItem xs="6" sm="3">
-                <MudMenu Label="Plates" Variant="Variant.Filled">
+                <MudMenu Label=@L["Plates"] Variant="Variant.Filled">
                     @foreach (var kv in _currentConfig.Scoring.PlateModifiers.OrderBy(kv=>kv.Key).Where(kv => kv.Value > 0))
                     {
                         <MudMenuItem>@kv.Key.GetShorthand() @(Math.Abs(kv.Value - 1) < .001 ? "" : $"- {@kv.Value}X")</MudMenuItem>
@@ -188,21 +188,21 @@
 
             @if (Math.Abs(_currentConfig.Scoring.StageBreakModifier - 1) > .0001)
             {
-                <MudItem xs="12">Broken scores get a multiplier of @_currentConfig.Scoring.StageBreakModifier</MudItem>
+                <MudItem xs="12">@L["Broken scores get a multiplier of X", _currentConfig.Scoring.StageBreakModifier]</MudItem>
             }
             @if (_currentConfig.Scoring.AdjustToTime)
             {
-                <MudItem xs="12">Songs will have score adjusted based on song length (treating 2 minutes as baseline)</MudItem>
+                <MudItem xs="12">@L["Songs will have score adjusted based on song length (treating 2 minutes as baseline)"]</MudItem>
             }
             <MudItem xs="12">
-                Repeated charts @(_currentConfig.AllowRepeats ? "are" : "are not") allowed.
+                @L["Repeated charts X allowed.", _currentConfig.AllowRepeats ? L["are"].Value : L["are not"].Value]
             </MudItem>
 
         </MudGrid>
     </DialogContent>
     <DialogActions>
         <MudSpacer></MudSpacer>
-        <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Close" OnClick="() => _showRules = false">Close</MudButton>
+        <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Close" OnClick="() => _showRules = false">@L["Close"]</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -1438,4 +1438,333 @@
   <data name="Singles vs Doubles" xml:space="preserve">
 	  <value>Singles vs Doubles</value>
   </data>
+  <data name="Score Rankings" xml:space="preserve">
+	  <value>Score Rankings</value>
+  </data>
+  <data name="Scoring Rankings" xml:space="preserve">
+	  <value>Scoring Rankings</value>
+  </data>
+  <data name="Score Rankings (the colored scores) are based on comparisons to similarly skilled players." xml:space="preserve">
+	  <value>Score Rankings (the colored scores) are based on comparisons to similarly skilled players.</value>
+  </data>
+  <data name="The higher percent of players in your range that you perform better than, the better the color:" xml:space="preserve">
+	  <value>The higher percent of players in your range that you perform better than, the better the color:</value>
+  </data>
+  <data name="100% (or everyone with a PG)" xml:space="preserve">
+	  <value>100% (or everyone with a PG)</value>
+	  <comment>Top color band on /ScoreRankings.</comment>
+  </data>
+  <data name="Similarly skilled players to you for Singles:" xml:space="preserve">
+	  <value>Similarly skilled players to you for Singles:</value>
+  </data>
+  <data name="Similarly skilled players to you for Doubles (CoOp charts use doubles competitive level):" xml:space="preserve">
+	  <value>Similarly skilled players to you for Doubles (CoOp charts use doubles competitive level):</value>
+  </data>
+  <data name="Active Tournaments" xml:space="preserve">
+	  <value>Active Tournaments</value>
+  </data>
+  <data name="Upcoming Tournaments" xml:space="preserve">
+	  <value>Upcoming Tournaments</value>
+  </data>
+  <data name="Previous Tournaments" xml:space="preserve">
+	  <value>Previous Tournaments</value>
+  </data>
+  <data name="Tournament" xml:space="preserve">
+	  <value>Tournament</value>
+  </data>
+  <data name="Start Date" xml:space="preserve">
+	  <value>Start Date</value>
+  </data>
+  <data name="End Date" xml:space="preserve">
+	  <value>End Date</value>
+  </data>
+  <data name="Location" xml:space="preserve">
+	  <value>Location</value>
+  </data>
+  <data name="Always" xml:space="preserve">
+	  <value>Always</value>
+	  <comment>Fallback for tournament StartDate when not set.</comment>
+  </data>
+  <data name="Never" xml:space="preserve">
+	  <value>Never</value>
+	  <comment>Fallback for tournament EndDate when not set.</comment>
+  </data>
+  <data name="Start Date: X" xml:space="preserve">
+	  <value>Start Date: {0}</value>
+	  <comment>{0} = formatted date string or the localized "Always" fallback.</comment>
+  </data>
+  <data name="End Date: X" xml:space="preserve">
+	  <value>End Date: {0}</value>
+	  <comment>{0} = formatted date string or the localized "Never" fallback.</comment>
+  </data>
+  <data name="Players have X to play charts. You are allowed to finish the song you are on when your time runs out. Your total score is total combined score of all charts you play." xml:space="preserve">
+	  <value>Players have {0} to play charts. You are allowed to finish the song you are on when your time runs out. Your total score is total combined score of all charts you play.</value>
+	  <comment>{0} = MaxTime as h:mm.</comment>
+  </data>
+  <data name="Base Level Scores" xml:space="preserve">
+	  <value>Base Level Scores</value>
+  </data>
+  <data name="Broken scores get a multiplier of X" xml:space="preserve">
+	  <value>Broken scores get a multiplier of {0}</value>
+	  <comment>{0} = StageBreakModifier value.</comment>
+  </data>
+  <data name="Songs will have score adjusted based on song length (treating 2 minutes as baseline)" xml:space="preserve">
+	  <value>Songs will have score adjusted based on song length (treating 2 minutes as baseline)</value>
+  </data>
+  <data name="are" xml:space="preserve">
+	  <value>are</value>
+	  <comment>Used in "Repeated charts {are/are not} allowed." sentence on the rules dialog.</comment>
+  </data>
+  <data name="are not" xml:space="preserve">
+	  <value>are not</value>
+	  <comment>Used in "Repeated charts {are/are not} allowed." sentence on the rules dialog.</comment>
+  </data>
+  <data name="Repeated charts X allowed." xml:space="preserve">
+	  <value>Repeated charts {0} allowed.</value>
+	  <comment>{0} = "are" or "are not" (also localized as separate keys).</comment>
+  </data>
+  <data name="X Brackets" xml:space="preserve">
+	  <value>{0} Brackets</value>
+	  <comment>Page title on /Tournament/{id}/Admin. {0} = tournament name.</comment>
+  </data>
+  <data name="Sync Qualifier Leaderboard" xml:space="preserve">
+	  <value>Sync Qualifier Leaderboard</value>
+  </data>
+  <data name="New Player Name" xml:space="preserve">
+	  <value>New Player Name</value>
+  </data>
+  <data name="Add Player" xml:space="preserve">
+	  <value>Add Player</value>
+  </data>
+  <data name="Player Name" xml:space="preserve">
+	  <value>Player Name</value>
+  </data>
+  <data name="Seed" xml:space="preserve">
+	  <value>Seed</value>
+  </data>
+  <data name="Discord Id" xml:space="preserve">
+	  <value>Discord Id</value>
+  </data>
+  <data name="Notes" xml:space="preserve">
+	  <value>Notes</value>
+  </data>
+  <data name="Potential Conflict" xml:space="preserve">
+	  <value>Potential Conflict</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+	  <value>Delete</value>
+  </data>
+  <data name="Permissions" xml:space="preserve">
+	  <value>Permissions</value>
+  </data>
+  <data name="Players (Paste UserId from Account Page if not Public)" xml:space="preserve">
+	  <value>Players (Paste UserId from Account Page if not Public)</value>
+  </data>
+  <data name="Tournament Role" xml:space="preserve">
+	  <value>Tournament Role</value>
+  </data>
+  <data name="Machines" xml:space="preserve">
+	  <value>Machines</value>
+  </data>
+  <data name="Machine Name" xml:space="preserve">
+	  <value>Machine Name</value>
+  </data>
+  <data name="Is Warmup" xml:space="preserve">
+	  <value>Is Warmup</value>
+  </data>
+  <data name="Priority" xml:space="preserve">
+	  <value>Priority</value>
+  </data>
+  <data name="Player added" xml:space="preserve">
+	  <value>Player added</value>
+  </data>
+  <data name="This user does not exist. Double check the User Id" xml:space="preserve">
+	  <value>This user does not exist. Double check the User Id</value>
+  </data>
+  <data name="Players synced" xml:space="preserve">
+	  <value>Players synced</value>
+  </data>
+  <data name="Record Session" xml:space="preserve">
+	  <value>Record Session</value>
+  </data>
+  <data name="Test Scores" xml:space="preserve">
+	  <value>Test Scores</value>
+  </data>
+  <data name="Show Extra Info" xml:space="preserve">
+	  <value>Show Extra Info</value>
+  </data>
+  <data name="Difficulty Range" xml:space="preserve">
+	  <value>Difficulty Range</value>
+  </data>
+  <data name="Average Difficulty" xml:space="preserve">
+	  <value>Average Difficulty</value>
+  </data>
+  <data name="Total Chart Bonus" xml:space="preserve">
+	  <value>Total Chart Bonus</value>
+  </data>
+  <data name="Pass Rate" xml:space="preserve">
+	  <value>Pass Rate</value>
+  </data>
+  <data name="Average PPS" xml:space="preserve">
+	  <value>Average PPS</value>
+  </data>
+  <data name="Rest Time" xml:space="preserve">
+	  <value>Rest Time</value>
+  </data>
+  <data name="Verification" xml:space="preserve">
+	  <value>Verification</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+	  <value>Edit</value>
+  </data>
+  <data name="X Charts" xml:space="preserve">
+	  <value>{0} Charts</value>
+	  <comment>{0} = chart count integer. Button label on /Tournament/Stamina/{id}.</comment>
+  </data>
+  <data name="In Person" xml:space="preserve">
+	  <value>In Person</value>
+  </data>
+  <data name="Estimated Point Gain Timeline" xml:space="preserve">
+	  <value>Estimated Point Gain Timeline</value>
+  </data>
+  <data name="Points Per Second" xml:space="preserve">
+	  <value>Points Per Second</value>
+  </data>
+  <data name="Chart Statistics" xml:space="preserve">
+	  <value>Chart Statistics</value>
+  </data>
+  <data name="Play Count" xml:space="preserve">
+	  <value>Play Count</value>
+  </data>
+  <data name="Best Score" xml:space="preserve">
+	  <value>Best Score</value>
+  </data>
+  <data name="X Plays" xml:space="preserve">
+	  <value>{0} Plays</value>
+	  <comment>{0} = play count integer.</comment>
+  </data>
+  <data name="Stamina Session Builder" xml:space="preserve">
+	  <value>Stamina Session Builder</value>
+  </data>
+  <data name="Tournament Settings" xml:space="preserve">
+	  <value>Tournament Settings</value>
+  </data>
+  <data name="PreBuilt Tournament Configuration" xml:space="preserve">
+	  <value>PreBuilt Tournament Configuration</value>
+  </data>
+  <data name="Default" xml:space="preserve">
+	  <value>Default</value>
+  </data>
+  <data name="Levels" xml:space="preserve">
+	  <value>Levels</value>
+  </data>
+  <data name="Adjust Scores to Song Duration (uses 2 minutes as average chart duration)" xml:space="preserve">
+	  <value>Adjust Scores to Song Duration (uses 2 minutes as average chart duration)</value>
+  </data>
+  <data name="Continous Modifier Scale (modifier increments between letter grades)" xml:space="preserve">
+	  <value>Continous Modifier Scale (modifier increments between letter grades)</value>
+	  <comment>Source spelling preserved verbatim ("Continous" rather than "Continuous").</comment>
+  </data>
+  <data name="Perfect Score Modifier (Acts as a letter grade beyond SSS+)" xml:space="preserve">
+	  <value>Perfect Score Modifier (Acts as a letter grade beyond SSS+)</value>
+  </data>
+  <data name="Minimum Score" xml:space="preserve">
+	  <value>Minimum Score</value>
+  </data>
+  <data name="Input Json" xml:space="preserve">
+	  <value>Input Json</value>
+  </data>
+  <data name="Set Charts" xml:space="preserve">
+	  <value>Set Charts</value>
+  </data>
+  <data name="Extra Settings" xml:space="preserve">
+	  <value>Extra Settings</value>
+  </data>
+  <data name="Allow Repeats" xml:space="preserve">
+	  <value>Allow Repeats</value>
+  </data>
+  <data name="Stage Break Modifier" xml:space="preserve">
+	  <value>Stage Break Modifier</value>
+  </data>
+  <data name="Session Duration (Minutes)" xml:space="preserve">
+	  <value>Session Duration (Minutes)</value>
+  </data>
+  <data name="Custom Scoring Formula" xml:space="preserve">
+	  <value>Custom Scoring Formula</value>
+  </data>
+  <data name="Admin Settings" xml:space="preserve">
+	  <value>Admin Settings</value>
+  </data>
+  <data name="Tournament Dates (EST)" xml:space="preserve">
+	  <value>Tournament Dates (EST)</value>
+  </data>
+  <data name="Tournament Name" xml:space="preserve">
+	  <value>Tournament Name</value>
+  </data>
+  <data name="Test With Player Data" xml:space="preserve">
+	  <value>Test With Player Data</value>
+  </data>
+  <data name="Import Your Phoenix Scores" xml:space="preserve">
+	  <value>Import Your Phoenix Scores</value>
+  </data>
+  <data name="Hide Record-less Charts" xml:space="preserve">
+	  <value>Hide Record-less Charts</value>
+  </data>
+  <data name="Hide Zero Scoring Charts" xml:space="preserve">
+	  <value>Hide Zero Scoring Charts</value>
+  </data>
+  <data name="Player To Test (Must Be Set To Public)" xml:space="preserve">
+	  <value>Player To Test (Must Be Set To Public)</value>
+  </data>
+  <data name="Effective Level" xml:space="preserve">
+	  <value>Effective Level</value>
+  </data>
+  <data name="Your Score" xml:space="preserve">
+	  <value>Your Score</value>
+  </data>
+  <data name="Points Pre-Score" xml:space="preserve">
+	  <value>Points Pre-Score</value>
+  </data>
+  <data name="Points Per Second Pre-Score" xml:space="preserve">
+	  <value>Points Per Second Pre-Score</value>
+  </data>
+  <data name="Your Points" xml:space="preserve">
+	  <value>Your Points</value>
+  </data>
+  <data name="Your Points per Second" xml:space="preserve">
+	  <value>Your Points per Second</value>
+  </data>
+  <data name="Example Set Builder" xml:space="preserve">
+	  <value>Example Set Builder</value>
+  </data>
+  <data name="Seconds of Rest Per Chart" xml:space="preserve">
+	  <value>Seconds of Rest Per Chart</value>
+  </data>
+  <data name="Build Session" xml:space="preserve">
+	  <value>Build Session</value>
+  </data>
+  <data name="Score: X" xml:space="preserve">
+	  <value>Score: {0}</value>
+	  <comment>{0} = total session score integer.</comment>
+  </data>
+  <data name="Total Charts: X" xml:space="preserve">
+	  <value>Total Charts: {0}</value>
+	  <comment>{0} = chart count integer.</comment>
+  </data>
+  <data name="Rest Time Per Chart: X" xml:space="preserve">
+	  <value>Rest Time Per Chart: {0}</value>
+	  <comment>{0} = formatted m:ss timespan.</comment>
+  </data>
+  <data name="Duration" xml:space="preserve">
+	  <value>Duration</value>
+  </data>
+  <data name="Chart Score" xml:space="preserve">
+	  <value>Chart Score</value>
+  </data>
+  <data name="Session Score" xml:space="preserve">
+	  <value>Session Score</value>
+  </data>
+  <data name="Couldn't parse JSON" xml:space="preserve">
+	  <value>Couldn't parse JSON</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary

**Final folder PR of Phase 1.** `Pages/Competition/`. Largest by string density across all 8 PRs: 5 files, ~95 new keys, ~25 reused. 500+/171- diff.

After this lands, all Phase 1 folders are extracted. Phase 2 (per-locale translation passes) is the next step whenever you're ready.

## Files changed

| File | Notes |
|---|---|
| [ScoreRankings.razor](ScoreTracker/ScoreTracker/Pages/Competition/ScoreRankings.razor) | Page title + intro prose + 2 section headers + 2 leaderboard tables (Avatar / Player / Level / Anonymous reused). |
| [Tournaments.razor](ScoreTracker/ScoreTracker/Pages/Competition/Tournaments.razor) | 3 section headers, 6 column titles (×3 sections), and the rules dialog (5 MudMenu labels, Always / Never fallbacks, several format strings). |
| [MatchTournamentAdmin.razor](ScoreTracker/ScoreTracker/Pages/Competition/MatchTournamentAdmin.razor) | Page title `X Brackets` format, 3 section headers, player + machine table columns/forms, Tournament Role select, 3 C# snackbars. |
| [StaminaTournament.razor](ScoreTracker/ScoreTracker/Pages/Competition/StaminaTournament.razor) | Page title, 2 top-line buttons, Show Extra Info switch, 12 leaderboard column headers, `X Charts` / `X Plays` format strings, verification cell, timeline ApexChart series, Chart Statistics table, photo dialog. |
| [SessionBuilder.razor](ScoreTracker/ScoreTracker/Pages/Competition/SessionBuilder.razor) | 3 h3 headers, 8 expansion-panel titles, ~25 input labels and switches, test-table column titles, example-set result section. |

## Notable judgment calls

- **Source verbatim quirk preserved**: `"Continous Modifier Scale (modifier increments between letter grades)"` — the misspelling `Continous` (should be `Continuous`) is preserved verbatim with a resx comment flag, per the established convention of leaving source typos for separate cleanup.
- **Skipped per the mixed-prose rule**:
  - The `"CTYP - Chart Type<br/>STYP - Song Type<br/>..."` technical-variable legend in SessionBuilder's Custom Scoring Formula panel — `<br/>`-separated abbreviations interleaved with inline `@variable` references is the mixed-prose pattern.
- **Left hardcoded as language-neutral**:
  - Six color-band labels on `/ScoreRankings` (e.g. `0% -> 10%`, `50% -> 75%`) — pure numeric ranges with arrows.
  - `"I.E: { "Kugutsu S25":1.25, "Leather D26":2.3 }"` example-JSON line — data sample.
- **`Score Rankings` (page title) and `Scoring Rankings` (h5 heading)** are different keys — the source uses both spellings on the same page; both preserved verbatim.
- **Two duplicates removed** during composition: I initially added `Charts` and `Seconds` as new keys before realizing both already existed. Final set is dedup'd.

## Verification

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` — 0 errors.
- [ ] Render the five Competition pages: `/ScoreRankings`, `/Tournaments` (open the rules dialog by clicking through to a tournament, then back), `/Tournament/{guid}/Admin` as an admin (the `X Brackets` page-title format relies on a tournament name), `/Tournament/Stamina/{guid}` for a stamina tournament with at least one submitted run (Show Extra Info reveals the wider column set), and `/SessionBuilder` (and `/TournamentBuilder` — same component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)