### PR TITLE
Cache GetComparablePlayers per user

### DIFF
--- a/ScoreTracker/ScoreTracker.Application/Handlers/ScoreQualitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Application/Handlers/ScoreQualitySaga.cs
@@ -74,13 +74,19 @@ public sealed class ScoreQualitySaga :
     private async Task<IEnumerable<Guid>> GetComparablePlayers(ChartType chartType,
         CancellationToken cancellationToken)
     {
-        var myStats = await _playerStats.GetStats(_user.User.Id, cancellationToken);
-        var competitiveLevel = chartType == ChartType.Single
-            ? myStats.SinglesCompetitiveLevel
-            : myStats.DoublesCompetitiveLevel;
-
-        return await _playerStats.GetPlayersByCompetitiveRange(chartType, competitiveLevel,
-            .5, cancellationToken);
+        var userId = _user.User.Id;
+        return await _cache.GetOrCreateAsync(
+            $"{nameof(ScoreQualitySaga)}__{nameof(GetComparablePlayers)}__{userId}__{chartType}",
+            async o =>
+            {
+                o.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
+                var myStats = await _playerStats.GetStats(userId, cancellationToken);
+                var competitiveLevel = chartType == ChartType.Single
+                    ? myStats.SinglesCompetitiveLevel
+                    : myStats.DoublesCompetitiveLevel;
+                return (await _playerStats.GetPlayersByCompetitiveRange(chartType, competitiveLevel,
+                    .5, cancellationToken)).ToArray().AsEnumerable();
+            }) ?? Array.Empty<Guid>();
     }
 
     private async Task<IDictionary<Guid, PhoenixScore[]>> GetPlayerScores(ChartType chartType,


### PR DESCRIPTION
## Summary

Adds a 1h per-user cache around `ScoreQualitySaga.GetComparablePlayers`, the shared helper behind `GetCompetitivePlayersQuery`, `GetChartScoreRankingsQuery`, and `GetPlayerScoreQualityQuery`. ChartSkills calls `GetCompetitivePlayersQuery` on every Recalculate (every filter flip), and the underlying `GetPlayersByCompetitiveRange` SQL scan was running uncached on each call.

## Change

One-method wrap in `ScoreQualitySaga.cs`:

- Cache key: `ScoreQualitySaga__GetComparablePlayers__{userId}__{chartType}`
- TTL: 1h absolute (matches the existing `GetPlayerScores` cache convention in the same saga)
- Result materialized via `.ToArray()` before caching

## Why this and not the others from the audit

I originally proposed caching `GetTitleProgressQuery` alongside this. After looking at the handler, I dropped it from this PR — that query reads the *current user's* completed titles + scores and computes their title-progress display. Caching with 1h TTL would mean a user wouldn't see a newly-earned title for up to an hour after import. Better to revisit once the user-cache invalidator pattern is in place.

`GetPlayerScoreQualityQuery` is already partially cached via the saga's existing `GetPlayerScores` cache; full caching of the outer result would have the same staleness concern as title progress (it reflects the user's own scores).

## Memory impact (B1)

- ~2 KB per `(userId, chartType)` entry (a few hundred GUIDs)
- ~100 active logged-in users × 2 chart types = ~400 KB total at peak
- Trivial against the B1 budget

## Verification

- `dotnet build ScoreTracker/ScoreTracker.sln -c Release`: 0 errors
- `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj`: 279/279 passing

## Test plan

- [ ] Open ChartSkills as a logged-in user, flip chart type/level a few times, watch the EF SQL log — the `WHERE PlayerStats.SinglesCompetitiveLevel BETWEEN x AND y` query should fire once per (user, chartType) combination per hour, not on every filter flip
- [ ] Confirm `_competitivePlayerCount` still displays correctly on the page (it's the visible consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)