### PR TITLE
Complete pt-BR localization (442 keys across 13 batches)

### DIFF
--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -138,6 +138,8 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Calculated Tier List | Faixa calculada | Reuses the `Faixas de dificuldade` family. |
 | Game Stats | Estatísticas do jogo | |
 | User Matches / Match (vs another player) | Partidas do usuário / Partida | |
+| Plates (plural) | Plates | **Untranslated**, plural form. "Plate Breakdown" → "Detalhamento de plates"; "Plate Distribution" → "Distribuição de plates". |
+| Welcome (greeting) | Bem-vindo | Masculine default for the bare greeting. |
 | Judgment terms (Bad / Miss / Perfect / Great / Good) | Bad / Miss / Perfect / Great / Good | **Untranslated**, including plural forms (`Bads`, `Misses`, `Greats`, `Perfects`, `Goods`). Brazilian PIU community uses the English judgment terms. |
 | X Calculator | Calculadora de X | "Phoenix Score Calculator" → "Calculadora de pontuação da Phoenix" (existing); "Rating Calculator" → "Calculadora de rating"; "PIU Life Calculator" → "Calculadora de vida do PIU". |
 | Delete | Excluir | Action verb. Distinct from `Remove from X` → `Remover de X` (existing). |

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -66,6 +66,13 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Overview | Visão geral | |
 | Remaining | Restante | |
 | Copied to clipboard! | Copiado para a área de transferência! | Matches the existing "Copy to Clipboard" → "Copiar para a área de transferência" verb form. |
+| Communities | Comunidades | |
+| Create | Criar | |
+| Done | Concluído | Same as `Completed`. |
+| Last Updated | Última atualização | |
+| Maximum / Minimum (full word) | Máximo / Mínimo | Used when English source spells it out (e.g. "Maximum Level" → "Nível máximo"). Distinct from abbreviated `Min./Máx.` for `Min/Max` keys. |
+| Minutes / Seconds | Minutos / Segundos | |
+| Saved! | Salvo! | Snackbar success message. Masculine default. |
 
 ### PIU domain
 
@@ -121,6 +128,8 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Score Distribution | Distribuição de pontuação | "Show Score Distribution" → "Mostrar distribuição de pontuação". |
 | Ungraded | Sem nota | Matches `sem pass` / `sem nota` family. "Not Graded Count" → "Contagem de músicas sem nota". |
 | XX Progress | Progresso XX | No article — sidesteps the gender question for the legacy mix proper-noun. |
+| Admin (role/area) | Admin | **Untranslated**. Role name. |
+| Chart actions | Salvar / Atualizar / Criar chart | "Save Chart" → "Salvar chart"; "Update Chart" → "Atualizar chart"; "Chart saved" → "Chart salvo" (masculine — community treats `chart` as masc.). |
 
 ### Phrasing patterns to copy
 
@@ -133,6 +142,7 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 - **`(Data Backed)` parenthetical**: render as `(Baseado em dados)` / `(Baseada em dados)` — gender-agree with the preceding noun. E.g. "Pass (Data Backed)" → "Pass (Baseado em dados)" (`Pass` masculine); "Score (Data Backed)" → "Pontuação (Baseada em dados)" (`Pontuação` feminine).
 - **`Old X` / `New X` pairs**: render as `X antigo(a)` / `X novo(a)` — gender-agree with the noun. E.g. "Old Letter Grade" → "Letra de nota antiga", "New Letter Grade" → "Letra de nota nova" (`Letra` feminine).
 - **`Show X only` / `top` references**: "Show Top Only" → "Mostrar somente o topo" (literal). "Show Only ToDo Charts" → `Mostrar somente charts "Pendentes"` (established).
+- **Tech loanwords**: `cache`, `hash`, `URL`, `Rating` stay untranslated — universal in pt-BR tech UI. E.g. "Clear Cache" → "Limpar cache"; "Youtube Hash" → "Hash do YouTube".
 
 ## Open decisions (terms upcoming batches will need)
 
@@ -145,7 +155,6 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 | Bounty | **Bounty** (untranslated) | Niche PIU community concept; matches the pattern of leaving `Plate`, `pass`, `chart` untranslated. Confirms with Tier List and Bounty being parallel features. |
 | Pumbility | **Pumbility** (untranslated) | Proper noun for PIU's composite player rating; community uses the English term. |
 | UCS | **UCS** (untranslated) | Acronym (User-Created Step). Untranslated everywhere. |
-| Community / Communities | Comunidade / Comunidades | Direct cognate. |
 | Avatar | Avatar | Untranslated, common loanword in pt-BR UI. |
 | Tournament (singular) | Campeonato | Plural already established as `Campeonatos`. |
 | Match (versus another player) | Partida | Standard pt-BR for game match. (`User Matches` → `Partidas do usuário`, etc.) |

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -144,6 +144,9 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Qualifiers | qualifiers | **Untranslated**, lowercase. Brazilian tournament community uses both `qualifiers` and `qualificatórias`; we keep the loanword. E.g. "Qualifiers Leaderboard" → "Classificação dos qualifiers". |
 | Brackets (tournament) | Chaves | **Translated**. Standard pt-BR for tournament brackets. "{0} Brackets" → "{0} Chaves". |
 | Seed (tournament seeding) | Seed | **Untranslated**. Tournament jargon, common loanword. |
+| Stamina | stamina | **Untranslated**. Brazilian PIU community usage. E.g. "Stamina Session Builder" → "Construtor de sessão de stamina". |
+| Plays (PIU attempts) | plays | **Untranslated**, lowercase mid-phrase. "Play Count" → "Contagem de plays"; "{0} Plays" → "{0} plays". Same loanword treatment as `pass`/`run`/`chart`. |
+| Pre-Score (compound prefix) | pré-pontuação | "Points Pre-Score" → "Pontos pré-pontuação". |
 | Judgment terms (Bad / Miss / Perfect / Great / Good) | Bad / Miss / Perfect / Great / Good | **Untranslated**, including plural forms (`Bads`, `Misses`, `Greats`, `Perfects`, `Goods`). Brazilian PIU community uses the English judgment terms. |
 | X Calculator | Calculadora de X | "Phoenix Score Calculator" → "Calculadora de pontuação da Phoenix" (existing); "Rating Calculator" → "Calculadora de rating"; "PIU Life Calculator" → "Calculadora de vida do PIU". |
 | Delete | Excluir | Action verb. Distinct from `Remove from X` → `Remover de X` (existing). |
@@ -180,9 +183,7 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 
 | English | Recommendation | Notes |
 |---|---|---|
-| Admin / Admin Settings | Admin / Configurações de admin | "Admin" untranslated as role name. |
 | Add | Adicionar | |
-| Allow Repeats | Permitir repetições | |
 
 ## Process for future batches
 

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -145,6 +145,9 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 - **`Old X` / `New X` pairs**: render as `X antigo(a)` / `X novo(a)` — gender-agree with the noun. E.g. "Old Letter Grade" → "Letra de nota antiga", "New Letter Grade" → "Letra de nota nova" (`Letra` feminine).
 - **`Show X only` / `top` references**: "Show Top Only" → "Mostrar somente o topo" (literal). "Show Only ToDo Charts" → `Mostrar somente charts "Pendentes"` (established).
 - **Tech loanwords**: `cache`, `hash`, `URL`, `Rating` stay untranslated — universal in pt-BR tech UI. E.g. "Clear Cache" → "Limpar cache"; "Youtube Hash" → "Hash do YouTube".
+- **Decimal separator**: pt-BR uses comma — `9,6` not `9.6`. Localize numeric values inside translated prose.
+- **Source typos in long-key prose**: when the English key has a clearly-broken sentence (e.g. missing word), translate the *intended* meaning so the pt-BR reads as correct grammar. Don't preserve the typo.
+- **PIU community proper nouns / community jargon** in prose stay English: `run` (a play-through), `Rainbow` (lifebar color phase ≥1000), `data-mine` / `data-mining`, mix names (`NX2`, `Prime`, `XX`, `Phoenix`), and contributor names (`KyleTT`, `FEFEMZ`, `Team Infinitesimal`).
 
 ## Open decisions (terms upcoming batches will need)
 

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -131,6 +131,13 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Admin (role/area) | Admin | **Untranslated**. Role name. |
 | Chart actions | Salvar / Atualizar / Criar chart | "Save Chart" → "Salvar chart"; "Update Chart" → "Atualizar chart"; "Chart saved" → "Chart salvo" (masculine — community treats `chart` as masc.). |
 | Lifebar (one-word, the UI element) | lifebar | **Untranslated** when referring to the PIU UI element specifically. Bare `Life` translates as `Vida` (e.g. "Max Life" → "Vida máxima", "Life Threshold" → "Limite de vida"). Same split-treatment as `chart` (jargon untranslated) vs related Portuguese words. |
+| Folder (PIU difficulty-level group) | folder | **Untranslated**. Brazilian PIU community uses both `folder` and `pasta`; we keep `folder` to match the loanword policy. E.g. "Folder Averages" → "Médias do folder"; "Weighted Average Scores By Folder" → "Pontuações médias ponderadas por folder". |
+| Bounty / Bounties | Bounty / Bounties | **Untranslated**. PIU community concept. "Bounty Leaderboard" → "Classificação de bounties". |
+| Anonymous | Anônimo | |
+| Avatar | Avatar | **Untranslated**. Common loanword in pt-BR UI. |
+| Calculated Tier List | Faixa calculada | Reuses the `Faixas de dificuldade` family. |
+| Game Stats | Estatísticas do jogo | |
+| User Matches / Match (vs another player) | Partidas do usuário / Partida | |
 | Judgment terms (Bad / Miss / Perfect / Great / Good) | Bad / Miss / Perfect / Great / Good | **Untranslated**, including plural forms (`Bads`, `Misses`, `Greats`, `Perfects`, `Goods`). Brazilian PIU community uses the English judgment terms. |
 | X Calculator | Calculadora de X | "Phoenix Score Calculator" → "Calculadora de pontuação da Phoenix" (existing); "Rating Calculator" → "Calculadora de rating"; "PIU Life Calculator" → "Calculadora de vida do PIU". |
 | Delete | Excluir | Action verb. Distinct from `Remove from X` → `Remover de X` (existing). |
@@ -157,15 +164,10 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 
 | English | Recommendation | Notes |
 |---|---|---|
-| Bounty | **Bounty** (untranslated) | Niche PIU community concept; matches the pattern of leaving `Plate`, `pass`, `chart` untranslated. Confirms with Tier List and Bounty being parallel features. |
 | Pumbility | **Pumbility** (untranslated) | Proper noun for PIU's composite player rating; community uses the English term. |
 | UCS | **UCS** (untranslated) | Acronym (User-Created Step). Untranslated everywhere. |
-| Avatar | Avatar | Untranslated, common loanword in pt-BR UI. |
 | Tournament (singular) | Campeonato | Plural already established as `Campeonatos`. |
-| Match (versus another player) | Partida | Standard pt-BR for game match. (`User Matches` → `Partidas do usuário`, etc.) |
 | Stats | Estatísticas | |
-| Game Stats | Estatísticas do jogo | |
-| Calculated Tier List | Faixa calculada | Reuse `Faixas de dificuldade` family. |
 
 ### App / generic UI — high frequency
 
@@ -175,7 +177,6 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 | Add | Adicionar | |
 | Add Player | Adicionar jogador | |
 | Allow Repeats | Permitir repetições | |
-| Anonymous | Anônimo | |
 | Always | Sempre | |
 
 ## Process for future batches

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -40,11 +40,14 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Language | Linguagem | |
 | Medium | Médio | |
 | Page (start/end) | Página inicial / Página final | |
+| Place (rank/position) | Posição | Used as a leaderboard/ranking column header (more idiomatic than `Lugar` in this context). |
 | Private / Public | Privado / Público | "Make Private" → "Tornar privado" |
 | Restart | Reiniciar | |
 | Save | Salvar | "Save Scores" → "Salvar pontuações" |
-| Submit | (open — see below) | Currently a stub. |
+| Submit | Enviar | Standard pt-BR for form submit. |
+| Text View | Visualização em texto | |
 | Tools | Ferramentas | |
+| Upload Image | Carregar imagem | Aligns with existing `carregado` usage. |
 | Total | Total | |
 | Upload (verb / noun) | Upload / Carregar | Mixed. "Upload Scores" → "Upload de pontuações"; "uploaded" → "carregado". Lean on context. |
 | Username | Nome de usuário | |
@@ -71,7 +74,8 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Scores (plural / collection) | Pontuações | "Save Scores" → "Salvar pontuações"; "Official Scores" → "Pontuações oficiais"; "My Score" → "Minhas Pontuações" (intentionally plural in this entry). |
 | Phoenix Score Calculator | Calculadora de pontuação da Phoenix | |
 | Score Loss | Perda de pontuação | |
-| Song | Música | "Song Name" → "Nome da música"; "Song Duration" → "Duração da música". (Note: bare-key "Song" is currently a stub — see below.) |
+| Song | Música | "Song Name" → "Nome da música"; "Song Duration" → "Duração da música". |
+| Song Artist | Artista da música | |
 | Song Type | Tipo de música | |
 | Title (in-game title award) | Título | "Title Progress" → "Progresso do título"; "Titles" → "Títulos". |
 | To Do | Pendentes | "Add to ToDo" → "Adicionar à lista de tarefas"; "Show Only ToDo Charts" → `Mostrar somente charts "Pendentes"`. |
@@ -120,12 +124,6 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 | Admin / Admin Settings | Admin / Configurações de admin | "Admin" untranslated as role name. |
 | Add | Adicionar | |
 | Add Player | Adicionar jogador | |
-| Submit | Enviar | Standard pt-BR for form submit. (Currently a stub — see below.) |
-| Upload Image | Carregar imagem | Aligns with existing `carregado` usage. |
-| Song (bare key) | Música | Aligns with existing `Nome da música`. (Currently a stub.) |
-| Song Artist | Artista da música | |
-| Text View | Visualização em texto | |
-| Place (e.g. "1st place") | Lugar | "You are X place!" → "Você está em {0}!". (Currently a stub returning English `Place`.) |
 | All | Todos / Todas | Pick gender per key context. |
 | Allow Repeats | Permitir repetições | |
 | Anonymous | Anônimo | |
@@ -133,19 +131,6 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 | Avg Plate | Plate média | `Plate` stays English (established), modifier translated. |
 | Avg Score | Pontuação média | |
 | BPM | BPM | Untranslated. |
-
-## Stub entries that need translation in the next batch
-
-These six keys are already in `App.pt-BR.resx` but with **English values** — they were added as placeholders (note the matching `<comment>` field on each). They render English at runtime, same as if they were missing, but they don't show up as "missing" in a key-diff. Fix in the next batch:
-
-- `Place` (line 483) — translate per "Place" decision above.
-- `Upload Image` (line 487) — `Carregar imagem`.
-- `Song` (line 491) — `Música`.
-- `Submit` (line 495) — `Enviar`.
-- `Song Artist` (line 499) — `Artista da música`.
-- `Text View` (line 503) — `Visualização em texto`.
-
-(Whether to drop the `<comment>` field when translating is a style preference — fr-FR drops it, ko-KR keeps it. Either is fine; consistency within a batch is what matters.)
 
 ## Process for future batches
 

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -140,6 +140,10 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | User Matches / Match (vs another player) | Partidas do usuário / Partida | |
 | Plates (plural) | Plates | **Untranslated**, plural form. "Plate Breakdown" → "Detalhamento de plates"; "Plate Distribution" → "Distribuição de plates". |
 | Welcome (greeting) | Bem-vindo | Masculine default for the bare greeting. |
+| Tournament / Campeonato (singular) | Campeonato | "Active Tournaments" → "Campeonatos ativos"; "Previous/Upcoming Tournaments" → "Campeonatos anteriores/próximos". |
+| Qualifiers | qualifiers | **Untranslated**, lowercase. Brazilian tournament community uses both `qualifiers` and `qualificatórias`; we keep the loanword. E.g. "Qualifiers Leaderboard" → "Classificação dos qualifiers". |
+| Brackets (tournament) | Chaves | **Translated**. Standard pt-BR for tournament brackets. "{0} Brackets" → "{0} Chaves". |
+| Seed (tournament seeding) | Seed | **Untranslated**. Tournament jargon, common loanword. |
 | Judgment terms (Bad / Miss / Perfect / Great / Good) | Bad / Miss / Perfect / Great / Good | **Untranslated**, including plural forms (`Bads`, `Misses`, `Greats`, `Perfects`, `Goods`). Brazilian PIU community uses the English judgment terms. |
 | X Calculator | Calculadora de X | "Phoenix Score Calculator" → "Calculadora de pontuação da Phoenix" (existing); "Rating Calculator" → "Calculadora de rating"; "PIU Life Calculator" → "Calculadora de vida do PIU". |
 | Delete | Excluir | Action verb. Distinct from `Remove from X` → `Remover de X` (existing). |
@@ -158,6 +162,8 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 - **Source typos in long-key prose**: when the English key has a clearly-broken sentence (e.g. missing word), translate the *intended* meaning so the pt-BR reads as correct grammar. Don't preserve the typo.
 - **PIU community proper nouns / community jargon** in prose stay English: `run` (a play-through), `Rainbow` (lifebar color phase ≥1000), `data-mine` / `data-mining`, mix names (`NX2`, `Prime`, `XX`, `Phoenix`), and contributor names (`KyleTT`, `FEFEMZ`, `Team Infinitesimal`).
 - **"To perfect" (verb — to achieve a Perfect grade)**: render as `tirar perfect`. E.g. "harder for higher level players to perfect" → "mais difíceis para jogadores de nível mais alto tirarem perfect". The community-jargon `perfectar` exists but is less standard.
+- **`Is X` boolean column headers**: drop the `Is` prefix, render the noun/adjective alone. E.g. "Is Warmup" → "Aquecimento", "IsBroken" → "Quebrada". `É X` reads stilted as a column header.
+- **Inline conjunctions composed via placeholders**: when English source uses tiny separately-keyed words (`are`, `are not`) that get composed into a sentence at runtime, translate each as the grammatical equivalent that fits the host sentence (`são` / `não são`). Verify by reading the host string with each value substituted.
 
 ## Open decisions (terms upcoming batches will need)
 
@@ -169,8 +175,6 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 |---|---|---|
 | Pumbility | **Pumbility** (untranslated) | Proper noun for PIU's composite player rating; community uses the English term. |
 | UCS | **UCS** (untranslated) | Acronym (User-Created Step). Untranslated everywhere. |
-| Tournament (singular) | Campeonato | Plural already established as `Campeonatos`. |
-| Stats | Estatísticas | |
 
 ### App / generic UI — high frequency
 
@@ -178,9 +182,7 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 |---|---|---|
 | Admin / Admin Settings | Admin / Configurações de admin | "Admin" untranslated as role name. |
 | Add | Adicionar | |
-| Add Player | Adicionar jogador | |
 | Allow Repeats | Permitir repetições | |
-| Always | Sempre | |
 
 ## Process for future batches
 

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -53,6 +53,10 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Username | Nome de usuário | |
 | Very Easy / Very Hard | Muito fácil / Muito difícil | |
 | Video | Vídeo | |
+| Age | Idade | |
+| Days Old | dias de idade | lowercase — used as suffix to a number ("42 dias de idade"). |
+| Filters | Filtros | |
+| Settings | Configurações | |
 
 ### PIU domain
 
@@ -64,7 +68,7 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | CoOp | CoOp | Untranslated. "CoOp Aggregation" → "Agregação de CoOp". |
 | Singles / Doubles | Singles / Doubles | Untranslated. |
 | Difficulty Level | Nível de dificuldade | |
-| Letter Grade | Letras de nota | |
+| Letter Grade | Letras de nota | Min/Max forms use singular: "Min Letter Grade" → "Letra de nota mín.", "Max Letter Grade" → "Letra de nota máx." |
 | Mix | Versão | "Mix" → "Versão". XX, Phoenix proper names stay untranslated. |
 | Phoenix | Phoenix | Game version proper name. Untranslated. |
 | XX | XX | Game version proper name. Untranslated. |
@@ -87,6 +91,17 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Tournaments | Campeonatos | |
 | Popularity | Popularidade | |
 | Progress | Progresso | "Progress Charts" → "Gráficos de progresso" (note: here `Charts` means graphs, not PIU charts — translated as `Gráficos`). |
+| BPM | BPM | Untranslated. "Min BPM" → "BPM mín."; "Max BPM" → "BPM máx." |
+| Difficulty Categorization | Categorização de dificuldade | |
+| Note Count | Contagem de notas | Matches the "Contagem de pass" pattern. Min/Max: "Contagem mín./máx. de notas". |
+| Personalized Difficulty | Dificuldade personalizada | |
+| Player Count | Quantidade de jogadores | "Quantidade" reads more naturally than "Contagem" for the CoOp player-number numeric input. |
+| PIU Tier List | Faixa oficial PIU | Page title; the official tier list provided by piugame.com. |
+| Score Ranking | Ranking de pontuação | "Ranking" is a common pt-BR loanword. Distinct from `Leaderboard` → `Classificação`. |
+| Scoring Level | Nível de pontuação | Matches the "Nível de dificuldade" pattern. |
+| Skill | Habilidade | Chart trait/skill (runs, drills, twists, etc.). |
+| Stage Pass | Pass do estágio | Tristate filter on chart-pass status. |
+| Step Artist | Autor dos passos | Chart designer. Some pt-BR community usage leaves it in English; we translate. |
 
 ### Phrasing patterns to copy
 
@@ -94,6 +109,9 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 - **"With pass" / "without pass"**: phrased as `com pass` / `sem pass`. See "Hide Completed Charts" → "Ocultar charts com pass".
 - **App self-reference**: "Rastreador de Pontuações" (the app's name in pt-BR). Used in disclaimers about account creation, password storage, etc.
 - **Disclaimer voice**: existing privacy / make-public / make-private disclaimers use full sentences with `você`, dropped commas, and Portuguese conjunctions (`e`, `ou`, `mas`). Match that register — neither stiff nor slangy.
+- **`Show X` toggles**: render as `Mostrar X` (lowercase X). E.g. "Show Age" → "Mostrar idade", "Show Skills" → "Mostrar habilidades", "Show Step Artist" → "Mostrar autor dos passos".
+- **`Min/Max X` filter labels**: prefer postfixed abbreviation `X mín.` / `X máx.` over prefixed `Mín./Máx. X`. E.g. "Min BPM" → "BPM mín."; "Max Letter Grade" → "Letra de nota máx."
+- **`(Data Backed)` parenthetical**: render as `(Baseado em dados)` / `(Baseada em dados)` — gender-agree with the preceding noun. E.g. "Pass (Data Backed)" → "Pass (Baseado em dados)" (`Pass` masculine); "Score (Data Backed)" → "Pontuação (Baseada em dados)" (`Pontuação` feminine).
 
 ## Open decisions (terms upcoming batches will need)
 
@@ -114,13 +132,11 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 | Game Stats | Estatísticas do jogo | |
 | Difficulty | Dificuldade | Bare noun. |
 | Calculated Tier List | Faixa calculada | Reuse `Faixas de dificuldade` family. |
-| PIU Tier List | Faixa oficial PIU | Adjust to fit the singular/plural form needed per key. |
 
 ### App / generic UI — high frequency
 
 | English | Recommendation | Notes |
 |---|---|---|
-| Settings | Configurações | Standard pt-BR. |
 | Admin / Admin Settings | Admin / Configurações de admin | "Admin" untranslated as role name. |
 | Add | Adicionar | |
 | Add Player | Adicionar jogador | |
@@ -130,7 +146,6 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 | Always | Sempre | |
 | Avg Plate | Plate média | `Plate` stays English (established), modifier translated. |
 | Avg Score | Pontuação média | |
-| BPM | BPM | Untranslated. |
 
 ## Process for future batches
 

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -130,8 +130,10 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | XX Progress | Progresso XX | No article — sidesteps the gender question for the legacy mix proper-noun. |
 | Admin (role/area) | Admin | **Untranslated**. Role name. |
 | Chart actions | Salvar / Atualizar / Criar chart | "Save Chart" → "Salvar chart"; "Update Chart" → "Atualizar chart"; "Chart saved" → "Chart salvo" (masculine — community treats `chart` as masc.). |
-
-### Phrasing patterns to copy
+| Lifebar (one-word, the UI element) | lifebar | **Untranslated** when referring to the PIU UI element specifically. Bare `Life` translates as `Vida` (e.g. "Max Life" → "Vida máxima", "Life Threshold" → "Limite de vida"). Same split-treatment as `chart` (jargon untranslated) vs related Portuguese words. |
+| Judgment terms (Bad / Miss / Perfect / Great / Good) | Bad / Miss / Perfect / Great / Good | **Untranslated**, including plural forms (`Bads`, `Misses`, `Greats`, `Perfects`, `Goods`). Brazilian PIU community uses the English judgment terms. |
+| X Calculator | Calculadora de X | "Phoenix Score Calculator" → "Calculadora de pontuação da Phoenix" (existing); "Rating Calculator" → "Calculadora de rating"; "PIU Life Calculator" → "Calculadora de vida do PIU". |
+| Delete | Excluir | Action verb. Distinct from `Remove from X` → `Remover de X` (existing). |
 
 - **Possessives**: "Minhas Pontuações", "sua conta", "seu progresso" — possessive precedes noun, agrees in gender/number.
 - **"With pass" / "without pass"**: phrased as `com pass` / `sem pass`. See "Hide Completed Charts" → "Ocultar charts com pass".

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -57,6 +57,15 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Days Old | dias de idade | lowercase — used as suffix to a number ("42 dias de idade"). |
 | Filters | Filtros | |
 | Settings | Configurações | |
+| All | Todos | Plural masculine. (When the underlying noun is feminine, use `Todas`; pick per key context.) |
+| Category | Categoria | |
+| Description | Descrição | |
+| Level | Nível | "Min/Max Level" → "Nível mín./máx."; "Min/Max" alone → "Mín./Máx." |
+| Median | Mediana | |
+| Min / Max (bare) | Mín. / Máx. | Abbreviated. Used as standalone column or filter labels. |
+| Overview | Visão geral | |
+| Remaining | Restante | |
+| Copied to clipboard! | Copiado para a área de transferência! | Matches the existing "Copy to Clipboard" → "Copiar para a área de transferência" verb form. |
 
 ### PIU domain
 
@@ -68,12 +77,13 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | CoOp | CoOp | Untranslated. "CoOp Aggregation" → "Agregação de CoOp". |
 | Singles / Doubles | Singles / Doubles | Untranslated. |
 | Difficulty Level | Nível de dificuldade | |
-| Letter Grade | Letras de nota | Min/Max forms use singular: "Min Letter Grade" → "Letra de nota mín.", "Max Letter Grade" → "Letra de nota máx." |
+| Letter Grade | Letras de nota | Min/Max forms use singular: "Min Letter Grade" → "Letra de nota mín.", "Max Letter Grade" → "Letra de nota máx." Old/New variants: "Old Letter Grade" → "Letra de nota antiga", "New Letter Grade" → "Letra de nota nova". |
+| Letter-grade tier names (As, Ss, SSs, SSSs) | As, Ss, SSs, SSSs | **Untranslated**. Column-header labels for letter-grade counts ("how many A grades, how many S grades, …"). PIU jargon. |
 | Mix | Versão | "Mix" → "Versão". XX, Phoenix proper names stay untranslated. |
 | Phoenix | Phoenix | Game version proper name. Untranslated. |
 | XX | XX | Game version proper name. Untranslated. |
 | Plate | Plate | **Untranslated**. PIU community uses the English term in pt-BR contexts. |
-| Pass (the verb / noun for completing a chart) | pass | **Untranslated**, lowercase. "Hide Completed Charts" → "Ocultar charts com pass". "Passed Count" → "Contagem de pass". "Not Passed Count" → "Contagem de músicas sem pass". |
+| Pass (the verb / noun for completing a chart) | pass | **Untranslated**, lowercase. "Hide Completed Charts" → "Ocultar charts com pass". "Passed Count" → "Contagem de pass". "Not Passed Count" → "Contagem de músicas sem pass". Bare "Pass" / "Passes" → `pass` / `passes` (chart-series labels). Boolean column headers: "Passed" → `Com pass`, "Unpassed" → `Sem pass`. |
 | Score (singular, generic) | Pontuação | "Score" → "Pontuação"; "Score State" → "Estado da pontuação". |
 | Scores (plural / collection) | Pontuações | "Save Scores" → "Salvar pontuações"; "Official Scores" → "Pontuações oficiais"; "My Score" → "Minhas Pontuações" (intentionally plural in this entry). |
 | Phoenix Score Calculator | Calculadora de pontuação da Phoenix | |
@@ -102,6 +112,15 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Skill | Habilidade | Chart trait/skill (runs, drills, twists, etc.). |
 | Stage Pass | Pass do estágio | Tristate filter on chart-pass status. |
 | Step Artist | Autor dos passos | Chart designer. Some pt-BR community usage leaves it in English; we translate. |
+| Avg Plate | Plate média | `Plate` stays English (untranslated jargon); modifier translated. |
+| Avg Score | Pontuação média | |
+| Competitive Level | Nível competitivo | "Competitive Level: {0}" → "Nível competitivo: {0}". |
+| Difficulty (bare noun) | Dificuldade | Distinct from `Difficulty Level` → `Nível de dificuldade`. |
+| Pumbility | Pumbility | Untranslated. Proper-noun-style PIU concept. |
+| Rating | Rating | **Untranslated**. Brazilian PIU community uses the English loanword (matches the `Pumbility`/`Plate`/`Bounty` policy). |
+| Score Distribution | Distribuição de pontuação | "Show Score Distribution" → "Mostrar distribuição de pontuação". |
+| Ungraded | Sem nota | Matches `sem pass` / `sem nota` family. "Not Graded Count" → "Contagem de músicas sem nota". |
+| XX Progress | Progresso XX | No article — sidesteps the gender question for the legacy mix proper-noun. |
 
 ### Phrasing patterns to copy
 
@@ -112,6 +131,8 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 - **`Show X` toggles**: render as `Mostrar X` (lowercase X). E.g. "Show Age" → "Mostrar idade", "Show Skills" → "Mostrar habilidades", "Show Step Artist" → "Mostrar autor dos passos".
 - **`Min/Max X` filter labels**: prefer postfixed abbreviation `X mín.` / `X máx.` over prefixed `Mín./Máx. X`. E.g. "Min BPM" → "BPM mín."; "Max Letter Grade" → "Letra de nota máx."
 - **`(Data Backed)` parenthetical**: render as `(Baseado em dados)` / `(Baseada em dados)` — gender-agree with the preceding noun. E.g. "Pass (Data Backed)" → "Pass (Baseado em dados)" (`Pass` masculine); "Score (Data Backed)" → "Pontuação (Baseada em dados)" (`Pontuação` feminine).
+- **`Old X` / `New X` pairs**: render as `X antigo(a)` / `X novo(a)` — gender-agree with the noun. E.g. "Old Letter Grade" → "Letra de nota antiga", "New Letter Grade" → "Letra de nota nova" (`Letra` feminine).
+- **`Show X only` / `top` references**: "Show Top Only" → "Mostrar somente o topo" (literal). "Show Only ToDo Charts" → `Mostrar somente charts "Pendentes"` (established).
 
 ## Open decisions (terms upcoming batches will need)
 
@@ -130,7 +151,6 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 | Match (versus another player) | Partida | Standard pt-BR for game match. (`User Matches` → `Partidas do usuário`, etc.) |
 | Stats | Estatísticas | |
 | Game Stats | Estatísticas do jogo | |
-| Difficulty | Dificuldade | Bare noun. |
 | Calculated Tier List | Faixa calculada | Reuse `Faixas de dificuldade` family. |
 
 ### App / generic UI — high frequency
@@ -140,12 +160,9 @@ Pulled from the 442 missing keys. Each is a term that doesn't yet have an establ
 | Admin / Admin Settings | Admin / Configurações de admin | "Admin" untranslated as role name. |
 | Add | Adicionar | |
 | Add Player | Adicionar jogador | |
-| All | Todos / Todas | Pick gender per key context. |
 | Allow Repeats | Permitir repetições | |
 | Anonymous | Anônimo | |
 | Always | Sempre | |
-| Avg Plate | Plate média | `Plate` stays English (established), modifier translated. |
-| Avg Score | Pontuação média | |
 
 ## Process for future batches
 

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -1,0 +1,157 @@
+# pt-BR localization glossary
+
+Working reference for translating `App.en-US.resx` into `App.pt-BR.resx`. Captures the conventions already established by the existing 131 translated entries so future batches stay consistent.
+
+For the localization mechanism itself (resx layout, `L["..."]` usage, key conventions), see [ARCHITECTURE.md](ARCHITECTURE.md#cross-cutting-concerns). For PIU domain terms in English, see [DOMAIN.md](DOMAIN.md).
+
+## Style conventions
+
+- **Address the user with informal `você`.** All existing prose uses `você` / `seu` / `sua`, never `tu` and never the formal `o senhor / a senhora`. Match that.
+- **Sentence case in values, even when the English key is Title Case.** Key `"Add to Favorites"` → value `"Adicionar aos favoritos"`. Key `"Difficulty Level"` → value `"Nível de dificuldade"`. The English source preserves Title Case for searchability; pt-BR follows native sentence-case norms. Exception: brand-like terms (`Phoenix`, `PIUScores`, `Rastreador de Pontuações` for the app name itself) keep their internal capitalization.
+- **Preserve positional placeholders verbatim.** `{0}`, `{1}`, `{2}` go into the value untouched, in whatever order Portuguese grammar wants. Example: key `"You are X place!"` (English value `"You are {0} Place!"`) → pt-BR value `"Você está em {0}!"` — placeholder kept, surrounding text rephrased.
+- **Skip prose with inline markup.** Per CLAUDE.md, `<MudText>` bodies with embedded `<MudLink>`/other elements stay hardcoded English. Don't extract them, don't translate them.
+- **Use proper Brazilian orthography.** Acute and grave accents, cedilla, tildes — `áéíóúâêôãõàç`. Don't ASCII-fold.
+
+## Established term mappings
+
+These have **at least one** existing translation in `App.pt-BR.resx`. New translations of the same term must reuse the established form unless there's a documented reason to change it.
+
+### App / generic UI
+
+| English | pt-BR | Notes |
+|---|---|---|
+| Score Tracker (the app) | Rastreador de Pontuações | Brand name. Title case. |
+| Account | Conta | |
+| About | Sobre | |
+| Actions | Ações | |
+| Average | Média | |
+| Cancel | Cancelar | |
+| Close | Fechar | |
+| Completed | Concluído | |
+| Date (recorded) | Data de registro | "Recorded Date" → "Data de registro" |
+| Download | Baixar | verb. "Download Scores" → "Baixar pontuações" |
+| Easy / Easier | Fácil / Mais fácil | |
+| Easiest | Mais fácil | "Easiest Player" → "Jogador mais fácil" |
+| Hard / Harder | Difícil / Mais difícil | |
+| Hardest | Mais difícil | |
+| Login (noun) | Login | Untranslated. |
+| Log in (verb) | Fazer login | "Log In With {0}" → "Fazer login com {0}" |
+| Logout | Fazer logout | |
+| Language | Linguagem | |
+| Medium | Médio | |
+| Page (start/end) | Página inicial / Página final | |
+| Private / Public | Privado / Público | "Make Private" → "Tornar privado" |
+| Restart | Reiniciar | |
+| Save | Salvar | "Save Scores" → "Salvar pontuações" |
+| Submit | (open — see below) | Currently a stub. |
+| Tools | Ferramentas | |
+| Total | Total | |
+| Upload (verb / noun) | Upload / Carregar | Mixed. "Upload Scores" → "Upload de pontuações"; "uploaded" → "carregado". Lean on context. |
+| Username | Nome de usuário | |
+| Very Easy / Very Hard | Muito fácil / Muito difícil | |
+| Video | Vídeo | |
+
+### PIU domain
+
+| English | pt-BR | Notes |
+|---|---|---|
+| Chart(s) | chart / charts | **Untranslated**, lowercase even mid-phrase. "Chart Type" → "Tipo de chart". "Saved Charts" → "Charts salvos". |
+| Charts List | Lista de charts | |
+| Chart Randomizer | Sorteador de charts | |
+| CoOp | CoOp | Untranslated. "CoOp Aggregation" → "Agregação de CoOp". |
+| Singles / Doubles | Singles / Doubles | Untranslated. |
+| Difficulty Level | Nível de dificuldade | |
+| Letter Grade | Letras de nota | |
+| Mix | Versão | "Mix" → "Versão". XX, Phoenix proper names stay untranslated. |
+| Phoenix | Phoenix | Game version proper name. Untranslated. |
+| XX | XX | Game version proper name. Untranslated. |
+| Plate | Plate | **Untranslated**. PIU community uses the English term in pt-BR contexts. |
+| Pass (the verb / noun for completing a chart) | pass | **Untranslated**, lowercase. "Hide Completed Charts" → "Ocultar charts com pass". "Passed Count" → "Contagem de pass". "Not Passed Count" → "Contagem de músicas sem pass". |
+| Score (singular, generic) | Pontuação | "Score" → "Pontuação"; "Score State" → "Estado da pontuação". |
+| Scores (plural / collection) | Pontuações | "Save Scores" → "Salvar pontuações"; "Official Scores" → "Pontuações oficiais"; "My Score" → "Minhas Pontuações" (intentionally plural in this entry). |
+| Phoenix Score Calculator | Calculadora de pontuação da Phoenix | |
+| Score Loss | Perda de pontuação | |
+| Song | Música | "Song Name" → "Nome da música"; "Song Duration" → "Duração da música". (Note: bare-key "Song" is currently a stub — see below.) |
+| Song Type | Tipo de música | |
+| Title (in-game title award) | Título | "Title Progress" → "Progresso do título"; "Titles" → "Títulos". |
+| To Do | Pendentes | "Add to ToDo" → "Adicionar à lista de tarefas"; "Show Only ToDo Charts" → `Mostrar somente charts "Pendentes"`. |
+| Favorites | Favoritos | "Add to Favorites" → "Adicionar aos favoritos". |
+| Tier Lists | Faixas de dificuldade | |
+| Weekly Charts | Charts Semanais | `Charts` stays English (per the chart-untranslated rule); `Semanais` is the descriptive modifier. |
+| Leaderboard | Classificação | |
+| Players | Jogadores | |
+| Tournaments | Campeonatos | |
+| Popularity | Popularidade | |
+| Progress | Progresso | "Progress Charts" → "Gráficos de progresso" (note: here `Charts` means graphs, not PIU charts — translated as `Gráficos`). |
+
+### Phrasing patterns to copy
+
+- **Possessives**: "Minhas Pontuações", "sua conta", "seu progresso" — possessive precedes noun, agrees in gender/number.
+- **"With pass" / "without pass"**: phrased as `com pass` / `sem pass`. See "Hide Completed Charts" → "Ocultar charts com pass".
+- **App self-reference**: "Rastreador de Pontuações" (the app's name in pt-BR). Used in disclaimers about account creation, password storage, etc.
+- **Disclaimer voice**: existing privacy / make-public / make-private disclaimers use full sentences with `você`, dropped commas, and Portuguese conjunctions (`e`, `ou`, `mas`). Match that register — neither stiff nor slangy.
+
+## Open decisions (terms upcoming batches will need)
+
+Pulled from the 442 missing keys. Each is a term that doesn't yet have an established pt-BR translation in the resx, and that future batches will hit. Decide once per term, then add the row to **Established term mappings** above and use it.
+
+### PIU domain — high frequency
+
+| English | Recommendation | Notes |
+|---|---|---|
+| Bounty | **Bounty** (untranslated) | Niche PIU community concept; matches the pattern of leaving `Plate`, `pass`, `chart` untranslated. Confirms with Tier List and Bounty being parallel features. |
+| Pumbility | **Pumbility** (untranslated) | Proper noun for PIU's composite player rating; community uses the English term. |
+| UCS | **UCS** (untranslated) | Acronym (User-Created Step). Untranslated everywhere. |
+| Community / Communities | Comunidade / Comunidades | Direct cognate. |
+| Avatar | Avatar | Untranslated, common loanword in pt-BR UI. |
+| Tournament (singular) | Campeonato | Plural already established as `Campeonatos`. |
+| Match (versus another player) | Partida | Standard pt-BR for game match. (`User Matches` → `Partidas do usuário`, etc.) |
+| Stats | Estatísticas | |
+| Game Stats | Estatísticas do jogo | |
+| Difficulty | Dificuldade | Bare noun. |
+| Calculated Tier List | Faixa calculada | Reuse `Faixas de dificuldade` family. |
+| PIU Tier List | Faixa oficial PIU | Adjust to fit the singular/plural form needed per key. |
+
+### App / generic UI — high frequency
+
+| English | Recommendation | Notes |
+|---|---|---|
+| Settings | Configurações | Standard pt-BR. |
+| Admin / Admin Settings | Admin / Configurações de admin | "Admin" untranslated as role name. |
+| Add | Adicionar | |
+| Add Player | Adicionar jogador | |
+| Submit | Enviar | Standard pt-BR for form submit. (Currently a stub — see below.) |
+| Upload Image | Carregar imagem | Aligns with existing `carregado` usage. |
+| Song (bare key) | Música | Aligns with existing `Nome da música`. (Currently a stub.) |
+| Song Artist | Artista da música | |
+| Text View | Visualização em texto | |
+| Place (e.g. "1st place") | Lugar | "You are X place!" → "Você está em {0}!". (Currently a stub returning English `Place`.) |
+| All | Todos / Todas | Pick gender per key context. |
+| Allow Repeats | Permitir repetições | |
+| Anonymous | Anônimo | |
+| Always | Sempre | |
+| Avg Plate | Plate média | `Plate` stays English (established), modifier translated. |
+| Avg Score | Pontuação média | |
+| BPM | BPM | Untranslated. |
+
+## Stub entries that need translation in the next batch
+
+These six keys are already in `App.pt-BR.resx` but with **English values** — they were added as placeholders (note the matching `<comment>` field on each). They render English at runtime, same as if they were missing, but they don't show up as "missing" in a key-diff. Fix in the next batch:
+
+- `Place` (line 483) — translate per "Place" decision above.
+- `Upload Image` (line 487) — `Carregar imagem`.
+- `Song` (line 491) — `Música`.
+- `Submit` (line 495) — `Enviar`.
+- `Song Artist` (line 499) — `Artista da música`.
+- `Text View` (line 503) — `Visualização em texto`.
+
+(Whether to drop the `<comment>` field when translating is a style preference — fr-FR drops it, ko-KR keeps it. Either is fine; consistency within a batch is what matters.)
+
+## Process for future batches
+
+1. Pick a feature folder (Tournaments, Tier Lists, Progress, Admin, Tools, etc.).
+2. List its English keys (`grep -oP '(?<=L\[")[^"]+' ScoreTracker/ScoreTracker/Pages/<Folder>/**/*.razor` or similar).
+3. Cross-reference against `App.pt-BR.resx` to find which are missing.
+4. Translate using this glossary. **If a new term needs a decision, add a row to "Established term mappings" before translating.**
+5. `dotnet build ScoreTracker/ScoreTracker.sln -c Release` to confirm resx well-formedness.
+6. PR titled like `Translate <Folder> to pt-BR (Phase N)`.

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -147,6 +147,8 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Stamina | stamina | **Untranslated**. Brazilian PIU community usage. E.g. "Stamina Session Builder" → "Construtor de sessão de stamina". |
 | Plays (PIU attempts) | plays | **Untranslated**, lowercase mid-phrase. "Play Count" → "Contagem de plays"; "{0} Plays" → "{0} plays". Same loanword treatment as `pass`/`run`/`chart`. |
 | Pre-Score (compound prefix) | pré-pontuação | "Points Pre-Score" → "Pontos pré-pontuação". |
+| Rankings (plural noun, generic) | Rankings | **Untranslated**, matches `Rating` loanword policy. "World Rankings" → "Rankings mundiais"; "Score Rankings" → "Rankings de pontuação". Distinct from `Leaderboard` → `Classificação`. |
+| Tag / Tags | Tag / Tags | **Untranslated**. Brazilian Portuguese tech UI loanword. |
 | Judgment terms (Bad / Miss / Perfect / Great / Good) | Bad / Miss / Perfect / Great / Good | **Untranslated**, including plural forms (`Bads`, `Misses`, `Greats`, `Perfects`, `Goods`). Brazilian PIU community uses the English judgment terms. |
 | X Calculator | Calculadora de X | "Phoenix Score Calculator" → "Calculadora de pontuação da Phoenix" (existing); "Rating Calculator" → "Calculadora de rating"; "PIU Life Calculator" → "Calculadora de vida do PIU". |
 | Delete | Excluir | Action verb. Distinct from `Remove from X` → `Remover de X` (existing). |

--- a/LOCALIZATION-pt-BR.md
+++ b/LOCALIZATION-pt-BR.md
@@ -155,6 +155,7 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 - **Decimal separator**: pt-BR uses comma — `9,6` not `9.6`. Localize numeric values inside translated prose.
 - **Source typos in long-key prose**: when the English key has a clearly-broken sentence (e.g. missing word), translate the *intended* meaning so the pt-BR reads as correct grammar. Don't preserve the typo.
 - **PIU community proper nouns / community jargon** in prose stay English: `run` (a play-through), `Rainbow` (lifebar color phase ≥1000), `data-mine` / `data-mining`, mix names (`NX2`, `Prime`, `XX`, `Phoenix`), and contributor names (`KyleTT`, `FEFEMZ`, `Team Infinitesimal`).
+- **"To perfect" (verb — to achieve a Perfect grade)**: render as `tirar perfect`. E.g. "harder for higher level players to perfect" → "mais difíceis para jogadores de nível mais alto tirarem perfect". The community-jargon `perfectar` exists but is less standard.
 
 ## Open decisions (terms upcoming batches will need)
 

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1626,4 +1626,184 @@
   <data name="X Brackets" xml:space="preserve">
     <value>{0} Chaves</value>
   </data>
+  <data name="Adjust Scores to Song Duration (uses 2 minutes as average chart duration)" xml:space="preserve">
+    <value>Ajustar pontuações pela duração da música (usa 2 minutos como duração média de chart)</value>
+  </data>
+  <data name="Admin Settings" xml:space="preserve">
+    <value>Configurações de admin</value>
+  </data>
+  <data name="Allow Repeats" xml:space="preserve">
+    <value>Permitir repetições</value>
+  </data>
+  <data name="Average Difficulty" xml:space="preserve">
+    <value>Dificuldade média</value>
+  </data>
+  <data name="Average PPS" xml:space="preserve">
+    <value>PPS médio</value>
+  </data>
+  <data name="Average Score" xml:space="preserve">
+    <value>Pontuação média</value>
+  </data>
+  <data name="Best Score" xml:space="preserve">
+    <value>Melhor pontuação</value>
+  </data>
+  <data name="Build Session" xml:space="preserve">
+    <value>Construir sessão</value>
+  </data>
+  <data name="Chart Score" xml:space="preserve">
+    <value>Pontuação do chart</value>
+  </data>
+  <data name="Chart Statistics" xml:space="preserve">
+    <value>Estatísticas do chart</value>
+  </data>
+  <data name="Continous Modifier Scale (modifier increments between letter grades)" xml:space="preserve">
+    <value>Escala de modificador contínuo (incrementos do modificador entre letras de nota)</value>
+  </data>
+  <data name="Couldn't parse JSON" xml:space="preserve">
+    <value>Não foi possível processar o JSON</value>
+  </data>
+  <data name="Custom Scoring Formula" xml:space="preserve">
+    <value>Fórmula de pontuação personalizada</value>
+  </data>
+  <data name="Default" xml:space="preserve">
+    <value>Padrão</value>
+  </data>
+  <data name="Difficulty Range" xml:space="preserve">
+    <value>Intervalo de dificuldade</value>
+  </data>
+  <data name="Duration" xml:space="preserve">
+    <value>Duração</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+    <value>Editar</value>
+  </data>
+  <data name="Effective Level" xml:space="preserve">
+    <value>Nível efetivo</value>
+  </data>
+  <data name="Estimated Point Gain Timeline" xml:space="preserve">
+    <value>Linha do tempo estimada de ganho de pontos</value>
+  </data>
+  <data name="Example Set Builder" xml:space="preserve">
+    <value>Construtor de conjunto de exemplo</value>
+  </data>
+  <data name="Extra Settings" xml:space="preserve">
+    <value>Configurações extras</value>
+  </data>
+  <data name="Hide Record-less Charts" xml:space="preserve">
+    <value>Ocultar charts sem registro</value>
+  </data>
+  <data name="Hide Zero Scoring Charts" xml:space="preserve">
+    <value>Ocultar charts com pontuação zero</value>
+  </data>
+  <data name="Import Your Phoenix Scores" xml:space="preserve">
+    <value>Importar suas pontuações da Phoenix</value>
+  </data>
+  <data name="In Person" xml:space="preserve">
+    <value>Presencial</value>
+  </data>
+  <data name="Input Json" xml:space="preserve">
+    <value>JSON de entrada</value>
+  </data>
+  <data name="Levels" xml:space="preserve">
+    <value>Níveis</value>
+  </data>
+  <data name="Minimum Score" xml:space="preserve">
+    <value>Pontuação mínima</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Nenhum</value>
+  </data>
+  <data name="Pass Rate" xml:space="preserve">
+    <value>Taxa de pass</value>
+  </data>
+  <data name="Perfect Score Modifier (Acts as a letter grade beyond SSS+)" xml:space="preserve">
+    <value>Modificador de pontuação perfeita (atua como uma letra de nota além de SSS+)</value>
+  </data>
+  <data name="Play Count" xml:space="preserve">
+    <value>Contagem de plays</value>
+  </data>
+  <data name="Player To Test (Must Be Set To Public)" xml:space="preserve">
+    <value>Jogador para teste (deve estar definido como público)</value>
+  </data>
+  <data name="Points Per Second" xml:space="preserve">
+    <value>Pontos por segundo</value>
+  </data>
+  <data name="Points Per Second Pre-Score" xml:space="preserve">
+    <value>Pontos por segundo pré-pontuação</value>
+  </data>
+  <data name="Points Pre-Score" xml:space="preserve">
+    <value>Pontos pré-pontuação</value>
+  </data>
+  <data name="PreBuilt Tournament Configuration" xml:space="preserve">
+    <value>Configuração de campeonato pré-construída</value>
+  </data>
+  <data name="Record Session" xml:space="preserve">
+    <value>Registrar sessão</value>
+  </data>
+  <data name="Rest Time" xml:space="preserve">
+    <value>Tempo de descanso</value>
+  </data>
+  <data name="Rest Time Per Chart: X" xml:space="preserve">
+    <value>Tempo de descanso por chart: {0}</value>
+  </data>
+  <data name="Score: X" xml:space="preserve">
+    <value>Pontuação: {0}</value>
+  </data>
+  <data name="Seconds of Rest Per Chart" xml:space="preserve">
+    <value>Segundos de descanso por chart</value>
+  </data>
+  <data name="Session Duration (Minutes)" xml:space="preserve">
+    <value>Duração da sessão (minutos)</value>
+  </data>
+  <data name="Session Score" xml:space="preserve">
+    <value>Pontuação da sessão</value>
+  </data>
+  <data name="Set Charts" xml:space="preserve">
+    <value>Definir charts</value>
+  </data>
+  <data name="Show Extra Info" xml:space="preserve">
+    <value>Mostrar informações extras</value>
+  </data>
+  <data name="Stage Break Modifier" xml:space="preserve">
+    <value>Modificador de quebra de estágio</value>
+  </data>
+  <data name="Stamina Session Builder" xml:space="preserve">
+    <value>Construtor de sessão de stamina</value>
+  </data>
+  <data name="Test Scores" xml:space="preserve">
+    <value>Pontuações de teste</value>
+  </data>
+  <data name="Test With Player Data" xml:space="preserve">
+    <value>Testar com dados do jogador</value>
+  </data>
+  <data name="Total Chart Bonus" xml:space="preserve">
+    <value>Bônus total de charts</value>
+  </data>
+  <data name="Total Charts: X" xml:space="preserve">
+    <value>Total de charts: {0}</value>
+  </data>
+  <data name="Tournament Dates (EST)" xml:space="preserve">
+    <value>Datas do campeonato (EST)</value>
+  </data>
+  <data name="Tournament Name" xml:space="preserve">
+    <value>Nome do campeonato</value>
+  </data>
+  <data name="Tournament Settings" xml:space="preserve">
+    <value>Configurações do campeonato</value>
+  </data>
+  <data name="Verification" xml:space="preserve">
+    <value>Verificação</value>
+  </data>
+  <data name="X Charts" xml:space="preserve">
+    <value>{0} charts</value>
+  </data>
+  <data name="X Plays" xml:space="preserve">
+    <value>{0} plays</value>
+  </data>
+  <data name="Your Points" xml:space="preserve">
+    <value>Seus pontos</value>
+  </data>
+  <data name="Your Points per Second" xml:space="preserve">
+    <value>Seus pontos por segundo</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -948,4 +948,82 @@
   <data name="Visible Life" xml:space="preserve">
     <value>Vida visível</value>
   </data>
+  <data name="Bads at low health let you live for roughly 3x as long as misses, this gap increases the higher the life threshold you want to keep, up to misses punishing 6x as much when maintaining 100% visual life." xml:space="preserve">
+    <value>Bads em vida baixa fazem você sobreviver cerca de 3x mais que misses; essa diferença aumenta quanto maior for o limite de vida que você quer manter, até misses punirem 6x mais ao manter 100% de vida visual.</value>
+  </data>
+  <data name="Bads mostly hurt your recovery." xml:space="preserve">
+    <value>Bads atrapalham principalmente sua recuperação.</value>
+  </data>
+  <data name="By default at high combo, perfects gain 9.6 life, greats gain 8 life, goods gain 0 life." xml:space="preserve">
+    <value>Por padrão, em combo alto, perfects ganham 9,6 de vida, greats ganham 8 de vida, e goods ganham 0 de vida.</value>
+  </data>
+  <data name="By default, bads lose 50 health, misses lose 250 health (at ~100% health)." xml:space="preserve">
+    <value>Por padrão, bads tiram 50 de vida e misses tiram 250 de vida (em ~100% de vida).</value>
+  </data>
+  <data name="Disclaimer: This data was data-mined in NX2 and Prime, it is unconfirmed how accurate it is today." xml:space="preserve">
+    <value>Aviso: estes dados foram extraídos via data-mining no NX2 e no Prime; não há confirmação de quão precisos eles ainda são hoje.</value>
+  </data>
+  <data name="Disclaimer: This list is being refined, some charts are missing step artists and some may have incorrect artists." xml:space="preserve">
+    <value>Aviso: esta lista está sendo refinada; alguns charts estão sem autor dos passos e outros podem ter autores incorretos.</value>
+  </data>
+  <data name="Each perfect or great you get increases the multiplier by a minor amount." xml:space="preserve">
+    <value>Cada perfect ou great que você acerta aumenta o multiplicador em uma pequena quantidade.</value>
+  </data>
+  <data name="Effectively, this means that your life gain is heavily affected by combo, reaching maximum gain at ~40-50 combo." xml:space="preserve">
+    <value>Na prática, isso significa que seu ganho de vida é fortemente afetado pelo combo, atingindo o ganho máximo em ~40-50 de combo.</value>
+  </data>
+  <data name="Huge thank you for KyleTT for compiling this information from FEFEMZ's  recordings." xml:space="preserve">
+    <value>Muito obrigado a KyleTT por compilar essas informações a partir das gravações do FEFEMZ.</value>
+  </data>
+  <data name="Lifebar overflows exponentially by level, up to about a 2350 overflow at level 28." xml:space="preserve">
+    <value>A lifebar transborda exponencialmente conforme o nível, chegando a um excedente de cerca de 2350 no nível 28.</value>
+  </data>
+  <data name="Lifebars are weird." xml:space="preserve">
+    <value>Lifebars são estranhas.</value>
+  </data>
+  <data name="Misses lose LESS health the further beneath 1000 health you are at (at 0 life you would lose 20 health for a miss)" xml:space="preserve">
+    <value>Misses tiram MENOS vida quanto mais abaixo de 1000 você estiver (em 0 de vida, um miss tiraria 20 de vida)</value>
+  </data>
+  <data name="Misses or back-to-back Bads early in a run put you in a terribly position for maintaining life, as they reset your life gain multiplier and require you to combo ~40-50 to regain it. Start runs strong for increased success rates." xml:space="preserve">
+    <value>Misses ou bads consecutivos no início da run colocam você em uma posição péssima para manter vida, pois resetam seu multiplicador de ganho e exigem ~40-50 de combo para recuperá-lo. Comece as runs forte para aumentar suas taxas de sucesso.</value>
+  </data>
+  <data name="Misses severely hurt your lifebar." xml:space="preserve">
+    <value>Misses prejudicam severamente sua lifebar.</value>
+  </data>
+  <data name="Note that this information is not final until referenced against actual released mix." xml:space="preserve">
+    <value>Observe que essas informações não são finais até serem comparadas com a versão lançada.</value>
+  </data>
+  <data name="Starting life is 500, visible  Life (Rainbow life bar) is 1000." xml:space="preserve">
+    <value>A vida inicial é 500; a vida visível (lifebar Rainbow) é 1000.</value>
+  </data>
+  <data name="TLDR: Misses matter less at low life, but are always significantly more punishing than Bads." xml:space="preserve">
+    <value>TLDR: misses importam menos em vida baixa, mas sempre são significativamente mais punitivos que bads.</value>
+  </data>
+  <data name="Team Infinitesimal, data-mine from NX2 + Prime" xml:space="preserve">
+    <value>Team Infinitesimal, data-mine do NX2 + Prime</value>
+  </data>
+  <data name="This is modified by a multiplier that is almost entirely reset on a miss, and decreased drastically on a bad." xml:space="preserve">
+    <value>Isso é modificado por um multiplicador que é quase totalmente resetado em um miss e drasticamente reduzido em um bad.</value>
+  </data>
+  <data name="To recover from Bads you require 17-21 combo per Bad. Bads typically let you live for 3x as long as misses." xml:space="preserve">
+    <value>Para se recuperar de bads, é necessário 17-21 de combo por bad. Bads geralmente fazem você sobreviver 3x mais que misses.</value>
+  </data>
+  <data name="To remain alive you need to maintain 17-21 combo per Miss." xml:space="preserve">
+    <value>Para permanecer vivo, você precisa manter 17-21 de combo por miss.</value>
+  </data>
+  <data name="To remain at 50% visible life, you need 37-46 combo per Miss." xml:space="preserve">
+    <value>Para manter 50% de vida visível, você precisa de 37-46 de combo por miss.</value>
+  </data>
+  <data name="To remain at Rainbow Life, you 46-55 combo per Miss." xml:space="preserve">
+    <value>Para manter a vida Rainbow, você precisa de 46-55 de combo por miss.</value>
+  </data>
+  <data name="Try to maintain 17-21 combo per bad." xml:space="preserve">
+    <value>Procure manter 17-21 de combo por bad.</value>
+  </data>
+  <data name="Try to maintain 40-50 combo per miss." xml:space="preserve">
+    <value>Procure manter 40-50 de combo por miss.</value>
+  </data>
+  <data name="When at 12% or lower visual life, a miss gives less life loss than a bad, but inhibits your recovery severely. This only really matters for notes at the end of a song or before guaranteed 100+ combo sections." xml:space="preserve">
+    <value>Em 12% ou menos de vida visível, um miss tira menos vida que um bad, mas inibe sua recuperação severamente. Isso só importa de fato para notas no fim da música ou antes de seções com 100+ de combo garantido.</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -585,4 +585,166 @@
   <data name="Step Artist" xml:space="preserve">
     <value>Autor dos passos</value>
   </data>
+  <data name="All" xml:space="preserve">
+    <value>Todos</value>
+  </data>
+  <data name="As" xml:space="preserve">
+    <value>As</value>
+  </data>
+  <data name="Avg Plate" xml:space="preserve">
+    <value>Plate média</value>
+  </data>
+  <data name="Avg Score" xml:space="preserve">
+    <value>Pontuação média</value>
+  </data>
+  <data name="Best Attempts" xml:space="preserve">
+    <value>Melhores tentativas</value>
+  </data>
+  <data name="Category" xml:space="preserve">
+    <value>Categoria</value>
+  </data>
+  <data name="Chart" xml:space="preserve">
+    <value>chart</value>
+  </data>
+  <data name="Community Completion" xml:space="preserve">
+    <value>Conclusão da comunidade</value>
+  </data>
+  <data name="Competitive Level" xml:space="preserve">
+    <value>Nível competitivo</value>
+  </data>
+  <data name="Competitive Level: X" xml:space="preserve">
+    <value>Nível competitivo: {0}</value>
+  </data>
+  <data name="Completion" xml:space="preserve">
+    <value>Conclusão</value>
+  </data>
+  <data name="Copied to clipboard!" xml:space="preserve">
+    <value>Copiado para a área de transferência!</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Descrição</value>
+  </data>
+  <data name="Difficulty" xml:space="preserve">
+    <value>Dificuldade</value>
+  </data>
+  <data name="Difficulty Letters" xml:space="preserve">
+    <value>Letras por dificuldade</value>
+  </data>
+  <data name="Difficulty Passes" xml:space="preserve">
+    <value>Passes por dificuldade</value>
+  </data>
+  <data name="Difficulty Progress" xml:space="preserve">
+    <value>Progresso por dificuldade</value>
+  </data>
+  <data name="Level" xml:space="preserve">
+    <value>Nível</value>
+  </data>
+  <data name="Max" xml:space="preserve">
+    <value>Máx.</value>
+  </data>
+  <data name="Max Level" xml:space="preserve">
+    <value>Nível máx.</value>
+  </data>
+  <data name="Max Score" xml:space="preserve">
+    <value>Pontuação máx.</value>
+  </data>
+  <data name="Median" xml:space="preserve">
+    <value>Mediana</value>
+  </data>
+  <data name="Min" xml:space="preserve">
+    <value>Mín.</value>
+  </data>
+  <data name="Min Level" xml:space="preserve">
+    <value>Nível mín.</value>
+  </data>
+  <data name="Min Score" xml:space="preserve">
+    <value>Pontuação mín.</value>
+  </data>
+  <data name="My Relative Difficulty" xml:space="preserve">
+    <value>Minha dificuldade relativa</value>
+  </data>
+  <data name="New Letter Grade" xml:space="preserve">
+    <value>Letra de nota nova</value>
+  </data>
+  <data name="Old Letter Grade" xml:space="preserve">
+    <value>Letra de nota antiga</value>
+  </data>
+  <data name="Overall Letters" xml:space="preserve">
+    <value>Letras gerais</value>
+  </data>
+  <data name="Overall Passes" xml:space="preserve">
+    <value>Passes gerais</value>
+  </data>
+  <data name="Overview" xml:space="preserve">
+    <value>Visão geral</value>
+  </data>
+  <data name="PIUGame Leaderboard Difficulty" xml:space="preserve">
+    <value>Dificuldade da classificação PIUGame</value>
+  </data>
+  <data name="Pass" xml:space="preserve">
+    <value>pass</value>
+  </data>
+  <data name="Passed" xml:space="preserve">
+    <value>Com pass</value>
+  </data>
+  <data name="Passes" xml:space="preserve">
+    <value>passes</value>
+  </data>
+  <data name="Passes By Level" xml:space="preserve">
+    <value>Passes por nível</value>
+  </data>
+  <data name="Rating" xml:space="preserve">
+    <value>Rating</value>
+  </data>
+  <data name="Remaining" xml:space="preserve">
+    <value>Restante</value>
+  </data>
+  <data name="SSSs" xml:space="preserve">
+    <value>SSSs</value>
+  </data>
+  <data name="SSs" xml:space="preserve">
+    <value>SSs</value>
+  </data>
+  <data name="Score Distribution" xml:space="preserve">
+    <value>Distribuição de pontuação</value>
+  </data>
+  <data name="Score Distribution Lines" xml:space="preserve">
+    <value>Linhas de distribuição de pontuação</value>
+  </data>
+  <data name="Scoring Difficulty" xml:space="preserve">
+    <value>Dificuldade de pontuação</value>
+  </data>
+  <data name="Share Url" xml:space="preserve">
+    <value>URL de compartilhamento</value>
+  </data>
+  <data name="Share Your Progress Page" xml:space="preserve">
+    <value>Compartilhar sua página de progresso</value>
+  </data>
+  <data name="Show Scoreless" xml:space="preserve">
+    <value>Mostrar sem pontuação</value>
+  </data>
+  <data name="Show Top Only" xml:space="preserve">
+    <value>Mostrar somente o topo</value>
+  </data>
+  <data name="Singles vs Doubles" xml:space="preserve">
+    <value>Singles vs Doubles</value>
+  </data>
+  <data name="Ss" xml:space="preserve">
+    <value>Ss</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Título</value>
+  </data>
+  <data name="Total" xml:space="preserve">
+    <value>Total</value>
+  </data>
+  <data name="Ungraded" xml:space="preserve">
+    <value>Sem nota</value>
+  </data>
+  <data name="Unpassed" xml:space="preserve">
+    <value>Sem pass</value>
+  </data>
+  <data name="XX Progress" xml:space="preserve">
+    <value>Progresso XX</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1026,4 +1026,133 @@
   <data name="When at 12% or lower visual life, a miss gives less life loss than a bad, but inhibits your recovery severely. This only really matters for notes at the end of a song or before guaranteed 100+ combo sections." xml:space="preserve">
     <value>Em 12% ou menos de vida visível, um miss tira menos vida que um bad, mas inibe sua recuperação severamente. Isso só importa de fato para notas no fim da música ou antes de seções com 100+ de combo garantido.</value>
   </data>
+  <data name="Anonymous" xml:space="preserve">
+    <value>Anônimo</value>
+  </data>
+  <data name="Avatar" xml:space="preserve">
+    <value>Avatar</value>
+  </data>
+  <data name="Bounties" xml:space="preserve">
+    <value>Bounties</value>
+  </data>
+  <data name="Bounty Leaderboard" xml:space="preserve">
+    <value>Classificação de bounties</value>
+  </data>
+  <data name="Calculated Tier List" xml:space="preserve">
+    <value>Faixa calculada</value>
+  </data>
+  <data name="Chart Average" xml:space="preserve">
+    <value>Média do chart</value>
+  </data>
+  <data name="Chart Count By Level" xml:space="preserve">
+    <value>Contagem de charts por nível</value>
+  </data>
+  <data name="ChartScoring" xml:space="preserve">
+    <value>Pontuação de chart</value>
+  </data>
+  <data name="Competitively" xml:space="preserve">
+    <value>Competitivamente</value>
+  </data>
+  <data name="Determined to be X between Y and Z" xml:space="preserve">
+    <value>Determinado como {0} entre {1} e {2}</value>
+  </data>
+  <data name="Difficulty By Letter" xml:space="preserve">
+    <value>Dificuldade por letra</value>
+  </data>
+  <data name="Difficulty By Player Level" xml:space="preserve">
+    <value>Dificuldade por nível de jogador</value>
+  </data>
+  <data name="Existing" xml:space="preserve">
+    <value>Existente</value>
+  </data>
+  <data name="Final Result" xml:space="preserve">
+    <value>Resultado final</value>
+  </data>
+  <data name="Final Result: X" xml:space="preserve">
+    <value>Resultado final: {0}</value>
+  </data>
+  <data name="Folder Averages" xml:space="preserve">
+    <value>Médias do folder</value>
+  </data>
+  <data name="Folder Weighted Distribution" xml:space="preserve">
+    <value>Distribuição ponderada do folder</value>
+  </data>
+  <data name="Game Stats" xml:space="preserve">
+    <value>Estatísticas do jogo</value>
+  </data>
+  <data name="Letter Difficulty" xml:space="preserve">
+    <value>Dificuldade por letra</value>
+  </data>
+  <data name="LetterDifficulties" xml:space="preserve">
+    <value>Dificuldades por letra</value>
+  </data>
+  <data name="Maximums" xml:space="preserve">
+    <value>Máximos</value>
+  </data>
+  <data name="Minimums" xml:space="preserve">
+    <value>Mínimos</value>
+  </data>
+  <data name="Missing" xml:space="preserve">
+    <value>Faltante</value>
+  </data>
+  <data name="Monthly Total" xml:space="preserve">
+    <value>Total mensal</value>
+  </data>
+  <data name="Note Counts" xml:space="preserve">
+    <value>Contagem de notas</value>
+  </data>
+  <data name="Percentile Distribution" xml:space="preserve">
+    <value>Distribuição percentil</value>
+  </data>
+  <data name="Player" xml:space="preserve">
+    <value>Jogador</value>
+  </data>
+  <data name="Player Levels" xml:space="preserve">
+    <value>Níveis de jogador</value>
+  </data>
+  <data name="Player Weights" xml:space="preserve">
+    <value>Pesos dos jogadores</value>
+  </data>
+  <data name="Private User - X" xml:space="preserve">
+    <value>Usuário privado - {0}</value>
+  </data>
+  <data name="Scoring Level by Player Competitive Level" xml:space="preserve">
+    <value>Nível de pontuação por nível competitivo do jogador</value>
+  </data>
+  <data name="Selected Chart" xml:space="preserve">
+    <value>Chart selecionado</value>
+  </data>
+  <data name="Similar Players" xml:space="preserve">
+    <value>Jogadores similares</value>
+  </data>
+  <data name="Standard High" xml:space="preserve">
+    <value>Padrão alto</value>
+  </data>
+  <data name="Standard Low" xml:space="preserve">
+    <value>Padrão baixo</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Iniciar</value>
+  </data>
+  <data name="Target Player Level" xml:space="preserve">
+    <value>Nível-alvo do jogador</value>
+  </data>
+  <data name="Total Popularity Singles vs Doubles" xml:space="preserve">
+    <value>Popularidade total Singles vs Doubles</value>
+  </data>
+  <data name="Total Singles vs Doubles" xml:space="preserve">
+    <value>Total Singles vs Doubles</value>
+  </data>
+  <data name="User Matches" xml:space="preserve">
+    <value>Partidas do usuário</value>
+  </data>
+  <data name="Weighted Average Scores By Folder" xml:space="preserve">
+    <value>Pontuações médias ponderadas por folder</value>
+  </data>
+  <data name="X Note counts" xml:space="preserve">
+    <value>Contagem de notas - {0}</value>
+  </data>
+  <data name="X Progress" xml:space="preserve">
+    <value>Progresso - {0}</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1155,4 +1155,58 @@
   <data name="X Progress" xml:space="preserve">
     <value>Progresso - {0}</value>
   </data>
+  <data name="All players with scores within the target folder are assigned weights based on how close their competitive level is to X." xml:space="preserve">
+    <value>Todos os jogadores com pontuações dentro do folder-alvo recebem pesos com base em quão próximo o nível competitivo deles está de {0}.</value>
+  </data>
+  <data name="At this point, it's identified that this chart has no players with a weight of .5 or higher (within 1 level). The chart is marked as not having a scoring level as any estimation would be based on missing data." xml:space="preserve">
+    <value>Neste ponto, identifica-se que este chart não tem jogadores com peso de 0,5 ou maior (dentro de 1 nível). O chart é marcado como sem nível de pontuação, pois qualquer estimativa seria baseada em dados ausentes.</value>
+  </data>
+  <data name="For CoOps, scoring level is simply the lowest level player who's been able to pass the chart." xml:space="preserve">
+    <value>Para charts de CoOp, o nível de pontuação é simplesmente o jogador de menor nível que já conseguiu passar o chart.</value>
+  </data>
+  <data name="Highlighted players have a recorded score on the chart in question." xml:space="preserve">
+    <value>Jogadores destacados têm uma pontuação registrada no chart em questão.</value>
+  </data>
+  <data name="In this case, the chart is determined to be above by X utilizing standard deviations in the Y folder." xml:space="preserve">
+    <value>Neste caso, o chart é determinado como acima em {0} utilizando desvios padrão no folder {1}.</value>
+  </data>
+  <data name="In this case, the chart is determined to be below by X utilizing standard deviations in the Y folder." xml:space="preserve">
+    <value>Neste caso, o chart é determinado como abaixo em {0} utilizando desvios padrão no folder {1}.</value>
+  </data>
+  <data name="No one has passed this CoOp yet so no level is assigned." xml:space="preserve">
+    <value>Ninguém passou este CoOp ainda, então nenhum nível é atribuído.</value>
+  </data>
+  <data name="The chart in question has its weighted average score projected onto the score distributions" xml:space="preserve">
+    <value>O chart em questão tem sua pontuação média ponderada projetada nas distribuições de pontuação</value>
+  </data>
+  <data name="The listed scoring difficulty is calculated for players competitively playing in the officially listed folder for a chart." xml:space="preserve">
+    <value>A dificuldade de pontuação listada é calculada para jogadores que jogam competitivamente no folder oficial listado de um chart.</value>
+  </data>
+  <data name="The outcome of this algorithm has drastically different results for players at different levels though" xml:space="preserve">
+    <value>O resultado deste algoritmo, no entanto, gera resultados drasticamente diferentes para jogadores em níveis diferentes</value>
+  </data>
+  <data name="The target folder and the three surrounding are provided weighted average scores utilizing the player weights above." xml:space="preserve">
+    <value>O folder-alvo e os três adjacentes recebem pontuações médias ponderadas utilizando os pesos dos jogadores acima.</value>
+  </data>
+  <data name="The weighted average for this chart is better than the average for a X." xml:space="preserve">
+    <value>A média ponderada deste chart é melhor que a média de um {0}.</value>
+  </data>
+  <data name="The weighted average for this chart is worst than the average for a X." xml:space="preserve">
+    <value>A média ponderada deste chart é pior que a média de um {0}.</value>
+  </data>
+  <data name="There was not enough data for the targeted player level to evaluate a final difficulty." xml:space="preserve">
+    <value>Não havia dados suficientes para o nível de jogador alvo para avaliar uma dificuldade final.</value>
+  </data>
+  <data name="These averages are shifted away from the level in question by .5 of a standard deviation within their respective folder to make sure level changes are better represented by the bulk of a surrounding folder." xml:space="preserve">
+    <value>Essas médias são deslocadas do nível em questão por 0,5 de um desvio padrão dentro de seus respectivos folders para garantir que as mudanças de nível sejam melhor representadas pela maioria de um folder adjacente.</value>
+  </data>
+  <data name="This gives this chart a scoring level of: X" xml:space="preserve">
+    <value>Isso dá a este chart um nível de pontuação de: {0}</value>
+  </data>
+  <data name="This is intended. There are charts that are relatively easier to score to others in the folder for players just pushing into the folder, but are harder for higher level players to perfect." xml:space="preserve">
+    <value>Isso é intencional. Há charts que são relativamente mais fáceis de pontuar comparados a outros do folder para jogadores que estão apenas entrando no folder, mas são mais difíceis para jogadores de nível mais alto tirarem perfect.</value>
+  </data>
+  <data name="This isn't perfect, but until I have more data other algorithms haven't been successful at projecting CoOps onto difficulty levels" xml:space="preserve">
+    <value>Isto não é perfeito, mas até eu ter mais dados, outros algoritmos não tiveram sucesso em projetar CoOps em níveis de dificuldade</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1209,4 +1209,199 @@
   <data name="This isn't perfect, but until I have more data other algorithms haven't been successful at projecting CoOps onto difficulty levels" xml:space="preserve">
     <value>Isto não é perfeito, mas até eu ter mais dados, outros algoritmos não tiveram sucesso em projetar CoOps em níveis de dificuldade</value>
   </data>
+  <data name="About The Site" xml:space="preserve">
+    <value>Sobre o site</value>
+  </data>
+  <data name="Added to ToDo List!" xml:space="preserve">
+    <value>Adicionado à lista de tarefas!</value>
+  </data>
+  <data name="Additional Comments" xml:space="preserve">
+    <value>Comentários adicionais</value>
+  </data>
+  <data name="Also Sync for PIU Tracker" xml:space="preserve">
+    <value>Sincronizar também com o PIU Tracker</value>
+  </data>
+  <data name="An unknown error occurred" xml:space="preserve">
+    <value>Ocorreu um erro desconhecido</value>
+  </data>
+  <data name="Bad Suggestion" xml:space="preserve">
+    <value>Sugestão ruim</value>
+  </data>
+  <data name="Change Card" xml:space="preserve">
+    <value>Trocar cartão</value>
+  </data>
+  <data name="Chart Details" xml:space="preserve">
+    <value>Detalhes do chart</value>
+  </data>
+  <data name="Chart Difficulty by Letter Grade" xml:space="preserve">
+    <value>Dificuldade do chart por letra de nota</value>
+  </data>
+  <data name="Chart Leaderboard" xml:space="preserve">
+    <value>Classificação do chart</value>
+  </data>
+  <data name="Combined" xml:space="preserve">
+    <value>Combinado</value>
+  </data>
+  <data name="Could not find chart" xml:space="preserve">
+    <value>Chart não encontrado</value>
+  </data>
+  <data name="Could not find song" xml:space="preserve">
+    <value>Música não encontrada</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>País</value>
+  </data>
+  <data name="Doesn't Match My Personal Skills" xml:space="preserve">
+    <value>Não combina com minhas habilidades</value>
+  </data>
+  <data name="Doubles Level" xml:space="preserve">
+    <value>Nível Doubles</value>
+  </data>
+  <data name="Download Example" xml:space="preserve">
+    <value>Baixar exemplo</value>
+  </data>
+  <data name="File cannot be larger than 10 MB" xml:space="preserve">
+    <value>O arquivo não pode ser maior que 10 MB</value>
+  </data>
+  <data name="From" xml:space="preserve">
+    <value>De</value>
+  </data>
+  <data name="Game Card" xml:space="preserve">
+    <value>Cartão do jogo</value>
+  </data>
+  <data name="Good Suggestion" xml:space="preserve">
+    <value>Boa sugestão</value>
+  </data>
+  <data name="Hide" xml:space="preserve">
+    <value>Ocultar</value>
+  </data>
+  <data name="Hide Chart for this Category" xml:space="preserve">
+    <value>Ocultar chart desta categoria</value>
+  </data>
+  <data name="I Don't Like The Chart" xml:space="preserve">
+    <value>Não gosto deste chart</value>
+  </data>
+  <data name="I Just Want to Hide The Chart" xml:space="preserve">
+    <value>Só quero ocultar este chart</value>
+  </data>
+  <data name="Include Broken Scores" xml:space="preserve">
+    <value>Incluir pontuações quebradas</value>
+  </data>
+  <data name="IsBroken" xml:space="preserve">
+    <value>Quebrada</value>
+  </data>
+  <data name="Letter Grade Template" xml:space="preserve">
+    <value>Modelo de letra de nota</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Nome</value>
+  </data>
+  <data name="Not Relevant to Category" xml:space="preserve">
+    <value>Não relevante para a categoria</value>
+  </data>
+  <data name="Note Count: X" xml:space="preserve">
+    <value>Contagem de notas: {0}</value>
+  </data>
+  <data name="Other" xml:space="preserve">
+    <value>Outro</value>
+  </data>
+  <data name="Parsed Scores" xml:space="preserve">
+    <value>Pontuações processadas</value>
+  </data>
+  <data name="Passes by Competitive Level" xml:space="preserve">
+    <value>Passes por nível competitivo</value>
+  </data>
+  <data name="Plate Breakdown" xml:space="preserve">
+    <value>Detalhamento de plates</value>
+  </data>
+  <data name="Plate Distribution" xml:space="preserve">
+    <value>Distribuição de plates</value>
+  </data>
+  <data name="Plates" xml:space="preserve">
+    <value>Plates</value>
+  </data>
+  <data name="Privacy Policy" xml:space="preserve">
+    <value>Política de privacidade</value>
+  </data>
+  <data name="Reason" xml:space="preserve">
+    <value>Motivo</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Remover</value>
+  </data>
+  <data name="Removed from ToDo List!" xml:space="preserve">
+    <value>Removido da lista de tarefas!</value>
+  </data>
+  <data name="Score Distribution By Player Level" xml:space="preserve">
+    <value>Distribuição de pontuação por nível do jogador</value>
+  </data>
+  <data name="Scores" xml:space="preserve">
+    <value>Pontuações</value>
+  </data>
+  <data name="Scores by Competitive Level" xml:space="preserve">
+    <value>Pontuações por nível competitivo</value>
+  </data>
+  <data name="See Leaderboards" xml:space="preserve">
+    <value>Ver classificações</value>
+  </data>
+  <data name="Show" xml:space="preserve">
+    <value>Mostrar</value>
+  </data>
+  <data name="Singles Level" xml:space="preserve">
+    <value>Nível Singles</value>
+  </data>
+  <data name="Song Name Mappings" xml:space="preserve">
+    <value>Mapeamentos de nome de música</value>
+  </data>
+  <data name="Song Names" xml:space="preserve">
+    <value>Nomes de músicas</value>
+  </data>
+  <data name="Source Code" xml:space="preserve">
+    <value>Código-fonte</value>
+  </data>
+  <data name="Stats" xml:space="preserve">
+    <value>Estatísticas</value>
+  </data>
+  <data name="Step Artist: X" xml:space="preserve">
+    <value>Autor dos passos: {0}</value>
+  </data>
+  <data name="Supported Formats" xml:space="preserve">
+    <value>Formatos suportados</value>
+  </data>
+  <data name="TRUE/FALSE Template" xml:space="preserve">
+    <value>Modelo TRUE/FALSE</value>
+  </data>
+  <data name="The Category Isn't Interesting to Me'" xml:space="preserve">
+    <value>A categoria não me interessa</value>
+  </data>
+  <data name="To" xml:space="preserve">
+    <value>Para</value>
+  </data>
+  <data name="Top 50 X" xml:space="preserve">
+    <value>Top 50 - {0}</value>
+  </data>
+  <data name="Type" xml:space="preserve">
+    <value>Tipo</value>
+  </data>
+  <data name="Use Password" xml:space="preserve">
+    <value>Usar senha</value>
+  </data>
+  <data name="Use Script" xml:space="preserve">
+    <value>Usar script</value>
+  </data>
+  <data name="Welcome" xml:space="preserve">
+    <value>Bem-vindo</value>
+  </data>
+  <data name="What Should I Play" xml:space="preserve">
+    <value>O que devo jogar</value>
+  </data>
+  <data name="What Should I Play?" xml:space="preserve">
+    <value>O que devo jogar?</value>
+  </data>
+  <data name="XXLetterGrade" xml:space="preserve">
+    <value>Letras de nota XX</value>
+  </data>
+  <data name="Your Score" xml:space="preserve">
+    <value>Sua pontuação</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -481,27 +481,21 @@
     <value>{0} votos</value>
   </data>
   <data name="Place" xml:space="preserve">
-    <value>Place</value>
-    <comment>Place</comment>
+    <value>Posição</value>
   </data>
   <data name="Upload Image" xml:space="preserve">
-    <value>Upload Image</value>
-    <comment>Upload Image</comment>
+    <value>Carregar imagem</value>
   </data>
   <data name="Song" xml:space="preserve">
-    <value>Song</value>
-    <comment>Song</comment>
+    <value>Música</value>
   </data>
   <data name="Submit" xml:space="preserve">
-    <value>Submit</value>
-    <comment>Submit</comment>
+    <value>Enviar</value>
   </data>
   <data name="Song Artist" xml:space="preserve">
-    <value>Song Artist</value>
-    <comment>Song Artist</comment>
+    <value>Artista da música</value>
   </data>
   <data name="Text View" xml:space="preserve">
-    <value>Text View</value>
-    <comment>Text View</comment>
+    <value>Visualização em texto</value>
   </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1446,4 +1446,184 @@
   <data name="You somehow ended up in a state between realities. Refresh the page to try again." xml:space="preserve">
     <value>Você de alguma forma acabou em um estado entre realidades. Atualize a página para tentar novamente.</value>
   </data>
+  <data name="Active Tournaments" xml:space="preserve">
+    <value>Campeonatos ativos</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Adicionar</value>
+  </data>
+  <data name="Add Player" xml:space="preserve">
+    <value>Adicionar jogador</value>
+  </data>
+  <data name="Add Scores" xml:space="preserve">
+    <value>Adicionar pontuações</value>
+  </data>
+  <data name="Always" xml:space="preserve">
+    <value>Sempre</value>
+  </data>
+  <data name="are" xml:space="preserve">
+    <value>são</value>
+  </data>
+  <data name="are not" xml:space="preserve">
+    <value>não são</value>
+  </data>
+  <data name="Base Level Scores" xml:space="preserve">
+    <value>Pontuações de nível base</value>
+  </data>
+  <data name="Broken scores get a multiplier of X" xml:space="preserve">
+    <value>Pontuações quebradas recebem um multiplicador de {0}</value>
+  </data>
+  <data name="Chart Types" xml:space="preserve">
+    <value>Tipos de chart</value>
+  </data>
+  <data name="Check Your Best Pumbility Charts" xml:space="preserve">
+    <value>Verifique seus melhores charts de Pumbility</value>
+  </data>
+  <data name="Discord Id" xml:space="preserve">
+    <value>ID do Discord</value>
+  </data>
+  <data name="End Date" xml:space="preserve">
+    <value>Data de término</value>
+  </data>
+  <data name="End Date: X" xml:space="preserve">
+    <value>Data de término: {0}</value>
+  </data>
+  <data name="Event" xml:space="preserve">
+    <value>Evento</value>
+  </data>
+  <data name="Event Links" xml:space="preserve">
+    <value>Links do evento</value>
+  </data>
+  <data name="Import" xml:space="preserve">
+    <value>Importar</value>
+  </data>
+  <data name="Is Warmup" xml:space="preserve">
+    <value>Aquecimento</value>
+  </data>
+  <data name="Letter Grades" xml:space="preserve">
+    <value>Letras de nota</value>
+  </data>
+  <data name="Link" xml:space="preserve">
+    <value>Link</value>
+  </data>
+  <data name="Location" xml:space="preserve">
+    <value>Local</value>
+  </data>
+  <data name="Machine Name" xml:space="preserve">
+    <value>Nome da máquina</value>
+  </data>
+  <data name="Machines" xml:space="preserve">
+    <value>Máquinas</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Nunca</value>
+  </data>
+  <data name="New Player Name" xml:space="preserve">
+    <value>Nome do novo jogador</value>
+  </data>
+  <data name="Notes" xml:space="preserve">
+    <value>Notas</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Senha</value>
+  </data>
+  <data name="Pending" xml:space="preserve">
+    <value>Pendente</value>
+  </data>
+  <data name="Permissions" xml:space="preserve">
+    <value>Permissões</value>
+  </data>
+  <data name="Photos" xml:space="preserve">
+    <value>Fotos</value>
+  </data>
+  <data name="Play Num" xml:space="preserve">
+    <value>Jogue ao menos {0}</value>
+  </data>
+  <data name="Player Name" xml:space="preserve">
+    <value>Nome do jogador</value>
+  </data>
+  <data name="Player added" xml:space="preserve">
+    <value>Jogador adicionado</value>
+  </data>
+  <data name="Players (Paste UserId from Account Page if not Public)" xml:space="preserve">
+    <value>Jogadores (cole o UserId da página da conta se não for público)</value>
+  </data>
+  <data name="Players have X to play charts. You are allowed to finish the song you are on when your time runs out. Your total score is total combined score of all charts you play." xml:space="preserve">
+    <value>Os jogadores têm {0} para jogar charts. Você pode terminar a música em que está quando o tempo acabar. Sua pontuação total é a soma das pontuações de todos os charts que você jogar.</value>
+  </data>
+  <data name="Players synced" xml:space="preserve">
+    <value>Jogadores sincronizados</value>
+  </data>
+  <data name="Potential Conflict" xml:space="preserve">
+    <value>Conflito potencial</value>
+  </data>
+  <data name="Previous Tournaments" xml:space="preserve">
+    <value>Campeonatos anteriores</value>
+  </data>
+  <data name="Priority" xml:space="preserve">
+    <value>Prioridade</value>
+  </data>
+  <data name="Qualifier Submit Phrase 1" xml:space="preserve">
+    <value>Você não precisa estar logado para usar essa ferramenta. Digite um nome de usuário para começar a enviar.</value>
+  </data>
+  <data name="Qualifier Submit Phrase 2" xml:space="preserve">
+    <value>Este é seu primeiro envio! Certifique-se de que seu nome de usuário seja identificável via Discord ou Start.GG.</value>
+  </data>
+  <data name="Qualifiers Leaderboard" xml:space="preserve">
+    <value>Classificação dos qualifiers</value>
+  </data>
+  <data name="Qualifiers Submission" xml:space="preserve">
+    <value>Envio dos qualifiers</value>
+  </data>
+  <data name="Repeated charts X allowed." xml:space="preserve">
+    <value>Charts repetidos {0} permitidos.</value>
+  </data>
+  <data name="Rules" xml:space="preserve">
+    <value>Regras</value>
+  </data>
+  <data name="Seed" xml:space="preserve">
+    <value>Seed</value>
+  </data>
+  <data name="Song Types" xml:space="preserve">
+    <value>Tipos de música</value>
+  </data>
+  <data name="Songs will have score adjusted based on song length (treating 2 minutes as baseline)" xml:space="preserve">
+    <value>As músicas terão a pontuação ajustada com base na duração da música (considerando 2 minutos como base)</value>
+  </data>
+  <data name="Start Date" xml:space="preserve">
+    <value>Data de início</value>
+  </data>
+  <data name="Start Date: X" xml:space="preserve">
+    <value>Data de início: {0}</value>
+  </data>
+  <data name="Submission Page" xml:space="preserve">
+    <value>Página de envio</value>
+  </data>
+  <data name="Suggested Chart" xml:space="preserve">
+    <value>Chart sugerido</value>
+  </data>
+  <data name="Sync Qualifier Leaderboard" xml:space="preserve">
+    <value>Sincronizar classificação dos qualifiers</value>
+  </data>
+  <data name="This user does not exist. Double check the User Id" xml:space="preserve">
+    <value>Este usuário não existe. Confira o ID do usuário.</value>
+  </data>
+  <data name="To Leaderboard" xml:space="preserve">
+    <value>Ver classificação</value>
+  </data>
+  <data name="Tournament" xml:space="preserve">
+    <value>Campeonato</value>
+  </data>
+  <data name="Tournament Role" xml:space="preserve">
+    <value>Função do campeonato</value>
+  </data>
+  <data name="Upcoming Tournaments" xml:space="preserve">
+    <value>Próximos campeonatos</value>
+  </data>
+  <data name="Website" xml:space="preserve">
+    <value>Site</value>
+  </data>
+  <data name="X Brackets" xml:space="preserve">
+    <value>{0} Chaves</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -747,4 +747,103 @@
   <data name="XX Progress" xml:space="preserve">
     <value>Progresso XX</value>
   </data>
+  <data name="Admin" xml:space="preserve">
+    <value>Admin</value>
+  </data>
+  <data name="Bulk Vote" xml:space="preserve">
+    <value>Voto em massa</value>
+  </data>
+  <data name="Channel Name" xml:space="preserve">
+    <value>Nome do canal</value>
+  </data>
+  <data name="Chart Update" xml:space="preserve">
+    <value>Atualização de chart</value>
+  </data>
+  <data name="Chart saved" xml:space="preserve">
+    <value>Chart salvo</value>
+  </data>
+  <data name="Clear Cache" xml:space="preserve">
+    <value>Limpar cache</value>
+  </data>
+  <data name="Communities" xml:space="preserve">
+    <value>Comunidades</value>
+  </data>
+  <data name="Community Invite" xml:space="preserve">
+    <value>Convite da comunidade</value>
+  </data>
+  <data name="Create" xml:space="preserve">
+    <value>Criar</value>
+  </data>
+  <data name="Create Song" xml:space="preserve">
+    <value>Criar música</value>
+  </data>
+  <data name="Do It" xml:space="preserve">
+    <value>Executar</value>
+  </data>
+  <data name="Done" xml:space="preserve">
+    <value>Concluído</value>
+  </data>
+  <data name="Image Name" xml:space="preserve">
+    <value>Nome da imagem</value>
+  </data>
+  <data name="Korean Name" xml:space="preserve">
+    <value>Nome em coreano</value>
+  </data>
+  <data name="Last Updated" xml:space="preserve">
+    <value>Última atualização</value>
+  </data>
+  <data name="Leaderboard Name" xml:space="preserve">
+    <value>Nome da classificação</value>
+  </data>
+  <data name="Level/Players" xml:space="preserve">
+    <value>Nível/Jogadores</value>
+  </data>
+  <data name="Maximum Level" xml:space="preserve">
+    <value>Nível máximo</value>
+  </data>
+  <data name="Minimum Level" xml:space="preserve">
+    <value>Nível mínimo</value>
+  </data>
+  <data name="Minutes" xml:space="preserve">
+    <value>Minutos</value>
+  </data>
+  <data name="ReCalculate Ratings" xml:space="preserve">
+    <value>Recalcular ratings</value>
+  </data>
+  <data name="Restored" xml:space="preserve">
+    <value>Restaurado</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Salvar</value>
+  </data>
+  <data name="Save Chart" xml:space="preserve">
+    <value>Salvar chart</value>
+  </data>
+  <data name="Saved!" xml:space="preserve">
+    <value>Salvo!</value>
+  </data>
+  <data name="Seconds" xml:space="preserve">
+    <value>Segundos</value>
+  </data>
+  <data name="Show Regional Guests" xml:space="preserve">
+    <value>Mostrar convidados regionais</value>
+  </data>
+  <data name="Update Chart" xml:space="preserve">
+    <value>Atualizar chart</value>
+  </data>
+  <data name="Updated X Y" xml:space="preserve">
+    <value>Atualizado: {0} {1}</value>
+  </data>
+  <data name="Video URL" xml:space="preserve">
+    <value>URL do vídeo</value>
+  </data>
+  <data name="Video info is not formatted correctly" xml:space="preserve">
+    <value>Informações do vídeo não estão formatadas corretamente</value>
+  </data>
+  <data name="Your Difficulty Rating" xml:space="preserve">
+    <value>Seu rating de dificuldade</value>
+  </data>
+  <data name="Youtube Hash" xml:space="preserve">
+    <value>Hash do YouTube</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -498,4 +498,91 @@
   <data name="Text View" xml:space="preserve">
     <value>Visualização em texto</value>
   </data>
+  <data name="Age" xml:space="preserve">
+    <value>Idade</value>
+  </data>
+  <data name="BPM" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="Days Old" xml:space="preserve">
+    <value>dias de idade</value>
+  </data>
+  <data name="Difficulty Categorization" xml:space="preserve">
+    <value>Categorização de dificuldade</value>
+  </data>
+  <data name="Filters" xml:space="preserve">
+    <value>Filtros</value>
+  </data>
+  <data name="Max BPM" xml:space="preserve">
+    <value>BPM máx.</value>
+  </data>
+  <data name="Max Letter Grade" xml:space="preserve">
+    <value>Letra de nota máx.</value>
+  </data>
+  <data name="Max Note Count" xml:space="preserve">
+    <value>Contagem máx. de notas</value>
+  </data>
+  <data name="Min BPM" xml:space="preserve">
+    <value>BPM mín.</value>
+  </data>
+  <data name="Min Letter Grade" xml:space="preserve">
+    <value>Letra de nota mín.</value>
+  </data>
+  <data name="Min Note Count" xml:space="preserve">
+    <value>Contagem mín. de notas</value>
+  </data>
+  <data name="Note Count" xml:space="preserve">
+    <value>Contagem de notas</value>
+  </data>
+  <data name="PIU Tier List" xml:space="preserve">
+    <value>Faixa oficial PIU</value>
+  </data>
+  <data name="Pass (Data Backed)" xml:space="preserve">
+    <value>Pass (Baseado em dados)</value>
+  </data>
+  <data name="Personalized Difficulty" xml:space="preserve">
+    <value>Dificuldade personalizada</value>
+  </data>
+  <data name="Player Count" xml:space="preserve">
+    <value>Quantidade de jogadores</value>
+  </data>
+  <data name="Popularity (PIU Game Leaderboard)" xml:space="preserve">
+    <value>Popularidade (Classificação do PIU Game)</value>
+  </data>
+  <data name="Score (Data Backed)" xml:space="preserve">
+    <value>Pontuação (Baseada em dados)</value>
+  </data>
+  <data name="Score Ranking" xml:space="preserve">
+    <value>Ranking de pontuação</value>
+  </data>
+  <data name="Scoring Level" xml:space="preserve">
+    <value>Nível de pontuação</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Configurações</value>
+  </data>
+  <data name="Show Age" xml:space="preserve">
+    <value>Mostrar idade</value>
+  </data>
+  <data name="Show Difficulty" xml:space="preserve">
+    <value>Mostrar dificuldade</value>
+  </data>
+  <data name="Show Skills" xml:space="preserve">
+    <value>Mostrar habilidades</value>
+  </data>
+  <data name="Show Song Name" xml:space="preserve">
+    <value>Mostrar nome da música</value>
+  </data>
+  <data name="Show Step Artist" xml:space="preserve">
+    <value>Mostrar autor dos passos</value>
+  </data>
+  <data name="Skill" xml:space="preserve">
+    <value>Habilidade</value>
+  </data>
+  <data name="Stage Pass" xml:space="preserve">
+    <value>Pass do estágio</value>
+  </data>
+  <data name="Step Artist" xml:space="preserve">
+    <value>Autor dos passos</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1404,4 +1404,46 @@
   <data name="Your Score" xml:space="preserve">
     <value>Sua pontuação</value>
   </data>
+  <data name="After the upload, if there are some rows/charts/attempts that did not upload correctly, you will be given the option to download a list of the failed rows and the reason they failed." xml:space="preserve">
+    <value>Após o upload, se algumas linhas/charts/tentativas não tiverem sido carregadas corretamente, você terá a opção de baixar uma lista das linhas com falha e o motivo da falha.</value>
+  </data>
+  <data name="All charts you uploaded were successfully updated!" xml:space="preserve">
+    <value>Todos os charts que você carregou foram atualizados com sucesso!</value>
+  </data>
+  <data name="If you leave this page or cancel, the upload will stop but you will not lose any scores that have already been recorded from your upload." xml:space="preserve">
+    <value>Se você sair desta página ou cancelar, o upload será interrompido, mas você não perderá nenhuma pontuação que já tenha sido registrada no upload.</value>
+  </data>
+  <data name="In some of those cases, it may be faster to upload a Spreadsheet instead of manually inputting thousands of grades." xml:space="preserve">
+    <value>Em alguns desses casos, pode ser mais rápido carregar uma planilha em vez de inserir manualmente milhares de notas.</value>
+  </data>
+  <data name="Original Concept (excel score tracking) Constructed by KyleTT" xml:space="preserve">
+    <value>Conceito original (rastreamento de pontuações em Excel) criado por KyleTT</value>
+  </data>
+  <data name="Site constructed and maintained by DrMurloc" xml:space="preserve">
+    <value>Site criado e mantido por DrMurloc</value>
+  </data>
+  <data name="Some adjustments to account for typos or difference in naming conventions have been accounted for. Song Names are Case Insensitive. (Note that some of these look the same because they are whitespace adjustments)" xml:space="preserve">
+    <value>Alguns ajustes para considerar erros de digitação ou diferenças nas convenções de nomenclatura foram aplicados. Os nomes das músicas não diferenciam maiúsculas de minúsculas. (Observe que alguns destes parecem iguais porque são ajustes de espaços em branco)</value>
+  </data>
+  <data name="Some players already maintain scores via Spreadsheets." xml:space="preserve">
+    <value>Alguns jogadores já mantêm suas pontuações em planilhas.</value>
+  </data>
+  <data name="Spreadsheet is uploading and being processed..." xml:space="preserve">
+    <value>A planilha está sendo carregada e processada...</value>
+  </data>
+  <data name="There was an unknown error while parsing the file" xml:space="preserve">
+    <value>Ocorreu um erro desconhecido ao processar o arquivo</value>
+  </data>
+  <data name="Welcome to Score Tracker, X!" xml:space="preserve">
+    <value>Bem-vindo ao Rastreador de Pontuações, {0}!</value>
+  </data>
+  <data name="X/Y Uploaded. Z Remaining. W Failed to record" xml:space="preserve">
+    <value>{0}/{1} Carregado. {2} Restante. {3} Falha no registro</value>
+  </data>
+  <data name="You had a few charts that were not able to be downloaded. You can download a CSV of the failures to make adjustments and try again." xml:space="preserve">
+    <value>Você tinha alguns charts que não puderam ser baixados. Você pode baixar o CSV das falhas para fazer ajustes e tentar novamente.</value>
+  </data>
+  <data name="You somehow ended up in a state between realities. Refresh the page to try again." xml:space="preserve">
+    <value>Você de alguma forma acabou em um estado entre realidades. Atualize a página para tentar novamente.</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -846,4 +846,106 @@
   <data name="Youtube Hash" xml:space="preserve">
     <value>Hash do YouTube</value>
   </data>
+  <data name="Added" xml:space="preserve">
+    <value>Adicionado</value>
+  </data>
+  <data name="Arrows Pressed" xml:space="preserve">
+    <value>Setas pressionadas</value>
+  </data>
+  <data name="Bads vs Misses Observations" xml:space="preserve">
+    <value>Observações: Bads vs Misses</value>
+  </data>
+  <data name="Changed Level" xml:space="preserve">
+    <value>Nível alterado</value>
+  </data>
+  <data name="Chart Compare" xml:space="preserve">
+    <value>Comparar charts</value>
+  </data>
+  <data name="Chart Count" xml:space="preserve">
+    <value>Contagem de charts</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Excluir</value>
+  </data>
+  <data name="Great Combo, Bad Break" xml:space="preserve">
+    <value>Combo de greats, quebra com bad</value>
+  </data>
+  <data name="Great Combo, Miss Break" xml:space="preserve">
+    <value>Combo de greats, quebra com miss</value>
+  </data>
+  <data name="Greats" xml:space="preserve">
+    <value>Greats</value>
+  </data>
+  <data name="Life Bar by Level" xml:space="preserve">
+    <value>Lifebar por nível</value>
+  </data>
+  <data name="Life Threshold" xml:space="preserve">
+    <value>Limite de vida</value>
+  </data>
+  <data name="Life gain description" xml:space="preserve">
+    <value>Descrição de ganho de vida</value>
+  </data>
+  <data name="Life loss description" xml:space="preserve">
+    <value>Descrição de perda de vida</value>
+  </data>
+  <data name="Lifebar Description" xml:space="preserve">
+    <value>Descrição da lifebar</value>
+  </data>
+  <data name="Lifebar stats" xml:space="preserve">
+    <value>Estatísticas da lifebar</value>
+  </data>
+  <data name="Max Life" xml:space="preserve">
+    <value>Vida máxima</value>
+  </data>
+  <data name="Max Rating" xml:space="preserve">
+    <value>Rating máximo</value>
+  </data>
+  <data name="Note Count from Full Life to Death/Threshold based on Combo between Breaks" xml:space="preserve">
+    <value>Quantidade de notas da vida cheia até a morte/limite, com base no combo entre quebras</value>
+  </data>
+  <data name="Notes to Full Life From Start of Song (50%)" xml:space="preserve">
+    <value>Notas até a vida cheia desde o início da música (50%)</value>
+  </data>
+  <data name="PIU Life Calculator" xml:space="preserve">
+    <value>Calculadora de vida do PIU</value>
+  </data>
+  <data name="Perfect Combo, Bad Break" xml:space="preserve">
+    <value>Combo de perfects, quebra com bad</value>
+  </data>
+  <data name="Perfect Combo, Miss Break" xml:space="preserve">
+    <value>Combo de perfects, quebra com miss</value>
+  </data>
+  <data name="Perfects" xml:space="preserve">
+    <value>Perfects</value>
+  </data>
+  <data name="Rating Calculator" xml:space="preserve">
+    <value>Calculadora de rating</value>
+  </data>
+  <data name="Recovery Observations" xml:space="preserve">
+    <value>Observações de recuperação</value>
+  </data>
+  <data name="Removed" xml:space="preserve">
+    <value>Removido</value>
+  </data>
+  <data name="Saved Settings" xml:space="preserve">
+    <value>Configurações salvas</value>
+  </data>
+  <data name="Settings Name" xml:space="preserve">
+    <value>Nome das configurações</value>
+  </data>
+  <data name="Source" xml:space="preserve">
+    <value>Fonte</value>
+  </data>
+  <data name="Starting Life" xml:space="preserve">
+    <value>Vida inicial</value>
+  </data>
+  <data name="Step Artists" xml:space="preserve">
+    <value>Autores dos passos</value>
+  </data>
+  <data name="TLDR" xml:space="preserve">
+    <value>TLDR</value>
+  </data>
+  <data name="Visible Life" xml:space="preserve">
+    <value>Vida visível</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1806,4 +1806,94 @@
   <data name="Your Points per Second" xml:space="preserve">
     <value>Seus pontos por segundo</value>
   </data>
+  <data name="100% (or everyone with a PG)" xml:space="preserve">
+    <value>100% (ou todos com um PG)</value>
+  </data>
+  <data name="Add UCS" xml:space="preserve">
+    <value>Adicionar UCS</value>
+  </data>
+  <data name="Co-Op" xml:space="preserve">
+    <value>Co-Op</value>
+  </data>
+  <data name="Current" xml:space="preserve">
+    <value>Atual</value>
+  </data>
+  <data name="Home" xml:space="preserve">
+    <value>Início</value>
+  </data>
+  <data name="Leaderboard Player Compare" xml:space="preserve">
+    <value>Comparar jogadores na classificação</value>
+  </data>
+  <data name="Leaderboard Type" xml:space="preserve">
+    <value>Tipo de classificação</value>
+  </data>
+  <data name="Monthly Leaderboard" xml:space="preserve">
+    <value>Classificação mensal</value>
+  </data>
+  <data name="No Recorded Scores" xml:space="preserve">
+    <value>Sem pontuações registradas</value>
+  </data>
+  <data name="Official Leaderboard Search" xml:space="preserve">
+    <value>Busca na classificação oficial</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>Abrir</value>
+  </data>
+  <data name="Road to BITE (Monthly Leaderboard July 8th - August 4th)" xml:space="preserve">
+    <value>Road to BITE (Classificação mensal de 8 de julho a 4 de agosto)</value>
+  </data>
+  <data name="Score Rankings" xml:space="preserve">
+    <value>Rankings de pontuação</value>
+  </data>
+  <data name="Score Rankings (the colored scores) are based on comparisons to similarly skilled players." xml:space="preserve">
+    <value>Os Rankings de pontuação (as pontuações coloridas) são baseados em comparações com jogadores de habilidade similar.</value>
+  </data>
+  <data name="Scoring Rankings" xml:space="preserve">
+    <value>Rankings de pontuação</value>
+  </data>
+  <data name="Show Only Suggested Charts" xml:space="preserve">
+    <value>Mostrar somente charts sugeridos</value>
+  </data>
+  <data name="Similarly skilled players to you for Doubles (CoOp charts use doubles competitive level):" xml:space="preserve">
+    <value>Jogadores com habilidade similar à sua para Doubles (charts de CoOp usam o nível competitivo de Doubles):</value>
+  </data>
+  <data name="Similarly skilled players to you for Singles:" xml:space="preserve">
+    <value>Jogadores com habilidade similar à sua para Singles:</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Tags" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="The higher percent of players in your range that you perform better than, the better the color:" xml:space="preserve">
+    <value>Quanto maior a porcentagem de jogadores em sua faixa que você supera, melhor a cor:</value>
+  </data>
+  <data name="UCS Leaderboard" xml:space="preserve">
+    <value>Classificação de UCS</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>Desconhecido</value>
+  </data>
+  <data name="Uploader" xml:space="preserve">
+    <value>Carregador</value>
+  </data>
+  <data name="Validation" xml:space="preserve">
+    <value>Validação</value>
+  </data>
+  <data name="Week X - Top Y Charts" xml:space="preserve">
+    <value>Semana {0} - Top {1} charts</value>
+  </data>
+  <data name="Weekly Charts" xml:space="preserve">
+    <value>Charts Semanais</value>
+  </data>
+  <data name="World Rankings" xml:space="preserve">
+    <value>Rankings mundiais</value>
+  </data>
+  <data name="Wouldn't You Like To Know" xml:space="preserve">
+    <value>Você gostaria de saber, não?</value>
+  </data>
+  <data name="X% of Y Comparable Players" xml:space="preserve">
+    <value>{0}% de {1} jogadores comparáveis</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary

Brings `App.pt-BR.resx` from 23% coverage (131 keys, 6 of them rendering English-as-stub) to **100% coverage** of `App.en-US.resx` (573 / 573). Adds [LOCALIZATION-pt-BR.md](LOCALIZATION-pt-BR.md) as a working glossary for future locale work.

## Approach

Phased batches by feature folder, one PR-style commit each, with the glossary growing alongside. Every batch was manually reviewed and confirmed before commit. Build (`dotnet build ScoreTracker/ScoreTracker.sln -c Release`) ran clean after each batch (0 errors).

| Batch | Scope | Keys |
|---|---|---|
| Glossary | Initial scaffold from existing 131 entries | — |
| 1 | Stub fixes (English-as-value entries) | 6 |
| 2 | TierLists | 29 |
| 3 | Progress | 54 |
| 4 | Admin + Communities + OfficialLeaderboards | 33 |
| 5 | Tools labels | 34 |
| 6 | Tools prose (lifebar mechanics paragraphs) | 26 |
| 7 | Experiments labels | 43 |
| 8 | Experiments prose (chart-scoring algorithm explanation) | 18 |
| 9 | Top-level page labels (Charts, ChartDetails, Upload*, Welcome, etc.) | 65 |
| 10 | Top-level prose (upload-flow disclaimers, error messages) | 14 |
| 11 | Competition tournament cluster | 60 |
| 12 | Competition stamina cluster (SessionBuilder + StaminaTournament) | 60 |
| 13 | Competition leaderboards + orphan keys | 30 |

Total: **472 new translations** (442 missing + 6 stub fixes + 24 orphan keys defined in en-US but not used in any Razor page).

## Key translation policies

Captured in detail in [LOCALIZATION-pt-BR.md](LOCALIZATION-pt-BR.md). The biggest:

- **Voice**: informal `você`, sentence-case values even when English keys are Title Case, positional placeholders preserved verbatim.
- **PIU jargon kept English**: `chart`, `pass`, `Plate`, `Plates`, `Bounty`, `Pumbility`, `UCS`, `Singles`, `Doubles`, `CoOp`, `Phoenix`, `XX`, `Rainbow`, `Folder`, `Stamina`, `Seed`, `Qualifiers`, judgment terms (`Bad`/`Miss`/`Perfect`/`Great`/`Good` and plurals), and `Rating` / `Rankings` (loanwords matching Brazilian PIU community usage).
- **PIU jargon translated**: `Tier Lists` → `Faixas de dificuldade`, `Mix` → `Versão`, `Letter Grade` → `Letras de nota`, `Brackets` → `Chaves`, `Step Artist` → `Autor dos passos`, `Weekly Charts` → `Charts Semanais`.
- **Decimal separator**: pt-BR comma (`9,6`).
- **Source typos**: translated to read as correct grammar (e.g. `is worst than` → `é pior que`, missing-word in `you 46-55 combo per Miss` → `você precisa de 46-55 de combo por miss`). Fix-typo policy is documented in the glossary.
- **Inline-conjunction composition** (`are` / `are not` keys composing into `Repeated charts X allowed.`) → `são` / `não são` to keep the host sentence grammatical.

Several existing translations from the original contributor were preserved as-is per maintainer guidance, even where the native idiom would suggest alternatives (`Linguagem` over `Idioma`, `Letras de nota` over `Nota`).

## Reviewer notes

- **File structure**: `App.pt-BR.resx` is alphabetical at the top (original 131 entries) and append-style at the tail (all 13 batches grouped per commit, sorted alphabetically within each batch). Functionally fine, cosmetically untidy — a re-sort pass is a reasonable separate follow-up.
- **24 orphan keys**: pt-BR.resx now has 597 total entries vs en-US's 573. The 24 extras are keys defined in pt-BR but no longer referenced by en-US. Translated for completeness; safe to remove in a separate cleanup if you prefer leanness over symmetry.
- **Glossary**: [LOCALIZATION-pt-BR.md](LOCALIZATION-pt-BR.md) is the source of truth for every recurring decision. Future translators (or future you) can extend pt-BR consistently from this doc, and the same playbook applies to es-MX (94 keys) / ko-KR (154) / fr-FR (196) if you ever return to them.
- **Tone calibration**: humorous error messages were preserved (`You somehow ended up in a state between realities` → `Você de alguma forma acabou em um estado entre realidades`; `Wouldn't You Like To Know` → `Você gostaria de saber, não?`). If any read flat to a native ear, easy to revise.

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` — 0 errors after each batch
- [ ] Spot-check a few pages with culture set to `pt-BR` (Tier Lists, Progress, Tournaments, Tools/PIU Life Calculator)
- [ ] Confirm long error/success snackbars and disclaimers render without overflow on narrow viewports
- [ ] Ask a Brazilian PIU community member to skim and flag anything that reads stiff

🤖 Generated with [Claude Code](https://claude.com/claude-code)