### PR TITLE
Localize partial-coverage files (Phase 1, PR #9)

### DIFF
--- a/ScoreTracker/ScoreTracker/Pages/ChartDetails.razor
+++ b/ScoreTracker/ScoreTracker/Pages/ChartDetails.razor
@@ -14,7 +14,7 @@
 @using System.Text.RegularExpressions
 @using ScoreTracker.Domain.Models
 @using ScoreTracker.Web.Services
-<PageTitle>@(_selectedChart==null?"Chart Details":$"{_selectedChart.Song.Name} {_selectedChart.DifficultyString}")</PageTitle>
+<PageTitle>@(_selectedChart==null?L["Chart Details"].Value:$"{_selectedChart.Song.Name} {_selectedChart.DifficultyString}")</PageTitle>
 <HeadContent>
     <meta name="description" content=@(_selectedChart==null?"Look up statistics and leaderboards on specific PIU charts!":$"Statistic and Leaderboards for {_selectedChart.Song.Name} {_selectedChart.DifficultyString} by {_selectedChart.Song.Artist}{(_selectedChart.StepArtist==null?"":$", charted by {_selectedChart.StepArtist}")}.")/>
     <meta property="og:image" content=@(_selectedChart==null?"":_selectedChart.Song.ImagePath.ToString())>
@@ -22,7 +22,7 @@
     <meta property="og:description" content=@(_selectedChart==null?"Look up statistics and leaderboards on specific PIU charts!":$"Statistic and Leaderboards for {_selectedChart.Song.Name} {_selectedChart.DifficultyString} by {_selectedChart.Song.Artist}{(_selectedChart.StepArtist==null?"":$", charted by {_selectedChart.StepArtist}")}.")>
     </HeadContent>
 
-<MudText Typo="Typo.h3">Chart Details</MudText>
+<MudText Typo="Typo.h3">@L["Chart Details"]</MudText>
 @if (_nameAvatars.Any())
 {
     
@@ -34,11 +34,11 @@
     <MudText Typo="Typo.h4">@_selectedChart.Song.Name @_selectedChart.DifficultyString</MudText>
     @if (_selectedChart.StepArtist != null && _selectedChart.StepArtist != "Unknown")
     {
-        <MudText>Step Artist: @_selectedChart.StepArtist</MudText>
+        <MudText>@L["Step Artist: X", _selectedChart.StepArtist]</MudText>
     }
     @if (_selectedChart.NoteCount > 0)
     {
-        <MudText>Note Count: @_selectedChart.NoteCount</MudText>
+        <MudText>@L["Note Count: X", _selectedChart.NoteCount]</MudText>
     }
     <br/>
     <MudButton Color="Color.Primary" Variant="Variant.Outlined" StartIcon="@Icons.Custom.Brands.YouTube" OnClick="()=>VideoDisplayer.ShowVideo(_selectedChart.Id)">@L["Open Video"]</MudButton>
@@ -47,19 +47,19 @@
     @if (CurrentUser.IsLoggedIn)
     {
         <br/>
-        <MudText Typo="Typo.h5">Your Score</MudText>
+        <MudText Typo="Typo.h5">@L["Your Score"]</MudText>
         <EditChartGrid ChartId="_selectedChart.Id" CurrentMix="_currentMix"></EditChartGrid>
     }
     @if (_currentMix == MixEnum.Phoenix)
     {
-        <MudText Typo="Typo.h5">Chart Difficulty by Letter Grade</MudText>
+        <MudText Typo="Typo.h5">@L["Chart Difficulty by Letter Grade"]</MudText>
         <ApexChart TItem="LevelDistribution"
-                   Title="Difficulty By Letter"
+                   Title=@L["Difficulty By Letter"]
                    @ref=_percentChart
                    Options="_percentOptions">
             <ApexPointSeries TItem="LevelDistribution"
                              Items="_levelDistribution"
-                             Name="Difficulty By Letter"
+                             Name=@L["Difficulty By Letter"]
                              SeriesType="SeriesType.Line"
                              XValue="@(e => e.Level.GetName())"
                              YValue="@(e => (decimal)e.Percentile)"
@@ -69,51 +69,51 @@
         @if (_plateBreakdowns.Any(kv => kv.Value > 0))
         {
             <br/>
-            <MudText Typo="Typo.h5">Plate Distribution</MudText>
+            <MudText Typo="Typo.h5">@L["Plate Distribution"]</MudText>
             <ApexChart TItem="StringDataPoint"
                        @ref=_plateGraph
-                       Title="Plate Breakdown">
+                       Title=@L["Plate Breakdown"]>
                 <ApexPointSeries TItem="StringDataPoint"
                                  Items="_plateBreakdowns.Select(kv=>new StringDataPoint(kv.Key.GetShorthand(),kv.Value))"
                                  SeriesType="SeriesType.Bar"
-                                 Name="Plates"
+                                 Name=@L["Plates"]
                                  XValue="@(e => e.X)"
                                  YValue="@(e => e.Y)"
                                  OrderBy="e => (int)PhoenixPlateHelperMethods.ParseShorthand((string)e.X)"/>
             </ApexChart>
             <br/>
-            <MudText Typo="Typo.h5">Score Distribution By Player Level</MudText>
+            <MudText Typo="Typo.h5">@L["Score Distribution By Player Level"]</MudText>
             <ApexChart TItem="DataPoint"
-                       Title="Scores by Competitive Level"
+                       Title=@L["Scores by Competitive Level"]
                        @ref=_scoreGraph
                        Options="_scoreBoxesOptions">
                 <ApexPointSeries TItem="DataPoint"
                                  Items="_scoreMinimums.Select(kv=>new DataPoint(kv.Key,kv.Value))"
-                                 Name="Min"
+                                 Name=@L["Min"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.X)"
                                  YValue="@(e => e.Y)"
                                  OrderBy="e => e.X" />
                 <ApexPointSeries TItem="DataPoint"
                                  Items="_scoreMaximums.Select(kv=>new DataPoint(kv.Key,kv.Value))"
-                                 Name="Max"
+                                 Name=@L["Max"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.X)"
                                  YValue="@(e => e.Y)"
                                  OrderBy="e => e.X" />
                 <ApexPointSeries TItem="DataPoint"
                                  Items="_scoreAverages.Select(kv=>new DataPoint(kv.Key,kv.Value))"
-                                 Name="Average"
+                                 Name=@L["Average"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.X)"
                                  YValue="@(e => e.Y)"
                                  OrderBy="e => e.X" />
                 @if (CurrentUser.IsLoggedIn && _myScore != null)
                 {
-                    
+
                     <ApexPointSeries TItem="DataPoint"
                                      Items="new[]{ new DataPoint(_myLevel,_myScore.Value),new DataPoint(_myLevel+1,_myScore.Value)}"
-                                     Name="My Score"
+                                     Name=@L["My Score"]
                                      SeriesType="SeriesType.Line"
                                      XValue="@(e => e.X)"
                                      YValue="@(e => e.Y)"
@@ -122,11 +122,11 @@
             </ApexChart>
             <br/>
             <ApexChart TItem="DataPoint"
-                       Title="Passes by Competitive Level"
+                       Title=@L["Passes by Competitive Level"]
                        @ref=_passGraph>
                 <ApexPointSeries TItem="DataPoint"
                                  Items="_passCounts.Select(kv=>new DataPoint(kv.Key,kv.Value))"
-                                 Name="Passes"
+                                 Name=@L["Passes"]
                                  SeriesType="SeriesType.Line"
                                  XValue="@(e => e.X)"
                                  YValue="@(e => e.Y)"
@@ -137,14 +137,14 @@
         @if (_worldScores.Any())
         {
             <br/>
-            <MudText Typo="Typo.h5">Chart Leaderboard</MudText>
+            <MudText Typo="Typo.h5">@L["Chart Leaderboard"]</MudText>
             <MudTable T="(int,UserPhoenixScore)" Items="_worldScores.OrderByDescending(s => s.Score).Select((s, i) => (i + 1,s))" Breakpoint="Breakpoint.None" Dense="true">
                 <HeaderContent>
-                    <MudTh>Place</MudTh>
-                    <MudTh>Avatar</MudTh>
-                    <MudTh>Name</MudTh>
-                    <MudTh>Level</MudTh>
-                    <MudTh>Score</MudTh>
+                    <MudTh>@L["Place"]</MudTh>
+                    <MudTh>@L["Avatar"]</MudTh>
+                    <MudTh>@L["Name"]</MudTh>
+                    <MudTh>@L["Level"]</MudTh>
+                    <MudTh>@L["Score"]</MudTh>
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd>@context.Item1</MudTd>

--- a/ScoreTracker/ScoreTracker/Pages/Charts.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Charts.razor
@@ -629,7 +629,7 @@
     private async Task CopyShareLink()
     {
         await Javascript.InvokeVoidAsync("navigator.clipboard.writeText", ShareUrl);
-        Snackbar.Add("Copied to clipboard!", Severity.Success);
+        Snackbar.Add(L["Copied to clipboard!"].Value, Severity.Success);
     }
 
     private async Task LoadCharts(Guid? userId)

--- a/ScoreTracker/ScoreTracker/Pages/Communities/Communities.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Communities/Communities.razor
@@ -10,7 +10,7 @@
 @using ScoreTracker.Domain.ValueTypes
 @using System.Web
 @using ChartType = ScoreTracker.Domain.Enums.ChartType
-<PageTitle>Communities</PageTitle>
+<PageTitle>@L["Communities"]</PageTitle>
 @foreach (var item in new[] { ("Your Communities",true), ("Other Communities",false) })
 {
     <MudText Typo="Typo.h5">@item.Item1</MudText>
@@ -239,7 +239,7 @@
     private async Task CopyCode(Guid code)
     {
         await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", $"https://piuscores.arroweclip.se/Communities/Invite/{code}");
-        Snackbar.Add("Copied to clipboard!", Severity.Success);
+        Snackbar.Add(L["Copied to clipboard!"].Value, Severity.Success);
     }
 
     protected override async Task OnInitializedAsync()

--- a/ScoreTracker/ScoreTracker/Pages/Competition/WeeklyCharts.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Competition/WeeklyCharts.razor
@@ -17,7 +17,7 @@
 @using System.Data.Common
 @using ScoreTracker.Web.Services.Contracts
 
-<PageTitle>Weekly Charts</PageTitle>
+<PageTitle>@L["Weekly Charts"]</PageTitle>
 
 
 <MudGrid>
@@ -36,7 +36,7 @@
     }
     <MudItem xs="6" sm="4">
         <MudSelect T="DateTimeOffset?" Value="_selectedWeek" ValueChanged="SetSelectedDate" Label=@L["Selected Week"] Clearable="true">
-            <MudSelectItem T="DateTimeOffset?" Value="null">Current</MudSelectItem>
+            <MudSelectItem T="DateTimeOffset?" Value="null">@L["Current"]</MudSelectItem>
             @foreach (var date in _pastDates.OrderByDescending(d => d))
             {
 
@@ -51,7 +51,7 @@
     <MudItem xs="6" sm="4">
         @if (_isLoggedIn && _showCompetitiveToggle && _selectedWeek == null)
         {
-            <MudSwitch T="bool" Color="Color.Primary" Label="Show Only Suggested Charts" Value="_showOnlyCompetitive" ValueChanged="v => SetShowOnlyCompetitive(v)"></MudSwitch>
+            <MudSwitch T="bool" Color="Color.Primary" Label=@L["Show Only Suggested Charts"] Value="_showOnlyCompetitive" ValueChanged="v => SetShowOnlyCompetitive(v)"></MudSwitch>
         }
 
     </MudItem>
@@ -103,22 +103,22 @@
 
 </MudGrid>
 <br/>
-<MudText Typo="Typo.h5">@(_isPastBite?"Monthly Leaderboard":"Road to BITE (Monthly Leaderboard July 8th - August 4th)")</MudText>
+<MudText Typo="Typo.h5">@(_isPastBite?L["Monthly Leaderboard"].Value:L["Road to BITE (Monthly Leaderboard July 8th - August 4th)"].Value)</MudText>
 @if (_selectedWeek == null)
 {
-    
-    <MudText Typo="Typo.subtitle1">Week @_currentWeekInMonth - Top @(_currentWeekInMonth*4) Charts</MudText>
+
+    <MudText Typo="Typo.subtitle1">@L["Week X - Top Y Charts", _currentWeekInMonth, _currentWeekInMonth*4]</MudText>
 }
 else if(_monthlyWeeks.Any())
 {
     <MudText Typo="Typo.subtitle1">@((_monthlyWeeks.Min() - TimeSpan.FromDays(7)).ToString("d")) - @(((_isCurrentMonth?DateTimeOffset.Now:(_monthlyWeeks.Max()-TimeSpan.FromDays(1))).ToString("d")))</MudText>
 }
 <br />
-<MudSelect T="ChartType?" Value="_chartType" ValueChanged="SetChartType" Disabled="_isLoading" Label="Leaderboard Type">
-    <MudSelectItem T="ChartType?" Value="null">Combined</MudSelectItem>
-    <MudSelectItem T="ChartType?" Value="ChartType.Single">Singles</MudSelectItem>
-    <MudSelectItem T="ChartType?" Value="ChartType.Double">Doubles</MudSelectItem>
-    <MudSelectItem T="ChartType?" Value="ChartType.CoOp">Co-Op</MudSelectItem>
+<MudSelect T="ChartType?" Value="_chartType" ValueChanged="SetChartType" Disabled="_isLoading" Label=@L["Leaderboard Type"]>
+    <MudSelectItem T="ChartType?" Value="null">@L["Combined"]</MudSelectItem>
+    <MudSelectItem T="ChartType?" Value="ChartType.Single">@L["Singles"]</MudSelectItem>
+    <MudSelectItem T="ChartType?" Value="ChartType.Double">@L["Doubles"]</MudSelectItem>
+    <MudSelectItem T="ChartType?" Value="ChartType.CoOp">@L["Co-Op"]</MudSelectItem>
 </MudSelect>
 <br/>
 <MudTable T="Guid" Items="_monthlyPlaces.OrderBy(kv => kv.Value).Select(kv=>kv.Key)" FixedHeader="true" Striped="true" Breakpoint="Breakpoint.None" Dense="true">

--- a/ScoreTracker/ScoreTracker/Pages/Progress/CompetitiveLevel.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/CompetitiveLevel.razor
@@ -16,20 +16,20 @@
 @using ScoreTracker.Web.Services.Contracts
 @using ChartType = ScoreTracker.Domain.Enums.ChartType
 
-<PageTitle>Competitive Level</PageTitle>
+<PageTitle>@L["Competitive Level"]</PageTitle>
 
-<MudText Typo="Typo.h3">Competitive Level</MudText>
+<MudText Typo="Typo.h3">@L["Competitive Level"]</MudText>
 <br/>
 <MudSelect T="ChartType" Label=@L["Chart Type"] Value="_currentType" ValueChanged="SetType">
-    <MudSelectItem T="ChartType" Value="ChartType.CoOp">All</MudSelectItem>
-    <MudSelectItem T="ChartType" Value="ChartType.Single">Singles</MudSelectItem>
-    <MudSelectItem T="ChartType" Value="ChartType.Double">Doubles</MudSelectItem>
+    <MudSelectItem T="ChartType" Value="ChartType.CoOp">@L["All"]</MudSelectItem>
+    <MudSelectItem T="ChartType" Value="ChartType.Single">@L["Singles"]</MudSelectItem>
+    <MudSelectItem T="ChartType" Value="ChartType.Double">@L["Doubles"]</MudSelectItem>
 </MudSelect>
 <MudGrid>
     @if (_stats != null)
     {
         <MudItem xs="12">
-            <MudText Typo="Typo.body1">Competitive Level: @($"{(_currentType == ChartType.CoOp ? _stats.CompetitiveLevel : _currentType == ChartType.Single ? _stats.SinglesCompetitiveLevel : _stats.DoublesCompetitiveLevel):0.00000}")</MudText>
+            <MudText Typo="Typo.body1">@L["Competitive Level: X", $"{(_currentType == ChartType.CoOp ? _stats.CompetitiveLevel : _currentType == ChartType.Single ? _stats.SinglesCompetitiveLevel : _stats.DoublesCompetitiveLevel):0.00000}"]</MudText>
         </MudItem>
     }
     @if (_competetiveScores.Any())
@@ -42,42 +42,42 @@
         }
     }
     <MudItem xs="12" sm="6" md="3">
-        <MudNumericField T="int" HideSpinButtons="true" Label="Min Level" @bind-Value="_minLevel" Min="1" Max=@_maxLevel></MudNumericField>
+        <MudNumericField T="int" HideSpinButtons="true" Label=@L["Min Level"] @bind-Value="_minLevel" Min="1" Max=@_maxLevel></MudNumericField>
     </MudItem>
     <MudItem xs="12" sm="6" md="3">
-        <MudNumericField T="int" HideSpinButtons="true" Label="Max Level" @bind-Value="_maxLevel" Min="@_minLevel" Max="DifficultyLevel.Max"></MudNumericField>
+        <MudNumericField T="int" HideSpinButtons="true" Label=@L["Max Level"] @bind-Value="_maxLevel" Min="@_minLevel" Max="DifficultyLevel.Max"></MudNumericField>
     </MudItem>
     <MudItem xs="12" sm="6" md="3">
-        <MudCheckBox T="bool" @bind-Value="_showScoreless" Label="Show Scoreless"></MudCheckBox>
+        <MudCheckBox T="bool" @bind-Value="_showScoreless" Label=@L["Show Scoreless"]></MudCheckBox>
     </MudItem>
     <MudItem xs="12" sm="6" md="3">
-        <MudCheckBox T="bool" @bind-Value="_showTopOnly" Label="Show Top Only"></MudCheckBox>
+        <MudCheckBox T="bool" @bind-Value="_showTopOnly" Label=@L["Show Top Only"]></MudCheckBox>
     </MudItem>
 </MudGrid>
 <br/>
 <MudTable T="Chart" Items="FilteredCharts" Breakpoint="Breakpoint.None" Dense="true">
     <HeaderContent>
         <MudTh>
-            <MudTableSortLabel T="Chart" SortBy="e => e.Song.Name">Song</MudTableSortLabel>
+            <MudTableSortLabel T="Chart" SortBy="e => e.Song.Name">@L["Song"]</MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel T="Chart" SortBy="e=>e.Level">Chart</MudTableSortLabel>
+            <MudTableSortLabel T="Chart" SortBy="e=>e.Level">@L["Chart"]</MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel T="Chart" SortBy="e => _scores.TryGetValue(e.Id,out var score)?score:0">Score</MudTableSortLabel>
+            <MudTableSortLabel T="Chart" SortBy="e => _scores.TryGetValue(e.Id,out var score)?score:0">@L["Score"]</MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel T="Chart" SortBy="e=>_scores.TryGetValue(e.Id,out var score)?ScoringConfiguration.CalculateFungScore(e.Level,score,e.Type):0">Competitive Level</MudTableSortLabel>
+            <MudTableSortLabel T="Chart" SortBy="e=>_scores.TryGetValue(e.Id,out var score)?ScoringConfiguration.CalculateFungScore(e.Level,score,e.Type):0">@L["Competitive Level"]</MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel T="Chart" SortBy="e=>_myDifficulty.TryGetValue(e.Id, out var z)?z:0">My Relative Difficulty</MudTableSortLabel>
+            <MudTableSortLabel T="Chart" SortBy="e=>_myDifficulty.TryGetValue(e.Id, out var z)?z:0">@L["My Relative Difficulty"]</MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel T="Chart" SortBy="e=>_scoreDifficulty.TryGetValue(e.Id, out var z)?z:0">Scoring Difficulty</MudTableSortLabel>
+            <MudTableSortLabel T="Chart" SortBy="e=>_scoreDifficulty.TryGetValue(e.Id, out var z)?z:0">@L["Scoring Difficulty"]</MudTableSortLabel>
         </MudTh>
 
         <MudTh>
-            <MudTableSortLabel T="Chart" SortBy="e=>_officialScoreDifficulty.TryGetValue(e.Id, out var z)?z:0">PIUGame Leaderboard Difficulty</MudTableSortLabel>
+            <MudTableSortLabel T="Chart" SortBy="e=>_officialScoreDifficulty.TryGetValue(e.Id, out var z)?z:0">@L["PIUGame Leaderboard Difficulty"]</MudTableSortLabel>
         </MudTh>
 
     </HeaderContent>

--- a/ScoreTracker/ScoreTracker/Pages/Progress/Titles.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/Titles.razor
@@ -10,18 +10,18 @@
 @using ScoreTracker.Web.Components
 @using ScoreTracker.Web.Dtos
 @using ScoreTracker.Web.Services.Contracts
-<PageTitle>Titles</PageTitle>
+<PageTitle>@L["Titles"]</PageTitle>
 
 <MudDataGrid @ref="_dataGrid" T="TitleProgressDto" Items="_titleProgress" Hover="true" ReadOnly="true"
              Groupable="true" FixedHeader="true" Height="500" Loading="@_isLoading">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Titles</MudText>
+        <MudText Typo="Typo.h6">@L["Titles"]</MudText>
     </ToolBarContent>
     <Columns>
-        <PropertyColumn Property="t=>t.TitleCategory" Title="Category" Grouping="true"></PropertyColumn>
-        <PropertyColumn Property="t=>t.TitleName" Title="Title" Groupable="false"></PropertyColumn>
-        <PropertyColumn Property="t=>t.TitleDescription" Title="Description" Groupable="false"></PropertyColumn>
-        <TemplateColumn Title="Community Completion" Groupable="false" T="TitleProgressDto">
+        <PropertyColumn Property="t=>t.TitleCategory" Title=@L["Category"] Grouping="true"></PropertyColumn>
+        <PropertyColumn Property="t=>t.TitleName" Title=@L["Title"] Groupable="false"></PropertyColumn>
+        <PropertyColumn Property="t=>t.TitleDescription" Title=@L["Description"] Groupable="false"></PropertyColumn>
+        <TemplateColumn Title=@L["Community Completion"] Groupable="false" T="TitleProgressDto">
             <CellTemplate>
                 @if (_titleCounts.TryGetValue(context.Item.TitleName, out var count))
                 {
@@ -40,7 +40,7 @@
         </TemplateColumn>
         @if (CurrentUser.IsLoggedIn)
         {
-            <TemplateColumn T="TitleProgressDto" Field="IsTrackable" Title="Completion" Groupable="false">
+            <TemplateColumn T="TitleProgressDto" Field="IsTrackable" Title=@L["Completion"] Groupable="false">
                 <CellTemplate>
                     @if (context.Item.IsTrackable)
                     {

--- a/ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor
+++ b/ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor
@@ -26,7 +26,7 @@
 @using Discord
 @using Microsoft.OpenApi
 @inject ChartVideoDisplayer VideoDisplayer
-<PageTitle>PIU Tier List</PageTitle>
+<PageTitle>@L["PIU Tier List"]</PageTitle>
 <HeadContent>
     <meta name="description" content="PIU Charts organized by difficulty with optional personalization based on individual skill."/>
     <meta property="og:title" content="PIU Tier List">

--- a/ScoreTracker/ScoreTracker/Pages/WhatShouldIPlay.razor
+++ b/ScoreTracker/ScoreTracker/Pages/WhatShouldIPlay.razor
@@ -18,9 +18,9 @@
 @using ScoreTracker.Web.Shared
 @using ChartType = ScoreTracker.Domain.Enums.ChartType
 
-<PageTitle>What Should I Play</PageTitle>
+<PageTitle>@L["What Should I Play"]</PageTitle>
 
-<MudText Typo="Typo.h3">What Should I Play?</MudText>
+<MudText Typo="Typo.h3">@L["What Should I Play?"]</MudText>
 <br/>
 @if (_progress != null && _chartDict.Any())
 {
@@ -50,9 +50,9 @@
 <MudGrid>
     <MudItem xs="4" sm="3">
         <MudSelect T="ChartType?" Label=@L["Chart Type"] Value="_chartType" ValueChanged="SetChartType" Disabled="_isLoading">
-            <MudSelectItem T="ChartType?" Value="null">All</MudSelectItem>
-            <MudSelectItem T="ChartType?" Value="ChartType.Single">Singles</MudSelectItem>
-            <MudSelectItem T="ChartType?" Value="ChartType.Double">Doubles</MudSelectItem>
+            <MudSelectItem T="ChartType?" Value="null">@L["All"]</MudSelectItem>
+            <MudSelectItem T="ChartType?" Value="ChartType.Single">@L["Singles"]</MudSelectItem>
+            <MudSelectItem T="ChartType?" Value="ChartType.Double">@L["Doubles"]</MudSelectItem>
         </MudSelect>
     </MudItem>
     <MudItem xs="2" sm="1">
@@ -82,7 +82,7 @@
             @if (key == "Weekly Charts")
             {
                             <br />
-                <MudLink Typo="Typo.subtitle1" Href="/WeeklyCharts">See Leaderboards</MudLink>
+                <MudLink Typo="Typo.subtitle1" Href="/WeeklyCharts">@L["See Leaderboards"]</MudLink>
             }
         </MudItem>
         @foreach (var chart in _charts[key])
@@ -113,7 +113,7 @@
                     <MudCardActions>
                         @if (_topCharts.Contains(chart.Id))
                         {
-                            <MudTooltip Text=@($"Top 50 {chart.Type}s")>
+                            <MudTooltip Text=@L["Top 50 X", chart.Type]>
                                 <MudIcon Icon="@PiuScoresIcons.Crown" Style="color:#00ffff"></MudIcon>
                             </MudTooltip>
                         }
@@ -187,7 +187,7 @@ else
     @foreach (var sectionName in _hiddenSections)
     {
     <MudItem xs="6" sm="4" md="3">
-        <MudButton Color="Color.Primary" Variant="Variant.Outlined" OnClick="()=>ShowSection(sectionName)">Show @sectionName</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Outlined" OnClick="()=>ShowSection(sectionName)">@L["Show"] @sectionName</MudButton>
     </MudItem>
     }
 </MudGrid>
@@ -195,32 +195,32 @@ else
 {
     <MudGrid>
         <MudItem xs="12">
-            <MudText Typo="Typo.h4">Stats</MudText>
+            <MudText Typo="Typo.h4">@L["Stats"]</MudText>
         </MudItem>
         <MudItem xs="12">
             <b>PUMBILITY</b>: @_stats.SkillRating
         </MudItem>
         <MudItem xs="12">
-            <b>Competitive Level</b>: @_stats.CompetitiveLevel.ToString("0.00") <MudIconButton Icon="@Icons.Material.Filled.QuestionMark" Color="Color.Primary" Target="_blank" Href="/CompetitiveLevel" Size="Size.Small"></MudIconButton>
+            <b>@L["Competitive Level"]</b>: @_stats.CompetitiveLevel.ToString("0.00") <MudIconButton Icon="@Icons.Material.Filled.QuestionMark" Color="Color.Primary" Target="_blank" Href="/CompetitiveLevel" Size="Size.Small"></MudIconButton>
         </MudItem>
         <MudItem xs="12">
-            <b>Singles Level</b>: @_stats.SinglesCompetitiveLevel.ToString("0.00")
+            <b>@L["Singles Level"]</b>: @_stats.SinglesCompetitiveLevel.ToString("0.00")
         </MudItem>
         <MudItem xs="12">
-            <b>Doubles Level</b>: @_stats.DoublesCompetitiveLevel.ToString("0.00")
+            <b>@L["Doubles Level"]</b>: @_stats.DoublesCompetitiveLevel.ToString("0.00")
         </MudItem>
     </MudGrid>
 }
 @if (_playerHistory.Any())
 {
     <ApexChart TItem="PlayerRatingRecord"
-               Title="Competitive Level"
+               Title=@L["Competitive Level"]
                XAxisType="XAxisType.Datetime"
                Options="_scoreBoxesOptions">
         <ApexPointSeries TItem="PlayerRatingRecord"
                          Color="#EA3F24"
                          Items="_playerHistory"
-                         Name="Singles"
+                         Name=@L["Singles"]
                          SeriesType="SeriesType.Line"
                          XValue="@(e => e.Date)"
                          YValue="@(e => (decimal)e.SinglesLevel)"
@@ -228,7 +228,7 @@ else
         <ApexPointSeries TItem="PlayerRatingRecord"
                          Color="#76FA4F"
                          Items="_playerHistory"
-                         Name="Doubles"
+                         Name=@L["Doubles"]
                          SeriesType="SeriesType.Line"
                          XValue="@(e => e.Date)"
                          YValue="@(e => (decimal)e.DoublesLevel)"
@@ -236,7 +236,7 @@ else
         <ApexPointSeries TItem="PlayerRatingRecord"
                          Color="#00FFFF"
                          Items="_playerHistory"
-                         Name="Combined"
+                         Name=@L["Combined"]
                          SeriesType="SeriesType.Line"
                          XValue="@(e => e.Date)"
                          YValue="@(e => (decimal)e.CompetitiveLevel)"
@@ -253,8 +253,8 @@ else
         }
     </DialogContent>
     <DialogActions>
-        <MudButton StartIcon="@Icons.Material.Filled.ThumbUp" Color="Color.Secondary" Variant="Variant.Filled" Disabled="_isSaving" OnClick="SubmitPositiveFeedback">Good Suggestion</MudButton>
-        <MudButton StartIcon="@Icons.Material.Filled.ThumbDown" Color="Color.Secondary" Variant="Variant.Filled" Disabled="_isSaving" OnClick="()=>_showRateDialog=true">Bad Suggestion</MudButton>
+        <MudButton StartIcon="@Icons.Material.Filled.ThumbUp" Color="Color.Secondary" Variant="Variant.Filled" Disabled="_isSaving" OnClick="SubmitPositiveFeedback">@L["Good Suggestion"]</MudButton>
+        <MudButton StartIcon="@Icons.Material.Filled.ThumbDown" Color="Color.Secondary" Variant="Variant.Filled" Disabled="_isSaving" OnClick="()=>_showRateDialog=true">@L["Bad Suggestion"]</MudButton>
         <MudSpacer>
 
         </MudSpacer>
@@ -266,20 +266,20 @@ else
     <DialogContent>
         <MudGrid>
             <MudItem xs="12">
-                <MudSelect T="string" @bind-Value="_feedbackCategory" Label="Reason">
-                    <MudSelectItem Value=@("Doesn't Match My Personal Skills")>Doesn't Match My Personal Skills</MudSelectItem>
-                    <MudSelectItem Value=@("I Don't Like The Chart")>I Don't Like The Chart</MudSelectItem>
-                    <MudSelectItem Value=@("Not Relevant to Category")>Not Relevant to Category</MudSelectItem>
-                    <MudSelectItem Value=@("I Just Want to Hide The Chart")>I Just Want to Hide The Chart</MudSelectItem>
-                    <MudSelectItem Value=@("The Category Isn't Interesting to Me")>The Category Isn't Interesting to Me'</MudSelectItem>
-                    <MudSelectItem Value=@("Other")>Other</MudSelectItem>
+                <MudSelect T="string" @bind-Value="_feedbackCategory" Label=@L["Reason"]>
+                    <MudSelectItem Value=@("Doesn't Match My Personal Skills")>@L["Doesn't Match My Personal Skills"]</MudSelectItem>
+                    <MudSelectItem Value=@("I Don't Like The Chart")>@L["I Don't Like The Chart"]</MudSelectItem>
+                    <MudSelectItem Value=@("Not Relevant to Category")>@L["Not Relevant to Category"]</MudSelectItem>
+                    <MudSelectItem Value=@("I Just Want to Hide The Chart")>@L["I Just Want to Hide The Chart"]</MudSelectItem>
+                    <MudSelectItem Value=@("The Category Isn't Interesting to Me")>@L["The Category Isn't Interesting to Me'"]</MudSelectItem>
+                    <MudSelectItem Value=@("Other")>@L["Other"]</MudSelectItem>
                 </MudSelect>
             </MudItem>
             <MudItem xs="12">
-                <MudTextField @bind-Value="_notes" Lines="3" MaxLength="250" Counter=@(250-_notes.Length) Label="Additional Comments"></MudTextField>
+                <MudTextField @bind-Value="_notes" Lines="3" MaxLength="250" Counter=@(250-_notes.Length) Label=@L["Additional Comments"]></MudTextField>
             </MudItem>
             <MudItem xs="12">
-                <MudCheckBox T="bool" @bind-Value="_shouldHide" Label="Hide Chart for this Category"></MudCheckBox>
+                <MudCheckBox T="bool" @bind-Value="_shouldHide" Label=@L["Hide Chart for this Category"]></MudCheckBox>
             </MudItem>
         </MudGrid>
     </DialogContent>
@@ -335,13 +335,13 @@ else
         if (!_todos.Contains(chartId))
         {
             await Mediator.Send(new SaveChartToListCommand(ChartListType.ToDo, chartId));
-            Snackbar.Add("Added to ToDo List!", Severity.Success);
+            Snackbar.Add(L["Added to ToDo List!"].Value, Severity.Success);
             _todos.Add(chartId);
         }
         else
         {
             await Mediator.Send(new RemoveChartFromListCommand(ChartListType.ToDo, chartId));
-            Snackbar.Add("Removed from ToDo List!", Severity.Success);
+            Snackbar.Add(L["Removed from ToDo List!"].Value, Severity.Success);
             _todos.Remove(chartId);
         }
         StateHasChanged();

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -1767,4 +1767,182 @@
   <data name="Couldn't parse JSON" xml:space="preserve">
 	  <value>Couldn't parse JSON</value>
   </data>
+  <data name="PIU Tier List" xml:space="preserve">
+	  <value>PIU Tier List</value>
+  </data>
+  <data name="Category" xml:space="preserve">
+	  <value>Category</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+	  <value>Title</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+	  <value>Description</value>
+  </data>
+  <data name="Community Completion" xml:space="preserve">
+	  <value>Community Completion</value>
+  </data>
+  <data name="Completion" xml:space="preserve">
+	  <value>Completion</value>
+  </data>
+  <data name="Competitive Level" xml:space="preserve">
+	  <value>Competitive Level</value>
+  </data>
+  <data name="All" xml:space="preserve">
+	  <value>All</value>
+  </data>
+  <data name="Competitive Level: X" xml:space="preserve">
+	  <value>Competitive Level: {0}</value>
+	  <comment>{0} = competitive level (5 decimals).</comment>
+  </data>
+  <data name="Min Level" xml:space="preserve">
+	  <value>Min Level</value>
+  </data>
+  <data name="Max Level" xml:space="preserve">
+	  <value>Max Level</value>
+  </data>
+  <data name="Show Scoreless" xml:space="preserve">
+	  <value>Show Scoreless</value>
+  </data>
+  <data name="Show Top Only" xml:space="preserve">
+	  <value>Show Top Only</value>
+  </data>
+  <data name="My Relative Difficulty" xml:space="preserve">
+	  <value>My Relative Difficulty</value>
+  </data>
+  <data name="Scoring Difficulty" xml:space="preserve">
+	  <value>Scoring Difficulty</value>
+  </data>
+  <data name="PIUGame Leaderboard Difficulty" xml:space="preserve">
+	  <value>PIUGame Leaderboard Difficulty</value>
+  </data>
+  <data name="Weekly Charts" xml:space="preserve">
+	  <value>Weekly Charts</value>
+  </data>
+  <data name="Current" xml:space="preserve">
+	  <value>Current</value>
+  </data>
+  <data name="Show Only Suggested Charts" xml:space="preserve">
+	  <value>Show Only Suggested Charts</value>
+  </data>
+  <data name="Monthly Leaderboard" xml:space="preserve">
+	  <value>Monthly Leaderboard</value>
+  </data>
+  <data name="Road to BITE (Monthly Leaderboard July 8th - August 4th)" xml:space="preserve">
+	  <value>Road to BITE (Monthly Leaderboard July 8th - August 4th)</value>
+	  <comment>Date-window heading used pre-BITE; specific to a fixed annual event window.</comment>
+  </data>
+  <data name="Week X - Top Y Charts" xml:space="preserve">
+	  <value>Week {0} - Top {1} Charts</value>
+	  <comment>{0} = week number, {1} = top-N count (week*4).</comment>
+  </data>
+  <data name="Leaderboard Type" xml:space="preserve">
+	  <value>Leaderboard Type</value>
+  </data>
+  <data name="Combined" xml:space="preserve">
+	  <value>Combined</value>
+  </data>
+  <data name="Co-Op" xml:space="preserve">
+	  <value>Co-Op</value>
+	  <comment>Used as a select-item label on /WeeklyCharts. Distinct from the existing "CoOp" key (no hyphen) used elsewhere — both spellings appear in source verbatim.</comment>
+  </data>
+  <data name="What Should I Play" xml:space="preserve">
+	  <value>What Should I Play</value>
+	  <comment>Page title (no question mark in source).</comment>
+  </data>
+  <data name="What Should I Play?" xml:space="preserve">
+	  <value>What Should I Play?</value>
+	  <comment>h3 header on the same page (with question mark in source).</comment>
+  </data>
+  <data name="See Leaderboards" xml:space="preserve">
+	  <value>See Leaderboards</value>
+  </data>
+  <data name="Top 50 X" xml:space="preserve">
+	  <value>Top 50 {0}</value>
+	  <comment>{0} = chart type (e.g. "Singles" / "Doubles"). Tooltip on the crown icon for top-50 charts.</comment>
+  </data>
+  <data name="Stats" xml:space="preserve">
+	  <value>Stats</value>
+  </data>
+  <data name="Singles Level" xml:space="preserve">
+	  <value>Singles Level</value>
+  </data>
+  <data name="Doubles Level" xml:space="preserve">
+	  <value>Doubles Level</value>
+  </data>
+  <data name="Good Suggestion" xml:space="preserve">
+	  <value>Good Suggestion</value>
+  </data>
+  <data name="Bad Suggestion" xml:space="preserve">
+	  <value>Bad Suggestion</value>
+  </data>
+  <data name="Reason" xml:space="preserve">
+	  <value>Reason</value>
+  </data>
+  <data name="Doesn't Match My Personal Skills" xml:space="preserve">
+	  <value>Doesn't Match My Personal Skills</value>
+  </data>
+  <data name="I Don't Like The Chart" xml:space="preserve">
+	  <value>I Don't Like The Chart</value>
+  </data>
+  <data name="Not Relevant to Category" xml:space="preserve">
+	  <value>Not Relevant to Category</value>
+  </data>
+  <data name="I Just Want to Hide The Chart" xml:space="preserve">
+	  <value>I Just Want to Hide The Chart</value>
+  </data>
+  <data name="The Category Isn't Interesting to Me'" xml:space="preserve">
+	  <value>The Category Isn't Interesting to Me'</value>
+	  <comment>Source has a stray trailing apostrophe — preserved verbatim.</comment>
+  </data>
+  <data name="Other" xml:space="preserve">
+	  <value>Other</value>
+  </data>
+  <data name="Additional Comments" xml:space="preserve">
+	  <value>Additional Comments</value>
+  </data>
+  <data name="Hide Chart for this Category" xml:space="preserve">
+	  <value>Hide Chart for this Category</value>
+  </data>
+  <data name="Added to ToDo List!" xml:space="preserve">
+	  <value>Added to ToDo List!</value>
+  </data>
+  <data name="Removed from ToDo List!" xml:space="preserve">
+	  <value>Removed from ToDo List!</value>
+  </data>
+  <data name="Chart Details" xml:space="preserve">
+	  <value>Chart Details</value>
+  </data>
+  <data name="Step Artist: X" xml:space="preserve">
+	  <value>Step Artist: {0}</value>
+	  <comment>{0} = step artist name (data).</comment>
+  </data>
+  <data name="Note Count: X" xml:space="preserve">
+	  <value>Note Count: {0}</value>
+	  <comment>{0} = note count integer.</comment>
+  </data>
+  <data name="Chart Difficulty by Letter Grade" xml:space="preserve">
+	  <value>Chart Difficulty by Letter Grade</value>
+  </data>
+  <data name="Plate Distribution" xml:space="preserve">
+	  <value>Plate Distribution</value>
+  </data>
+  <data name="Plate Breakdown" xml:space="preserve">
+	  <value>Plate Breakdown</value>
+  </data>
+  <data name="Plates" xml:space="preserve">
+	  <value>Plates</value>
+  </data>
+  <data name="Score Distribution By Player Level" xml:space="preserve">
+	  <value>Score Distribution By Player Level</value>
+  </data>
+  <data name="Scores by Competitive Level" xml:space="preserve">
+	  <value>Scores by Competitive Level</value>
+  </data>
+  <data name="Passes by Competitive Level" xml:space="preserve">
+	  <value>Passes by Competitive Level</value>
+  </data>
+  <data name="Chart Leaderboard" xml:space="preserve">
+	  <value>Chart Leaderboard</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary

Follow-up that closes the gaps community PR [#47](https://github.com/DrMurloc/PumpItUpScoreTracker/pull/47) caught — files that already had partial `L[...]` usage at the start of Phase 1, so my auto-generated "needs work" list skipped them, but in fact still had hardcoded English. Adds 56 new keys; reuses 9.

After this lands, **PR #47 can be closed** — everything it caught is now covered (in Phase 1 conventions).

## Files changed (8 razor + 1 resx)

| File | Notes |
|---|---|
| [TierLists/ChartSkills.razor](ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor) | Page title only — `PIU Tier List` (PR #47 had this wrong as `Tier Lists`; the actual source includes the PIU brand prefix). |
| [Progress/Titles.razor](ScoreTracker/ScoreTracker/Pages/Progress/Titles.razor) | Page title, h6 toolbar header, five column titles. |
| [Communities/Communities.razor](ScoreTracker/ScoreTracker/Pages/Communities/Communities.razor) | Page title + share snackbar. |
| [Charts.razor](ScoreTracker/ScoreTracker/Pages/Charts.razor) | Just the share snackbar (rest of the file was already localized pre-Phase 1). |
| [Competition/WeeklyCharts.razor](ScoreTracker/ScoreTracker/Pages/Competition/WeeklyCharts.razor) | Page title, `Current` select item, `Show Only Suggested Charts` switch, the conditional Monthly Leaderboard / Road-to-BITE h5, `Week X - Top Y Charts` format subtitle, Leaderboard Type select + 4 items. |
| [Progress/CompetitiveLevel.razor](ScoreTracker/ScoreTracker/Pages/Progress/CompetitiveLevel.razor) | Page title, h3, three ChartType select items, `Competitive Level: X` body format, 4 numeric/checkbox labels, 7 sortable table headers. |
| [WhatShouldIPlay.razor](ScoreTracker/ScoreTracker/Pages/WhatShouldIPlay.razor) | Page title (no `?`) + h3 (with `?`), three filter dropdown items, See Leaderboards link, `Top 50 X` tooltip format, `Show X` hidden-section button, 4 Stats labels, player-history ApexChart series, the score-feedback dialog with 6 reason options (including source-verbatim `The Category Isn't Interesting to Me'` with stray trailing apostrophe), 2 ToDo snackbars. |
| [ChartDetails.razor](ScoreTracker/ScoreTracker/Pages/ChartDetails.razor) | Fallback page title, h3 header, `Step Artist: X` / `Note Count: X` body format strings, 4 h5 section headers, 4 ApexChart titles + series labels, leaderboard table headers. |

## New keys (56) and reused (9)

**Reused:** `Singles`, `Doubles`, `Song`, `Chart`, `Score`, `Plate`, `Min`, `Max`, `Average`, `My Score`, `Passes`, `Place`, `Avatar`, `Name`, `Level`, `Difficulty By Letter`, `Your Score`, `Difficulty Level`, `Submit`, `Close`, `Copied to clipboard!`, `Chart Type`, `Communities`, `Titles`, `Tier Lists` — wait, that's more than 9. Resx-level reuse is broader; I'm counting "new keys I added" vs the conservative "reused-by-key-name-in-this-PR" interpretation.

**Notable new:** `PIU Tier List`, `Competitive Level`, `Combined`, `Co-Op` (distinct from existing `CoOp`), `What Should I Play` and `What Should I Play?` (separate keys per source punctuation), `Chart Details`, `Plate Distribution`, `Plate Breakdown`, `Score Distribution By Player Level`, `Scores by Competitive Level`, `Passes by Competitive Level`, `Chart Leaderboard`, `Chart Difficulty by Letter Grade`, plus format keys `Competitive Level: X`, `Step Artist: X`, `Note Count: X`, `Week X - Top Y Charts`, `Top 50 X`.

## Source verbatim quirks preserved

- `PIU Tier List` keeps the PIU brand prefix as one unit (PR #47's `Tier Lists` would have lost this).
- WhatShouldIPlay has `What Should I Play` (no `?`) as page title and `What Should I Play?` (with `?`) as h3 — both kept as separate keys.
- `Co-Op` (with hyphen) on `/WeeklyCharts` is a new key distinct from the existing `CoOp` (no hyphen) used in other files. Both spellings appear in the source. Flagged in resx comment.
- `The Category Isn't Interesting to Me'` preserves a stray trailing apostrophe in the source.

## Differences from PR #47

- **Convention**: Phase 1 follows verbatim-source-as-key (so `Avg Score` rather than `Average Score`, `Passes` rather than `Passed Count` where the source uses those words). PR #47 sometimes substituted other phrasings.
- **Casing reconciliation**: `Copy to Clipboard` (existing key, lowercase `to`) is reused for source `Copy To Clipboard` — same string semantically; one key.
- **Dead-key revival avoided**: PR #47 would have re-introduced `8-10 estimated charts played per player.`, which we deleted in Phase 0. Not added here.

## Verification

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` — 0 errors.
- [ ] Render `/CompetitiveLevel`, `/WeeklyCharts`, `/WhatShouldIPlay`, `/Chart/{guid}`, `/Communities`, `/StepArtists`, `/CompetitiveLevel`. Confirm headers, dropdowns, dialogs, and snackbars.

## Closes

This obsoletes [#47](https://github.com/DrMurloc/PumpItUpScoreTracker/pull/47); recommend closing it with a thank-you to `nabulator` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)