### PR TITLE
Migrate RecommendedChartsSaga to IRandomNumberGenerator + GetRecommendedCharts tests

### DIFF
--- a/ScoreTracker/ScoreTracker.Application/Handlers/RecommendedChartsSaga.cs
+++ b/ScoreTracker/ScoreTracker.Application/Handlers/RecommendedChartsSaga.cs
@@ -25,11 +25,12 @@ namespace ScoreTracker.Application.Handlers
         private readonly IWeeklyTournamentRepository _weeklyTournament;
         private readonly IChartListRepository _chartList;
         private readonly IDateTimeOffsetAccessor _dateTime;
+        private readonly IRandomNumberGenerator _random;
 
         public RecommendedChartsSaga(IMediator mediator, ICurrentUserAccessor currentUser, IUserRepository users,
             IPlayerStatsRepository stats, IPhoenixRecordRepository scores, IChartBountyRepository bounties,
             IWeeklyTournamentRepository weeklyTournament, IChartListRepository chartList,
-            IDateTimeOffsetAccessor dateTime)
+            IDateTimeOffsetAccessor dateTime, IRandomNumberGenerator random)
         {
             _mediator = mediator;
             _currentUser = currentUser;
@@ -40,6 +41,7 @@ namespace ScoreTracker.Application.Handlers
             _weeklyTournament = weeklyTournament;
             _chartList = chartList;
             _dateTime = dateTime;
+            _random = random;
         }
 
         public async Task<IEnumerable<ChartRecommendation>> Handle(GetRecommendedChartsQuery request,
@@ -59,7 +61,6 @@ namespace ScoreTracker.Application.Handlers
                     g => (ISet<Guid>)g.Select(i => i.ChartId).Distinct().ToHashSet());
             var charts =
                 (await _mediator.Send(new GetChartsQuery(MixEnum.Phoenix), cancellationToken)).ToDictionary(c => c.Id);
-            var random = new Random();
             return (await GetPushLevels(feedback, cancellationToken, titles, scores, request.ChartType, charts))
                 .Concat(await GetWeeklyCharts(cancellationToken, playerStats.SinglesCompetitiveLevel,
                     playerStats.DoublesCompetitiveLevel, request.LevelOffset, feedback, request.ChartType, charts))
@@ -139,7 +140,7 @@ namespace ScoreTracker.Application.Handlers
                     .ToHashSet();
 
             var cutoff = _dateTime.Now - TimeSpan.FromDays(30);
-            var random = new Random();
+            var random = _random;
             var now = _dateTime.Now;
 
             var skipped = ignoredChartIds.TryGetValue("Revisit Old Scores", out var r) ? r : new HashSet<Guid>();
@@ -162,7 +163,7 @@ namespace ScoreTracker.Application.Handlers
             CancellationToken cancellationToken)
         {
             var skipped = ignoredChartIds.TryGetValue("Improve Your Top 50", out var r) ? r : new HashSet<Guid>();
-            var random = new Random();
+            var random = _random;
             var result = Array.Empty<RecordedPhoenixScore>().AsEnumerable();
 
             if (chartType is null or ChartType.Single)
@@ -170,7 +171,7 @@ namespace ScoreTracker.Application.Handlers
                         new GetTop50CompetitiveQuery(_currentUser.User.Id, ChartType.Single),
                         cancellationToken)).Where(c => c.Score != null && c.Score < 1000000)
                     .Where(c => !skipped.Contains(c.ChartId))
-                    .OrderBy(c => random.Next())
+                    .OrderBy(c => random.Next(int.MaxValue))
                     .Take(chartType == ChartType.Single ? 6 : 3));
 
             if (chartType is null or ChartType.Double)
@@ -178,7 +179,7 @@ namespace ScoreTracker.Application.Handlers
                         new GetTop50CompetitiveQuery(_currentUser.User.Id, ChartType.Double),
                         cancellationToken)).Where(c => c.Score != null && c.Score < 1000000)
                     .Where(c => !skipped.Contains(c.ChartId))
-                    .OrderBy(c => random.Next())
+                    .OrderBy(c => random.Next(int.MaxValue))
                     .Take(chartType == ChartType.Double ? 6 : 3));
             return result
                 .Select(c => new ChartRecommendation("Improve Your Top 50", c.ChartId,
@@ -231,7 +232,7 @@ namespace ScoreTracker.Application.Handlers
 
             var myScores = scores
                 .ToDictionary(s => s.ChartId);
-            var random = new Random();
+            var random = _random;
             var chartOrder = (await GetApproachableCharts(cancellationToken, charts)).Where(id =>
                     chartsResults.ContainsKey(id)
                     && (!myScores.TryGetValue(id, out var score) || score.IsBroken))
@@ -249,14 +250,14 @@ namespace ScoreTracker.Application.Handlers
             IDictionary<string, ISet<Guid>> ignoredChartIds, CancellationToken cancellationToken,
             RecordedPhoenixScore[] scores, ChartType? chartType, IDictionary<Guid, Chart> charts)
         {
-            var random = new Random();
+            var random = _random;
             var ignoredCharts = ignoredChartIds.TryGetValue("Bounties", out var set) ? set : new HashSet<Guid>();
             var existingScores = scores.Where(s => s.Score != null).Select(s => s.ChartId).Distinct().ToHashSet();
             return (await _mediator.Send(new GetChartBountiesQuery(), cancellationToken)).Where(b =>
                     chartType == null || charts[b.ChartId].Type == chartType)
                 .OrderByDescending(b => b.Worth)
                 .Take(20)
-                .OrderBy(r => random.Next())
+                .OrderBy(r => random.Next(int.MaxValue))
                 .Take(5)
                 .Select(b => new ChartRecommendation("Bounties", b.ChartId,
                     "Charts that have low data present on the site", $"{b.Worth} Points"));
@@ -289,7 +290,7 @@ namespace ScoreTracker.Application.Handlers
                 ? cs
                 : new HashSet<Guid>();
             var result = new List<Guid>();
-            var random = new Random();
+            var random = _random;
             var reduction = chartOrder.Where(c => !myScores.TryGetValue(c, out var score) || score.IsBroken)
                 .Where(c => !skippedCharts.Contains(c) && charts.ContainsKey(c))
                 .ToArray();
@@ -299,14 +300,14 @@ namespace ScoreTracker.Application.Handlers
                 result.AddRange(reduction
                     .Where(c => charts[c].Type == ChartType.Single)
                     .Take(chartType == ChartType.Single ? 12 : 6)
-                    .OrderBy(_ => random.Next())
+                    .OrderBy(_ => random.Next(int.MaxValue))
                     .Take(chartType == ChartType.Single ? 6 : 3 + missingDoubles));
 
             if (chartType is null or ChartType.Double)
                 result.AddRange(reduction
                     .Where(c => charts[c].Type == ChartType.Double)
                     .Take(chartType == ChartType.Double ? 12 : 6)
-                    .OrderBy(_ => random.Next())
+                    .OrderBy(_ => random.Next(int.MaxValue))
                     .Take(chartType == ChartType.Double ? 6 : 3 + missingSingles));
             return result.Select(s => new ChartRecommendation($"{pushLevel.Title.Name}", s,
                 "Recommended Charts for achieving your next title"));

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs
@@ -1,27 +1,27 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Moq;
 using ScoreTracker.Application.Commands;
 using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Models.Titles;
+using ScoreTracker.Domain.Models.Titles.Phoenix;
 using ScoreTracker.Domain.Records;
 using ScoreTracker.Domain.SecondaryPorts;
 using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.PersonalProgress.Queries;
 using ScoreTracker.Tests.TestData;
 using ScoreTracker.Tests.TestHelpers;
 using Xunit;
 
 namespace ScoreTracker.Tests.ApplicationTests;
 
-// GetRecommendedChartsQuery is not covered: the handler instantiates `new Random()`
-// in five different sub-methods (GetOldScores, GetRandomFromTop50Charts, GetPassFills,
-// GetBounties, GetPushLevels) and dispatches to ten+ mediator queries to assemble the
-// final list. Without an IRandomNumberGenerator-style port and a way to substitute
-// the inner queries, any assertion would either be brittle (snapshot-y) or
-// re-implement the saga's filter logic. Flagging for a refactor pass — same shape
-// as the WeeklyTournamentSaga.Consume(UpdateWeeklyChartsEvent) gap called out in
-// the priority-2 PR.
 public sealed class RecommendedChartsSagaTests
 {
     private static readonly DateTimeOffset Now = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
@@ -45,6 +45,174 @@ public sealed class RecommendedChartsSagaTests
         users.Verify(u => u.SaveFeedback(userId, feedback, It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task HandleGetRecommendedChartsIncludesSSSPlusButNotPGScoresUnderPushPGs()
+    {
+        // GetPGPushes selects scores where score is non-null, != 1,000,000 (PG),
+        // and LetterGrade == SSSPlus (>= 995,000). This is the only sub-method that
+        // is fully deterministic; the rest are guarded by random or empty data.
+        var sssPlusChart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var pgChart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var ctx = new RecommendedChartsContext()
+            .WithCharts(sssPlusChart, pgChart)
+            .WithScores(
+                Score(sssPlusChart.Id, 999500),     // SSSPlus, not PG → eligible
+                Score(pgChart.Id, 1000000));         // PG → excluded
+
+        var result = (await ctx.Saga.Handle(
+            new GetRecommendedChartsQuery(ChartType: null, LevelOffset: 0),
+            CancellationToken.None)).ToArray();
+
+        Assert.Contains(result, r => (string)r.Category == "Push PGs" && r.ChartId == sssPlusChart.Id);
+        Assert.DoesNotContain(result, r => r.ChartId == pgChart.Id);
+    }
+
+    [Fact]
+    public async Task HandleGetRecommendedChartsExcludesPushPGsChartsThatHaveShouldHideFeedback()
+    {
+        var hiddenChart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var visibleChart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var userId = Guid.NewGuid();
+        var ctx = new RecommendedChartsContext(currentUserId: userId)
+            .WithCharts(hiddenChart, visibleChart)
+            .WithScores(
+                Score(hiddenChart.Id, 999500),
+                Score(visibleChart.Id, 999500))
+            .WithFeedback(
+                new SuggestionFeedbackRecord(Name.From("Push PGs"), Name.From("NotInterested"),
+                    Notes: "", ShouldHide: true, IsPositive: false, ChartId: hiddenChart.Id));
+
+        var result = (await ctx.Saga.Handle(
+            new GetRecommendedChartsQuery(ChartType: null, LevelOffset: 0),
+            CancellationToken.None)).ToArray();
+
+        Assert.DoesNotContain(result,
+            r => (string)r.Category == "Push PGs" && r.ChartId == hiddenChart.Id);
+        Assert.Contains(result,
+            r => (string)r.Category == "Push PGs" && r.ChartId == visibleChart.Id);
+    }
+
+    [Fact]
+    public async Task HandleGetRecommendedChartsClampsCompetitiveLevelToTenWhenStatsAreLower()
+    {
+        // PlayerStats.CompetitiveLevel = 5 → clamped to 10. GetOldScores then iterates
+        // BuildRange(competitive - 2, competitive, 0) = levels 8 and 9. We pin that
+        // GetMyRelativeTierListQuery is dispatched for those clamped levels and not
+        // for level 3 (which would be 5 - 2 = 3 without the clamp).
+        var ctx = new RecommendedChartsContext().WithCompetitiveLevel(5);
+
+        await ctx.Saga.Handle(
+            new GetRecommendedChartsQuery(ChartType: null, LevelOffset: 0),
+            CancellationToken.None);
+
+        ctx.Mediator.Verify(m => m.Send(
+            It.Is<GetMyRelativeTierListQuery>(q => (int)q.Level == 8),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        ctx.Mediator.Verify(m => m.Send(
+            It.Is<GetMyRelativeTierListQuery>(q => (int)q.Level == 9),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        ctx.Mediator.Verify(m => m.Send(
+            It.Is<GetMyRelativeTierListQuery>(q => (int)q.Level == 3),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private sealed class RecommendedChartsContext
+    {
+        public Mock<IMediator> Mediator { get; } = new();
+        public Mock<ICurrentUserAccessor> CurrentUser { get; } = new();
+        public Mock<IUserRepository> Users { get; } = new();
+        public Mock<IPlayerStatsRepository> Stats { get; } = new();
+        public Mock<IPhoenixRecordRepository> Scores { get; } = new();
+        public Mock<IChartBountyRepository> Bounties { get; } = new();
+        public Mock<IWeeklyTournamentRepository> Weekly { get; } = new();
+        public Mock<IChartListRepository> ChartList { get; } = new();
+        public Mock<IRandomNumberGenerator> Random { get; } = new();
+        public RecommendedChartsSaga Saga { get; }
+
+        public RecommendedChartsContext(Guid? currentUserId = null)
+        {
+            var userId = currentUserId ?? Guid.NewGuid();
+            CurrentUser.SetupGet(u => u.User).Returns(new UserBuilder().WithId(userId).Build());
+            Stats.Setup(s => s.GetStats(userId, It.IsAny<CancellationToken>())).ReturnsAsync(ZeroStats(userId));
+            // Random.Next(...) returns 0 by default → OrderBy keys are uniform → input order preserved.
+            Random.Setup(r => r.Next(It.IsAny<int>())).Returns(0);
+            // Default empty for all the mediator queries that random-using sub-methods rely on.
+            Mediator.Setup(m => m.Send(It.IsAny<GetTitleProgressQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[] { OneTitle() });
+            Mediator.Setup(m => m.Send(It.IsAny<GetPhoenixRecordsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<RecordedPhoenixScore>());
+            Mediator.Setup(m => m.Send(It.IsAny<GetChartsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<Chart>());
+            Mediator.Setup(m => m.Send(It.IsAny<GetMyRelativeTierListQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<SongTierListEntry>());
+            Mediator.Setup(m => m.Send(It.IsAny<GetTierListQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<SongTierListEntry>());
+            Mediator.Setup(m => m.Send(It.IsAny<GetTop50CompetitiveQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<RecordedPhoenixScore>());
+            Mediator.Setup(m => m.Send(It.IsAny<GetChartBountiesQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<ChartBounty>());
+            Users.Setup(u => u.GetFeedback(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<SuggestionFeedbackRecord>());
+            Weekly.Setup(w => w.GetWeeklyCharts(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<WeeklyTournamentChart>());
+
+            Saga = new RecommendedChartsSaga(Mediator.Object, CurrentUser.Object, Users.Object, Stats.Object,
+                Scores.Object, Bounties.Object, Weekly.Object, ChartList.Object,
+                FakeDateTime.At(Now).Object, Random.Object);
+        }
+
+        public RecommendedChartsContext WithCharts(params Chart[] charts)
+        {
+            Mediator.Setup(m => m.Send(It.IsAny<GetChartsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(charts);
+            return this;
+        }
+
+        public RecommendedChartsContext WithScores(params RecordedPhoenixScore[] scores)
+        {
+            Mediator.Setup(m => m.Send(It.IsAny<GetPhoenixRecordsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(scores);
+            return this;
+        }
+
+        public RecommendedChartsContext WithFeedback(params SuggestionFeedbackRecord[] feedback)
+        {
+            Users.Setup(u => u.GetFeedback(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(feedback);
+            return this;
+        }
+
+        public RecommendedChartsContext WithCompetitiveLevel(double level)
+        {
+            Stats.Setup(s => s.GetStats(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PlayerStatsRecord(Guid.NewGuid(), TotalRating: 0, HighestLevel: 1,
+                    ClearCount: 0, CoOpRating: 0, CoOpScore: 0, SkillRating: 0, SkillScore: 0,
+                    SkillLevel: 0, SinglesRating: 0, SinglesScore: 0, SinglesLevel: 0,
+                    DoublesRating: 0, DoublesScore: 0, DoublesLevel: 0,
+                    CompetitiveLevel: level, SinglesCompetitiveLevel: level,
+                    DoublesCompetitiveLevel: level));
+            return this;
+        }
+    }
+
+    // GetPushLevels indexes titles[firstAchieved] and crashes on an empty title list,
+    // so every test needs at least one PhoenixDifficultyTitle in scope. Use level 28
+    // (DifficultyLevel max is 29) and don't put any matching charts in the fixture, so
+    // GetPushLevels returns nothing and doesn't pollute the test's assertions.
+    private static TitleProgress OneTitle() =>
+        new PhoenixTitleProgress(new PhoenixDifficultyTitle(Name.From("Lvl 28 Title"),
+            DifficultyLevel.From(28), ratingRequired: 1));
+
+    private static RecordedPhoenixScore Score(Guid chartId, int score) =>
+        new(chartId, score, PhoenixPlate.SuperbGame, IsBroken: false,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+    private static PlayerStatsRecord ZeroStats(Guid userId) =>
+        new(userId, TotalRating: 0, HighestLevel: 1, ClearCount: 0, CoOpRating: 0, CoOpScore: 0,
+            SkillRating: 0, SkillScore: 0, SkillLevel: 0, SinglesRating: 0, SinglesScore: 0,
+            SinglesLevel: 0, DoublesRating: 0, DoublesScore: 0, DoublesLevel: 0,
+            CompetitiveLevel: 0, SinglesCompetitiveLevel: 0, DoublesCompetitiveLevel: 0);
+
     private static RecommendedChartsSaga BuildSaga(
         Guid? currentUserId = null,
         Mock<IMediator>? mediator = null,
@@ -55,7 +223,8 @@ public sealed class RecommendedChartsSagaTests
         Mock<IChartBountyRepository>? bounties = null,
         Mock<IWeeklyTournamentRepository>? weeklyTournament = null,
         Mock<IChartListRepository>? chartList = null,
-        Mock<IDateTimeOffsetAccessor>? dateTime = null)
+        Mock<IDateTimeOffsetAccessor>? dateTime = null,
+        Mock<IRandomNumberGenerator>? random = null)
     {
         currentUser ??= new Mock<ICurrentUserAccessor>();
         var id = currentUserId ?? Guid.NewGuid();
@@ -68,7 +237,9 @@ public sealed class RecommendedChartsSagaTests
         weeklyTournament ??= new Mock<IWeeklyTournamentRepository>();
         chartList ??= new Mock<IChartListRepository>();
         dateTime ??= FakeDateTime.At(Now);
+        random ??= new Mock<IRandomNumberGenerator>();
         return new RecommendedChartsSaga(mediator.Object, currentUser.Object, users.Object, stats.Object,
-            scores.Object, bounties.Object, weeklyTournament.Object, chartList.Object, dateTime.Object);
+            scores.Object, bounties.Object, weeklyTournament.Object, chartList.Object, dateTime.Object,
+            random.Object);
     }
 }


### PR DESCRIPTION
## Summary

Same shape as PR #76 (WeeklyTournamentSaga), applied to `RecommendedChartsSaga`. Replaces six `new Random()` violations with the existing `IRandomNumberGenerator` Domain port (already used by `RandomizerSaga`, required by CLAUDE.md), unblocking three tests for `GetRecommendedChartsQuery` that PR #75 marked as out-of-scope.

The two PRs are independent and can merge in either order.

## Migration

- 6 `new Random()` instances replaced. One was dead code (an unused local in the main `Handle`); the other five live in the random-using sub-methods (`GetOldScores`, `GetRandomFromTop50Charts`, `GetPassFills`, `GetBounties`, `GetPushLevels`).
- `random.Next()` (no-arg) call sites → `random.Next(int.MaxValue)` since the port only exposes `Next(int)`. Semantically equivalent for the `OrderBy(_ => random.Next())` shuffling pattern this saga uses.
- Constructor adds the `IRandomNumberGenerator` dep; DI is already wired in `Program.cs`.

## New tests

The single existing `SubmitFeedback` test gets the new dep added to its `BuildSaga` helper. Three new tests for the previously-untestable `GetRecommendedChartsQuery`:

1. **`IncludesSSSPlusButNotPGScoresUnderPushPGs`** — `GetPGPushes` is the only fully deterministic sub-method (no random calls). Pins that an SSSPlus score (`999500`) ends up under "Push PGs" and a perfect 1,000,000 score does not.
2. **`ExcludesPushPGsChartsThatHaveShouldHideFeedback`** — feedback records with `ShouldHide=true` and `SuggestionCategory="Push PGs"` exclude the chart from "Push PGs" recommendations; non-hidden charts in the same category are still included.
3. **`ClampsCompetitiveLevelToTenWhenStatsAreLower`** — given `CompetitiveLevel=5`, the saga dispatches `GetMyRelativeTierListQuery` for levels 8 and 9 (the clamped `10-2`, `10-1`) and not for level 3 (the unclamped `5-2`). Strong proof of the floor.

The class-level "not covered" comment is removed from the test file.

## Notes for review

- **Diff stat is inflated by CRLF normalization** — git is converting LF→CRLF on commit because of repo settings. `git diff -w HEAD~1` (or GitHub's "Hide whitespace changes") shows the actual change is ~13 inserts / 12 deletes on the saga + the new test code.
- `GetPushLevels` indexes `titles[firstAchieved]` and crashes on an empty title list, so every test in the new context provides one `PhoenixDifficultyTitle` at level 28 with no matching charts in the fixture (returns nothing, doesn't pollute assertions). Documented in a comment on the `OneTitle` helper.

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` succeeds.
- [x] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` — 406 passed (was 403), 0 failed, 0 skipped.
- [x] The pre-existing `SubmitFeedback` test still passes — migration is behavior-preserving.
- [ ] CI green on Azure Pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)