### PR TITLE
Add tests for high-priority untested logic (sessions, sagas, rankings)

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerRatingSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerRatingSagaTests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using MediatR;
+using Moq;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.PersonalProgress;
+using ScoreTracker.PersonalProgress.Queries;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class PlayerRatingSagaTests
+{
+    [Fact]
+    public async Task ConsumeUserCreatedSavesZeroedStatsRecord()
+    {
+        var stats = new Mock<IPlayerStatsRepository>();
+        var saga = BuildSaga(stats: stats);
+        var userId = Guid.NewGuid();
+
+        await saga.Consume(BuildContext(new UserCreatedEvent(userId)));
+
+        stats.Verify(s => s.SaveStats(userId,
+            It.Is<PlayerStatsRecord>(p => p.UserId == userId && p.TotalRating == 0
+                                          && p.ClearCount == 0 && p.HighestLevel == DifficultyLevel.From(1)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleGetTop50ForPlayerExcludesCoOpCharts()
+    {
+        var single = new ChartBuilder().WithType(ChartType.Single).WithLevel(15).Build();
+        var coOp = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(3).Build();
+        var charts = ChartsMockReturning(new[] { single, coOp });
+        var scores = ScoresMockReturning(Guid.NewGuid(), new[]
+        {
+            Score(single.Id, 950000),
+            Score(coOp.Id, 990000)
+        });
+        var saga = BuildSaga(charts: charts, scores: scores);
+
+        var result = (await saga.Handle(
+            new GetTop50ForPlayerQuery(Guid.NewGuid(), ChartType: null),
+            CancellationToken.None)).ToArray();
+
+        Assert.Single(result);
+        Assert.Equal(single.Id, result[0].ChartId);
+    }
+
+    [Fact]
+    public async Task HandleGetTop50ForPlayerFiltersByChartTypeWhenSpecified()
+    {
+        var single = new ChartBuilder().WithType(ChartType.Single).WithLevel(15).Build();
+        var dbl = new ChartBuilder().WithType(ChartType.Double).WithLevel(17).Build();
+        var charts = ChartsMockReturning(new[] { single, dbl });
+        var scores = ScoresMockReturning(Guid.NewGuid(), new[]
+        {
+            Score(single.Id, 950000),
+            Score(dbl.Id, 950000)
+        });
+        var saga = BuildSaga(charts: charts, scores: scores);
+
+        var result = (await saga.Handle(
+            new GetTop50ForPlayerQuery(Guid.NewGuid(), ChartType.Double),
+            CancellationToken.None)).ToArray();
+
+        Assert.Single(result);
+        Assert.Equal(dbl.Id, result[0].ChartId);
+    }
+
+    [Fact]
+    public async Task HandleGetTop50ForPlayerRespectsCountLimitAndOrdersByRatingDescending()
+    {
+        var c1 = new ChartBuilder().WithType(ChartType.Single).WithLevel(15).Build();
+        var c2 = new ChartBuilder().WithType(ChartType.Single).WithLevel(15).Build();
+        var c3 = new ChartBuilder().WithType(ChartType.Single).WithLevel(15).Build();
+        var charts = ChartsMockReturning(new[] { c1, c2, c3 });
+        // Higher score = higher Pumbility rating for same chart type/level.
+        var scores = ScoresMockReturning(Guid.NewGuid(), new[]
+        {
+            Score(c1.Id, 800000),
+            Score(c2.Id, 990000),
+            Score(c3.Id, 900000)
+        });
+        var saga = BuildSaga(charts: charts, scores: scores);
+
+        var result = (await saga.Handle(
+            new GetTop50ForPlayerQuery(Guid.NewGuid(), ChartType: null, Count: 2),
+            CancellationToken.None)).ToArray();
+
+        Assert.Equal(2, result.Length);
+        Assert.Equal(c2.Id, result[0].ChartId); // 990000 first
+        Assert.Equal(c3.Id, result[1].ChartId); // 900000 second
+    }
+
+    [Theory]
+    [InlineData(null, 100)]
+    [InlineData(ChartType.Single, 50)]
+    [InlineData(ChartType.Double, 50)]
+    public async Task HandleGetTop50CompetitiveTakesOneHundredForAllAndFiftyForFilteredType(
+        ChartType? requestType, int expectedTakeCount)
+    {
+        // Build 120 charts so the take limit is observable for both 100 (no filter) and 50 (filtered).
+        var charts = Enumerable.Range(0, 120)
+            .Select(i => new ChartBuilder().WithType(i % 2 == 0 ? ChartType.Single : ChartType.Double)
+                .WithLevel(15 + (i % 5)).Build())
+            .ToArray();
+        var chartsMock = ChartsMockReturning(charts);
+        var scores = ScoresMockReturning(Guid.NewGuid(),
+            charts.Select((c, i) => Score(c.Id, 800000 + i * 100)).ToArray());
+        var saga = BuildSaga(charts: chartsMock, scores: scores);
+
+        var result = (await saga.Handle(
+            new GetTop50CompetitiveQuery(Guid.NewGuid(), requestType),
+            CancellationToken.None)).ToArray();
+
+        var matching = requestType == null
+            ? charts.Length
+            : charts.Count(c => c.Type == requestType);
+        Assert.Equal(Math.Min(expectedTakeCount, matching), result.Length);
+    }
+
+    [Fact]
+    public async Task HandleRecalculateStatsSavesNewStatsAndAlwaysPublishesStatsUpdatedEvent()
+    {
+        var userId = Guid.NewGuid();
+        var stats = new Mock<IPlayerStatsRepository>();
+        stats.Setup(s => s.GetStats(userId, It.IsAny<CancellationToken>())).ReturnsAsync(ZeroStats(userId));
+        var bus = new Mock<IBus>();
+        var mediator = new Mock<IMediator>();
+        var saga = BuildSaga(charts: ChartsMockReturning(Array.Empty<Chart>()),
+            scores: ScoresMockReturning(userId, Array.Empty<RecordedPhoenixScore>()),
+            stats: stats, bus: bus, mediator: mediator);
+
+        await saga.Handle(new PlayerRatingSaga.RecalculateStats(userId), CancellationToken.None);
+
+        stats.Verify(s => s.SaveStats(userId, It.IsAny<PlayerStatsRecord>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        bus.Verify(b => b.Publish(It.Is<PlayerStatsUpdatedEvent>(e => e.UserId == userId),
+            It.IsAny<CancellationToken>()), Times.Once);
+        mediator.Verify(m => m.Publish(It.Is<PlayerStatsUpdatedEvent>(e => e.UserId == userId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleRecalculateStatsPublishesRatingsImprovedWhenSkillRatingIncreases()
+    {
+        var userId = Guid.NewGuid();
+        var single = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var stats = new Mock<IPlayerStatsRepository>();
+        stats.Setup(s => s.GetStats(userId, It.IsAny<CancellationToken>())).ReturnsAsync(ZeroStats(userId));
+        var bus = new Mock<IBus>();
+        var saga = BuildSaga(
+            charts: ChartsMockReturning(new[] { single }),
+            scores: ScoresMockReturning(userId, new[] { Score(single.Id, 950000) }),
+            stats: stats, bus: bus);
+
+        await saga.Handle(new PlayerRatingSaga.RecalculateStats(userId), CancellationToken.None);
+
+        bus.Verify(b => b.Publish(It.Is<PlayerRatingsImprovedEvent>(e => e.UserId == userId
+                                                                         && e.NewTop50 > e.OldTop50),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleRecalculateStatsDoesNotPublishRatingsImprovedWhenNothingImproves()
+    {
+        var userId = Guid.NewGuid();
+        var stats = new Mock<IPlayerStatsRepository>();
+        // Old stats already at high values — with no new scores, new stats are all 0,
+        // so nothing exceeds old stats and no PlayerRatingsImprovedEvent should fire.
+        stats.Setup(s => s.GetStats(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PlayerStatsRecord(userId, TotalRating: 999999, HighestLevel: 25,
+                ClearCount: 1000, CoOpRating: 999999, CoOpScore: 1000000, SkillRating: 999999, SkillScore: 1000000,
+                SkillLevel: 25, SinglesRating: 999999, SinglesScore: 1000000, SinglesLevel: 25,
+                DoublesRating: 999999, DoublesScore: 1000000, DoublesLevel: 25, CompetitiveLevel: 25,
+                SinglesCompetitiveLevel: 25, DoublesCompetitiveLevel: 25));
+        var bus = new Mock<IBus>();
+        var saga = BuildSaga(
+            charts: ChartsMockReturning(Array.Empty<Chart>()),
+            scores: ScoresMockReturning(userId, Array.Empty<RecordedPhoenixScore>()),
+            stats: stats, bus: bus);
+
+        await saga.Handle(new PlayerRatingSaga.RecalculateStats(userId), CancellationToken.None);
+
+        bus.Verify(b => b.Publish(It.IsAny<PlayerRatingsImprovedEvent>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleRecalculatePumbilityCallsUpdateScoreStatsForGivenCharts()
+    {
+        var userId = Guid.NewGuid();
+        var c1 = new ChartBuilder().WithType(ChartType.Single).WithLevel(15).Build();
+        var c2 = new ChartBuilder().WithType(ChartType.Single).WithLevel(17).Build();
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetCharts(MixEnum.Phoenix, It.IsAny<DifficultyLevel?>(),
+                It.IsAny<ChartType?>(),
+                It.Is<IEnumerable<Guid>>(ids => ids != null && ids.Contains(c1.Id) && ids.Contains(c2.Id)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { c1, c2 });
+        var scores = new Mock<IPhoenixRecordRepository>();
+        scores.Setup(s => s.GetPlayerScores(
+                It.Is<IEnumerable<Guid>>(ids => ids.Contains(userId)),
+                It.Is<IEnumerable<Guid>>(ids => ids.Contains(c1.Id) && ids.Contains(c2.Id)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new UserPhoenixScore(userId, c1.Id, Name.From("alice"), 950000, PhoenixPlate.SuperbGame, false),
+                new UserPhoenixScore(userId, c2.Id, Name.From("alice"), 900000, PhoenixPlate.MarvelousGame, false)
+            });
+        var saga = BuildSaga(charts: charts, scores: scores);
+
+        await saga.Handle(
+            new PlayerRatingSaga.RecalculatePumbility(userId, new[] { c1.Id, c2.Id }),
+            CancellationToken.None);
+
+        scores.Verify(s => s.UpdateScoreStats(userId,
+            It.Is<IEnumerable<PhoenixRecordStats>>(stats =>
+                stats.Count() == 2 && stats.Any(p => p.ChartId == c1.Id) && stats.Any(p => p.ChartId == c2.Id)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumePlayerScoreUpdatedDelegatesToStatsAndPumbilityRecalc()
+    {
+        var userId = Guid.NewGuid();
+        var chartId = Guid.NewGuid();
+        var stats = new Mock<IPlayerStatsRepository>();
+        stats.Setup(s => s.GetStats(userId, It.IsAny<CancellationToken>())).ReturnsAsync(ZeroStats(userId));
+        var scores = new Mock<IPhoenixRecordRepository>();
+        scores.Setup(s => s.GetRecordedScores(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RecordedPhoenixScore>());
+        scores.Setup(s => s.GetPlayerScores(
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<IEnumerable<Guid>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UserPhoenixScore>());
+        var saga = BuildSaga(charts: ChartsMockReturning(Array.Empty<Chart>()),
+            scores: scores, stats: stats);
+
+        await saga.Consume(BuildContext(new PlayerScoreUpdatedEvent(userId,
+            NewChartIds: new[] { chartId },
+            UpscoredChartIds: new Dictionary<Guid, int>())));
+
+        // RecalculateStats path → SaveStats called; RecalculatePumbility path → UpdateScoreStats called.
+        stats.Verify(s => s.SaveStats(userId, It.IsAny<PlayerStatsRecord>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        scores.Verify(s => s.UpdateScoreStats(userId, It.IsAny<IEnumerable<PhoenixRecordStats>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static PlayerRatingSaga BuildSaga(
+        Mock<IPhoenixRecordRepository>? scores = null,
+        Mock<IChartRepository>? charts = null,
+        Mock<IPlayerStatsRepository>? stats = null,
+        Mock<IBus>? bus = null,
+        Mock<IMediator>? mediator = null)
+    {
+        scores ??= new Mock<IPhoenixRecordRepository>();
+        charts ??= new Mock<IChartRepository>();
+        stats ??= new Mock<IPlayerStatsRepository>();
+        bus ??= new Mock<IBus>();
+        mediator ??= new Mock<IMediator>();
+        return new PlayerRatingSaga(scores.Object, charts.Object, stats.Object, bus.Object, mediator.Object);
+    }
+
+    private static Mock<IChartRepository> ChartsMockReturning(IEnumerable<Chart> result)
+    {
+        var m = new Mock<IChartRepository>();
+        m.Setup(c => c.GetCharts(MixEnum.Phoenix, It.IsAny<DifficultyLevel?>(), It.IsAny<ChartType?>(),
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return m;
+    }
+
+    private static Mock<IPhoenixRecordRepository> ScoresMockReturning(Guid userId,
+        IEnumerable<RecordedPhoenixScore> result)
+    {
+        var m = new Mock<IPhoenixRecordRepository>();
+        m.Setup(s => s.GetRecordedScores(userId, It.IsAny<CancellationToken>())).ReturnsAsync(result);
+        m.Setup(s => s.GetRecordedScores(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(result);
+        return m;
+    }
+
+    private static RecordedPhoenixScore Score(Guid chartId, int score, bool isBroken = false) =>
+        new(chartId, score, PhoenixPlate.SuperbGame, isBroken,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+    private static PlayerStatsRecord ZeroStats(Guid userId) =>
+        new(userId, TotalRating: 0, HighestLevel: 1, ClearCount: 0, CoOpRating: 0, CoOpScore: 0,
+            SkillRating: 0, SkillScore: 0, SkillLevel: 0, SinglesRating: 0, SinglesScore: 0, SinglesLevel: 0,
+            DoublesRating: 0, DoublesScore: 0, DoublesLevel: 0, CompetitiveLevel: 0,
+            SinglesCompetitiveLevel: 0, DoublesCompetitiveLevel: 0);
+
+    private static ConsumeContext<T> BuildContext<T>(T message) where T : class
+    {
+        var ctx = new Mock<ConsumeContext<T>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TierListSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TierListSagaTests.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class TierListSagaTests
+{
+    [Fact]
+    public async Task ConsumeChartDifficultyUpdatedSavesNothingWhenNoChartsExist()
+    {
+        var tierLists = new Mock<ITierListRepository>();
+        var saga = BuildSaga(tierLists: tierLists);
+
+        await saga.Consume(BuildContext(new ChartDifficultyUpdatedEvent(ChartType.Single, 15)));
+
+        tierLists.Verify(t => t.SaveEntry(It.IsAny<SongTierListEntry>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ConsumeChartDifficultyUpdatedSkipsChartsThatHaveNoRating()
+    {
+        var ratedChart = new ChartBuilder().WithLevel(15).WithType(ChartType.Single).Build();
+        var unratedChart = new ChartBuilder().WithLevel(15).WithType(ChartType.Single).Build();
+        var charts = ChartsMockReturning(level: 15, type: ChartType.Single, new[] { ratedChart, unratedChart });
+        var ratings = RatingsMockReturning(new[] { Rating(ratedChart.Id, difficulty: 15.5) });
+        var tierLists = new Mock<ITierListRepository>();
+        var saga = BuildSaga(charts: charts, chartRatings: ratings, tierLists: tierLists);
+
+        await saga.Consume(BuildContext(new ChartDifficultyUpdatedEvent(ChartType.Single, 15)));
+
+        tierLists.Verify(t => t.SaveEntry(
+            It.Is<SongTierListEntry>(e => e.ChartId == ratedChart.Id), It.IsAny<CancellationToken>()),
+            Times.Once);
+        tierLists.Verify(t => t.SaveEntry(
+            It.Is<SongTierListEntry>(e => e.ChartId == unratedChart.Id), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // diff = ratingDifficulty - chartLevel - 0.5; the saga's switch cascade puts diff
+    // into buckets (-∞,-.75] → Overrated, (-.75,-.375] → VeryEasy, (-.375,-.125] → Easy,
+    // (-.125,.125) → Medium, [.125,.375) → Hard, [.375,.75) → VeryHard, [.75,∞) → Underrated.
+    // Inputs below land cleanly inside their bucket (chart level fixed at 15).
+    [Theory]
+    [InlineData(14.0, TierListCategory.Overrated)]   // diff = -1.5
+    [InlineData(15.0, TierListCategory.VeryEasy)]    // diff = -0.5
+    [InlineData(15.25, TierListCategory.Easy)]       // diff = -0.25
+    [InlineData(15.5, TierListCategory.Medium)]      // diff = 0
+    [InlineData(15.75, TierListCategory.Hard)]       // diff = 0.25
+    [InlineData(16.0, TierListCategory.VeryHard)]    // diff = 0.5
+    [InlineData(16.5, TierListCategory.Underrated)]  // diff = 1.0
+    public async Task ConsumeChartDifficultyUpdatedAssignsCategoryFromDifficultyDelta(
+        double ratingDifficulty, TierListCategory expected)
+    {
+        var chart = new ChartBuilder().WithLevel(15).WithType(ChartType.Single).Build();
+        var charts = ChartsMockReturning(level: 15, type: ChartType.Single, new[] { chart });
+        var ratings = RatingsMockReturning(new[] { Rating(chart.Id, difficulty: ratingDifficulty) });
+        var tierLists = new Mock<ITierListRepository>();
+        var saga = BuildSaga(charts: charts, chartRatings: ratings, tierLists: tierLists);
+
+        await saga.Consume(BuildContext(new ChartDifficultyUpdatedEvent(ChartType.Single, 15)));
+
+        tierLists.Verify(t => t.SaveEntry(
+            It.Is<SongTierListEntry>(e => e.ChartId == chart.Id && e.Category == expected),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumeChartDifficultyUpdatedAssignsContiguousAscendingOrderStartingAtZero()
+    {
+        var c1 = new ChartBuilder().WithLevel(15).WithType(ChartType.Single).Build();
+        var c2 = new ChartBuilder().WithLevel(15).WithType(ChartType.Single).Build();
+        var c3 = new ChartBuilder().WithLevel(15).WithType(ChartType.Single).Build();
+        var charts = ChartsMockReturning(level: 15, type: ChartType.Single, new[] { c1, c2, c3 });
+        var ratings = RatingsMockReturning(new[]
+        {
+            Rating(c1.Id, difficulty: 15.5),
+            Rating(c2.Id, difficulty: 15.5),
+            Rating(c3.Id, difficulty: 15.5)
+        });
+        var saved = new List<SongTierListEntry>();
+        var tierLists = new Mock<ITierListRepository>();
+        tierLists.Setup(t => t.SaveEntry(It.IsAny<SongTierListEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<SongTierListEntry, CancellationToken>((e, _) => saved.Add(e));
+        var saga = BuildSaga(charts: charts, chartRatings: ratings, tierLists: tierLists);
+
+        await saga.Consume(BuildContext(new ChartDifficultyUpdatedEvent(ChartType.Single, 15)));
+
+        Assert.Equal(new[] { 0, 1, 2 }, saved.Select(e => e.Order).ToArray());
+    }
+
+    [Fact]
+    public async Task ConsumeChartDifficultyUpdatedSavesEntriesUnderDifficultyTierList()
+    {
+        var chart = new ChartBuilder().WithLevel(15).Build();
+        var charts = ChartsMockReturning(level: 15, type: ChartType.Single, new[] { chart });
+        var ratings = RatingsMockReturning(new[] { Rating(chart.Id, difficulty: 15.5) });
+        var tierLists = new Mock<ITierListRepository>();
+        var saga = BuildSaga(charts: charts, chartRatings: ratings, tierLists: tierLists);
+
+        await saga.Consume(BuildContext(new ChartDifficultyUpdatedEvent(ChartType.Single, 15)));
+
+        tierLists.Verify(t => t.SaveEntry(
+            It.Is<SongTierListEntry>(e => (string)e.TierListName == "Difficulty"),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task HandleRelativeTierListReturnsEmptyWhenUserHasNoMatchingScores()
+    {
+        var charts = ChartsMockReturning(level: 15, type: ChartType.Single,
+            new[] { new ChartBuilder().WithLevel(15).Build() });
+        var scores = new Mock<IPhoenixRecordRepository>();
+        scores.Setup(s => s.GetRecordedScores(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RecordedPhoenixScore>());
+        var saga = BuildSaga(charts: charts, scores: scores);
+
+        var result = await saga.Handle(
+            new GetMyRelativeTierListQuery(ChartType.Single, DifficultyLevel.From(15), Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData(15, "Scores")]
+    [InlineData(23, "Scores")]
+    [InlineData(24, "Official Scores")]
+    [InlineData(28, "Official Scores")]
+    public async Task HandleRelativeTierListChoosesTierListNameByLevel(int level, string expectedListName)
+    {
+        var chart = new ChartBuilder().WithLevel(level).Build();
+        var charts = ChartsMockReturning(level: level, type: ChartType.Single, new[] { chart });
+        var scores = new Mock<IPhoenixRecordRepository>();
+        scores.Setup(s => s.GetRecordedScores(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new RecordedPhoenixScore(chart.Id, 950000, PhoenixPlate.SuperbGame, false, DateTimeOffset.UtcNow)
+            });
+        var tierLists = new Mock<ITierListRepository>();
+        tierLists.Setup(t => t.GetAllEntries(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SongTierListEntry>());
+        var saga = BuildSaga(charts: charts, scores: scores, tierLists: tierLists);
+
+        await saga.Handle(
+            new GetMyRelativeTierListQuery(ChartType.Single, DifficultyLevel.From(level), Guid.NewGuid()),
+            CancellationToken.None);
+
+        tierLists.Verify(t => t.GetAllEntries(
+            It.Is<Name>(n => (string)n == expectedListName), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(10, true)]   // included: Range(10, 18) => 10..27
+    [InlineData(27, true)]
+    [InlineData(9, false)]   // excluded
+    [InlineData(28, false)]
+    public async Task ConsumeProcessPassTierListIteratesLevelsTenThroughTwentySevenInclusive(int level, bool expected)
+    {
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetCharts(It.IsAny<MixEnum>(), It.IsAny<DifficultyLevel?>(), It.IsAny<ChartType?>(),
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Chart>());
+        var scores = new Mock<IPhoenixRecordRepository>();
+        scores.Setup(s => s.GetPgUsers(It.IsAny<ChartType>(), It.IsAny<DifficultyLevel>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<(Guid UserId, Guid ChartId)>());
+        scores.Setup(s => s.GetRecordedScores(It.IsAny<IEnumerable<Guid>>(), It.IsAny<ChartType>(),
+                It.IsAny<DifficultyLevel>(), It.IsAny<DifficultyLevel>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RecordedPhoenixScore>());
+        var tierLists = new Mock<ITierListRepository>();
+        tierLists.Setup(t => t.GetUsersOnLevel(It.IsAny<DifficultyLevel>(), It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync(Array.Empty<Guid>());
+        var saga = BuildSaga(charts: charts, scores: scores, tierLists: tierLists);
+
+        await saga.Consume(BuildContext(new ProcessPassTierListCommand()));
+
+        var times = expected ? Times.AtLeastOnce() : Times.Never();
+        charts.Verify(c => c.GetCharts(MixEnum.Phoenix, DifficultyLevel.From(level), ChartType.Single,
+            It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()), times);
+    }
+
+    private static TierListSaga BuildSaga(
+        Mock<IChartDifficultyRatingRepository>? chartRatings = null,
+        Mock<IChartRepository>? charts = null,
+        Mock<ITierListRepository>? tierLists = null,
+        Mock<IPhoenixRecordRepository>? scores = null,
+        Mock<ICurrentUserAccessor>? currentUser = null,
+        Mock<IPlayerStatsRepository>? playerStats = null)
+    {
+        chartRatings ??= EmptyRatingsMock();
+        charts ??= EmptyChartsMock();
+        tierLists ??= new Mock<ITierListRepository>();
+        scores ??= new Mock<IPhoenixRecordRepository>();
+        currentUser ??= new Mock<ICurrentUserAccessor>();
+        playerStats ??= new Mock<IPlayerStatsRepository>();
+        return new TierListSaga(chartRatings.Object, charts.Object, tierLists.Object, scores.Object,
+            currentUser.Object, playerStats.Object);
+    }
+
+    private static Mock<IChartRepository> EmptyChartsMock()
+    {
+        var m = new Mock<IChartRepository>();
+        m.Setup(c => c.GetCharts(It.IsAny<MixEnum>(), It.IsAny<DifficultyLevel?>(), It.IsAny<ChartType?>(),
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Chart>());
+        return m;
+    }
+
+    private static Mock<IChartDifficultyRatingRepository> EmptyRatingsMock()
+    {
+        var m = new Mock<IChartDifficultyRatingRepository>();
+        m.Setup(c => c.GetAllChartRatedDifficulties(It.IsAny<MixEnum>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ChartDifficultyRatingRecord>());
+        return m;
+    }
+
+    private static Mock<IChartRepository> ChartsMockReturning(int level, ChartType type, IEnumerable<Chart> result)
+    {
+        var m = EmptyChartsMock();
+        m.Setup(c => c.GetCharts(MixEnum.Phoenix, DifficultyLevel.From(level), type,
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return m;
+    }
+
+    private static Mock<IChartDifficultyRatingRepository> RatingsMockReturning(
+        IEnumerable<ChartDifficultyRatingRecord> ratings)
+    {
+        var m = new Mock<IChartDifficultyRatingRepository>();
+        m.Setup(c => c.GetAllChartRatedDifficulties(MixEnum.Phoenix, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ratings);
+        return m;
+    }
+
+    private static ChartDifficultyRatingRecord Rating(Guid chartId, double difficulty) =>
+        new(chartId, difficulty, RatingCount: 1, StandardDeviation: 0);
+
+    private static ConsumeContext<T> BuildContext<T>(T message) where T : class
+    {
+        var ctx = new Mock<ConsumeContext<T>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdatePhoenixRecordHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdatePhoenixRecordHandlerTests.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class UpdatePhoenixRecordHandlerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly Guid UserId = Guid.NewGuid();
+    private static readonly Guid ChartId = Guid.NewGuid();
+
+    [Fact]
+    public async Task HandleNewClearSavesRecordSchedulesFireAndRecordsNewChart()
+    {
+        var ctx = new HandlerContext();
+        ctx.Batches.Setup(b => b.RegisterFireAt(UserId, It.IsAny<DateTime>())).Returns(true);
+
+        await ctx.Handler.Handle(
+            new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 950000,
+                Plate: PhoenixPlate.SuperbGame),
+            CancellationToken.None);
+
+        ctx.Records.Verify(r => r.UpdateBestAttempt(UserId,
+            It.Is<RecordedPhoenixScore>(s => s.ChartId == ChartId && !s.IsBroken
+                                             && s.Score == (PhoenixScore)950000
+                                             && s.Plate == PhoenixPlate.SuperbGame
+                                             && s.RecordedDate == Now),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Scheduler.Verify(s => s.SchedulePublish(
+            It.IsAny<DateTime>(),
+            It.Is<UpdatePhoenixRecordHandler.TryFireScoreMessage>(m => m.UserId == UserId),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Batches.Verify(b => b.RecordNewChart(UserId, ChartId), Times.Once);
+        ctx.Batches.Verify(b => b.RecordUpscoreIfNotNew(It.IsAny<Guid>(), It.IsAny<Guid>(),
+            It.IsAny<PhoenixScore>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleKeepBestStatsKeepsHigherExistingScore()
+    {
+        var ctx = new HandlerContext();
+        ctx.GivenExistingScore(score: 950000, plate: PhoenixPlate.SuperbGame, isBroken: false);
+
+        await ctx.Handler.Handle(
+            new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 900000,
+                Plate: PhoenixPlate.SuperbGame, KeepBestStats: true),
+            CancellationToken.None);
+
+        ctx.Records.Verify(r => r.UpdateBestAttempt(UserId,
+            It.Is<RecordedPhoenixScore>(s => s.Score == (PhoenixScore)950000),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleKeepBestStatsKeepsHigherExistingPlate()
+    {
+        var ctx = new HandlerContext();
+        ctx.GivenExistingScore(score: 900000, plate: PhoenixPlate.PerfectGame, isBroken: false);
+
+        await ctx.Handler.Handle(
+            new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 900000,
+                Plate: PhoenixPlate.FairGame, KeepBestStats: true),
+            CancellationToken.None);
+
+        ctx.Records.Verify(r => r.UpdateBestAttempt(UserId,
+            It.Is<RecordedPhoenixScore>(s => s.Plate == PhoenixPlate.PerfectGame),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleKeepBestStatsPreservesExistingClearWhenRequestIsBroken()
+    {
+        var ctx = new HandlerContext();
+        ctx.GivenExistingScore(score: 900000, plate: PhoenixPlate.SuperbGame, isBroken: false);
+
+        await ctx.Handler.Handle(
+            new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: true, Score: 950000,
+                Plate: PhoenixPlate.SuperbGame, KeepBestStats: true),
+            CancellationToken.None);
+
+        ctx.Records.Verify(r => r.UpdateBestAttempt(UserId,
+            It.Is<RecordedPhoenixScore>(s => !s.IsBroken),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleWithoutKeepBestStatsOverwritesWithRequestValues()
+    {
+        var ctx = new HandlerContext();
+        ctx.GivenExistingScore(score: 950000, plate: PhoenixPlate.PerfectGame, isBroken: false);
+
+        await ctx.Handler.Handle(
+            new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 800000,
+                Plate: PhoenixPlate.FairGame, KeepBestStats: false),
+            CancellationToken.None);
+
+        ctx.Records.Verify(r => r.UpdateBestAttempt(UserId,
+            It.Is<RecordedPhoenixScore>(s => s.Score == (PhoenixScore)800000
+                                             && s.Plate == PhoenixPlate.FairGame),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleNewClearWhenExistingWasBrokenRecordsNewChart()
+    {
+        var ctx = new HandlerContext();
+        // Existing was broken at the same score → transition to a clear is a new clear,
+        // and 950000 < 950000 is false so it is NOT also an upscore.
+        ctx.GivenExistingScore(score: 950000, plate: PhoenixPlate.SuperbGame, isBroken: true);
+        ctx.Batches.Setup(b => b.RegisterFireAt(UserId, It.IsAny<DateTime>())).Returns(true);
+
+        await ctx.Handler.Handle(
+            new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 950000,
+                Plate: PhoenixPlate.SuperbGame),
+            CancellationToken.None);
+
+        ctx.Batches.Verify(b => b.RecordNewChart(UserId, ChartId), Times.Once);
+        ctx.Batches.Verify(b => b.RecordUpscoreIfNotNew(It.IsAny<Guid>(), It.IsAny<Guid>(),
+            It.IsAny<PhoenixScore>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleClearedWithHigherScoreFromBrokenIsBothNewChartAndUpscore()
+    {
+        // When transitioning from broken→clear with a higher score, both branches fire;
+        // the accumulator (per its contract) takes new-clear precedence.
+        var ctx = new HandlerContext();
+        ctx.GivenExistingScore(score: 700000, plate: PhoenixPlate.RoughGame, isBroken: true);
+        ctx.Batches.Setup(b => b.RegisterFireAt(UserId, It.IsAny<DateTime>())).Returns(true);
+
+        await ctx.Handler.Handle(
+            new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 950000,
+                Plate: PhoenixPlate.SuperbGame),
+            CancellationToken.None);
+
+        ctx.Batches.Verify(b => b.RecordNewChart(UserId, ChartId), Times.Once);
+        ctx.Batches.Verify(b => b.RecordUpscoreIfNotNew(UserId, ChartId,
+            It.Is<PhoenixScore>(s => s == (PhoenixScore)700000)), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleUpscoreRecordsUpscoreWithPreviousScore()
+    {
+        var ctx = new HandlerContext();
+        ctx.GivenExistingScore(score: 900000, plate: PhoenixPlate.SuperbGame, isBroken: false);
+        ctx.Batches.Setup(b => b.RegisterFireAt(UserId, It.IsAny<DateTime>())).Returns(true);
+
+        await ctx.Handler.Handle(
+            new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 970000,
+                Plate: PhoenixPlate.SuperbGame),
+            CancellationToken.None);
+
+        ctx.Batches.Verify(b => b.RecordUpscoreIfNotNew(UserId, ChartId,
+            It.Is<PhoenixScore>(s => s == (PhoenixScore)900000)), Times.Once);
+        ctx.Batches.Verify(b => b.RecordNewChart(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleNoNewClearAndNoUpscoreDoesNotScheduleOrBatch()
+    {
+        var ctx = new HandlerContext();
+        // Existing un-broken with same score → not a new clear, not an upscore.
+        ctx.GivenExistingScore(score: 900000, plate: PhoenixPlate.SuperbGame, isBroken: false);
+
+        await ctx.Handler.Handle(
+            new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 900000,
+                Plate: PhoenixPlate.SuperbGame),
+            CancellationToken.None);
+
+        ctx.Batches.Verify(b => b.RegisterFireAt(It.IsAny<Guid>(), It.IsAny<DateTime>()), Times.Never);
+        ctx.Scheduler.Verify(s => s.SchedulePublish(
+            It.IsAny<DateTime>(),
+            It.IsAny<UpdatePhoenixRecordHandler.TryFireScoreMessage>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        ctx.Batches.Verify(b => b.RecordNewChart(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
+        ctx.Batches.Verify(b => b.RecordUpscoreIfNotNew(It.IsAny<Guid>(), It.IsAny<Guid>(),
+            It.IsAny<PhoenixScore>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleSkipsSchedulingWhenBatchAlreadyActiveButStillRecords()
+    {
+        var ctx = new HandlerContext();
+        // Batch already active: RegisterFireAt returns false, so the handler must NOT
+        // schedule a new fire message — but it must still record the new clear.
+        ctx.Batches.Setup(b => b.RegisterFireAt(UserId, It.IsAny<DateTime>())).Returns(false);
+
+        await ctx.Handler.Handle(
+            new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 950000,
+                Plate: PhoenixPlate.SuperbGame),
+            CancellationToken.None);
+
+        ctx.Scheduler.Verify(s => s.SchedulePublish(
+            It.IsAny<DateTime>(),
+            It.IsAny<UpdatePhoenixRecordHandler.TryFireScoreMessage>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        ctx.Batches.Verify(b => b.RecordNewChart(UserId, ChartId), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumeReschedulesAndDoesNotPublishWhenFireAtIsInTheFuture()
+    {
+        var ctx = new HandlerContext();
+        var fireAt = Now.UtcDateTime + TimeSpan.FromMinutes(1);
+        ctx.Batches.Setup(b => b.GetFireAt(UserId)).Returns(fireAt);
+
+        await ctx.Handler.Consume(BuildContext(new UpdatePhoenixRecordHandler.TryFireScoreMessage(UserId)));
+
+        ctx.Scheduler.Verify(s => s.SchedulePublish(
+            fireAt + TimeSpan.FromMinutes(2),
+            It.Is<UpdatePhoenixRecordHandler.TryFireScoreMessage>(m => m.UserId == UserId),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Bus.Verify(b => b.Publish(It.IsAny<PlayerScoreUpdatedEvent>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        ctx.Batches.Verify(b => b.TakeBatch(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConsumeTakesBatchAndPublishesWhenFireAtHasBeenReached()
+    {
+        var ctx = new HandlerContext();
+        var fireAt = Now.UtcDateTime - TimeSpan.FromSeconds(1); // already past
+        var newCharts = new[] { Guid.NewGuid() };
+        var upscored = new System.Collections.Generic.Dictionary<Guid, int> { { Guid.NewGuid(), 900000 } };
+        ctx.Batches.Setup(b => b.GetFireAt(UserId)).Returns(fireAt);
+        ctx.Batches.Setup(b => b.TakeBatch(UserId)).Returns(new PendingScoreBatch(newCharts, upscored));
+
+        await ctx.Handler.Consume(BuildContext(new UpdatePhoenixRecordHandler.TryFireScoreMessage(UserId)));
+
+        ctx.Bus.Verify(b => b.Publish(
+            It.Is<PlayerScoreUpdatedEvent>(e => e.UserId == UserId
+                                                && e.NewChartIds == newCharts
+                                                && e.UpscoredChartIds == upscored),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Scheduler.Verify(s => s.SchedulePublish(
+            It.IsAny<DateTime>(),
+            It.IsAny<UpdatePhoenixRecordHandler.TryFireScoreMessage>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private sealed class HandlerContext
+    {
+        public Mock<IPhoenixRecordRepository> Records { get; } = new();
+        public Mock<ICurrentUserAccessor> CurrentUser { get; } = new();
+        public Mock<IDateTimeOffsetAccessor> DateTime { get; } = FakeDateTime.At(Now);
+        public Mock<IBus> Bus { get; } = new();
+        public Mock<IMessageScheduler> Scheduler { get; } = new();
+        public Mock<IPlayerScoreBatchAccumulator> Batches { get; } = new();
+
+        public UpdatePhoenixRecordHandler Handler { get; }
+
+        public HandlerContext()
+        {
+            CurrentUser.SetupGet(u => u.User).Returns(new UserBuilder().WithId(UserId).Build());
+            Handler = new UpdatePhoenixRecordHandler(Records.Object, CurrentUser.Object, DateTime.Object,
+                Bus.Object, Scheduler.Object, Batches.Object);
+        }
+
+        public void GivenExistingScore(PhoenixScore score, PhoenixPlate plate, bool isBroken)
+        {
+            Records.Setup(r => r.GetRecordedScore(UserId, ChartId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new RecordedPhoenixScore(ChartId, score, plate, isBroken,
+                    Now - TimeSpan.FromDays(1)));
+        }
+    }
+
+    private static ConsumeContext<T> BuildContext<T>(T message) where T : class
+    {
+        var ctx = new Mock<ConsumeContext<T>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/WeeklyTournamentSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/WeeklyTournamentSagaTests.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class WeeklyTournamentSagaTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task ConsumeUpdateWeeklyChartsExitsEarlyWhenAnyCurrentWeekIsStillActive()
+    {
+        var weeklyTournies = new Mock<IWeeklyTournamentRepository>();
+        weeklyTournies.Setup(w => w.GetWeeklyCharts(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                // Expiration date in the future relative to `Now` → week still active.
+                new WeeklyTournamentChart(Guid.NewGuid(), Now.AddDays(2))
+            });
+        var saga = BuildSaga(weeklyTournies: weeklyTournies);
+
+        await saga.Consume(BuildContext(new UpdateWeeklyChartsEvent()));
+
+        weeklyTournies.Verify(w => w.ClearTheBoard(It.IsAny<CancellationToken>()), Times.Never);
+        weeklyTournies.Verify(w => w.RegisterWeeklyChart(It.IsAny<WeeklyTournamentChart>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        weeklyTournies.Verify(w => w.WriteHistories(It.IsAny<IEnumerable<UserTourneyHistory>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleRegisterWeeklyChartScoreSkipsWhenChartNotInCurrentWeek()
+    {
+        var someOtherChartId = Guid.NewGuid();
+        var weeklyTournies = new Mock<IWeeklyTournamentRepository>();
+        weeklyTournies.Setup(w => w.GetWeeklyCharts(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new WeeklyTournamentChart(someOtherChartId, Now.AddDays(2)) });
+        var saga = BuildSaga(weeklyTournies: weeklyTournies);
+
+        var requestedChartId = Guid.NewGuid();
+        await saga.Handle(
+            new RegisterWeeklyChartScore(Entry(requestedChartId, score: 950000)),
+            CancellationToken.None);
+
+        weeklyTournies.Verify(w => w.SaveEntry(It.IsAny<WeeklyTournamentEntry>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleRegisterWeeklyChartScoreSavesEntryWithComputedCompetitiveLevelWhenNew()
+    {
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var ctx = new HandlerContext(chart);
+        ctx.GivenStats(singlesCompetitive: 18.5, doublesCompetitive: 12.0);
+        ctx.GivenNoExistingEntries(chart.Id);
+
+        var userId = Guid.NewGuid();
+        await ctx.Saga.Handle(
+            new RegisterWeeklyChartScore(Entry(chart.Id, score: 950000, userId: userId)),
+            CancellationToken.None);
+
+        // Single chart → uses SinglesCompetitiveLevel.
+        ctx.WeeklyTournies.Verify(w => w.SaveEntry(
+            It.Is<WeeklyTournamentEntry>(e => e.UserId == userId && e.Score == (PhoenixScore)950000
+                                              && e.CompetitiveLevel == 18.5),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleRegisterWeeklyChartScoreKeepsHigherExistingScoreWhenLowerSubmitted()
+    {
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext(chart);
+        ctx.GivenStats(singlesCompetitive: 20, doublesCompetitive: 20);
+        ctx.GivenExistingEntries(chart.Id, new[]
+        {
+            Entry(chart.Id, score: 950000, userId: userId)
+        });
+
+        await ctx.Saga.Handle(
+            new RegisterWeeklyChartScore(Entry(chart.Id, score: 800000, userId: userId)),
+            CancellationToken.None);
+
+        ctx.WeeklyTournies.Verify(w => w.SaveEntry(
+            It.Is<WeeklyTournamentEntry>(e => e.UserId == userId && e.Score == (PhoenixScore)950000),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleRegisterWeeklyChartScoreReplacesScoreWhenHigherSubmitted()
+    {
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext(chart);
+        ctx.GivenStats(singlesCompetitive: 20, doublesCompetitive: 20);
+        ctx.GivenExistingEntries(chart.Id, new[]
+        {
+            Entry(chart.Id, score: 800000, userId: userId)
+        });
+
+        await ctx.Saga.Handle(
+            new RegisterWeeklyChartScore(Entry(chart.Id, score: 990000, userId: userId)),
+            CancellationToken.None);
+
+        ctx.WeeklyTournies.Verify(w => w.SaveEntry(
+            It.Is<WeeklyTournamentEntry>(e => e.UserId == userId && e.Score == (PhoenixScore)990000),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleRegisterWeeklyChartScoreClearsBrokenWhenSubmissionIsUnbroken()
+    {
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext(chart);
+        ctx.GivenStats(singlesCompetitive: 20, doublesCompetitive: 20);
+        ctx.GivenExistingEntries(chart.Id, new[]
+        {
+            Entry(chart.Id, score: 950000, userId: userId, isBroken: true)
+        });
+
+        await ctx.Saga.Handle(
+            new RegisterWeeklyChartScore(Entry(chart.Id, score: 950000, userId: userId, isBroken: false)),
+            CancellationToken.None);
+
+        ctx.WeeklyTournies.Verify(w => w.SaveEntry(
+            It.Is<WeeklyTournamentEntry>(e => e.UserId == userId && !e.IsBroken),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleRegisterWeeklyChartScorePublishesEventWhenPlaceChanges()
+    {
+        // No existing entry → existingPlace == null → place change → publish.
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext(chart);
+        ctx.GivenStats(singlesCompetitive: 20, doublesCompetitive: 20);
+        ctx.GivenNoExistingEntries(chart.Id);
+        ctx.Users.Setup(u => u.GetUser(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserBuilder().WithId(userId).Build());
+
+        await ctx.Saga.Handle(
+            new RegisterWeeklyChartScore(Entry(chart.Id, score: 950000, userId: userId)),
+            CancellationToken.None);
+
+        ctx.Bus.Verify(b => b.Publish(
+            It.Is<UserWeeklyChartsProgressedEvent>(e => e.UserId == userId && e.ChartId == chart.Id
+                                                       && e.Score == 950000 && e.Place == 1),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleRegisterWeeklyChartScoreDoesNotPublishWhenPlaceUnchanged()
+    {
+        // Solo player improving their own (already 1st) score keeps place = 1 → no publish.
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext(chart);
+        ctx.GivenStats(singlesCompetitive: 20, doublesCompetitive: 20);
+        ctx.GivenExistingEntries(chart.Id, new[]
+        {
+            Entry(chart.Id, score: 900000, userId: userId)
+        });
+
+        await ctx.Saga.Handle(
+            new RegisterWeeklyChartScore(Entry(chart.Id, score: 950000, userId: userId)),
+            CancellationToken.None);
+
+        ctx.Bus.Verify(b => b.Publish(It.IsAny<UserWeeklyChartsProgressedEvent>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private sealed class HandlerContext
+    {
+        public Mock<IChartRepository> Charts { get; } = new();
+        public Mock<IWeeklyTournamentRepository> WeeklyTournies { get; } = new();
+        public Mock<IPlayerStatsRepository> PlayerStats { get; } = new();
+        public Mock<IBotClient> Bot { get; } = new();
+        public Mock<IUserRepository> Users { get; } = new();
+        public Mock<IBus> Bus { get; } = new();
+        public WeeklyTournamentSaga Saga { get; }
+
+        public HandlerContext(Chart chart)
+        {
+            WeeklyTournies.Setup(w => w.GetWeeklyCharts(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[] { new WeeklyTournamentChart(chart.Id, Now.AddDays(2)) });
+            Charts.Setup(c => c.GetCharts(MixEnum.Phoenix, It.IsAny<DifficultyLevel?>(),
+                    It.IsAny<ChartType?>(),
+                    It.Is<IEnumerable<Guid>>(ids => ids != null),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[] { chart });
+
+            Saga = BuildSaga(charts: Charts, weeklyTournies: WeeklyTournies, playerStats: PlayerStats,
+                bot: Bot, users: Users, bus: Bus);
+        }
+
+        public void GivenStats(double singlesCompetitive, double doublesCompetitive)
+        {
+            PlayerStats.Setup(s => s.GetStats(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PlayerStatsRecord(Guid.NewGuid(), TotalRating: 0, HighestLevel: 1,
+                    ClearCount: 0, CoOpRating: 0, CoOpScore: 0, SkillRating: 0, SkillScore: 0,
+                    SkillLevel: 0, SinglesRating: 0, SinglesScore: 0, SinglesLevel: 0,
+                    DoublesRating: 0, DoublesScore: 0, DoublesLevel: 0,
+                    CompetitiveLevel: (singlesCompetitive + doublesCompetitive) / 2,
+                    SinglesCompetitiveLevel: singlesCompetitive,
+                    DoublesCompetitiveLevel: doublesCompetitive));
+        }
+
+        public void GivenNoExistingEntries(Guid chartId)
+        {
+            WeeklyTournies.Setup(w => w.GetEntries(chartId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<WeeklyTournamentEntry>());
+        }
+
+        public void GivenExistingEntries(Guid chartId, IEnumerable<WeeklyTournamentEntry> entries)
+        {
+            WeeklyTournies.Setup(w => w.GetEntries(chartId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(entries);
+        }
+    }
+
+    private static WeeklyTournamentSaga BuildSaga(
+        Mock<IChartRepository>? charts = null,
+        Mock<IWeeklyTournamentRepository>? weeklyTournies = null,
+        Mock<IPlayerStatsRepository>? playerStats = null,
+        Mock<IBotClient>? bot = null,
+        Mock<IUserRepository>? users = null,
+        Mock<IBus>? bus = null,
+        Mock<IDateTimeOffsetAccessor>? dateTime = null)
+    {
+        charts ??= new Mock<IChartRepository>();
+        weeklyTournies ??= new Mock<IWeeklyTournamentRepository>();
+        playerStats ??= new Mock<IPlayerStatsRepository>();
+        bot ??= new Mock<IBotClient>();
+        users ??= new Mock<IUserRepository>();
+        bus ??= new Mock<IBus>();
+        dateTime ??= FakeDateTime.At(Now);
+        return new WeeklyTournamentSaga(charts.Object, weeklyTournies.Object, playerStats.Object,
+            bot.Object, NullLogger<WeeklyTournamentSaga>.Instance, users.Object, bus.Object,
+            dateTime.Object);
+    }
+
+    private static WeeklyTournamentEntry Entry(Guid chartId, int score, Guid? userId = null,
+        bool isBroken = false) =>
+        new(UserId: userId ?? Guid.NewGuid(), ChartId: chartId, Score: score,
+            Plate: PhoenixPlate.SuperbGame, IsBroken: isBroken, PhotoUrl: null,
+            CompetitiveLevel: 20);
+
+    private static ConsumeContext<T> BuildContext<T>(T message) where T : class
+    {
+        var ctx = new Mock<ConsumeContext<T>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/TournamentSessionTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/TournamentSessionTests.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Linq;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class TournamentSessionTests
+{
+    [Fact]
+    public void NewSessionStartsNeedingApprovalWithNoEntries()
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+
+        Assert.True(session.NeedsApproval);
+        Assert.Null(session.ApprovedVerificationType);
+        Assert.Empty(session.Entries);
+        Assert.Equal(0, session.CurrentScore);
+        Assert.Equal(0, session.TotalScore);
+    }
+
+    [Fact]
+    public void ApproveClearsNeedsApprovalAndSnapshotsVerificationType()
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+        session.SetVerificationType(SubmissionVerificationType.Photo);
+        Assert.True(session.NeedsApproval);
+
+        session.Approve();
+
+        Assert.False(session.NeedsApproval);
+        Assert.Equal(SubmissionVerificationType.Photo, session.ApprovedVerificationType);
+    }
+
+    [Fact]
+    public void AddPhotoReFlagsNeedsApprovalEvenAfterApprove()
+    {
+        var session = ApprovedSession();
+
+        session.AddPhoto(new Uri("https://example.invalid/p.png"));
+
+        Assert.True(session.NeedsApproval);
+        Assert.Single(session.PhotoUrls);
+    }
+
+    [Fact]
+    public void RemovePhotoReFlagsNeedsApproval()
+    {
+        var photo = new Uri("https://example.invalid/p.png");
+        var session = ApprovedSession();
+        session.AddPhoto(photo);
+        session.Approve();
+
+        session.RemovePhoto(photo);
+
+        Assert.True(session.NeedsApproval);
+        Assert.Empty(session.PhotoUrls);
+    }
+
+    [Theory]
+    [InlineData(SubmissionVerificationType.InPerson)]
+    [InlineData(SubmissionVerificationType.Unverified)]
+    public void SetVerificationTypeAutoApprovesForInPersonAndUnverified(SubmissionVerificationType type)
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+
+        session.SetVerificationType(type);
+
+        Assert.False(session.NeedsApproval);
+        Assert.Equal(type, session.VerificationType);
+    }
+
+    [Theory]
+    [InlineData(SubmissionVerificationType.Photo)]
+    [InlineData(SubmissionVerificationType.Video)]
+    public void SetVerificationTypeRequiresApprovalForPhotoAndVideoWhenNeverApproved(SubmissionVerificationType type)
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+
+        session.SetVerificationType(type);
+
+        Assert.True(session.NeedsApproval);
+        Assert.Equal(type, session.VerificationType);
+    }
+
+    [Fact]
+    public void SetVerificationTypeMatchingPreviouslyApprovedTypeDoesNotNeedApproval()
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+        session.SetVerificationType(SubmissionVerificationType.Photo);
+        session.Approve();
+        session.AddPhoto(new Uri("https://example.invalid/p.png")); // re-flags NeedsApproval
+
+        session.SetVerificationType(SubmissionVerificationType.Photo);
+
+        Assert.False(session.NeedsApproval);
+    }
+
+    [Fact]
+    public void SetVerificationTypeDifferentFromPreviouslyApprovedTypeNeedsApproval()
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+        session.SetVerificationType(SubmissionVerificationType.Photo);
+        session.Approve();
+
+        session.SetVerificationType(SubmissionVerificationType.Video);
+
+        Assert.True(session.NeedsApproval);
+    }
+
+    [Fact]
+    public void CanAddReturnsFalseWhenScorelessScoreIsZero()
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+        // SinglePerformance has a 0.0 ChartTypeModifier in the default ScoringConfiguration.
+        var chart = new ChartBuilder().WithType(ChartType.SinglePerformance).Build();
+
+        Assert.False(session.CanAdd(chart));
+    }
+
+    [Fact]
+    public void CanAddReturnsFalseWhenAddingChartWouldExceedMaxTime()
+    {
+        var config = Config();
+        config.MaxTime = TimeSpan.FromMinutes(2);
+        var session = new TournamentSession(Guid.NewGuid(), config);
+        var first = new ChartBuilder().WithSong(SongOfDuration("song-a", TimeSpan.FromSeconds(90))).Build();
+        var second = new ChartBuilder().WithSong(SongOfDuration("song-b", TimeSpan.FromSeconds(90))).Build();
+        session.Add(first, 900000, PhoenixPlate.SuperbGame, isBroken: false);
+
+        Assert.False(session.CanAdd(second));
+    }
+
+    [Fact]
+    public void CanAddRespectsAllowRepeatsFalseForSameSongLevelAndType()
+    {
+        var config = Config();
+        config.AllowRepeats = false;
+        var session = new TournamentSession(Guid.NewGuid(), config);
+        var first = new ChartBuilder().WithSongName("Repeat").WithLevel(15).WithType(ChartType.Single).Build();
+        // Same song name, level, and type but different chart instance.
+        var second = new ChartBuilder().WithSongName("Repeat").WithLevel(15).WithType(ChartType.Single).Build();
+        session.Add(first, 900000, PhoenixPlate.SuperbGame, isBroken: false);
+
+        Assert.False(session.CanAdd(second));
+    }
+
+    [Fact]
+    public void CanAddAllowsRepeatsWhenConfigEnablesThem()
+    {
+        var config = Config();
+        config.AllowRepeats = true;
+        var session = new TournamentSession(Guid.NewGuid(), config);
+        var first = new ChartBuilder().WithSongName("Repeat").WithLevel(15).WithType(ChartType.Single).Build();
+        var second = new ChartBuilder().WithSongName("Repeat").WithLevel(15).WithType(ChartType.Single).Build();
+        session.Add(first, 900000, PhoenixPlate.SuperbGame, isBroken: false);
+
+        Assert.True(session.CanAdd(second));
+    }
+
+    [Fact]
+    public void AddFlipsNeedsApprovalAndAppendsEntry()
+    {
+        var session = ApprovedSession();
+        var chart = new ChartBuilder().Build();
+
+        session.Add(chart, 950000, PhoenixPlate.SuperbGame, isBroken: false);
+
+        Assert.True(session.NeedsApproval);
+        Assert.Single(session.Entries);
+    }
+
+    [Fact]
+    public void AddThrowsArgumentExceptionForChartThatCannotBeAdded()
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+        var invalid = new ChartBuilder().WithType(ChartType.SinglePerformance).Build();
+
+        Assert.Throws<ArgumentException>(() =>
+            session.Add(invalid, 900000, PhoenixPlate.SuperbGame, isBroken: false));
+    }
+
+    [Fact]
+    public void AddWithoutApprovalDoesNotFlipNeedsApproval()
+    {
+        var session = ApprovedSession();
+        var chart = new ChartBuilder().Build();
+
+        session.AddWithoutApproval(chart, 950000, PhoenixPlate.SuperbGame, isBroken: false);
+
+        Assert.False(session.NeedsApproval);
+        Assert.Single(session.Entries);
+    }
+
+    [Fact]
+    public void SwapReplacesEntryAndFlipsNeedsApproval()
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+        var chart = new ChartBuilder().Build();
+        session.Add(chart, 800000, PhoenixPlate.FairGame, isBroken: false);
+        session.Approve();
+        var original = session.Entries.Single();
+
+        session.Swap(original, 990000, PhoenixPlate.PerfectGame, isBroken: false);
+
+        var swapped = session.Entries.Single();
+        Assert.Equal((PhoenixScore)990000, swapped.Score);
+        Assert.Equal(PhoenixPlate.PerfectGame, swapped.Plate);
+        Assert.True(session.NeedsApproval);
+    }
+
+    [Fact]
+    public void SwapIsNoOpWhenEntryNotInList()
+    {
+        var session = ApprovedSession();
+        var chart = new ChartBuilder().Build();
+        var stranger = new TournamentSession.Entry(chart, 900000, PhoenixPlate.SuperbGame,
+            IsBroken: false, SessionScore: 1, BonusPoints: 0);
+
+        session.Swap(stranger, 1000000, PhoenixPlate.PerfectGame, isBroken: false);
+
+        Assert.Empty(session.Entries);
+        Assert.False(session.NeedsApproval);
+    }
+
+    [Fact]
+    public void RemoveRemovesEntryAndFlipsNeedsApproval()
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+        session.Add(new ChartBuilder().Build(), 900000, PhoenixPlate.SuperbGame, isBroken: false);
+        session.Approve();
+        var entry = session.Entries.Single();
+
+        session.Remove(entry);
+
+        Assert.Empty(session.Entries);
+        Assert.True(session.NeedsApproval);
+    }
+
+    [Fact]
+    public void TotalScoreReflectsAddedEntriesWhenStartedEmpty()
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+        Assert.Equal(0, session.TotalScore);
+
+        session.Add(new ChartBuilder().WithSongName("a").Build(), 950000, PhoenixPlate.SuperbGame, isBroken: false);
+        var afterFirst = session.TotalScore;
+        session.Add(new ChartBuilder().WithSongName("b").Build(), 990000, PhoenixPlate.PerfectGame, isBroken: false);
+        var afterSecond = session.TotalScore;
+
+        Assert.True(afterFirst > 0);
+        Assert.True(afterSecond > afterFirst);
+        // CurrentScore is captured only by the entries-overload constructor — Add does not update it.
+        Assert.Equal(0, session.CurrentScore);
+    }
+
+    [Fact]
+    public void EntriesOverloadConstructorComputesCurrentScoreFromEntries()
+    {
+        var entries = new[]
+        {
+            new TournamentSession.Entry(new ChartBuilder().Build(), 900000, PhoenixPlate.SuperbGame,
+                IsBroken: false, SessionScore: 100, BonusPoints: 0),
+            new TournamentSession.Entry(new ChartBuilder().Build(), 950000, PhoenixPlate.SuperbGame,
+                IsBroken: false, SessionScore: 250, BonusPoints: 0)
+        };
+
+        var session = new TournamentSession(Guid.NewGuid(), Config(), entries);
+
+        Assert.Equal(350, session.CurrentScore);
+        Assert.Equal(350, session.TotalScore);
+    }
+
+    private static TournamentConfiguration Config() =>
+        new(new ScoringConfiguration());
+
+    private static TournamentSession ApprovedSession()
+    {
+        var session = new TournamentSession(Guid.NewGuid(), Config());
+        session.SetVerificationType(SubmissionVerificationType.InPerson);
+        return session;
+    }
+
+    private static Song SongOfDuration(string name, TimeSpan duration) =>
+        new(Name.From(name), SongType.Arcade, new Uri("https://example.invalid/song.png"),
+            duration, Name.From("artist"), Bpm: null);
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/WorldRankingServiceTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/WorldRankingServiceTests.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.Services;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class WorldRankingServiceTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task CalculateWorldRankingsClearsExistingRankingsBeforeWritingNewOnes()
+    {
+        var leaderboards = LeaderboardsMock(
+            usernames: new[] { "alice" },
+            statuses: new Dictionary<string, UserOfficialLeaderboard[]>
+            {
+                ["alice"] = new[] { Status("alice", "Cool Song S15", score: 950000) }
+            });
+        var saveOrder = new List<string>();
+        leaderboards.Setup(l => l.DeleteWorldRankings(It.IsAny<CancellationToken>()))
+            .Callback(() => saveOrder.Add("delete")).Returns(Task.CompletedTask);
+        leaderboards.Setup(l => l.SaveWorldRanking(It.IsAny<WorldRankingRecord>(), It.IsAny<CancellationToken>()))
+            .Callback(() => saveOrder.Add("save")).Returns(Task.CompletedTask);
+
+        await BuildService(leaderboards: leaderboards).CalculateWorldRankings(CancellationToken.None);
+
+        Assert.NotEmpty(saveOrder);
+        Assert.Equal("delete", saveOrder[0]);
+        Assert.All(saveOrder.Skip(1), op => Assert.Equal("save", op));
+    }
+
+    [Fact]
+    public async Task CalculateWorldRankingsSavesNothingWhenNoUsernames()
+    {
+        var leaderboards = LeaderboardsMock(usernames: Array.Empty<string>());
+
+        await BuildService(leaderboards: leaderboards).CalculateWorldRankings(CancellationToken.None);
+
+        leaderboards.Verify(l => l.DeleteWorldRankings(It.IsAny<CancellationToken>()), Times.Once);
+        leaderboards.Verify(l => l.SaveWorldRanking(It.IsAny<WorldRankingRecord>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CalculateWorldRankingsSkipsCoOpAndNonChartLeaderboards()
+    {
+        var leaderboards = LeaderboardsMock(
+            usernames: new[] { "alice" },
+            statuses: new Dictionary<string, UserOfficialLeaderboard[]>
+            {
+                ["alice"] = new[]
+                {
+                    Status("alice", "CoOp Charters S15", score: 950000),                          // CoOp filtered out
+                    Status("alice", "Skill Master S15", score: 950000, type: "Skill")             // Non-Chart filtered out
+                }
+            });
+
+        await BuildService(leaderboards: leaderboards).CalculateWorldRankings(CancellationToken.None);
+
+        // No "Chart" non-CoOp records → no rankings saved (the records.Any() guard).
+        leaderboards.Verify(l => l.SaveWorldRanking(It.IsAny<WorldRankingRecord>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CalculateWorldRankingsSavesSinglesDoublesAndAllForUserWithBothChartTypes()
+    {
+        var leaderboards = LeaderboardsMock(
+            usernames: new[] { "alice" },
+            statuses: new Dictionary<string, UserOfficialLeaderboard[]>
+            {
+                ["alice"] = new[]
+                {
+                    Status("alice", "Cool Song S15", score: 950000),
+                    Status("alice", "Cool Song D17", score: 900000)
+                }
+            });
+
+        await BuildService(leaderboards: leaderboards).CalculateWorldRankings(CancellationToken.None);
+
+        leaderboards.Verify(l => l.SaveWorldRanking(
+            It.Is<WorldRankingRecord>(r => (string)r.Username == "alice" && r.Type == "Singles"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        leaderboards.Verify(l => l.SaveWorldRanking(
+            It.Is<WorldRankingRecord>(r => (string)r.Username == "alice" && r.Type == "Doubles"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        leaderboards.Verify(l => l.SaveWorldRanking(
+            It.Is<WorldRankingRecord>(r => (string)r.Username == "alice" && r.Type == "All"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CalculateWorldRankingsSinglesTypeCountsOnlySingleCharts()
+    {
+        var leaderboards = LeaderboardsMock(
+            usernames: new[] { "alice" },
+            statuses: new Dictionary<string, UserOfficialLeaderboard[]>
+            {
+                ["alice"] = new[]
+                {
+                    Status("alice", "Song A S15", score: 950000),
+                    Status("alice", "Song B S20", score: 900000),
+                    Status("alice", "Song C D17", score: 800000)
+                }
+            });
+
+        await BuildService(leaderboards: leaderboards).CalculateWorldRankings(CancellationToken.None);
+
+        leaderboards.Verify(l => l.SaveWorldRanking(
+            It.Is<WorldRankingRecord>(r => r.Type == "Singles" && r.SinglesCount == 2 && r.DoublesCount == 0),
+            It.IsAny<CancellationToken>()), Times.Once);
+        leaderboards.Verify(l => l.SaveWorldRanking(
+            It.Is<WorldRankingRecord>(r => r.Type == "Doubles" && r.SinglesCount == 0 && r.DoublesCount == 1),
+            It.IsAny<CancellationToken>()), Times.Once);
+        leaderboards.Verify(l => l.SaveWorldRanking(
+            It.Is<WorldRankingRecord>(r => r.Type == "All" && r.SinglesCount == 2 && r.DoublesCount == 1),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllReturnsRecordedScoresForChartsThatExist()
+    {
+        var chartId = Guid.NewGuid();
+        var chart = new ChartBuilder().WithId(chartId).WithLevel(15)
+            .WithType(ChartType.Single).WithSongName("Cool Song").Build();
+        var leaderboards = LeaderboardsMock(
+            usernames: Array.Empty<string>(),
+            statuses: new Dictionary<string, UserOfficialLeaderboard[]>
+            {
+                ["alice"] = new[] { Status("alice", "Cool Song S15", score: 950000) }
+            });
+        var charts = ChartsForSongMock(songName: "Cool Song", new[] { chart });
+
+        var result = await BuildService(leaderboards: leaderboards, charts: charts)
+            .GetAll(Name.From("alice"), CancellationToken.None);
+
+        var record = Assert.Single(result);
+        Assert.Equal(chartId, record.ChartId);
+        Assert.Equal((PhoenixScore)950000, record.Score);
+    }
+
+    [Fact]
+    public async Task GetAllSkipsRecordsWhenNoMatchingChartFound()
+    {
+        // The chart returned for "Cool Song" is Single 17, but the leaderboard says S15 → no match.
+        var chart = new ChartBuilder().WithLevel(17).WithType(ChartType.Single)
+            .WithSongName("Cool Song").Build();
+        var leaderboards = LeaderboardsMock(
+            usernames: Array.Empty<string>(),
+            statuses: new Dictionary<string, UserOfficialLeaderboard[]>
+            {
+                ["alice"] = new[] { Status("alice", "Cool Song S15", score: 950000) }
+            });
+        var charts = ChartsForSongMock(songName: "Cool Song", new[] { chart });
+
+        var result = await BuildService(leaderboards: leaderboards, charts: charts)
+            .GetAll(Name.From("alice"), CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllStampsResultsWithCurrentDateTime()
+    {
+        var chart = new ChartBuilder().WithLevel(15).WithType(ChartType.Single)
+            .WithSongName("Cool Song").Build();
+        var leaderboards = LeaderboardsMock(
+            usernames: Array.Empty<string>(),
+            statuses: new Dictionary<string, UserOfficialLeaderboard[]>
+            {
+                ["alice"] = new[] { Status("alice", "Cool Song S15", score: 950000) }
+            });
+        var charts = ChartsForSongMock(songName: "Cool Song", new[] { chart });
+
+        var result = await BuildService(leaderboards: leaderboards, charts: charts)
+            .GetAll(Name.From("alice"), CancellationToken.None);
+
+        Assert.Equal(Now, result.Single().RecordedDate);
+    }
+
+    [Theory]
+    [InlineData("Singles", 1, 0)]
+    [InlineData("Doubles", 0, 1)]
+    [InlineData("All", 1, 1)]
+    public async Task GetTop50FiltersChartsByType(string type, int expectedSingleCount, int expectedDoubleCount)
+    {
+        var single = new ChartBuilder().WithLevel(15).WithType(ChartType.Single).WithSongName("Song A").Build();
+        var dbl = new ChartBuilder().WithLevel(17).WithType(ChartType.Double).WithSongName("Song B").Build();
+        var leaderboards = LeaderboardsMock(
+            usernames: Array.Empty<string>(),
+            statuses: new Dictionary<string, UserOfficialLeaderboard[]>
+            {
+                ["alice"] = new[]
+                {
+                    Status("alice", "Song A S15", score: 950000),
+                    Status("alice", "Song B D17", score: 900000)
+                }
+            });
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChartsForSong(MixEnum.Phoenix, It.Is<Name>(n => (string)n == "Song A"),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new[] { single });
+        charts.Setup(c => c.GetChartsForSong(MixEnum.Phoenix, It.Is<Name>(n => (string)n == "Song B"),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new[] { dbl });
+
+        var result = (await BuildService(leaderboards: leaderboards, charts: charts)
+            .GetTop50(Name.From("alice"), type, CancellationToken.None)).ToArray();
+
+        Assert.Equal(expectedSingleCount, result.Count(r => r.ChartId == single.Id));
+        Assert.Equal(expectedDoubleCount, result.Count(r => r.ChartId == dbl.Id));
+    }
+
+    private static WorldRankingService BuildService(
+        Mock<IOfficialLeaderboardRepository>? leaderboards = null,
+        Mock<IChartRepository>? charts = null,
+        Mock<IDateTimeOffsetAccessor>? dateTime = null)
+    {
+        leaderboards ??= LeaderboardsMock(usernames: Array.Empty<string>());
+        charts ??= new Mock<IChartRepository>();
+        dateTime ??= FakeDateTime.At(Now);
+        return new WorldRankingService(leaderboards.Object, NullLogger<WorldRankingService>.Instance,
+            charts.Object, dateTime.Object);
+    }
+
+    private static Mock<IOfficialLeaderboardRepository> LeaderboardsMock(
+        IEnumerable<string> usernames,
+        IDictionary<string, UserOfficialLeaderboard[]>? statuses = null)
+    {
+        var m = new Mock<IOfficialLeaderboardRepository>();
+        m.Setup(l => l.GetOfficialLeaderboardUsernames("Chart", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(usernames);
+        if (statuses != null)
+            foreach (var (user, entries) in statuses)
+                m.Setup(l => l.GetOfficialLeaderboardStatuses(user, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(entries);
+        return m;
+    }
+
+    private static Mock<IChartRepository> ChartsForSongMock(string songName, IEnumerable<Chart> result)
+    {
+        var m = new Mock<IChartRepository>();
+        m.Setup(c => c.GetChartsForSong(MixEnum.Phoenix, It.Is<Name>(n => (string)n == songName),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return m;
+    }
+
+    private static UserOfficialLeaderboard Status(string username, string leaderboardName, int score,
+        string type = "Chart") =>
+        new(Username: username, Place: 1, OfficialLeaderboardType: type,
+            LeaderboardName: leaderboardName, Score: score);
+}


### PR DESCRIPTION
## Summary

Adds 85 new tests across 5 files, hitting the highest-LOC / highest-leverage gaps identified during a coverage review against `ENTERPRISE.md`. Three commits, one priority each.

| Commit | New tests | Coverage |
|---|---|---|
| `5f0221a` | 34 | `TournamentSession` (the project's named reference rich-domain model) + `UpdatePhoenixRecordHandler` (central score-update flow, both `IRequestHandler` and `IConsumer`). |
| `3f33dfb` | 28 | `TierListSaga` and `WeeklyTournamentSaga` consumer paths — previously only their static helpers were tested, leaving 650+ LOC of `IConsumer<>`/`IRequestHandler<>` logic uncovered. |
| `7170079` | 23 | `WorldRankingService` (Domain service, untested) + `PlayerRatingSaga` (entire `PersonalProgress` project was untested). |

**Total: 364 passing, 0 failures (was 256).**

## Why

A coverage walk-through against the `ENTERPRISE.md` test taxonomy showed the unit and component layers were strong on value types but had a few load-bearing gaps:
- `TournamentSession` carries the project's invariant patterns (Approve/AddPhoto/SetVerificationType) and is the model `CLAUDE.md` points to as the example for rich domain modeling. Untested.
- `UpdatePhoenixRecordHandler` is on the score-update hot path and gates `PlayerScoreUpdatedEvent` publishing through the batch debouncer.
- The saga "Statics" tests gave a false sense of coverage on the `*Saga` files — only the pure helpers were exercised.
- `WorldRankingService` is a 145-LOC Domain service with no tests.
- `ScoreTracker.PersonalProgress` had zero tests.

## Notable behaviors pinned

- `TournamentSession.SetVerificationType` re-approval rule: re-applying the same type that was previously approved keeps `NeedsApproval=false`, but a *different* type re-flags it — this is a subtle invariant easily broken by refactors.
- `UpdatePhoenixRecordHandler` broken→clear with a higher score fires *both* `RecordNewChart` *and* `RecordUpscoreIfNotNew`; the accumulator's `IfNotNew` contract handles precedence. Pinned with a dedicated test rather than masked.
- `TierListSaga.ProcessPassTierListCommand` iterates `Enumerable.Range(10, 18)` → levels 10..27 inclusive — a 4-row Theory pins the off-by-one boundary on both ends.
- `TierListSaga.GetMyRelativeTierListQuery` switches between `"Scores"` and `"Official Scores"` at level 24.
- `WorldRankingService.CalculateWorldRankings` always calls `DeleteWorldRankings` before any `SaveWorldRanking`.
- `PlayerRatingSaga.RecalculateStats` always publishes `PlayerStatsUpdatedEvent` but only publishes `PlayerRatingsImprovedEvent` when at least one tracked rating goes up.

## Out of scope (called out, not attempted)

- `WeeklyTournamentSaga.Consume(UpdateWeeklyChartsEvent)` past the early-return: the chart-picking algorithm hardcodes specific `(level, ChartType)` bucket keys and uses `new Random()`, making it brittle to test without an exhaustive chart fixture. Worth flagging for any future refactor of that saga.
- Realism-label folder rename / xUnit traits per `ENTERPRISE.md` §"Dependency Realism Labels".
- Property-based / mutation / characterization tests.
- Anything in `ScoreTracker.Data` (real-dependency territory, deferred).

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` succeeds (warnings are pre-existing).
- [x] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` — 364 passed, 0 failed, 0 skipped.
- [x] Existing `TierListSagaStaticsTests` and `WeeklyTournamentSagaStaticsTests` still pass alongside the new consumer tests (kept rather than folded in).
- [ ] CI green on Azure Pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)