### PR TITLE
Bump PhoenixRecords and PlayerStats cache TTLs

### DIFF
--- a/ScoreTracker/ScoreTracker.Data/Repositories/EFPhoenixRecordsRepository.cs
+++ b/ScoreTracker/ScoreTracker.Data/Repositories/EFPhoenixRecordsRepository.cs
@@ -105,7 +105,7 @@ public sealed class EFPhoenixRecordsRepository : IPhoenixRecordRepository,
     {
         return await _cache.GetOrCreateAsync(ScoreCache(userId), async o =>
         {
-            o.AbsoluteExpiration = DateTimeOffset.Now + TimeSpan.FromMinutes(10);
+            o.AbsoluteExpiration = DateTimeOffset.Now + TimeSpan.FromMinutes(60);
             await using var database = await _factory.CreateDbContextAsync(cancellationToken);
             var result = (await database.PhoenixBestAttempt.Where(pba => pba.UserId == userId)
                 .Select(pba => new RecordedPhoenixScore(pba.ChartId, pba.Score,

--- a/ScoreTracker/ScoreTracker.Data/Repositories/EFPlayerStatsRepository.cs
+++ b/ScoreTracker/ScoreTracker.Data/Repositories/EFPlayerStatsRepository.cs
@@ -85,7 +85,7 @@ namespace ScoreTracker.Data.Repositories
             return await _cache.GetOrCreateAsync(CacheKey(userId), async o =>
             {
                 await using var database = await _factory.CreateDbContextAsync(cancellationToken);
-                o.AbsoluteExpiration = DateTimeOffset.Now + TimeSpan.FromMinutes(5);
+                o.AbsoluteExpiration = DateTimeOffset.Now + TimeSpan.FromMinutes(30);
 
                 var entity =
                     await database.PlayerStats.FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken);


### PR DESCRIPTION
## Summary

Two-line change: bump the absolute-expiration TTL on the per-user score cache and per-user stats cache. Both caches already self-invalidate on writes, so the existing conservative TTLs were costing extra DB round-trips on the read path with no freshness benefit.

## Changes

| Cache | Before | After | Why safe |
|---|---|---|---|
| `EFPhoenixRecordsRepository.GetCachedScores` | 10 min | 60 min | `UpdateBestAttempt` does write-through (`_cache.Set` with the new score on every save). User always sees their own imports instantly regardless of TTL. |
| `EFPlayerStatsRepository.GetStats` | 5 min | 30 min | `SaveStats` calls `_cache.Remove(userId)` whenever stats are recomputed. Recompute fires from `PlayerRatingSaga` consuming `PlayerScoreUpdatedEvent` (~2 min debounced after import). Worst-case post-import staleness is unchanged by the TTL bump. |

## Verification

- `dotnet build ScoreTracker/ScoreTracker.sln -c Release`: 0 errors.
- `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj`: 279/279 passing.

## Reviewer notes

- This was item #4 from the original ChartSkills perf audit. Items #1-3 landed in #71.
- A more aggressive follow-up would be to wire `IUserCacheInvalidator` (per-user `CancellationChangeToken` busting) so the page-level final tier-list cache and the new SimilarPlayers cache also drop on import. Holding that for now per discussion — these TTL bumps are the simple, low-risk slice.

## Test plan

- [ ] Import scores and confirm they appear immediately on the page (write-through still works)
- [ ] Trigger a stat recompute (via the recurring job or by importing) and confirm stats update within ~2 min of import
- [ ] Leave a session idle for >10 min (longer than the old TTL) and confirm cached reads still serve correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)