### PR TITLE
Migrate WeeklyTournamentSaga to IRandomNumberGenerator + chart-picker tests

### DIFF
--- a/ScoreTracker/ScoreTracker.Application/Handlers/WeeklyTournamentSaga.cs
+++ b/ScoreTracker/ScoreTracker.Application/Handlers/WeeklyTournamentSaga.cs
@@ -14,7 +14,7 @@ namespace ScoreTracker.Application.Handlers
     (IChartRepository charts, IWeeklyTournamentRepository weeklyTournies, IPlayerStatsRepository playerStats,
         IBotClient bot,
         ILogger<WeeklyTournamentSaga> logger, IUserRepository users, IBus bus,
-        IDateTimeOffsetAccessor dateTime) :
+        IDateTimeOffsetAccessor dateTime, IRandomNumberGenerator random) :
         IConsumer<UpdateWeeklyChartsEvent>,
         IRequestHandler<RegisterWeeklyChartScore>
     {
@@ -44,7 +44,6 @@ namespace ScoreTracker.Application.Handlers
 
             var alreadyPlayed = (await weeklyTournies.GetAlreadyPlayedCharts(context.CancellationToken)).Distinct()
                 .ToHashSet();
-            var random = new Random();
             var newCharts = new HashSet<Guid>();
             var chartDict = (await charts.GetCharts(MixEnum.Phoenix, cancellationToken: context.CancellationToken))
                 .ToDictionary(c => c.Id);

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/WeeklyTournamentSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/WeeklyTournamentSagaTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MassTransit;
@@ -42,6 +43,110 @@ public sealed class WeeklyTournamentSagaTests
             It.IsAny<CancellationToken>()), Times.Never);
         weeklyTournies.Verify(w => w.WriteHistories(It.IsAny<IEnumerable<UserTourneyHistory>>(),
             It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConsumeUpdateWeeklyChartsWritesHistoriesAndClearsBoardWhenWeekExpired()
+    {
+        // Now is 2026-05-01 12:00 UTC; an expired chart (ExpirationDate < Now) lets the
+        // chart-picker run end-to-end with a complete required-bucket fixture.
+        var ctx = ExpiredWeekContext();
+        var entryUser = Guid.NewGuid();
+        var entryChart = Guid.NewGuid();
+        ctx.WeeklyTournies.Setup(w => w.GetEntries(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new WeeklyTournamentEntry(entryUser, entryChart, 950000, PhoenixPlate.SuperbGame,
+                    IsBroken: false, PhotoUrl: null, CompetitiveLevel: 20)
+            });
+
+        await ctx.Saga.Consume(BuildContext(new UpdateWeeklyChartsEvent()));
+
+        ctx.WeeklyTournies.Verify(w => w.WriteHistories(
+            It.Is<IEnumerable<UserTourneyHistory>>(hs => hs.Any(h => h.UserId == entryUser
+                                                                    && h.ChartId == entryChart)),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.WeeklyTournies.Verify(w => w.ClearTheBoard(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumeUpdateWeeklyChartsRegistersExactlyOneChartPerMergedBucket()
+    {
+        // Required-bucket fixture has 8 charts; after merging CoOp 4-5 → 3,
+        // S26 → S25, and D28+D29 → D27, only 3 buckets remain. Each gets one chart.
+        var ctx = ExpiredWeekContext();
+        var nextMonday3am = new DateTimeOffset(2026, 5, 4, 3, 0, 0, TimeSpan.Zero);
+
+        await ctx.Saga.Consume(BuildContext(new UpdateWeeklyChartsEvent()));
+
+        ctx.WeeklyTournies.Verify(w => w.RegisterWeeklyChart(
+            It.Is<WeeklyTournamentChart>(c => c.ExpirationDate == nextMonday3am),
+            It.IsAny<CancellationToken>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task ConsumeUpdateWeeklyChartsExcludesAlreadyPlayedChartsWhenPicking()
+    {
+        // Two CoOp 3 charts; one is in alreadyPlayed, so only the unplayed one can be picked.
+        var ctx = ExpiredWeekContext();
+        var unplayed = ctx.Charts["coop3"];
+        var played = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(3).WithSongName("played").Build();
+        ctx.GivenChartList(ReplaceCoOp3WithBoth(ctx.Charts, played));
+        ctx.WeeklyTournies.Setup(w => w.GetAlreadyPlayedCharts(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { played.Id });
+
+        await ctx.Saga.Consume(BuildContext(new UpdateWeeklyChartsEvent()));
+
+        ctx.WeeklyTournies.Verify(w => w.RegisterWeeklyChart(
+            It.Is<WeeklyTournamentChart>(c => c.ChartId == unplayed.Id),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.WeeklyTournies.Verify(w => w.RegisterWeeklyChart(
+            It.Is<WeeklyTournamentChart>(c => c.ChartId == played.Id),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConsumeUpdateWeeklyChartsResetsAlreadyPlayedListWhenAllChartsInBucketAreExhausted()
+    {
+        // All 3 charts in the merged CoOp 3 bucket are in alreadyPlayed → no valid
+        // candidates remain after filtering, so the algorithm clears the already-played
+        // list for that bucket and falls back to picking from the full set.
+        var ctx = ExpiredWeekContext();
+        var coop3 = ctx.Charts["coop3"];
+        var coop4 = ctx.Charts["coop4"];
+        var coop5 = ctx.Charts["coop5"];
+        ctx.WeeklyTournies.Setup(w => w.GetAlreadyPlayedCharts(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { coop3.Id, coop4.Id, coop5.Id });
+
+        await ctx.Saga.Consume(BuildContext(new UpdateWeeklyChartsEvent()));
+
+        ctx.WeeklyTournies.Verify(w => w.ClearAlreadyPlayedCharts(
+            It.Is<IEnumerable<Guid>>(ids => ids.Contains(coop3.Id) && ids.Contains(coop4.Id)
+                                             && ids.Contains(coop5.Id)),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.WeeklyTournies.Verify(w => w.RegisterWeeklyChart(
+            It.Is<WeeklyTournamentChart>(c => c.ChartId == coop3.Id || c.ChartId == coop4.Id
+                                              || c.ChartId == coop5.Id),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumeUpdateWeeklyChartsMergesCoOpFourAndFiveIntoCoOpThreeBucket()
+    {
+        // Mark the CoOp 3 and CoOp 5 charts as already played. After the merge moves
+        // levels 4 and 5 into the level-3 bucket, only the CoOp-4 chart is unplayed
+        // — and the algorithm only iterates the merged (3, CoOp) bucket, so this
+        // chart can ONLY be picked if the merge actually happened.
+        var ctx = ExpiredWeekContext();
+        var coop4 = ctx.Charts["coop4"];
+        ctx.WeeklyTournies.Setup(w => w.GetAlreadyPlayedCharts(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ctx.Charts["coop3"].Id, ctx.Charts["coop5"].Id });
+
+        await ctx.Saga.Consume(BuildContext(new UpdateWeeklyChartsEvent()));
+
+        ctx.WeeklyTournies.Verify(w => w.RegisterWeeklyChart(
+            It.Is<WeeklyTournamentChart>(c => c.ChartId == coop4.Id),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -237,6 +342,74 @@ public sealed class WeeklyTournamentSagaTests
         }
     }
 
+    private static ChartPickerContext ExpiredWeekContext()
+    {
+        var ctx = new ChartPickerContext();
+        // GetWeeklyCharts is checked twice (early-return guard, then reused). Return
+        // an expired chart so the chart-picker proceeds.
+        ctx.WeeklyTournies.Setup(w => w.GetWeeklyCharts(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new WeeklyTournamentChart(Guid.NewGuid(), Now.AddDays(-1))
+            });
+        ctx.WeeklyTournies.Setup(w => w.GetEntries(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WeeklyTournamentEntry>());
+        ctx.WeeklyTournies.Setup(w => w.GetAlreadyPlayedCharts(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Guid>());
+        ctx.GivenChartList(ctx.Charts.Values);
+        return ctx;
+    }
+
+    private static IEnumerable<Chart> ReplaceCoOp3WithBoth(IDictionary<string, Chart> charts, Chart additional)
+    {
+        return charts.Values.Append(additional);
+    }
+
+    private sealed class ChartPickerContext
+    {
+        public Mock<IChartRepository> Charts_ { get; } = new();
+        public Mock<IWeeklyTournamentRepository> WeeklyTournies { get; } = new();
+        public Mock<IPlayerStatsRepository> PlayerStats { get; } = new();
+        public Mock<IBotClient> Bot { get; } = new();
+        public Mock<IUserRepository> Users { get; } = new();
+        public Mock<IBus> Bus { get; } = new();
+        public Mock<IRandomNumberGenerator> Random { get; } = new();
+        public IDictionary<string, Chart> Charts { get; }
+        public WeeklyTournamentSaga Saga { get; private set; }
+
+        public ChartPickerContext()
+        {
+            Charts = BuildRequiredChartFixture();
+            Random.Setup(r => r.Next(It.IsAny<int>())).Returns(0);
+            Saga = BuildSaga(charts: Charts_, weeklyTournies: WeeklyTournies, playerStats: PlayerStats,
+                bot: Bot, users: Users, bus: Bus, random: Random);
+        }
+
+        public void GivenChartList(IEnumerable<Chart> charts)
+        {
+            Charts_.Setup(c => c.GetCharts(MixEnum.Phoenix, It.IsAny<DifficultyLevel?>(),
+                    It.IsAny<ChartType?>(),
+                    It.IsAny<IEnumerable<Guid>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(charts);
+        }
+
+        // The chart-picker hard-codes lookups for these (level, type) buckets and crashes
+        // if any are missing — a known fragility of the algorithm.
+        private static IDictionary<string, Chart> BuildRequiredChartFixture() =>
+            new Dictionary<string, Chart>
+            {
+                ["coop3"] = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(3).WithSongName("c3").Build(),
+                ["coop4"] = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(4).WithSongName("c4").Build(),
+                ["coop5"] = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(5).WithSongName("c5").Build(),
+                ["single25"] = new ChartBuilder().WithType(ChartType.Single).WithLevel(25).WithSongName("s25").Build(),
+                ["single26"] = new ChartBuilder().WithType(ChartType.Single).WithLevel(26).WithSongName("s26").Build(),
+                ["double27"] = new ChartBuilder().WithType(ChartType.Double).WithLevel(27).WithSongName("d27").Build(),
+                ["double28"] = new ChartBuilder().WithType(ChartType.Double).WithLevel(28).WithSongName("d28").Build(),
+                ["double29"] = new ChartBuilder().WithType(ChartType.Double).WithLevel(29).WithSongName("d29").Build()
+            };
+    }
+
     private static WeeklyTournamentSaga BuildSaga(
         Mock<IChartRepository>? charts = null,
         Mock<IWeeklyTournamentRepository>? weeklyTournies = null,
@@ -244,7 +417,8 @@ public sealed class WeeklyTournamentSagaTests
         Mock<IBotClient>? bot = null,
         Mock<IUserRepository>? users = null,
         Mock<IBus>? bus = null,
-        Mock<IDateTimeOffsetAccessor>? dateTime = null)
+        Mock<IDateTimeOffsetAccessor>? dateTime = null,
+        Mock<IRandomNumberGenerator>? random = null)
     {
         charts ??= new Mock<IChartRepository>();
         weeklyTournies ??= new Mock<IWeeklyTournamentRepository>();
@@ -253,9 +427,10 @@ public sealed class WeeklyTournamentSagaTests
         users ??= new Mock<IUserRepository>();
         bus ??= new Mock<IBus>();
         dateTime ??= FakeDateTime.At(Now);
+        random ??= new Mock<IRandomNumberGenerator>();
         return new WeeklyTournamentSaga(charts.Object, weeklyTournies.Object, playerStats.Object,
             bot.Object, NullLogger<WeeklyTournamentSaga>.Instance, users.Object, bus.Object,
-            dateTime.Object);
+            dateTime.Object, random.Object);
     }
 
     private static WeeklyTournamentEntry Entry(Guid chartId, int score, Guid? userId = null,


### PR DESCRIPTION
## Summary

Aligns `WeeklyTournamentSaga` with the existing `IRandomNumberGenerator` Domain port (already used by `RandomizerSaga` and required by CLAUDE.md), which unblocks five tests for the `Consume(UpdateWeeklyChartsEvent)` chart-picker that PR #75 explicitly called out as untestable.

## Changes

**[WeeklyTournamentSaga.cs](ScoreTracker/ScoreTracker.Application/Handlers/WeeklyTournamentSaga.cs)** — replace the inline `new Random()` with the injected `IRandomNumberGenerator`. One-line behavioral change; DI is already wired in `Program.cs`.

**[WeeklyTournamentSagaTests.cs](ScoreTracker/ScoreTracker.Tests/ApplicationTests/WeeklyTournamentSagaTests.cs)** — five new tests that pin the chart-picker:

1. `WritesHistoriesAndClearsBoardWhenWeekExpired` — pins the pre-pick orchestration.
2. `RegistersExactlyOneChartPerMergedBucket` — given a minimum-required chart fixture, verifies exactly 3 `RegisterWeeklyChart` calls (CoOp / Single 25 / Double 27), implicitly proving the bucket merges from CoOp 4-5 → 3, S26 → S25, and D28+D29 → D27 all happened.
3. `ExcludesAlreadyPlayedChartsWhenPicking` — already-played charts are filtered out of candidate selection.
4. `ResetsAlreadyPlayedListWhenAllChartsInBucketAreExhausted` — when every chart in a merged bucket is in the already-played list, the algorithm clears that list and registers a chart anyway.
5. `MergesCoOpFourAndFiveIntoCoOpThreeBucket` — strongest merge proof: marks levels 3 and 5 as played, leaving only level 4 unplayed. Since the algorithm only iterates the merged `(3, CoOp)` bucket post-merge, the level-4 chart can be picked **only** if the merge ran.

## Surfaced fragility (worth flagging, not fixed in this PR)

The chart-picker hard-codes dictionary lookups for `(3, CoOp)`, `(4, CoOp)`, `(5, CoOp)`, `(25, Single)`, `(26, Single)`, `(27, Double)`, `(28, Double)`, `(29, Double)`. If the game's chart catalog ever lacks a chart at one of those exact level/type combos, `Consume(UpdateWeeklyChartsEvent)` crashes with `KeyNotFoundException`. Documented in the test fixture comment; fix is a separate PR.

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` succeeds.
- [x] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` — 408 passed (was 403), 0 failed, 0 skipped.
- [x] All 16 pre-existing `WeeklyTournamentSagaTests` still pass — the migration is behavior-preserving.
- [ ] CI green on Azure Pipelines.

## Next up (per the same plan)

`RecommendedChartsSaga` has 6 `new Random()` instances and is the other handler blocked by this same convention violation. Same migration pattern would apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)