### PR TITLE
Rename query-handler tests from DelegatesTo* to behavior-first names

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartVideosHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartVideosHandlerTests.cs
@@ -14,7 +14,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetChartVideosHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepository()
+    public async Task ReturnsVideoInformationForRequestedCharts()
     {
         var ids = new[] { Guid.NewGuid() };
         var expected = new List<ChartVideoInformation>();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartsBySongHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartsBySongHandlerTests.cs
@@ -15,7 +15,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetChartsBySongHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepository()
+    public async Task ReturnsChartsForSong()
     {
         var songName = Name.From("Test Song");
         var expected = new[] { new ChartBuilder().Build() };

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetChartsHandlerTests.cs
@@ -17,7 +17,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetChartsHandlerTests
 {
     [Fact]
-    public async Task DelegatesAllFiltersToRepository()
+    public async Task ReturnsChartsMatchingAllFilters()
     {
         var expected = new[] { new ChartBuilder().Build() };
         var ids = new[] { Guid.NewGuid() };

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetCoOpRatingHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetCoOpRatingHandlerTests.cs
@@ -15,7 +15,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetCoOpRatingHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepository()
+    public async Task ReturnsCoOpRatingForChart()
     {
         var chartId = Guid.NewGuid();
         var rating = new CoOpRating(chartId, 1, new Dictionary<int, DifficultyLevel> { { 1, DifficultyLevel.From(20) } });

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetCoOpRatingsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetCoOpRatingsHandlerTests.cs
@@ -13,7 +13,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetCoOpRatingsHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepository()
+    public async Task ReturnsAllCoOpRatings()
     {
         var ratingsList = new List<CoOpRating>();
         var ratings = new Mock<IChartDifficultyRatingRepository>();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetMyCoOpRatingHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetMyCoOpRatingHandlerTests.cs
@@ -15,7 +15,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetMyCoOpRatingHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepositoryWithCurrentUserId()
+    public async Task ReturnsCurrentUsersCoOpRatingForChart()
     {
         var user = new UserBuilder().Build();
         var chartId = Guid.NewGuid();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixRecordHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixRecordHandlerTests.cs
@@ -15,7 +15,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetPhoenixRecordHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepositoryForCurrentUser()
+    public async Task ReturnsRecordedScoreForCurrentUser()
     {
         var user = new UserBuilder().Build();
         var chartId = Guid.NewGuid();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixRecordsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixRecordsHandlerTests.cs
@@ -15,7 +15,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetPhoenixRecordsHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepositoryForRequestedUser()
+    public async Task ReturnsRecordedScoresForRequestedUser()
     {
         var userId = Guid.NewGuid();
         var scores = new List<RecordedPhoenixScore>();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixScoresForChartHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetPhoenixScoresForChartHandlerTests.cs
@@ -14,7 +14,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetPhoenixScoresForChartHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepository()
+    public async Task ReturnsRecordedUserScoresForChart()
     {
         var chartId = Guid.NewGuid();
         var scores = new List<UserPhoenixScore>();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetSavedChartsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetSavedChartsHandlerTests.cs
@@ -14,7 +14,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetSavedChartsHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepositoryForCurrentUser()
+    public async Task ReturnsSavedChartsForCurrentUser()
     {
         var user = new UserBuilder().Build();
         var saved = new List<SavedChartRecord>();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetSongNamesHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetSongNamesHandlerTests.cs
@@ -13,7 +13,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetSongNamesHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepository()
+    public async Task ReturnsSongNamesForMix()
     {
         var names = new[] { Name.From("song-a"), Name.From("song-b") };
         var charts = new Mock<IChartRepository>();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetTierListHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetTierListHandlerTests.cs
@@ -14,7 +14,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetTierListHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepository()
+    public async Task ReturnsAllEntriesForTierList()
     {
         var entries = new List<SongTierListEntry>();
         var name = Name.From("Difficulty");

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetUserByDiscordIdHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetUserByDiscordIdHandlerTests.cs
@@ -12,7 +12,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetUserByDiscordIdHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepository()
+    public async Task ReturnsUserMatchingExternalLogin()
     {
         var user = new UserBuilder().Build();
         var users = new Mock<IUserRepository>();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetUserByIdHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/GetUserByIdHandlerTests.cs
@@ -14,7 +14,7 @@ namespace ScoreTracker.Tests.ApplicationTests;
 public sealed class GetUserByIdHandlerTests
 {
     [Fact]
-    public async Task DelegatesToRepository()
+    public async Task ReturnsUserWithMatchingId()
     {
         var userId = Guid.NewGuid();
         var user = new UserBuilder().WithId(userId).Build();


### PR DESCRIPTION
## Summary

Follow-up to #79. The tightened naming guidance in `CLAUDE.md` "Test conventions" (added in #79) prefers behavior-first test method names over implementation-first ones. This sweep turns up 14 query-handler tests all named `DelegatesToRepository` (or a near variant), which describe the implementation call rather than what the handler returns. Renames each to a behavior-first name.

| File | Before | After |
|---|---|---|
| GetChartsHandlerTests | `DelegatesAllFiltersToRepository` | `ReturnsChartsMatchingAllFilters` |
| GetChartsBySongHandlerTests | `DelegatesToRepository` | `ReturnsChartsForSong` |
| GetCoOpRatingHandlerTests | `DelegatesToRepository` | `ReturnsCoOpRatingForChart` |
| GetCoOpRatingsHandlerTests | `DelegatesToRepository` | `ReturnsAllCoOpRatings` |
| GetMyCoOpRatingHandlerTests | `DelegatesToRepositoryWithCurrentUserId` | `ReturnsCurrentUsersCoOpRatingForChart` |
| GetChartVideosHandlerTests | `DelegatesToRepository` | `ReturnsVideoInformationForRequestedCharts` |
| GetSavedChartsHandlerTests | `DelegatesToRepositoryForCurrentUser` | `ReturnsSavedChartsForCurrentUser` |
| GetPhoenixRecordHandlerTests | `DelegatesToRepositoryForCurrentUser` | `ReturnsRecordedScoreForCurrentUser` |
| GetPhoenixRecordsHandlerTests | `DelegatesToRepositoryForRequestedUser` | `ReturnsRecordedScoresForRequestedUser` |
| GetPhoenixScoresForChartHandlerTests | `DelegatesToRepository` | `ReturnsRecordedUserScoresForChart` |
| GetSongNamesHandlerTests | `DelegatesToRepository` | `ReturnsSongNamesForMix` |
| GetTierListHandlerTests | `DelegatesToRepository` | `ReturnsAllEntriesForTierList` |
| GetUserByDiscordIdHandlerTests | `DelegatesToRepository` | `ReturnsUserMatchingExternalLogin` |
| GetUserByIdHandlerTests | `DelegatesToRepository` | `ReturnsUserWithMatchingId` |

## Why

`DelegatesToRepository` describes the call shape (handler → repo) rather than the contract (handler returns the chart that matches the song). The new conventions doc explicitly cites this as an anti-pattern. Each test still does the same thing it always did — just under a name a reviewer can read without opening the file.

## Scope

- 14 files, 14-line diff (one method-name rename per file).
- No test logic, setup, or assertions changed.
- All other `Handle*` / `Consume*` prefixed names (~90 across the saga tests) are intentionally left alone — that's the optional Tier 2 sweep, not this PR.

## Test plan

- [x] `dotnet test` — 411/411 pass after the renames
- [x] `grep` confirms zero `DelegatesTo*` test methods remain in the suite
- [ ] Reviewer: spot-check a couple of the new names to confirm they read better than the old ones

## Independence from #79

Branched off `main`, not off `claude/loving-nash-11191b`. This PR can merge in any order relative to #79 — they touch disjoint files (PR #79 modifies docs + `TierListSagaTests.cs`; this PR modifies 14 `Get*HandlerTests.cs` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)