### PR TITLE
Parallelize ChartSkills queries + fix Similar Players bug

### DIFF
--- a/ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor
+++ b/ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor
@@ -1817,7 +1817,7 @@ function(val, index) {
     };
     protected override async Task OnInitializedAsync()
     {
-        _filterNames= new Dictionary<Filter, string>()
+        _filterNames = new Dictionary<Filter, string>()
         {
             { Filter.SongType, L["Song Type"] },
             { Filter.SongName, L["Song Name"] },
@@ -1831,24 +1831,10 @@ function(val, index) {
             },
             { Filter.SongArtist, L["Song Artist"] }
         };
-        if (CurrentUser.IsLoggedIn)
-        {
-            
-            _scores = (await Mediator.Send(new GetPhoenixRecordsQuery(CurrentUser.User.Id)))
-                .ToDictionary(c => c.ChartId);
-            _ages = _scores.ToDictionary(c => c.Key, c => (int)(_now - c.Value.RecordedDate).TotalDays); 
-        }
-        var settingsString = await UiSettings.GetSetting(UserSettingsKey);
-        if (!string.IsNullOrWhiteSpace(settingsString))
-        {
-            _settings = JsonSerializer.Deserialize<FilterSettings>(settingsString);
-        }
-        _allCharts = (await Mediator.Send(new GetChartsQuery(MixEnum.Phoenix))).
-          ToDictionary(c => c.Id);
         _titles = PhoenixTitleList.BuildList();
         _chartType = ChartType.Double;
         _level = 18;
-        _tierListTypes=new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        _tierListTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             { "Pass", L["Pass (Data Backed)"] },
             { "Score", L["Score (Data Backed)"] },
@@ -1857,16 +1843,35 @@ function(val, index) {
             {"PG","PG"}
         };
 
+        // Kick off every independent async fetch in parallel — wall clock is now bounded by the slowest single query, not the sum.
+        var chartsTask = Mediator.Send(new GetChartsQuery(MixEnum.Phoenix));
+        var titleProgressTask = Mediator.Send(new GetTitleProgressQuery(MixEnum.Phoenix));
+        var userSettingsTask = UiSettings.GetSetting(UserSettingsKey);
+        var showAgeSettingTask = UiSettings.GetSetting("TierLists__ShowAge");
+        var levelSettingTask = UiSettings.GetSetting("TierLists__Level");
+        var chartTypeSettingTask = UiSettings.GetSetting("TierLists__ChartType");
+        var listTypeSettingTask = UiSettings.GetSetting("TierLists__ListType");
+        var personalizedSettingTask = UiSettings.GetSetting("TierLists__UsePersonalized");
+        var groupBySettingTask = UiSettings.GetSetting("TierLists__GroupBy");
+        var textViewSettingTask = UiSettings.GetSetting("TierLists__TextView");
+
         if (CurrentUser.IsLoggedIn)
         {
+            var userId = CurrentUser.User.Id;
+            var scoresTask = Mediator.Send(new GetPhoenixRecordsQuery(userId));
+            var topDoublesTask = Mediator.Send(new GetTop50CompetitiveQuery(userId, ChartType.Double));
+            var topSinglesTask = Mediator.Send(new GetTop50CompetitiveQuery(userId, ChartType.Single));
+            var statsTask = Mediator.Send(new GetPlayerStatsQuery(userId));
+            var todosTask = Mediator.Send(new GetSavedChartsQuery());
 
-            _topCharts = (await Mediator.Send(new GetTop50CompetitiveQuery(CurrentUser.User.Id, ChartType.Double)))
-                .Concat(await Mediator.Send(new GetTop50CompetitiveQuery(CurrentUser.User.Id, ChartType.Single)))
+            _scores = (await scoresTask).ToDictionary(c => c.ChartId);
+            _ages = _scores.ToDictionary(c => c.Key, c => (int)(_now - c.Value.RecordedDate).TotalDays);
+            _topCharts = (await topDoublesTask)
+                .Concat(await topSinglesTask)
                 .Select(c => c.ChartId).Distinct().ToHashSet();
-            var stats = await Mediator.Send(new GetPlayerStatsQuery(CurrentUser.User.Id));
+            var stats = await statsTask;
             if (stats.DoublesCompetitiveLevel > 1)
             {
-                
                 _level = (int)Math.Round(stats.DoublesCompetitiveLevel);
             }
             if (stats.SinglesCompetitiveLevel > 1 && stats.SinglesCompetitiveLevel > stats.DoublesCompetitiveLevel)
@@ -1874,25 +1879,33 @@ function(val, index) {
                 _chartType = ChartType.Single;
                 _level = (int)Math.Round(stats.SinglesCompetitiveLevel);
             }
-            _todos = (await Mediator.Send(new GetSavedChartsQuery())).Where(c => c.ListType == ChartListType.ToDo).Select(c => c.ChartId).Distinct().ToHashSet();
+            _todos = (await todosTask).Where(c => c.ListType == ChartListType.ToDo).Select(c => c.ChartId).Distinct().ToHashSet();
         }
-        _showAge = bool.TryParse(await UiSettings.GetSetting("TierLists__ShowAge"), out var res) && res;
-        _level = int.TryParse(await UiSettings.GetSetting("TierLists__Level"), out var l) ? l : 18;
-        _chartType = Enum.TryParse<ChartType>(await UiSettings.GetSetting("TierLists__ChartType"), out var cType) ? cType : ChartType.Double;
-        _tierListType = await UiSettings.GetSetting("TierLists__ListType") ?? "Pass";
-        _usePersonalizedData = (await UiSettings.GetSetting("TierLists__UsePersonalized") ?? true.ToString()) == true.ToString();
-        _groupBy = await UiSettings.GetSetting("TierLists__GroupBy") ?? "Difficulty";
-        _textView = (await UiSettings.GetSetting("TierLists__TextView") ?? false.ToString()) == true.ToString();
+
+        var settingsString = await userSettingsTask;
+        if (!string.IsNullOrWhiteSpace(settingsString))
+        {
+            _settings = JsonSerializer.Deserialize<FilterSettings>(settingsString);
+        }
+        _allCharts = (await chartsTask).ToDictionary(c => c.Id);
+
+        _showAge = bool.TryParse(await showAgeSettingTask, out var res) && res;
+        _level = int.TryParse(await levelSettingTask, out var l) ? l : 18;
+        _chartType = Enum.TryParse<ChartType>(await chartTypeSettingTask, out var cType) ? cType : ChartType.Double;
+        _tierListType = await listTypeSettingTask ?? "Pass";
+        _usePersonalizedData = (await personalizedSettingTask ?? true.ToString()) == true.ToString();
+        _groupBy = await groupBySettingTask ?? "Difficulty";
+        _textView = (await textViewSettingTask ?? false.ToString()) == true.ToString();
         if (DifficultyFilter is >= 1 and <= 29)
         {
             _level = DifficultyFilter.Value;
         }
-        _titleProgress = (await Mediator.Send(new GetTitleProgressQuery(MixEnum.Phoenix))).ToArray();
+        _titleProgress = (await titleProgressTask).ToArray();
         if (Enum.TryParse<ChartType>(ChartTypeFilter, out var chartType))
         {
             _chartType = chartType;
         }
-        if (TierListType!=null && _tierListTypes.ContainsKey(TierListType))
+        if (TierListType != null && _tierListTypes.ContainsKey(TierListType))
         {
             await SetTierListType(TierListType);
         }

--- a/ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor
+++ b/ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor
@@ -1449,40 +1449,51 @@ function(val, index) {
     private int _averageRating = 1;
     private async Task<IEnumerable<SongTierListEntry>> GetSimilarPlayers(ChartType type, int level)
     {
-
-        var myLevel = await Titles.GetCurrentTitleLevel(CurrentUser.User.Id, CancellationToken.None);
-        var lowLevel = await TierLists.GetUsersOnLevel(myLevel - 1, CancellationToken.None);
-        var onMyLevel = await TierLists.GetUsersOnLevel(myLevel - 1, CancellationToken.None);
-        var highLevel = await TierLists.GetUsersOnLevel(myLevel - +1, CancellationToken.None);
-        var userIds = (lowLevel)
-            .Concat(onMyLevel)
-            .Concat(highLevel)
-            .Where(u => u != CurrentUser.User.Id);
-        var userTiersLists = new Dictionary<Guid, IEnumerable<SongTierListEntry>>();
-        var myTierList = (await Mediator.Send(new GetMyRelativeTierListQuery(type, level)))
-            .ToDictionary(r => r.ChartId);
-        foreach (var userId in userIds)
+        var myUserId = CurrentUser.User.Id;
+        var cacheKey = $"{nameof(ChartSkills)}__SimilarPlayers__{myUserId}__{type}__{level}";
+        return await Cache.GetOrCreateAsync(cacheKey, async o =>
         {
-            userTiersLists[userId] = await Mediator.Send(new GetMyRelativeTierListQuery(type, level, userId));
-        }
-        var userTotals = userTiersLists.ToDictionary(kv => kv.Key, kv => kv.Value.Sum(e => myTierList.ContainsKey(e.ChartId) && myTierList[e.ChartId].Category != TierListCategory.Unrecorded && e.Category != TierListCategory.Unrecorded ?
-            (int)TierListCategory.Unrecorded - (int)Math.Abs(e.Category - myTierList[e.ChartId].Category)
-            : 0));
+            o.SlidingExpiration = TimeSpan.FromHours(1);
 
-        var chartWeights = new Dictionary<Guid, int>();
+            var myLevel = await Titles.GetCurrentTitleLevel(myUserId, CancellationToken.None);
+            var lowLevelTask = TierLists.GetUsersOnLevel(myLevel - 1, CancellationToken.None);
+            var onMyLevelTask = TierLists.GetUsersOnLevel(myLevel, CancellationToken.None);
+            var highLevelTask = TierLists.GetUsersOnLevel(myLevel + 1, CancellationToken.None);
+            await Task.WhenAll(lowLevelTask, onMyLevelTask, highLevelTask);
 
-        foreach (var kv in userTiersLists)
-            foreach (var entry in kv.Value.Where(e => e.Category != TierListCategory.Unrecorded))
-            {
-                if (!chartWeights.ContainsKey(entry.ChartId))
+            var userIds = lowLevelTask.Result
+                .Concat(onMyLevelTask.Result)
+                .Concat(highLevelTask.Result)
+                .Where(u => u != myUserId)
+                .Distinct()
+                .ToArray();
+
+            var myTierListTask = Mediator.Send(new GetMyRelativeTierListQuery(type, level));
+            var userTierListTasks = userIds
+                .Select(uid => (UserId: uid, Task: Mediator.Send(new GetMyRelativeTierListQuery(type, level, uid))))
+                .ToArray();
+            await Task.WhenAll(userTierListTasks.Select(t => (Task)t.Task).Append(myTierListTask));
+
+            var myTierList = myTierListTask.Result.ToDictionary(r => r.ChartId);
+            var userTiersLists = userTierListTasks.ToDictionary(t => t.UserId, t => t.Task.Result);
+
+            var userTotals = userTiersLists.ToDictionary(kv => kv.Key, kv => kv.Value.Sum(e => myTierList.ContainsKey(e.ChartId) && myTierList[e.ChartId].Category != TierListCategory.Unrecorded && e.Category != TierListCategory.Unrecorded ?
+                (int)TierListCategory.Unrecorded - (int)Math.Abs(e.Category - myTierList[e.ChartId].Category)
+                : 0));
+
+            var chartWeights = new Dictionary<Guid, int>();
+
+            foreach (var kv in userTiersLists)
+                foreach (var entry in kv.Value.Where(e => e.Category != TierListCategory.Unrecorded))
                 {
-                    chartWeights[entry.ChartId] = 0;
+                    if (!chartWeights.ContainsKey(entry.ChartId))
+                    {
+                        chartWeights[entry.ChartId] = 0;
+                    }
+                    chartWeights[entry.ChartId] += (TierListCategory.Unrecorded - entry.Category) * userTotals[kv.Key];
                 }
-                chartWeights[entry.ChartId] += (TierListCategory.Unrecorded - entry.Category) * userTotals[kv.Key];
-            }
-        return TierListSaga.ProcessIntoTierList("Similar Players", chartWeights);
-        
-
+            return TierListSaga.ProcessIntoTierList("Similar Players", chartWeights).ToArray().AsEnumerable();
+        });
     }
 
     private ISet<Guid> _topCharts = new HashSet<Guid>();

--- a/ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor
+++ b/ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor
@@ -754,6 +754,7 @@ function(val, index) {
     private IDictionary<Guid, RecordedPhoenixScore> _scores = new Dictionary<Guid, RecordedPhoenixScore>();
     private IDictionary<Guid, RecordedPhoenixScore> _folderScores = new Dictionary<Guid, RecordedPhoenixScore>();
     private IDictionary<Guid, Chart> _charts = new Dictionary<Guid, Chart>();
+    private IDictionary<Guid, Chart> _allCharts = new Dictionary<Guid, Chart>();
     private ISet<Guid> _unPopularCharts = new HashSet<Guid>();
     private ISet<Guid> _popularCharts = new HashSet<Guid>();
     private bool _isBuildingImage = false;
@@ -1551,7 +1552,9 @@ function(val, index) {
         await UiSettings.SetSetting("TierLists__ListType", _tierListType);
         await UiSettings.SetSetting("TierLists__UsePersonalized", _usePersonalizedData.ToString());
         await UiSettings.SetSetting("TierLists__GroupBy", _groupBy);
-        _charts = (await Mediator.Send(new GetChartsQuery(MixEnum.Phoenix, _level, _chartType))).ToDictionary(c => c.Id);
+        _charts = _allCharts.Values
+            .Where(c => c.Level == _level && c.Type == _chartType)
+            .ToDictionary(c => c.Id);
         _folderScores = _scores.Where(kv => _charts.ContainsKey(kv.Key)).ToDictionary(kv => kv.Key, kv => kv.Value);
         var titles = _titles.Where(t => t is ISpecificChartTitle).ToArray();
         _charTitles = _charts.Values.SelectMany(c => titles.Select(t => (c,t,((ISpecificChartTitle)t).AppliesToChart(c))))
@@ -1840,7 +1843,7 @@ function(val, index) {
         {
             _settings = JsonSerializer.Deserialize<FilterSettings>(settingsString);
         }
-        _charts = (await Mediator.Send(new GetChartsQuery(MixEnum.Phoenix))).
+        _allCharts = (await Mediator.Send(new GetChartsQuery(MixEnum.Phoenix))).
           ToDictionary(c => c.Id);
         _titles = PhoenixTitleList.BuildList();
         _chartType = ChartType.Double;


### PR DESCRIPTION
## Summary

Cuts cold-load wall-clock on the ChartSkills page (the most-complained-about page for slowness) by parallelizing the per-call MediatR query fan-out, fixing a longstanding correctness bug in Similar Players, and avoiding a redundant chart re-query on every filter change. Builds on the per-call DbContext refactor from #70 — that's what made parallelizing these queries safe.

## What's in here

Three commits, each independently revertible:

1. `a64b6d5` Fix ChartSkills similar-players bug, parallelize, cache
   - **Bug fix**: `onMyLevel = await TierLists.GetUsersOnLevel(myLevel - 1, ...)` was a duplicate of `lowLevel`. Users on the current level were silently never included in the similar-players cohort. Fixed to `myLevel`. Also cleaned up the noisy `myLevel - +1` to `myLevel + 1` (same value, less weird).
   - **Parallelize**: the three `GetUsersOnLevel` calls (low/onMy/high) are now `Task.WhenAll`'d (3 round-trips → 1). The per-user `GetMyRelativeTierListQuery` loop, which previously awaited serially for each similar user, now fans out — for ~20 similar users that's roughly 1 round-trip's wall-clock instead of 20.
   - **Cache**: result wrapped in `IMemoryCache` keyed by `(userId, chartType, level)` with 1h sliding expiration. Materialized via `.ToArray()` before caching to avoid a deferred-enumeration trap with the closure.

2. `5ef704a` Filter ChartSkills _charts in memory instead of re-querying
   - Split into `_allCharts` (full Phoenix set, populated once on init) and `_charts` (level/type filtered, recomputed in-memory in `Recalculate`). Removes a Mediator dispatch on every filter flip. The repository-layer query was already cache-backed, so this isn't a DB-hit reduction — it's removing one round-trip's worth of dispatch + projection overhead per filter change.

3. `d28dd62` Parallelize ChartSkills OnInitializedAsync query waterfall
   - The biggest single perf win. ~12 independent queries (charts, title progress, 7 UiSettings, 5 user-specific when logged in) used to run serially. Now launched up front and awaited in priority order. Wall-clock on cold load is bounded by the slowest single query rather than the sum.
   - Override chain preserved exactly: URL params > UiSettings > stats-derived defaults > hardcoded defaults.

## Verification

- `dotnet build ScoreTracker/ScoreTracker.sln -c Release`: 0 errors, pre-existing warnings only.
- `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj`: 279/279 passing.

## Reviewer notes

- The Similar Players bug fix is observable behavior change: users who were never included before will now appear in the cohort, so tier-list weights for "Similar Players" will shift slightly. The new behavior matches what the code clearly intended (three bands: below/at/above your title level).
- The parallelism is safe because every Mediator handler is transient and every EF repo opens its own DbContext per call (per-call DbContext refactor in #70). I verified the `TierListSaga` handler that services `GetMyRelativeTierListQuery` doesn't share scoped state across parallel invocations.
- `GetSimilarPlayers` is called from inside another `IMemoryCache` lambda (the final tier-list cache at the bottom of `Recalculate`). So the new Similar Players cache is a second-level cache: outer cache miss but inner hit means a fast rebuild (e.g. user comes back after 90 min — outer expired, inner still warm).

## Test plan

- [ ] Open ChartSkills as a logged-in user and confirm initial load feels faster (compare to current main if possible)
- [ ] Switch chart type (Single/Double) and difficulty level a few times — confirm `Recalculate` is responsive without a fresh `GetChartsQuery` on each switch
- [ ] Toggle "Use Personalized Data" — Similar Players cohort should now include same-level users; verify the tier list weights look reasonable
- [ ] Navigate away and come back to a previously-viewed (chartType, level) folder within an hour — should be near-instant due to cache
- [ ] Open as anonymous (logged-out) user and confirm the page still loads correctly without the user-specific branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)