### PR TITLE
Add tests for the four largest untested sagas

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using MediatR;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Exceptions;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class CommunitySagaTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task HandleCreateCommunityThrowsWhenCommunityNameAlreadyExists()
+    {
+        var ctx = new HandlerContext();
+        var existing = new Community(Name.From("Acme"), Guid.NewGuid(), CommunityPrivacyType.Public, false);
+        ctx.Communities.Setup(c => c.GetCommunityByName(It.Is<Name>(n => (string)n == "Acme"),
+            It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+
+        await Assert.ThrowsAsync<CommunityAlreadyExistsException>(() =>
+            ctx.Saga.Handle(new CreateCommunityCommand(Name.From("Acme"), CommunityPrivacyType.Public),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleCreateCommunitySavesNewCommunityWithCurrentUserAsOwnerAndMember()
+    {
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext(currentUserId: userId);
+
+        await ctx.Saga.Handle(new CreateCommunityCommand(Name.From("Acme"), CommunityPrivacyType.Public),
+            CancellationToken.None);
+
+        ctx.Communities.Verify(c => c.SaveCommunity(
+            It.Is<Community>(comm => (string)comm.Name == "Acme" && comm.OwnerId == userId
+                                     && comm.MemberIds.Contains(userId)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleJoinCommunityIsIdempotentForExistingMembers()
+    {
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext(currentUserId: userId);
+        var community = new Community(Name.From("Acme"), Guid.NewGuid(), CommunityPrivacyType.Public,
+            new[] { userId }, Array.Empty<Community.ChannelConfiguration>(),
+            new Dictionary<Guid, DateOnly?>(), false);
+        ctx.Communities.Setup(c => c.GetCommunityByName(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(community);
+
+        await ctx.Saga.Handle(new JoinCommunityCommand(Name.From("Acme"), null), CancellationToken.None);
+
+        ctx.Communities.Verify(c => c.SaveCommunity(It.IsAny<Community>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleJoinCommunityAddsMemberToPublicCommunity()
+    {
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext(currentUserId: userId);
+        var community = new Community(Name.From("Acme"), Guid.NewGuid(), CommunityPrivacyType.Public, false);
+        ctx.Communities.Setup(c => c.GetCommunityByName(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(community);
+
+        await ctx.Saga.Handle(new JoinCommunityCommand(Name.From("Acme"), null), CancellationToken.None);
+
+        ctx.Communities.Verify(c => c.SaveCommunity(
+            It.Is<Community>(comm => comm.MemberIds.Contains(userId)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleJoinCommunityThrowsWhenPrivateAndNoInviteCodeProvided()
+    {
+        var ctx = new HandlerContext();
+        var community = new Community(Name.From("Secret"), Guid.NewGuid(), CommunityPrivacyType.Private, false);
+        ctx.Communities.Setup(c => c.GetCommunityByName(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(community);
+
+        await Assert.ThrowsAsync<DeniedFromCommunityException>(() =>
+            ctx.Saga.Handle(new JoinCommunityCommand(Name.From("Secret"), InviteCode: null),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleLeaveCommunityRemovesMemberFromTheSet()
+    {
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext(currentUserId: userId);
+        var community = new Community(Name.From("Acme"), Guid.NewGuid(), CommunityPrivacyType.Public,
+            new[] { userId }, Array.Empty<Community.ChannelConfiguration>(),
+            new Dictionary<Guid, DateOnly?>(), false);
+        ctx.Communities.Setup(c => c.GetCommunityByName(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(community);
+
+        await ctx.Saga.Handle(new LeaveCommunityCommand(Name.From("Acme")), CancellationToken.None);
+
+        ctx.Communities.Verify(c => c.SaveCommunity(
+            It.Is<Community>(comm => !comm.MemberIds.Contains(userId)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleCreateInviteLinkThrowsWhenCallerIsNotAMember()
+    {
+        var callerId = Guid.NewGuid();
+        var ctx = new HandlerContext(currentUserId: callerId);
+        var community = new Community(Name.From("Acme"), Guid.NewGuid(), CommunityPrivacyType.Public, false);
+        ctx.Communities.Setup(c => c.GetCommunityByName(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(community);
+
+        await Assert.ThrowsAsync<DeniedFromCommunityException>(() =>
+            ctx.Saga.Handle(new CreateInviteLinkCommand(Name.From("Acme"), ExpirationDate: null),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleCreateInviteLinkPersistsTheCodeAndReturnsIt()
+    {
+        var memberId = Guid.NewGuid();
+        var ctx = new HandlerContext(currentUserId: memberId);
+        var community = new Community(Name.From("Acme"), Guid.NewGuid(), CommunityPrivacyType.Public,
+            new[] { memberId }, Array.Empty<Community.ChannelConfiguration>(),
+            new Dictionary<Guid, DateOnly?>(), false);
+        ctx.Communities.Setup(c => c.GetCommunityByName(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(community);
+
+        var code = await ctx.Saga.Handle(new CreateInviteLinkCommand(Name.From("Acme"), ExpirationDate: null),
+            CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, code);
+        ctx.Communities.Verify(c => c.SaveCommunity(
+            It.Is<Community>(comm => comm.InviteCodes.ContainsKey(code)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task HandleGetMyCommunitiesReturnsPersonalListWhenLoggedInElsePublicList(bool loggedIn)
+    {
+        var ctx = new HandlerContext(currentUserId: Guid.NewGuid(), isLoggedIn: loggedIn);
+
+        await ctx.Saga.Handle(new GetMyCommunitiesQuery(), CancellationToken.None);
+
+        if (loggedIn)
+        {
+            ctx.Communities.Verify(c => c.GetCommunities(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            ctx.Communities.Verify(c => c.GetPublicCommunities(It.IsAny<CancellationToken>()), Times.Never);
+        }
+        else
+        {
+            ctx.Communities.Verify(c => c.GetPublicCommunities(It.IsAny<CancellationToken>()), Times.Once);
+            ctx.Communities.Verify(c => c.GetCommunities(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+    }
+
+    [Fact]
+    public async Task HandleGetCommunityHidesPrivateCommunityFromNonMembers()
+    {
+        var ctx = new HandlerContext(currentUserId: Guid.NewGuid(), isLoggedIn: true);
+        var privateCommunity = new Community(Name.From("Secret"), Guid.NewGuid(),
+            CommunityPrivacyType.Private, false);
+        ctx.Communities.Setup(c => c.GetCommunityByName(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(privateCommunity);
+
+        await Assert.ThrowsAsync<CommunityNotFoundException>(() =>
+            ctx.Saga.Handle(new GetCommunityQuery(Name.From("Secret")), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ConsumeNewTitlesAcquiredBroadcastsTitleListToCommunityChannels()
+    {
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext();
+        ctx.GivenUser(userId, name: "alice");
+        ctx.GivenUserCommunitiesWithChannel(userId, communityName: "Acme", channelId: 12345);
+
+        await ctx.Saga.Consume(BuildContext(new NewTitlesAcquiredEvent(userId,
+            NewTitles: new[] { "First Title", "Second Title" },
+            ParagonUpgrades: new Dictionary<string, string>())));
+
+        ctx.Bot.Verify(b => b.SendMessages(
+            It.Is<IEnumerable<string>>(msgs => msgs.Any(m => m.Contains("alice") && m.Contains("First Title"))),
+            It.Is<IEnumerable<ulong>>(ids => ids.Contains(12345ul)),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task ConsumePlayerRatingsImprovedDoesNothingWhenUserNotFound()
+    {
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext();
+        ctx.Users.Setup(u => u.GetUser(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        await ctx.Saga.Consume(BuildContext(BuildRatingsImprovedAllSame(userId)));
+
+        ctx.Bot.Verify(b => b.SendMessages(It.IsAny<IEnumerable<string>>(),
+            It.IsAny<IEnumerable<ulong>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConsumePlayerRatingsImprovedSkipsBroadcastWhenNothingActuallyImproved()
+    {
+        // All "new" values equal "old" values → no parts of the message are appended → no send.
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext();
+        ctx.GivenUser(userId, "alice");
+        ctx.GivenUserCommunitiesWithChannel(userId, "Acme", channelId: 12345);
+
+        await ctx.Saga.Consume(BuildContext(BuildRatingsImprovedAllSame(userId)));
+
+        ctx.Bot.Verify(b => b.SendMessages(It.IsAny<IEnumerable<string>>(),
+            It.IsAny<IEnumerable<ulong>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConsumeUserUpdatedJoinsWorldAndCountryWhenPublic()
+    {
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext();
+
+        await ctx.Saga.Consume(BuildContext(new UserUpdatedEvent(userId, Country: "USA", IsPublic: true)));
+
+        ctx.Mediator.Verify(m => m.Send(
+            It.Is<JoinCommunityCommand>(j => (string)j.CommunityName == "World" && j.UserId == userId),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Mediator.Verify(m => m.Send(
+            It.Is<JoinCommunityCommand>(j => (string)j.CommunityName == "USA" && j.UserId == userId),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Mediator.Verify(m => m.Send(It.IsAny<LeaveCommunityCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ConsumeUserUpdatedLeavesWorldWhenNoLongerPublic()
+    {
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext();
+
+        await ctx.Saga.Consume(BuildContext(new UserUpdatedEvent(userId, Country: null, IsPublic: false)));
+
+        ctx.Mediator.Verify(m => m.Send(
+            It.Is<LeaveCommunityCommand>(l => (string)l.CommunityName == "World" && l.UserId == userId),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Mediator.Verify(m => m.Send(It.IsAny<JoinCommunityCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private sealed class HandlerContext
+    {
+        public Mock<ICurrentUserAccessor> CurrentUser { get; } = new();
+        public Mock<ICommunityRepository> Communities { get; } = new();
+        public Mock<IBotClient> Bot { get; } = new();
+        public Mock<IUserRepository> Users { get; } = new();
+        public Mock<IChartRepository> Charts { get; } = new();
+        public Mock<IPhoenixRecordRepository> Scores { get; } = new();
+        public Mock<IMediator> Mediator { get; } = new();
+        public Mock<IUcsRepository> Ucs { get; } = new();
+        public Mock<IDateTimeOffsetAccessor> DateTime { get; } = FakeDateTime.At(Now);
+        public CommunitySaga Saga { get; }
+
+        public HandlerContext(Guid? currentUserId = null, bool isLoggedIn = true)
+        {
+            var id = currentUserId ?? Guid.NewGuid();
+            CurrentUser.SetupGet(u => u.User).Returns(new UserBuilder().WithId(id).Build());
+            CurrentUser.SetupGet(u => u.IsLoggedIn).Returns(isLoggedIn);
+            Communities.Setup(c => c.GetCommunities(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<CommunityOverviewRecord>());
+            Saga = new CommunitySaga(CurrentUser.Object, Communities.Object, Bot.Object, Users.Object,
+                Charts.Object, Scores.Object, Mediator.Object, Ucs.Object, DateTime.Object);
+        }
+
+        public void GivenUser(Guid userId, string name)
+        {
+            Users.Setup(u => u.GetUser(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UserBuilder().WithId(userId).WithName(name).Build());
+        }
+
+        public void GivenUserCommunitiesWithChannel(Guid userId, string communityName, ulong channelId)
+        {
+            Communities.Setup(c => c.GetCommunities(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[]
+                {
+                    new CommunityOverviewRecord(Name.From(communityName), CommunityPrivacyType.Public,
+                        MemberCount: 1, IsRegional: false)
+                });
+            Communities.Setup(c => c.GetCommunityByName(It.Is<Name>(n => (string)n == communityName),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Community(Name.From(communityName), Guid.NewGuid(),
+                    CommunityPrivacyType.Public,
+                    new[] { userId },
+                    new[]
+                    {
+                        new Community.ChannelConfiguration(channelId, SendNewScores: true,
+                            SendTitles: true, SendNewMembers: true)
+                    },
+                    new Dictionary<Guid, DateOnly?>(), false));
+        }
+    }
+
+    private static PlayerRatingsImprovedEvent BuildRatingsImprovedAllSame(Guid userId) =>
+        new(userId, OldTop50: 100, OldSinglesTop50: 100, OldDoublesTop50: 100,
+            NewTop50: 100, NewSinglesTop50: 100, NewDoublesTop50: 100,
+            OldCompetitive: 20.0, NewCompetitive: 20.0,
+            OldSinglesCompetitive: 20.0, NewSinglesCompetitive: 20.0,
+            OldDoublesCompetitive: 20.0, NewDoublesCompetitive: 20.0,
+            CoOpRating: 0, PassCount: 0);
+
+    private static ConsumeContext<T> BuildContext<T>(T message) where T : class
+    {
+        var ctx = new Mock<ConsumeContext<T>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/MatchSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/MatchSagaTests.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Events;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Domain.Views;
+using ScoreTracker.Tests.TestData;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class MatchSagaTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly Guid TournamentId = Guid.NewGuid();
+
+    [Fact]
+    public async Task HandleCreateMatchLinkPersistsTheLink()
+    {
+        var matches = new Mock<IMatchRepository>();
+        var saga = BuildSaga(matches: matches);
+        var link = new MatchLink(Guid.NewGuid(), Name.From("A"), Name.From("B"),
+            IsWinners: true, PlayerCount: 2, Skip: 0);
+
+        await saga.Handle(new CreateMatchLinkCommand(TournamentId, link), CancellationToken.None);
+
+        matches.Verify(m => m.SaveMatchLink(TournamentId, link, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleDeleteMatchLinkRemovesTheLink()
+    {
+        var matches = new Mock<IMatchRepository>();
+        var saga = BuildSaga(matches: matches);
+        var linkId = Guid.NewGuid();
+
+        await saga.Handle(new DeleteMatchLinkCommand(linkId), CancellationToken.None);
+
+        matches.Verify(m => m.DeleteMatchLink(linkId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleSaveRandomSettingsPersistsByTournamentAndName()
+    {
+        var matches = new Mock<IMatchRepository>();
+        var saga = BuildSaga(matches: matches);
+        var settings = new RandomSettings();
+
+        await saga.Handle(
+            new SaveRandomSettingsCommand(TournamentId, Name.From("Mix"), settings),
+            CancellationToken.None);
+
+        matches.Verify(m => m.SaveRandomSettings(TournamentId,
+            It.Is<Name>(n => (string)n == "Mix"), settings, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleUpdateMatchPersistsAndPublishesMatchUpdatedEvent()
+    {
+        var matches = new Mock<IMatchRepository>();
+        var mediator = new Mock<IMediator>();
+        var saga = BuildSaga(matches: matches, mediator: mediator);
+        var view = NewMatch("Final");
+
+        await saga.Handle(new UpdateMatchCommand(TournamentId, view), CancellationToken.None);
+
+        matches.Verify(m => m.SaveMatch(TournamentId, view, It.IsAny<CancellationToken>()), Times.Once);
+        mediator.Verify(m => m.Publish(
+            It.Is<MatchUpdatedEvent>(e => e.TournamentId == TournamentId && e.NewState == view),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleGetMatchReturnsRepositoryValue()
+    {
+        var view = NewMatch("Semi");
+        var matches = new Mock<IMatchRepository>();
+        matches.Setup(m => m.GetMatch(TournamentId, It.Is<Name>(n => (string)n == "Semi"),
+            It.IsAny<CancellationToken>())).ReturnsAsync(view);
+        var saga = BuildSaga(matches: matches);
+
+        var result = await saga.Handle(new GetMatchQuery(TournamentId, Name.From("Semi")),
+            CancellationToken.None);
+
+        Assert.Same(view, result);
+    }
+
+    [Fact]
+    public async Task HandleResolveMatchTransitionsStateToFinalizingAndPublishes()
+    {
+        var view = NewMatch("Quarter") with { State = MatchState.InProgress };
+        var matches = new Mock<IMatchRepository>();
+        matches.Setup(m => m.GetMatch(TournamentId, It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(view);
+        var mediator = new Mock<IMediator>();
+        var saga = BuildSaga(matches: matches, mediator: mediator);
+
+        await saga.Handle(new ResolveMatchCommand(TournamentId, Name.From("Quarter")),
+            CancellationToken.None);
+
+        matches.Verify(m => m.SaveMatch(TournamentId,
+            It.Is<MatchView>(v => v.State == MatchState.Finalizing && v.LastUpdated == Now),
+            It.IsAny<CancellationToken>()), Times.Once);
+        mediator.Verify(m => m.Publish(
+            It.Is<MatchUpdatedEvent>(e => e.NewState.State == MatchState.Finalizing),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleFinishCardDrawSetsStateReadyAndZeroesScoresAndPoints()
+    {
+        var alice = Name.From("alice");
+        var bob = Name.From("bob");
+        var chart1 = Guid.NewGuid();
+        var chart2 = Guid.NewGuid();
+        var view = NewMatch("Round 1") with
+        {
+            State = MatchState.CardDraw,
+            Players = new[] { alice, bob },
+            ActiveCharts = new[] { chart1, chart2 }
+        };
+        var matches = new Mock<IMatchRepository>();
+        matches.Setup(m => m.GetMatch(TournamentId, It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(view);
+        var mediator = new Mock<IMediator>();
+        var saga = BuildSaga(matches: matches, mediator: mediator);
+
+        await saga.Handle(new FinishCardDrawCommand(TournamentId, Name.From("Round 1")),
+            CancellationToken.None);
+
+        matches.Verify(m => m.SaveMatch(TournamentId, It.Is<MatchView>(v =>
+                v.State == MatchState.Ready
+                && v.Scores.Count == 2
+                && v.Scores["alice"].Length == 2 && v.Scores["alice"].All(s => s == (PhoenixScore)0)
+                && v.Points["bob"].Length == 2 && v.Points["bob"].All(p => p == 0)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleUpdateMatchScoresUpdatesNestedScoreAndPublishes()
+    {
+        var alice = Name.From("alice");
+        var bob = Name.From("bob");
+        var chartId = Guid.NewGuid();
+        var view = NewMatch("Round 1") with
+        {
+            State = MatchState.Ready,
+            Players = new[] { alice, bob },
+            ActiveCharts = new[] { chartId },
+            Scores = new Dictionary<string, PhoenixScore[]>
+            {
+                ["alice"] = new[] { (PhoenixScore)0 },
+                ["bob"] = new[] { (PhoenixScore)0 }
+            },
+            Points = new Dictionary<string, int[]>
+            {
+                ["alice"] = new[] { 0 },
+                ["bob"] = new[] { 0 }
+            }
+        };
+        var matches = new Mock<IMatchRepository>();
+        matches.Setup(m => m.GetMatch(TournamentId, It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(view);
+        var mediator = new Mock<IMediator>();
+        var saga = BuildSaga(matches: matches, mediator: mediator);
+
+        await saga.Handle(
+            new UpdateMatchScoresCommand(TournamentId, Name.From("Round 1"), alice, ChartIndex: 0,
+                NewScore: 950000),
+            CancellationToken.None);
+
+        matches.Verify(m => m.SaveMatch(TournamentId, It.Is<MatchView>(v =>
+                v.Scores["alice"][0] == (PhoenixScore)950000 && v.Scores["bob"][0] == (PhoenixScore)0),
+            It.IsAny<CancellationToken>()), Times.Once);
+        mediator.Verify(m => m.Publish(It.IsAny<MatchUpdatedEvent>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleUpdateMatchScoresSendsDiscordWhenSongFirstCompletes()
+    {
+        var alice = Name.From("alice");
+        var bob = Name.From("bob");
+        var chartId = Guid.NewGuid();
+        // Alice already has a score; Bob's submission is what completes the song.
+        var view = NewMatch("Round 1") with
+        {
+            State = MatchState.Ready,
+            Players = new[] { alice, bob },
+            ActiveCharts = new[] { chartId },
+            Scores = new Dictionary<string, PhoenixScore[]>
+            {
+                ["alice"] = new[] { (PhoenixScore)900000 },
+                ["bob"] = new[] { (PhoenixScore)0 }
+            },
+            Points = new Dictionary<string, int[]>
+            {
+                ["alice"] = new[] { 0 },
+                ["bob"] = new[] { 0 }
+            }
+        };
+        var matches = new Mock<IMatchRepository>();
+        matches.Setup(m => m.GetMatch(TournamentId, It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(view);
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetChart(MixEnum.Phoenix, chartId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChartBuilder().WithId(chartId).Build());
+        var qualifiers = QualifiersMockReturning(notificationChannel: 12345);
+        var bot = new Mock<IBotClient>();
+        var saga = BuildSaga(matches: matches, charts: charts, qualifiers: qualifiers, bot: bot);
+
+        await saga.Handle(
+            new UpdateMatchScoresCommand(TournamentId, Name.From("Round 1"), bob, ChartIndex: 0,
+                NewScore: 950000),
+            CancellationToken.None);
+
+        bot.Verify(b => b.SendMessage(It.IsAny<string>(), 12345ul, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleUpdateMatchScoresDoesNotSendDiscordWhenSongAlreadyComplete()
+    {
+        var alice = Name.From("alice");
+        var bob = Name.From("bob");
+        var chartId = Guid.NewGuid();
+        var view = NewMatch("Round 1") with
+        {
+            State = MatchState.Ready,
+            Players = new[] { alice, bob },
+            ActiveCharts = new[] { chartId },
+            Scores = new Dictionary<string, PhoenixScore[]>
+            {
+                ["alice"] = new[] { (PhoenixScore)900000 },
+                ["bob"] = new[] { (PhoenixScore)850000 }
+            },
+            Points = new Dictionary<string, int[]>
+            {
+                ["alice"] = new[] { 1 },
+                ["bob"] = new[] { 0 }
+            }
+        };
+        var matches = new Mock<IMatchRepository>();
+        matches.Setup(m => m.GetMatch(TournamentId, It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(view);
+        var bot = new Mock<IBotClient>();
+        var saga = BuildSaga(matches: matches, bot: bot);
+
+        await saga.Handle(
+            new UpdateMatchScoresCommand(TournamentId, Name.From("Round 1"), bob, ChartIndex: 0,
+                NewScore: 990000),
+            CancellationToken.None);
+
+        bot.Verify(b => b.SendMessage(It.IsAny<string>(), It.IsAny<ulong>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(MatchState.NotStarted, "Card draw is ready")]
+    [InlineData(MatchState.Ready, "is ready to play")]
+    [InlineData(MatchState.InProgress, "TOs are requesting")]
+    public async Task HandlePingMatchTailorsMessageToCurrentState(MatchState state, string expectedSubstring)
+    {
+        var alice = Name.From("alice");
+        var view = NewMatch("Round 1") with
+        {
+            State = state,
+            Players = new[] { alice }
+        };
+        var matches = new Mock<IMatchRepository>();
+        matches.Setup(m => m.GetMatch(TournamentId, It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(view);
+        matches.Setup(m => m.GetMatchPlayers(TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new MatchPlayer(alice, Seed: 1, DiscordId: 999ul) });
+        var qualifiers = QualifiersMockReturning(notificationChannel: 12345);
+        var bot = new Mock<IBotClient>();
+        var saga = BuildSaga(matches: matches, qualifiers: qualifiers, bot: bot);
+
+        await saga.Handle(new PingMatchCommand(TournamentId, Name.From("Round 1")),
+            CancellationToken.None);
+
+        bot.Verify(b => b.SendMessage(It.Is<string>(s => s.Contains(expectedSubstring)),
+            12345ul, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleDrawChartsForCoOpEasyOverridesChartIdsWithEasyConstantBeforeRandomDraw()
+    {
+        // The "CoOp Easy" branch swaps ChartIds for the EasyCoOp constant before delegating
+        // chart selection to GetRandomChartsQuery. We pin that GetRandomChartsQuery is sent
+        // with the overridden, non-empty ChartIds set rather than whatever was on the
+        // original RandomSettings record.
+        var view = NewMatch("Round 1") with
+        {
+            State = MatchState.NotStarted,
+            RandomSettings = Name.From("CoOp Easy")
+        };
+        var matches = new Mock<IMatchRepository>();
+        matches.Setup(m => m.GetMatch(TournamentId, It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(view);
+        matches.Setup(m => m.GetRandomSettings(TournamentId, It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RandomSettings()); // No ChartIds preset.
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetRandomChartsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Chart>());
+        var saga = BuildSaga(matches: matches, mediator: mediator);
+
+        await saga.Handle(new DrawChartsCommand(TournamentId, Name.From("Round 1")),
+            CancellationToken.None);
+
+        mediator.Verify(m => m.Send(
+            It.Is<GetRandomChartsQuery>(q => q.Settings.ChartIds.Count > 0),
+            It.IsAny<CancellationToken>()), Times.Once);
+        matches.Verify(m => m.SaveMatch(TournamentId,
+            It.Is<MatchView>(v => v.State == MatchState.CardDraw),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleFinalizeMatchPromotesWinnersAndCompletesState()
+    {
+        var alice = Name.From("alice");
+        var bob = Name.From("bob");
+        var unknown1 = Name.From("Unknown 1");
+        var unknown2 = Name.From("Unknown 2");
+        var sourceMatch = NewMatch("Round 1") with
+        {
+            State = MatchState.Finalizing,
+            FinalPlaces = new[] { alice, bob },
+            Players = new[] { alice, bob },
+            Points = new Dictionary<string, int[]>
+            {
+                ["alice"] = new[] { 1 },
+                ["bob"] = new[] { 0 }
+            }
+        };
+        var nextMatch = NewMatch("Round 2") with
+        {
+            Players = new[] { unknown1, unknown2 }
+        };
+        var link = new MatchLink(Guid.NewGuid(), Name.From("Round 1"), Name.From("Round 2"),
+            IsWinners: true, PlayerCount: 1, Skip: 0);
+
+        var matches = new Mock<IMatchRepository>();
+        matches.Setup(m => m.GetMatch(TournamentId, It.Is<Name>(n => (string)n == "Round 1"),
+            It.IsAny<CancellationToken>())).ReturnsAsync(sourceMatch);
+        matches.Setup(m => m.GetMatch(TournamentId, It.Is<Name>(n => (string)n == "Round 2"),
+            It.IsAny<CancellationToken>())).ReturnsAsync(nextMatch);
+        matches.Setup(m => m.GetMatchLinksByFromMatchName(TournamentId, It.IsAny<Name>(),
+            It.IsAny<CancellationToken>())).ReturnsAsync(new[] { link });
+        var saga = BuildSaga(matches: matches);
+
+        await saga.Handle(new FinalizeMatchCommand(TournamentId, Name.From("Round 1")),
+            CancellationToken.None);
+
+        // Round 2 gets alice promoted into the first Unknown slot.
+        matches.Verify(m => m.SaveMatch(TournamentId,
+            It.Is<MatchView>(v => (string)v.MatchName == "Round 2" && v.Players[0] == alice),
+            It.IsAny<CancellationToken>()), Times.Once);
+        // Round 1 itself transitions to Completed.
+        matches.Verify(m => m.SaveMatch(TournamentId,
+            It.Is<MatchView>(v => (string)v.MatchName == "Round 1" && v.State == MatchState.Completed),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static MatchSaga BuildSaga(
+        Mock<IMediator>? mediator = null,
+        Mock<IMatchRepository>? matches = null,
+        Mock<IAdminNotificationClient>? admins = null,
+        Mock<IChartRepository>? charts = null,
+        Mock<IBotClient>? bot = null,
+        Mock<IQualifiersRepository>? qualifiers = null,
+        Mock<IDateTimeOffsetAccessor>? dateTime = null)
+    {
+        mediator ??= new Mock<IMediator>();
+        matches ??= new Mock<IMatchRepository>();
+        admins ??= new Mock<IAdminNotificationClient>();
+        charts ??= new Mock<IChartRepository>();
+        bot ??= new Mock<IBotClient>();
+        qualifiers ??= new Mock<IQualifiersRepository>();
+        dateTime ??= FakeDateTime.At(Now);
+        return new MatchSaga(mediator.Object, matches.Object, admins.Object, charts.Object,
+            bot.Object, qualifiers.Object, dateTime.Object);
+    }
+
+    private static Mock<IQualifiersRepository> QualifiersMockReturning(ulong notificationChannel)
+    {
+        var m = new Mock<IQualifiersRepository>();
+        m.Setup(q => q.GetQualifiersConfiguration(TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new QualifiersConfiguration(
+                charts: Array.Empty<Chart>(),
+                adjustments: new Dictionary<Guid, int>(),
+                scoringType: Name.From("default"),
+                notificationChannel: notificationChannel,
+                playCount: 1,
+                cutoffTime: null,
+                allCharts: false));
+        return m;
+    }
+
+    private static MatchView NewMatch(string name) =>
+        new(MatchName: Name.From(name), PhaseName: Name.From("Phase"), MatchOrder: 1, ChartCount: 0,
+            RandomSettings: Name.From("Default"), State: MatchState.NotStarted,
+            Players: Array.Empty<Name>(), ActiveCharts: Array.Empty<Guid>(),
+            VetoedCharts: Array.Empty<Guid>(), ProtectedCharts: Array.Empty<Guid>(),
+            Scores: new Dictionary<string, PhoenixScore[]>(),
+            Points: new Dictionary<string, int[]>(),
+            FinalPlaces: Array.Empty<Name>());
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/OfficialLeaderboardSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/OfficialLeaderboardSagaTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.Services.Contracts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class OfficialLeaderboardSagaTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task ConsumeStartLeaderboardImportFansOutToPopularityLeaderboardsAndWorldRankings()
+    {
+        var mediator = new Mock<IMediator>();
+        var worldRankings = new Mock<IWorldRankingService>();
+        var saga = BuildSaga(mediator: mediator, worldRankings: worldRankings);
+
+        await saga.Consume(BuildContext(new StartLeaderboardImportEvent()));
+
+        mediator.Verify(m => m.Send(It.IsAny<ProcessChartPopularityCommand>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        mediator.Verify(m => m.Send(It.IsAny<ProcessOfficialLeaderboardsCommand>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        worldRankings.Verify(w => w.CalculateWorldRankings(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleGetGameCardsQueryDelegatesToOfficialSiteClient()
+    {
+        var officialSite = new Mock<IOfficialSiteClient>();
+        var expected = new[] { new GameCardRecord(Name.From("alice"), Id: "card1", IsActive: true) };
+        officialSite.Setup(s => s.GetGameCards("user", "pass", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+        var saga = BuildSaga(officialSite: officialSite);
+
+        var result = await saga.Handle(new GetGameCardsQuery("user", "pass"), CancellationToken.None);
+
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task HandleProcessOfficialLeaderboardsClearsEachLeaderboardBeforeWritingEntries()
+    {
+        var officialSite = new Mock<IOfficialSiteClient>();
+        officialSite.Setup(s => s.GetLeaderboardEntries(It.IsAny<CancellationToken>())).ReturnsAsync(new[]
+        {
+            new UserOfficialLeaderboard("alice", Place: 0, "Rating", "Top Singles", Score: 100),
+            new UserOfficialLeaderboard("bob", Place: 0, "Rating", "Top Singles", Score: 90)
+        });
+        officialSite.Setup(s => s.GetAllOfficialChartScores(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<OfficialChartLeaderboardEntry>());
+        var leaderboards = new Mock<IOfficialLeaderboardRepository>();
+        var operations = new List<string>();
+        leaderboards.Setup(l => l.ClearLeaderboard(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, CancellationToken>((_, name, _) => operations.Add($"clear:{name}"))
+            .Returns(Task.CompletedTask);
+        leaderboards.Setup(l => l.WriteEntries(It.IsAny<IEnumerable<UserOfficialLeaderboard>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<UserOfficialLeaderboard>, CancellationToken>((batch, _) =>
+                operations.Add($"write:{batch.First().LeaderboardName}"))
+            .Returns(Task.CompletedTask);
+        var saga = BuildSaga(officialSite: officialSite, leaderboards: leaderboards);
+
+        await saga.Handle(new ProcessOfficialLeaderboardsCommand(), CancellationToken.None);
+
+        Assert.Equal(new[] { "clear:Top Singles", "write:Top Singles" },
+            operations.Where(o => o.EndsWith("Top Singles")).ToArray());
+    }
+
+    [Fact]
+    public async Task HandleProcessOfficialLeaderboardsAssignsTiedScoresTheSamePlaceWithOlympicGap()
+    {
+        var officialSite = new Mock<IOfficialSiteClient>();
+        // Two players tied at 100, one at 50 → tied players share place 1, next is place 3 (skipping 2).
+        officialSite.Setup(s => s.GetLeaderboardEntries(It.IsAny<CancellationToken>())).ReturnsAsync(new[]
+        {
+            new UserOfficialLeaderboard("alice", 0, "Rating", "Top", 100),
+            new UserOfficialLeaderboard("bob", 0, "Rating", "Top", 100),
+            new UserOfficialLeaderboard("carol", 0, "Rating", "Top", 50)
+        });
+        officialSite.Setup(s => s.GetAllOfficialChartScores(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<OfficialChartLeaderboardEntry>());
+        var leaderboards = new Mock<IOfficialLeaderboardRepository>();
+        IEnumerable<UserOfficialLeaderboard>? captured = null;
+        leaderboards.Setup(l => l.WriteEntries(It.IsAny<IEnumerable<UserOfficialLeaderboard>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<UserOfficialLeaderboard>, CancellationToken>((batch, _) =>
+                captured = batch.ToArray());
+        var saga = BuildSaga(officialSite: officialSite, leaderboards: leaderboards);
+
+        await saga.Handle(new ProcessOfficialLeaderboardsCommand(), CancellationToken.None);
+
+        Assert.NotNull(captured);
+        var byUser = captured!.ToDictionary(e => e.Username);
+        Assert.Equal(1, byUser["alice"].Place);
+        Assert.Equal(1, byUser["bob"].Place);
+        Assert.Equal(3, byUser["carol"].Place);
+    }
+
+    [Fact]
+    public async Task HandleProcessOfficialLeaderboardsSavesAvatarOncePerUniqueUsername()
+    {
+        var aliceAvatar = new Uri("https://example.invalid/alice.png");
+        var bobAvatar = new Uri("https://example.invalid/bob.png");
+        var chart1 = new ChartBuilder().Build();
+        var chart2 = new ChartBuilder().Build();
+        var officialSite = new Mock<IOfficialSiteClient>();
+        officialSite.Setup(s => s.GetLeaderboardEntries(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UserOfficialLeaderboard>());
+        // Alice appears on two charts; Bob appears on one.
+        officialSite.Setup(s => s.GetAllOfficialChartScores(It.IsAny<CancellationToken>())).ReturnsAsync(new[]
+        {
+            new OfficialChartLeaderboardEntry("alice", chart1, 950000, aliceAvatar),
+            new OfficialChartLeaderboardEntry("alice", chart2, 920000, aliceAvatar),
+            new OfficialChartLeaderboardEntry("bob", chart1, 900000, bobAvatar)
+        });
+        var leaderboards = new Mock<IOfficialLeaderboardRepository>();
+        var saga = BuildSaga(officialSite: officialSite, leaderboards: leaderboards);
+
+        await saga.Handle(new ProcessOfficialLeaderboardsCommand(), CancellationToken.None);
+
+        leaderboards.Verify(l => l.SaveAvatar("alice", aliceAvatar, It.IsAny<CancellationToken>()), Times.Once);
+        leaderboards.Verify(l => l.SaveAvatar("bob", bobAvatar, It.IsAny<CancellationToken>()), Times.Once);
+        leaderboards.Verify(l => l.SaveAvatar(It.IsAny<string>(), It.IsAny<Uri>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task HandleProcessChartPopularitySavesEntriesUnderPopularityTierList()
+    {
+        var chart = new ChartBuilder().WithLevel(15).WithType(ChartType.Single).Build();
+        var officialSite = new Mock<IOfficialSiteClient>();
+        officialSite.Setup(s => s.GetOfficialChartLeaderboardEntries(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ChartPopularityLeaderboardEntry(chart, Place: 100, new Uri("https://example.invalid/img.png"))
+            });
+        var tierLists = new Mock<ITierListRepository>();
+        var saga = BuildSaga(officialSite: officialSite, tierLists: tierLists);
+
+        await saga.Handle(new ProcessChartPopularityCommand(), CancellationToken.None);
+
+        tierLists.Verify(t => t.SaveEntry(
+            It.Is<SongTierListEntry>(e => (string)e.TierListName == "Popularity" && e.ChartId == chart.Id),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleProcessChartPopularityClassifiesPlaceMinusOneAsUnrecorded()
+    {
+        var chart = new ChartBuilder().WithLevel(15).WithType(ChartType.Single).Build();
+        var officialSite = new Mock<IOfficialSiteClient>();
+        officialSite.Setup(s => s.GetOfficialChartLeaderboardEntries(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ChartPopularityLeaderboardEntry(chart, Place: -1, new Uri("https://example.invalid/img.png"))
+            });
+        var tierLists = new Mock<ITierListRepository>();
+        var saga = BuildSaga(officialSite: officialSite, tierLists: tierLists);
+
+        await saga.Handle(new ProcessChartPopularityCommand(), CancellationToken.None);
+
+        tierLists.Verify(t => t.SaveEntry(
+            It.Is<SongTierListEntry>(e => e.Category == TierListCategory.Unrecorded && e.ChartId == chart.Id),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static OfficialLeaderboardSaga BuildSaga(
+        Mock<IOfficialSiteClient>? officialSite = null,
+        Mock<ITierListRepository>? tierLists = null,
+        Mock<IWorldRankingService>? worldRankings = null,
+        Mock<IOfficialLeaderboardRepository>? leaderboards = null,
+        Mock<ICurrentUserAccessor>? currentUser = null,
+        Mock<IUserRepository>? user = null,
+        Mock<IMediator>? mediator = null,
+        Mock<IPiuTrackerClient>? piuTracker = null,
+        Mock<IBus>? bus = null,
+        Mock<IFileUploadClient>? files = null,
+        Mock<IChartRepository>? charts = null,
+        Mock<IDateTimeOffsetAccessor>? dateTime = null)
+    {
+        officialSite ??= new Mock<IOfficialSiteClient>();
+        tierLists ??= new Mock<ITierListRepository>();
+        worldRankings ??= new Mock<IWorldRankingService>();
+        leaderboards ??= new Mock<IOfficialLeaderboardRepository>();
+        currentUser ??= new Mock<ICurrentUserAccessor>();
+        user ??= new Mock<IUserRepository>();
+        mediator ??= new Mock<IMediator>();
+        piuTracker ??= new Mock<IPiuTrackerClient>();
+        bus ??= new Mock<IBus>();
+        files ??= new Mock<IFileUploadClient>();
+        charts ??= new Mock<IChartRepository>();
+        dateTime ??= FakeDateTime.At(Now);
+        return new OfficialLeaderboardSaga(officialSite.Object, tierLists.Object, worldRankings.Object,
+            leaderboards.Object, currentUser.Object, user.Object, mediator.Object, piuTracker.Object,
+            NullLogger<OfficialLeaderboardSaga>.Instance, bus.Object, files.Object, charts.Object,
+            dateTime.Object);
+    }
+
+    private static ConsumeContext<T> BuildContext<T>(T message) where T : class
+    {
+        var ctx = new Mock<ConsumeContext<T>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+// GetRecommendedChartsQuery is not covered: the handler instantiates `new Random()`
+// in five different sub-methods (GetOldScores, GetRandomFromTop50Charts, GetPassFills,
+// GetBounties, GetPushLevels) and dispatches to ten+ mediator queries to assemble the
+// final list. Without an IRandomNumberGenerator-style port and a way to substitute
+// the inner queries, any assertion would either be brittle (snapshot-y) or
+// re-implement the saga's filter logic. Flagging for a refactor pass — same shape
+// as the WeeklyTournamentSaga.Consume(UpdateWeeklyChartsEvent) gap called out in
+// the priority-2 PR.
+public sealed class RecommendedChartsSagaTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task HandleSubmitFeedbackPersistsFeedbackForCurrentUser()
+    {
+        var userId = Guid.NewGuid();
+        var users = new Mock<IUserRepository>();
+        var saga = BuildSaga(currentUserId: userId, users: users);
+        var feedback = new SuggestionFeedbackRecord(
+            SuggestionCategory: Name.From("Bounties"),
+            FeedbackCategory: Name.From("NotInterested"),
+            Notes: "Already cleared",
+            ShouldHide: true,
+            IsPositive: false,
+            ChartId: Guid.NewGuid());
+
+        await saga.Handle(new SubmitFeedbackCommand(feedback), CancellationToken.None);
+
+        users.Verify(u => u.SaveFeedback(userId, feedback, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static RecommendedChartsSaga BuildSaga(
+        Guid? currentUserId = null,
+        Mock<IMediator>? mediator = null,
+        Mock<ICurrentUserAccessor>? currentUser = null,
+        Mock<IUserRepository>? users = null,
+        Mock<IPlayerStatsRepository>? stats = null,
+        Mock<IPhoenixRecordRepository>? scores = null,
+        Mock<IChartBountyRepository>? bounties = null,
+        Mock<IWeeklyTournamentRepository>? weeklyTournament = null,
+        Mock<IChartListRepository>? chartList = null,
+        Mock<IDateTimeOffsetAccessor>? dateTime = null)
+    {
+        currentUser ??= new Mock<ICurrentUserAccessor>();
+        var id = currentUserId ?? Guid.NewGuid();
+        currentUser.SetupGet(u => u.User).Returns(new UserBuilder().WithId(id).Build());
+        mediator ??= new Mock<IMediator>();
+        users ??= new Mock<IUserRepository>();
+        stats ??= new Mock<IPlayerStatsRepository>();
+        scores ??= new Mock<IPhoenixRecordRepository>();
+        bounties ??= new Mock<IChartBountyRepository>();
+        weeklyTournament ??= new Mock<IWeeklyTournamentRepository>();
+        chartList ??= new Mock<IChartListRepository>();
+        dateTime ??= FakeDateTime.At(Now);
+        return new RecommendedChartsSaga(mediator.Object, currentUser.Object, users.Object, stats.Object,
+            scores.Object, bounties.Object, weeklyTournament.Object, chartList.Object, dateTime.Object);
+    }
+}


### PR DESCRIPTION
## Summary

Priority 4 of the test-coverage walkthrough: cover the four largest remaining untested sagas in `ScoreTracker.Application.Handlers`. Four commits, one per saga.

| Commit | New tests | Saga | LOC |
|---|---|---|---|
| `7358824` | 15 | MatchSaga | 420 |
| `3a61b0e` | 16 | CommunitySaga | 478 |
| `989ed1e` | 7 | OfficialLeaderboardSaga | 329 |
| `d9e20d9` | 1 | RecommendedChartsSaga | 344 |

**Total: 39 new tests. 403 passing total (was 364), 0 failures.**

## Per-saga highlights

**MatchSaga** — Pin pass-throughs (CreateMatchLink, DeleteMatchLink, SaveRandomSettings, UpdateMatch, GetMatch), state transitions in ResolveMatchCommand and FinishCardDrawCommand (including Score/Point dict zeroing), the dual effect of UpdateMatchScoresCommand (always-publish vs Discord-on-first-complete with the songWasComplete guard), state-tailored PingMatchCommand messages (Theory), the DrawChartsCommand "CoOp Easy" branch that overrides ChartIds before delegating to GetRandomChartsQuery, and the FinalizeMatchCommand winner-promotion plus state→Completed transition.

**CommunitySaga** — Command-handler invariants (CreateCommunity collision, JoinCommunity idempotence and privacy gate, LeaveCommunity removal, CreateInviteLink membership gate), query visibility rules (GetCommunity hides private from non-members, GetMyCommunities branches on login state via Theory), and the high-value Discord-broadcast consumers — NewTitlesAcquired routes to community channels, PlayerRatingsImproved skips broadcasting when nothing improved or when user is unknown, UserUpdated joins/leaves the World/country communities based on IsPublic.

**OfficialLeaderboardSaga** — Consumer fan-out (StartLeaderboardImportEvent → ProcessChartPopularity + ProcessOfficialLeaderboards + CalculateWorldRankings), GetGameCardsQuery pass-through, ProcessOfficialLeaderboards behaviors (clear-before-write, Olympic-style tied-place ranking pinning the 1, 1, 3 sequence, and one-avatar-save-per-unique-user), plus ProcessChartPopularity tier-list-name and Place=-1→Unrecorded classification.

**RecommendedChartsSaga** — Only the SubmitFeedbackCommand pass-through. See "Out of scope" below.

## Out of scope (called out)

Two handlers across the four sagas are not testable without a refactor and are explicitly flagged for follow-up:

1. **`RecommendedChartsSaga.GetRecommendedChartsQuery`** — instantiates `new Random()` in five different sub-methods (GetOldScores, GetRandomFromTop50Charts, GetPassFills, GetBounties, GetPushLevels) and dispatches to ten-plus mediator queries to assemble the final list. Any assertion would either depend on non-deterministic ordering or re-implement the saga's filter pipeline. A class-level comment in [RecommendedChartsSagaTests.cs](ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs) documents the gap.

2. **`OfficialLeaderboardSaga.ImportOfficialPlayerScoresCommand` and `UpdateSongImagesCommand`** — the import flow is a 100+ LOC orchestrator that would need an exhaustive test fixture (PiuGameAccountDataImport + recorded scores + existing-record dictionaries + page-count seam) and exercises a known dead "INVALID" branch. Worth a future refactor pass before unit-testing.

Both gaps share the shape of the `WeeklyTournamentSaga.Consume(UpdateWeeklyChartsEvent)` chart-picker called out in the priority-2 PR — would all be unblocked by introducing an `IRandomNumberGenerator` port (already discussed for the score-import handler) and breaking the heavy orchestrators into smaller injected services.

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` succeeds (warnings unchanged from baseline).
- [x] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` — 403 passed, 0 failed, 0 skipped (was 364).
- [ ] CI green on Azure Pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)