### PR TITLE
Cover Tier 1 0%-coverage handlers and sagas

### DIFF
--- a/ScoreTracker/ScoreTracker.Domain/Services/WorldRankingService.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Services/WorldRankingService.cs
@@ -95,11 +95,6 @@ public sealed class WorldRankingService : IWorldRankingService
         }
     }
 
-    private static double AvgOr0(double[] charts)
-    {
-        return charts.Any() ? charts.Average() : 0;
-    }
-
     public async Task<IEnumerable<RecordedPhoenixScore>> GetAll(Name username, CancellationToken cancellationToken)
     {
         var result = new List<RecordedPhoenixScore>();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/AutoBuildSessionHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/AutoBuildSessionHandlerTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class AutoBuildSessionHandlerTests
+{
+    private static Chart ChartWithDuration(TimeSpan duration, int level = 20)
+    {
+        var song = new Song(Name.From($"song-{Guid.NewGuid()}"), SongType.Arcade,
+            new Uri("https://example.invalid/s.png"), duration, Name.From("artist"), Bpm: null);
+        return new ChartBuilder().WithSong(song).WithLevel(level).Build();
+    }
+
+    [Fact]
+    public async Task BuildsSessionFromScoredChartsWhileRespectingCanAddAndMinimumRest()
+    {
+        var chart = ChartWithDuration(TimeSpan.FromMinutes(2));
+        var charts = new Mock<IChartRepository>();
+        var phoenixRecords = new Mock<IPhoenixRecordRepository>();
+        var configuration = new TournamentConfiguration(ScoringConfiguration.PumbilityScoring(false))
+        {
+            MaxTime = TimeSpan.FromMinutes(60)
+        };
+        var userId = Guid.NewGuid();
+
+        charts.Setup(r => r.GetCharts(MixEnum.Phoenix, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { chart });
+        phoenixRecords.Setup(r => r.GetRecordedScores(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new RecordedPhoenixScore(chart.Id, 980000, PhoenixPlate.PerfectGame, false, DateTimeOffset.UtcNow)
+            });
+
+        var handler = new AutoBuildSessionHandler(charts.Object, phoenixRecords.Object);
+
+        var session = await handler.Handle(
+            new AutoBuildSessionQuery(configuration, userId, TimeSpan.Zero),
+            CancellationToken.None);
+
+        Assert.Single(session.Entries);
+        Assert.Equal(chart.Id, session.Entries[0].Chart.Id);
+    }
+
+    [Fact]
+    public async Task SkipsRecordsWithoutScoreOrPlate()
+    {
+        var chartA = ChartWithDuration(TimeSpan.FromMinutes(2));
+        var chartB = ChartWithDuration(TimeSpan.FromMinutes(2));
+        var charts = new Mock<IChartRepository>();
+        var phoenixRecords = new Mock<IPhoenixRecordRepository>();
+        var configuration = new TournamentConfiguration(ScoringConfiguration.PumbilityScoring(false))
+        {
+            MaxTime = TimeSpan.FromMinutes(60)
+        };
+        var userId = Guid.NewGuid();
+
+        charts.Setup(r => r.GetCharts(MixEnum.Phoenix, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { chartA, chartB });
+        phoenixRecords.Setup(r => r.GetRecordedScores(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new RecordedPhoenixScore(chartA.Id, null, PhoenixPlate.PerfectGame, false, DateTimeOffset.UtcNow),
+                new RecordedPhoenixScore(chartB.Id, 950000, null, false, DateTimeOffset.UtcNow)
+            });
+
+        var handler = new AutoBuildSessionHandler(charts.Object, phoenixRecords.Object);
+
+        var session = await handler.Handle(
+            new AutoBuildSessionQuery(configuration, userId, TimeSpan.Zero),
+            CancellationToken.None);
+
+        Assert.Empty(session.Entries);
+    }
+
+    [Fact]
+    public async Task ReturnsEmptySessionWhenMinimumRestIsLargerThanRemainingBudget()
+    {
+        var chart = ChartWithDuration(TimeSpan.FromMinutes(2));
+        var charts = new Mock<IChartRepository>();
+        var phoenixRecords = new Mock<IPhoenixRecordRepository>();
+        var configuration = new TournamentConfiguration(ScoringConfiguration.PumbilityScoring(false))
+        {
+            MaxTime = TimeSpan.FromMinutes(3)
+        };
+        var userId = Guid.NewGuid();
+
+        charts.Setup(r => r.GetCharts(MixEnum.Phoenix, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { chart });
+        phoenixRecords.Setup(r => r.GetRecordedScores(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new RecordedPhoenixScore(chart.Id, 980000, PhoenixPlate.PerfectGame, false, DateTimeOffset.UtcNow)
+            });
+
+        var handler = new AutoBuildSessionHandler(charts.Object, phoenixRecords.Object);
+
+        // 3 min budget − 2 min chart = 1 min rest; require 5 min so the only candidate is rejected.
+        var session = await handler.Handle(
+            new AutoBuildSessionQuery(configuration, userId, TimeSpan.FromMinutes(5)),
+            CancellationToken.None);
+
+        Assert.Empty(session.Entries);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/MarchOfMurlocsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/MarchOfMurlocsHandlerTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class MarchOfMurlocsHandlerTests
+{
+    private static TournamentRecord MoM(DateTimeOffset? endDate, bool isHighlighted = true) =>
+        new(Guid.NewGuid(), Name.From("MoM"), 0, TournamentType.Stamina, "Online",
+            isHighlighted, null, null, endDate, IsMoM: true);
+
+    private static Mock<ConsumeContext<T>> ContextOf<T>(T message) where T : class
+    {
+        var ctx = new Mock<ConsumeContext<T>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        return ctx;
+    }
+
+    [Fact]
+    public async Task TryScheduleCyclesImmediatelyWhenNoActiveMoMExists()
+    {
+        var tournaments = new Mock<ITournamentRepository>();
+        var charts = new Mock<IChartRepository>();
+        var bus = new Mock<IBus>();
+        var scheduler = new Mock<IMessageScheduler>();
+        var dateTime = FakeDateTime.At(2026, 4, 1);
+
+        tournaments.Setup(t => t.GetAllTournaments(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<TournamentRecord>());
+
+        var handler = new MarchOfMurlocsHandler(tournaments.Object, charts.Object, bus.Object,
+            scheduler.Object, dateTime.Object);
+
+        await handler.Consume(ContextOf(new MarchOfMurlocsHandler.TryScheduleMoM()).Object);
+
+        bus.Verify(b => b.Publish(It.IsAny<MarchOfMurlocsHandler.CycleMoM>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        scheduler.Verify(s => s.SchedulePublish(It.IsAny<DateTime>(),
+                It.IsAny<MarchOfMurlocsHandler.CycleMoM>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryScheduleCyclesImmediatelyWhenActiveMoMHasAlreadyEnded()
+    {
+        var tournaments = new Mock<ITournamentRepository>();
+        var charts = new Mock<IChartRepository>();
+        var bus = new Mock<IBus>();
+        var scheduler = new Mock<IMessageScheduler>();
+        var now = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+        var dateTime = FakeDateTime.At(now);
+
+        var endedMoM = MoM(now - TimeSpan.FromDays(1));
+        tournaments.Setup(t => t.GetAllTournaments(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { endedMoM });
+
+        var handler = new MarchOfMurlocsHandler(tournaments.Object, charts.Object, bus.Object,
+            scheduler.Object, dateTime.Object);
+
+        await handler.Consume(ContextOf(new MarchOfMurlocsHandler.TryScheduleMoM()).Object);
+
+        bus.Verify(b => b.Publish(It.IsAny<MarchOfMurlocsHandler.CycleMoM>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TrySchedulePostponesCycleUntilCurrentMoMEnds()
+    {
+        var tournaments = new Mock<ITournamentRepository>();
+        var charts = new Mock<IChartRepository>();
+        var bus = new Mock<IBus>();
+        var scheduler = new Mock<IMessageScheduler>();
+        var now = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+        var endDate = now + TimeSpan.FromDays(30);
+        var dateTime = FakeDateTime.At(now);
+
+        tournaments.Setup(t => t.GetAllTournaments(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { MoM(endDate) });
+
+        var handler = new MarchOfMurlocsHandler(tournaments.Object, charts.Object, bus.Object,
+            scheduler.Object, dateTime.Object);
+
+        await handler.Consume(ContextOf(new MarchOfMurlocsHandler.TryScheduleMoM()).Object);
+
+        bus.Verify(b => b.Publish(It.IsAny<MarchOfMurlocsHandler.CycleMoM>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        scheduler.Verify(s => s.SchedulePublish(
+                (endDate + TimeSpan.FromMinutes(1)).DateTime,
+                It.IsAny<MarchOfMurlocsHandler.CycleMoM>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CycleCreatesSingleAndDoubleTournamentsAndUnhighlightsPreviousMoMs()
+    {
+        var tournaments = new Mock<ITournamentRepository>();
+        var charts = new Mock<IChartRepository>();
+        var bus = new Mock<IBus>();
+        var scheduler = new Mock<IMessageScheduler>();
+        // Previous MoM ended in March → new season is "Spring" with end in June.
+        var previousEnd = new DateTimeOffset(2026, 3, 31, 23, 59, 59, TimeSpan.FromHours(-5));
+        var now = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+        var dateTime = FakeDateTime.At(now);
+        var previousMoM = MoM(previousEnd);
+
+        tournaments.Setup(t => t.GetAllTournaments(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { previousMoM });
+        charts.Setup(r => r.GetCharts(MixEnum.Phoenix, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build(),
+                new ChartBuilder().WithLevel(20).WithType(ChartType.Double).Build(),
+                new ChartBuilder().WithLevel(20).WithType(ChartType.CoOp).Build()
+            });
+
+        var savedConfigurations = new List<TournamentConfiguration>();
+        var savedRecords = new List<TournamentRecord>();
+        tournaments.Setup(t => t.CreateOrSaveTournament(It.IsAny<TournamentConfiguration>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TournamentConfiguration, CancellationToken>((cfg, _) => savedConfigurations.Add(cfg))
+            .Returns(Task.CompletedTask);
+        tournaments.Setup(t => t.CreateOrSaveTournament(It.IsAny<TournamentRecord>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TournamentRecord, CancellationToken>((rec, _) => savedRecords.Add(rec))
+            .Returns(Task.CompletedTask);
+
+        var handler = new MarchOfMurlocsHandler(tournaments.Object, charts.Object, bus.Object,
+            scheduler.Object, dateTime.Object);
+
+        await handler.Consume(ContextOf(new MarchOfMurlocsHandler.CycleMoM()).Object);
+
+        var newTournaments = savedConfigurations.Where(s => s.IsMom).ToArray();
+        Assert.Equal(2, newTournaments.Length);
+        Assert.Contains(newTournaments, t => ((string)t.Name).Contains("Spring") && ((string)t.Name).Contains("Singles"));
+        Assert.Contains(newTournaments, t => ((string)t.Name).Contains("Spring") && ((string)t.Name).Contains("Doubles"));
+        Assert.All(newTournaments, t => Assert.Equal(6, t.EndDate!.Value.Month));
+
+        tournaments.Verify(t => t.CreateScoringLevelSnapshots(It.IsAny<Guid>(),
+                It.IsAny<IEnumerable<(Guid, double)>>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+
+        Assert.Contains(savedRecords, r => r.Id == previousMoM.Id && !r.IsHighlighted);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/QualifiersSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/QualifiersSagaTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class QualifiersSagaTests
+{
+    private static QualifiersConfiguration Config(IEnumerable<Chart> charts) =>
+        new(charts, new Dictionary<Guid, int>(), Name.From("Score"), 0, 1, null, false);
+
+    private static Mock<ConsumeContext<RecentScoreImportedEvent>> ContextOf(RecentScoreImportedEvent message)
+    {
+        var ctx = new Mock<ConsumeContext<RecentScoreImportedEvent>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        return ctx;
+    }
+
+    [Fact]
+    public async Task SavesQualifiersWhenImportedScoreBeatsPreviousSubmission()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var config = Config(new[] { chart });
+        var tournamentId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var existing = new UserQualifiers(config, false, Name.From("hero"), userId,
+            new Dictionary<Guid, UserQualifiers.Submission>());
+        existing.AddPhoenixScore(chart.Id, 900000, null);
+
+        var qualifiersRepo = new Mock<IQualifiersRepository>();
+        var userRepo = new Mock<IUserRepository>();
+        var mediator = new Mock<IMediator>();
+
+        qualifiersRepo.Setup(r => r.GetRegisteredTournaments(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { tournamentId });
+        qualifiersRepo.Setup(r => r.GetQualifiersConfiguration(tournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(config);
+        qualifiersRepo.Setup(r => r.GetQualifiers(tournamentId, userId, config, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var saga = new QualifiersSaga(qualifiersRepo.Object, userRepo.Object,
+            NullLogger<QualifiersSaga>.Instance, mediator.Object);
+
+        var entry = new RecentScoreImportedEvent.Entry(chart.Id, 950000, "PerfectGame", false);
+        var message = new RecentScoreImportedEvent(userId, new[] { entry });
+
+        await saga.Consume(ContextOf(message).Object);
+
+        mediator.Verify(m => m.Send(
+                It.Is<SaveQualifiersCommand>(c =>
+                    c.TournamentId == tournamentId && c.Qualifiers.Submissions[chart.Id].Score == (PhoenixScore)950000),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DoesNotSaveWhenImportedScoreIsNotBetter()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var config = Config(new[] { chart });
+        var tournamentId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var existing = new UserQualifiers(config, false, Name.From("hero"), userId,
+            new Dictionary<Guid, UserQualifiers.Submission>());
+        existing.AddPhoenixScore(chart.Id, 950000, null);
+
+        var qualifiersRepo = new Mock<IQualifiersRepository>();
+        var userRepo = new Mock<IUserRepository>();
+        var mediator = new Mock<IMediator>();
+
+        qualifiersRepo.Setup(r => r.GetRegisteredTournaments(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { tournamentId });
+        qualifiersRepo.Setup(r => r.GetQualifiersConfiguration(tournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(config);
+        qualifiersRepo.Setup(r => r.GetQualifiers(tournamentId, userId, config, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var saga = new QualifiersSaga(qualifiersRepo.Object, userRepo.Object,
+            NullLogger<QualifiersSaga>.Instance, mediator.Object);
+
+        var entry = new RecentScoreImportedEvent.Entry(chart.Id, 800000, "PerfectGame", false);
+        var message = new RecentScoreImportedEvent(userId, new[] { entry });
+
+        await saga.Consume(ContextOf(message).Object);
+
+        mediator.Verify(m => m.Send(It.IsAny<SaveQualifiersCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreatesNewQualifiersEntryWhenUserHasNoneAndUserLookupSucceeds()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var config = Config(new[] { chart });
+        var tournamentId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var user = new UserBuilder().WithId(userId).WithName("hero").Build();
+
+        var qualifiersRepo = new Mock<IQualifiersRepository>();
+        var userRepo = new Mock<IUserRepository>();
+        var mediator = new Mock<IMediator>();
+
+        qualifiersRepo.Setup(r => r.GetRegisteredTournaments(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { tournamentId });
+        qualifiersRepo.Setup(r => r.GetQualifiersConfiguration(tournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(config);
+        qualifiersRepo.Setup(r => r.GetQualifiers(tournamentId, userId, config, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserQualifiers?)null);
+        userRepo.Setup(r => r.GetUser(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        var saga = new QualifiersSaga(qualifiersRepo.Object, userRepo.Object,
+            NullLogger<QualifiersSaga>.Instance, mediator.Object);
+
+        var entry = new RecentScoreImportedEvent.Entry(chart.Id, 900000, "PerfectGame", false);
+        var message = new RecentScoreImportedEvent(userId, new[] { entry });
+
+        await saga.Consume(ContextOf(message).Object);
+
+        mediator.Verify(m => m.Send(
+                It.Is<SaveQualifiersCommand>(c =>
+                    c.TournamentId == tournamentId && c.Qualifiers.UserId == userId &&
+                    c.Qualifiers.Submissions[chart.Id].Score == (PhoenixScore)900000),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SkipsTournamentWhenUserLookupFailsForNewEntry()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var config = Config(new[] { chart });
+        var tournamentId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var qualifiersRepo = new Mock<IQualifiersRepository>();
+        var userRepo = new Mock<IUserRepository>();
+        var mediator = new Mock<IMediator>();
+
+        qualifiersRepo.Setup(r => r.GetRegisteredTournaments(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { tournamentId });
+        qualifiersRepo.Setup(r => r.GetQualifiersConfiguration(tournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(config);
+        qualifiersRepo.Setup(r => r.GetQualifiers(tournamentId, userId, config, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserQualifiers?)null);
+        userRepo.Setup(r => r.GetUser(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var saga = new QualifiersSaga(qualifiersRepo.Object, userRepo.Object,
+            NullLogger<QualifiersSaga>.Instance, mediator.Object);
+
+        var entry = new RecentScoreImportedEvent.Entry(chart.Id, 900000, "PerfectGame", false);
+        var message = new RecentScoreImportedEvent(userId, new[] { entry });
+
+        await saga.Consume(ContextOf(message).Object);
+
+        mediator.Verify(m => m.Send(It.IsAny<SaveQualifiersCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RandomizerSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RandomizerSagaTests.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class RandomizerSagaTests
+{
+    private static (Mock<ICurrentUserAccessor>, Guid) UserAccessor(bool isLoggedIn = true)
+    {
+        var userId = Guid.NewGuid();
+        var user = new UserBuilder().WithId(userId).Build();
+        var accessor = new Mock<ICurrentUserAccessor>();
+        accessor.SetupGet(a => a.User).Returns(user);
+        accessor.SetupGet(a => a.IsLoggedIn).Returns(isLoggedIn);
+        return (accessor, userId);
+    }
+
+    private static Mock<IChartRepository> ChartsReturning(IEnumerable<Chart> result)
+    {
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(r => r.GetCharts(MixEnum.Phoenix, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return charts;
+    }
+
+    private static Mock<IPhoenixRecordRepository> ScoresReturning(Guid userId, IEnumerable<RecordedPhoenixScore> result)
+    {
+        var scores = new Mock<IPhoenixRecordRepository>();
+        scores.Setup(s => s.GetRecordedScores(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return scores;
+    }
+
+    private static RandomSettings SinglesAtLevelTwenty(int count = 3)
+    {
+        var settings = new RandomSettings { Count = count };
+        // Level-20 singles get weight 1; everything else stays 0.
+        settings.LevelWeights[20] = 1;
+        // Arcade song-type weight 1 (test charts default to Arcade).
+        settings.SongTypeWeights[SongType.Arcade] = 1;
+        return settings;
+    }
+
+    [Fact]
+    public async Task SaveUserRandomSettingsDelegatesToRepositoryWithCurrentUser()
+    {
+        var (accessor, userId) = UserAccessor();
+        var repo = new Mock<IRandomizerRepository>();
+        var saga = new RandomizerSaga(new Mock<IChartRepository>().Object, repo.Object, accessor.Object,
+            new Mock<IPhoenixRecordRepository>().Object, new Mock<IRandomNumberGenerator>().Object);
+
+        var settings = new RandomSettings();
+        await saga.Handle(new SaveUserRandomSettingsCommand(Name.From("favorites"), settings),
+            CancellationToken.None);
+
+        repo.Verify(r => r.SaveSettings(userId, It.Is<Name>(n => (string)n == "favorites"), settings,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteRandomSettingsDelegatesToRepositoryWithCurrentUser()
+    {
+        var (accessor, userId) = UserAccessor();
+        var repo = new Mock<IRandomizerRepository>();
+        var saga = new RandomizerSaga(new Mock<IChartRepository>().Object, repo.Object, accessor.Object,
+            new Mock<IPhoenixRecordRepository>().Object, new Mock<IRandomNumberGenerator>().Object);
+
+        await saga.Handle(new DeleteRandomSettingsCommand(Name.From("favorites")), CancellationToken.None);
+
+        repo.Verify(r => r.DeleteSettings(userId, It.Is<Name>(n => (string)n == "favorites"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetIncludedRandomChartsReturnsChartsWithNonZeroLevelWeight()
+    {
+        var (accessor, userId) = UserAccessor();
+        var match = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var miss = new ChartBuilder().WithLevel(15).WithType(ChartType.Single).Build();
+        var charts = ChartsReturning(new[] { match, miss });
+        var saga = new RandomizerSaga(charts.Object, new Mock<IRandomizerRepository>().Object,
+            accessor.Object, ScoresReturning(userId, Array.Empty<RecordedPhoenixScore>()).Object,
+            new Mock<IRandomNumberGenerator>().Object);
+
+        var result = await saga.Handle(new GetIncludedRandomChartsQuery(SinglesAtLevelTwenty()),
+            CancellationToken.None);
+
+        Assert.Equal(new[] { match.Id }, result.Select(c => c.Id).ToArray());
+    }
+
+    [Fact]
+    public async Task GetIncludedRandomChartsExcludesChartsWithoutScoringLevelWhenUseScoringLevelsIsTrue()
+    {
+        var (accessor, userId) = UserAccessor();
+        var withScoringLevel = new ChartBuilder().WithLevel(20).WithType(ChartType.Single)
+            .WithScoringLevel(20.5).Build();
+        var withoutScoringLevel = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var charts = ChartsReturning(new[] { withScoringLevel, withoutScoringLevel });
+        var settings = SinglesAtLevelTwenty();
+        settings.UseScoringLevels = true;
+
+        var saga = new RandomizerSaga(charts.Object, new Mock<IRandomizerRepository>().Object,
+            accessor.Object, ScoresReturning(userId, Array.Empty<RecordedPhoenixScore>()).Object,
+            new Mock<IRandomNumberGenerator>().Object);
+
+        var result = await saga.Handle(new GetIncludedRandomChartsQuery(settings), CancellationToken.None);
+
+        Assert.Equal(new[] { withScoringLevel.Id }, result.Select(c => c.Id).ToArray());
+    }
+
+    [Fact]
+    public async Task GetIncludedRandomChartsAppliesLetterGradeFilterAgainstUserScores()
+    {
+        var (accessor, userId) = UserAccessor();
+        var pgChart = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var aChart = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var unscored = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var charts = ChartsReturning(new[] { pgChart, aChart, unscored });
+
+        var settings = SinglesAtLevelTwenty();
+        settings.LetterGrades.Add(PhoenixLetterGrade.SSSPlus);
+
+        var scores = ScoresReturning(userId, new[]
+        {
+            new RecordedPhoenixScore(pgChart.Id, 999000, PhoenixPlate.PerfectGame, false, DateTimeOffset.UtcNow),
+            new RecordedPhoenixScore(aChart.Id, 850000, PhoenixPlate.FairGame, false, DateTimeOffset.UtcNow)
+        });
+
+        var saga = new RandomizerSaga(charts.Object, new Mock<IRandomizerRepository>().Object,
+            accessor.Object, scores.Object, new Mock<IRandomNumberGenerator>().Object);
+
+        var result = await saga.Handle(new GetIncludedRandomChartsQuery(settings), CancellationToken.None);
+
+        Assert.Equal(new[] { pgChart.Id }, result.Select(c => c.Id).ToArray());
+    }
+
+    [Fact]
+    public async Task GetIncludedRandomChartsClearStatusTrueRequiresClearedScore()
+    {
+        var (accessor, userId) = UserAccessor();
+        var clearedChart = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var brokenChart = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var unscoredChart = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var charts = ChartsReturning(new[] { clearedChart, brokenChart, unscoredChart });
+
+        var settings = SinglesAtLevelTwenty();
+        settings.ClearStatus = true;
+
+        var scores = ScoresReturning(userId, new[]
+        {
+            new RecordedPhoenixScore(clearedChart.Id, 950000, PhoenixPlate.PerfectGame, false, DateTimeOffset.UtcNow),
+            new RecordedPhoenixScore(brokenChart.Id, 950000, PhoenixPlate.PerfectGame, true, DateTimeOffset.UtcNow)
+        });
+
+        var saga = new RandomizerSaga(charts.Object, new Mock<IRandomizerRepository>().Object,
+            accessor.Object, scores.Object, new Mock<IRandomNumberGenerator>().Object);
+
+        var result = await saga.Handle(new GetIncludedRandomChartsQuery(settings), CancellationToken.None);
+
+        Assert.Equal(new[] { clearedChart.Id }, result.Select(c => c.Id).ToArray());
+    }
+
+    [Fact]
+    public async Task GetRandomChartsReturnsRequestedCountUsingWeightedRandomGenerator()
+    {
+        var (accessor, userId) = UserAccessor();
+        var chartA = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var chartB = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var chartC = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var charts = ChartsReturning(new[] { chartA, chartB, chartC });
+
+        var random = new Mock<IRandomNumberGenerator>();
+        // Each chart contributes 1 slot to the distribution; sequential picks 0,1,2 → all three.
+        random.SetupSequence(r => r.Next(It.IsAny<int>()))
+            .Returns(0).Returns(0).Returns(0); // index 0 of remaining each time
+        // Final ordering uses NextDouble to randomize; deterministic output keeps order stable.
+        random.Setup(r => r.NextDouble()).Returns(0.5);
+
+        var saga = new RandomizerSaga(charts.Object, new Mock<IRandomizerRepository>().Object,
+            accessor.Object, ScoresReturning(userId, Array.Empty<RecordedPhoenixScore>()).Object,
+            random.Object);
+
+        var settings = SinglesAtLevelTwenty(count: 3);
+        var result = (await saga.Handle(new GetRandomChartsQuery(settings), CancellationToken.None)).ToArray();
+
+        Assert.Equal(3, result.Length);
+        Assert.Equal(3, result.Select(c => c.Id).Distinct().Count());
+    }
+
+    [Fact]
+    public async Task GetRandomChartsReturnsAllIncludedWhenCountExceedsAvailableAndRepeatsDisallowed()
+    {
+        var (accessor, userId) = UserAccessor();
+        var chart = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var charts = ChartsReturning(new[] { chart });
+        var saga = new RandomizerSaga(charts.Object, new Mock<IRandomizerRepository>().Object,
+            accessor.Object, ScoresReturning(userId, Array.Empty<RecordedPhoenixScore>()).Object,
+            new Mock<IRandomNumberGenerator>().Object);
+
+        var settings = SinglesAtLevelTwenty(count: 5);
+        settings.AllowRepeats = false;
+
+        var result = (await saga.Handle(new GetRandomChartsQuery(settings), CancellationToken.None)).ToArray();
+
+        Assert.Single(result);
+        Assert.Equal(chart.Id, result[0].Id);
+    }
+
+    [Fact]
+    public async Task GetRandomChartsOrdersByDecreasingLevelWhenRequested()
+    {
+        var (accessor, userId) = UserAccessor();
+        var low = new ChartBuilder().WithLevel(18).WithType(ChartType.Single).Build();
+        var mid = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var high = new ChartBuilder().WithLevel(22).WithType(ChartType.Single).Build();
+        var charts = ChartsReturning(new[] { low, mid, high });
+
+        var random = new Mock<IRandomNumberGenerator>();
+        random.SetupSequence(r => r.Next(It.IsAny<int>())).Returns(0).Returns(0).Returns(0);
+
+        var settings = new RandomSettings
+        {
+            Count = 3,
+            Ordering = RandomSettings.ResultsOrdering.DecreasingLevel
+        };
+        settings.LevelWeights[18] = 1;
+        settings.LevelWeights[20] = 1;
+        settings.LevelWeights[22] = 1;
+        settings.SongTypeWeights[SongType.Arcade] = 1;
+
+        var saga = new RandomizerSaga(charts.Object, new Mock<IRandomizerRepository>().Object,
+            accessor.Object, ScoresReturning(userId, Array.Empty<RecordedPhoenixScore>()).Object,
+            random.Object);
+
+        var result = (await saga.Handle(new GetRandomChartsQuery(settings), CancellationToken.None)).ToArray();
+
+        Assert.Equal(3, result.Length);
+        Assert.Equal(new[] { high.Id, mid.Id, low.Id }, result.Select(c => c.Id).ToArray());
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SaveQualifiersHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SaveQualifiersHandlerTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class SaveQualifiersHandlerTests
+{
+    private const ulong NotificationChannel = 12345UL;
+
+    private static QualifiersConfiguration Config(IEnumerable<Chart> charts, int playCount = 2) =>
+        new(charts, new Dictionary<Guid, int>(), Name.From("Score"), NotificationChannel, playCount, null, false);
+
+    private static UserQualifiers BuildEntry(QualifiersConfiguration config, string userName,
+        IDictionary<Guid, PhoenixScore> submissions)
+    {
+        var entry = new UserQualifiers(config, false, Name.From(userName), Guid.NewGuid(),
+            new Dictionary<Guid, UserQualifiers.Submission>());
+        foreach (var kv in submissions)
+            entry.AddPhoenixScore(kv.Key, kv.Value, null);
+        return entry;
+    }
+
+    [Fact]
+    public async Task PersistsQualifiersAndAnnouncesFirstSubmissionAsNewChallenger()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var config = Config(new[] { chart });
+        var tournamentId = Guid.NewGuid();
+        var qualifiers = BuildEntry(config, "newcomer", new Dictionary<Guid, PhoenixScore> { [chart.Id] = 950000 });
+
+        var qualifiersRepo = new Mock<IQualifiersRepository>();
+        var bot = new Mock<IBotClient>();
+
+        // Old leaderboard: empty (no prior submission for this user)
+        qualifiersRepo.SetupSequence(r =>
+                r.GetAllUserQualifiers(tournamentId, config, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UserQualifiers>())
+            .ReturnsAsync(new[] { qualifiers });
+        qualifiersRepo.Setup(r => r.GetQualifiersConfiguration(tournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(config);
+
+        var handler = new SaveQualifiersHandler(qualifiersRepo.Object, bot.Object);
+
+        await handler.Handle(new SaveQualifiersCommand(tournamentId, qualifiers), CancellationToken.None);
+
+        qualifiersRepo.Verify(
+            r => r.SaveQualifiers(tournamentId, qualifiers, It.IsAny<CancellationToken>()),
+            Times.Once);
+        bot.Verify(
+            b => b.SendMessage(It.Is<string>(m => m.Contains("new challenger") && m.Contains("newcomer")),
+                NotificationChannel, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AnnouncesProgressionWhenLeaderboardPlaceImproves()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var config = Config(new[] { chart }, playCount: 1);
+        var tournamentId = Guid.NewGuid();
+
+        // Other player at 970,000 — top of board initially
+        var leader = BuildEntry(config, "leader", new Dictionary<Guid, PhoenixScore> { [chart.Id] = 970000 });
+        // Our player starts at 900,000 (2nd) and improves to 990,000 (1st)
+        var playerId = Guid.NewGuid();
+        var oldPlayer = new UserQualifiers(config, false, Name.From("hero"), playerId,
+            new Dictionary<Guid, UserQualifiers.Submission>());
+        oldPlayer.AddPhoenixScore(chart.Id, 900000, null);
+        var newPlayer = new UserQualifiers(config, false, Name.From("hero"), playerId,
+            new Dictionary<Guid, UserQualifiers.Submission>());
+        newPlayer.AddPhoenixScore(chart.Id, 990000, null);
+
+        var qualifiersRepo = new Mock<IQualifiersRepository>();
+        var bot = new Mock<IBotClient>();
+        qualifiersRepo.SetupSequence(r =>
+                r.GetAllUserQualifiers(tournamentId, config, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { leader, oldPlayer })
+            .ReturnsAsync(new[] { newPlayer, leader });
+        qualifiersRepo.Setup(r => r.GetQualifiersConfiguration(tournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(config);
+
+        var handler = new SaveQualifiersHandler(qualifiersRepo.Object, bot.Object);
+
+        await handler.Handle(new SaveQualifiersCommand(tournamentId, newPlayer), CancellationToken.None);
+
+        bot.Verify(
+            b => b.SendMessage(It.Is<string>(m => m.Contains("hero") && m.Contains("progressed to 1")),
+                NotificationChannel, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DoesNotAnnounceWhenSubmissionCountIsBelowConfiguredPlayCount()
+    {
+        // PlayCount = 3 but submitter only has 1 submission → progression branch suppressed
+        var chartA = new ChartBuilder().WithLevel(20).Build();
+        var chartB = new ChartBuilder().WithLevel(20).Build();
+        var config = Config(new[] { chartA, chartB }, playCount: 3);
+        var tournamentId = Guid.NewGuid();
+
+        var playerId = Guid.NewGuid();
+        var leader = BuildEntry(config, "leader",
+            new Dictionary<Guid, PhoenixScore> { [chartA.Id] = 980000, [chartB.Id] = 970000 });
+        var oldPlayer = new UserQualifiers(config, false, Name.From("hero"), playerId,
+            new Dictionary<Guid, UserQualifiers.Submission>());
+        oldPlayer.AddPhoenixScore(chartA.Id, 900000, null);
+        var newPlayer = new UserQualifiers(config, false, Name.From("hero"), playerId,
+            new Dictionary<Guid, UserQualifiers.Submission>());
+        newPlayer.AddPhoenixScore(chartA.Id, 950000, null);
+
+        var qualifiersRepo = new Mock<IQualifiersRepository>();
+        var bot = new Mock<IBotClient>();
+        qualifiersRepo.SetupSequence(r =>
+                r.GetAllUserQualifiers(tournamentId, config, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { leader, oldPlayer })
+            .ReturnsAsync(new[] { leader, newPlayer });
+        qualifiersRepo.Setup(r => r.GetQualifiersConfiguration(tournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(config);
+
+        var handler = new SaveQualifiersHandler(qualifiersRepo.Object, bot.Object);
+
+        await handler.Handle(new SaveQualifiersCommand(tournamentId, newPlayer), CancellationToken.None);
+
+        bot.Verify(
+            b => b.SendMessage(It.IsAny<string>(), It.IsAny<ulong>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/ScoreQualitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/ScoreQualitySagaTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Application.Queries;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class ScoreQualitySagaTests
+{
+    private static PlayerStatsRecord Stats(Guid userId, double singlesCompetitive = 20, double doublesCompetitive = 20)
+        => new(userId, (Rating)0, DifficultyLevel.From(20), 0, (Rating)0, (PhoenixScore)0, (Rating)0, (PhoenixScore)0,
+            0, (Rating)0, (PhoenixScore)0, 0, (Rating)0, (PhoenixScore)0, 0, 0, singlesCompetitive,
+            doublesCompetitive);
+
+    private static (Mock<ICurrentUserAccessor>, Guid) UserAccessor()
+    {
+        var userId = Guid.NewGuid();
+        var user = new UserBuilder().WithId(userId).Build();
+        var accessor = new Mock<ICurrentUserAccessor>();
+        accessor.SetupGet(a => a.User).Returns(user);
+        accessor.SetupGet(a => a.IsLoggedIn).Returns(true);
+        return (accessor, userId);
+    }
+
+    [Fact]
+    public async Task GetCompetitivePlayersDelegatesToPlayerStatsRepositoryWithCompetitiveBand()
+    {
+        var (accessor, userId) = UserAccessor();
+        var playerStats = new Mock<IPlayerStatsRepository>();
+        var charts = new Mock<IChartRepository>();
+        var scores = new Mock<IPhoenixRecordRepository>();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+
+        playerStats.Setup(p => p.GetStats(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Stats(userId, singlesCompetitive: 17.5));
+
+        var competitors = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        playerStats.Setup(p => p.GetPlayersByCompetitiveRange(ChartType.Single, 17.5, .5,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(competitors);
+
+        var saga = new ScoreQualitySaga(accessor.Object, playerStats.Object, cache, charts.Object, scores.Object);
+
+        var result = await saga.Handle(new GetCompetitivePlayersQuery(ChartType.Single), CancellationToken.None);
+
+        Assert.Equal(competitors, result);
+    }
+
+    [Fact]
+    public async Task GetPlayerScoreQualityReturnsTopPercentileWhenNoComparablePlayerScoresThatChart()
+    {
+        var (accessor, userId) = UserAccessor();
+        var chart = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+
+        var playerStats = new Mock<IPlayerStatsRepository>();
+        var charts = new Mock<IChartRepository>();
+        var scores = new Mock<IPhoenixRecordRepository>();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+
+        playerStats.Setup(p => p.GetStats(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Stats(userId));
+        playerStats.Setup(p => p.GetPlayersByCompetitiveRange(ChartType.Single, It.IsAny<double>(), .5,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Guid>());
+
+        charts.Setup(r => r.GetCharts(MixEnum.Phoenix, DifficultyLevel.From(20), ChartType.Single, null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { chart });
+
+        scores.Setup(r => r.GetPlayerScores(It.IsAny<IEnumerable<Guid>>(), ChartType.Single, DifficultyLevel.From(20),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<(Guid, RecordedPhoenixScore)>());
+
+        scores.Setup(r => r.GetRecordedScores(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new RecordedPhoenixScore(chart.Id, 950000, PhoenixPlate.PerfectGame, false, DateTimeOffset.UtcNow)
+            });
+
+        var saga = new ScoreQualitySaga(accessor.Object, playerStats.Object, cache, charts.Object, scores.Object);
+
+        var result = await saga.Handle(new GetPlayerScoreQualityQuery(DifficultyLevel.From(20), ChartType.Single),
+            CancellationToken.None);
+
+        Assert.Single(result);
+        Assert.Equal(1.0, result[chart.Id].Ranking);
+        Assert.Equal(1, result[chart.Id].PlayerCount);
+    }
+
+    [Fact]
+    public async Task GetPlayerScoreQualityReturnsTopPercentileWhenUserBeatsAllComparablePlayers()
+    {
+        var (accessor, userId) = UserAccessor();
+        var chart = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var competitor = Guid.NewGuid();
+
+        var playerStats = new Mock<IPlayerStatsRepository>();
+        var charts = new Mock<IChartRepository>();
+        var scores = new Mock<IPhoenixRecordRepository>();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+
+        playerStats.Setup(p => p.GetStats(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Stats(userId));
+        playerStats.Setup(p => p.GetPlayersByCompetitiveRange(ChartType.Single, It.IsAny<double>(), .5,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { competitor });
+
+        charts.Setup(r => r.GetCharts(MixEnum.Phoenix, DifficultyLevel.From(20), ChartType.Single, null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { chart });
+
+        var competitorScore = new RecordedPhoenixScore(chart.Id, 800000, PhoenixPlate.PerfectGame, false,
+            DateTimeOffset.UtcNow);
+        scores.Setup(r => r.GetPlayerScores(It.IsAny<IEnumerable<Guid>>(), ChartType.Single, DifficultyLevel.From(20),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { (competitor, competitorScore) });
+
+        scores.Setup(r => r.GetRecordedScores(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new RecordedPhoenixScore(chart.Id, 990000, PhoenixPlate.PerfectGame, false, DateTimeOffset.UtcNow)
+            });
+
+        var saga = new ScoreQualitySaga(accessor.Object, playerStats.Object, cache, charts.Object, scores.Object);
+
+        var result = await saga.Handle(new GetPlayerScoreQualityQuery(DifficultyLevel.From(20), ChartType.Single),
+            CancellationToken.None);
+
+        Assert.Equal(1.0, result[chart.Id].Ranking);
+        Assert.Equal(1, result[chart.Id].PlayerCount);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/ScoringDifficultySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/ScoringDifficultySagaTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Moq;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class ScoringDifficultySagaTests
+{
+    private static ScoringDifficultySaga Build(
+        Mock<IChartRepository>? charts = null,
+        Mock<IPhoenixRecordRepository>? scores = null,
+        Mock<IPlayerStatsRepository>? playerStats = null)
+    {
+        charts ??= new Mock<IChartRepository>();
+        charts.Setup(c => c.GetCharts(It.IsAny<MixEnum>(), It.IsAny<DifficultyLevel?>(), It.IsAny<ChartType?>(),
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Chart>());
+        scores ??= new Mock<IPhoenixRecordRepository>();
+        scores.Setup(s => s.GetAllPlayerScores(It.IsAny<ChartType>(), It.IsAny<DifficultyLevel>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<(Guid, RecordedPhoenixScore)>());
+        playerStats ??= new Mock<IPlayerStatsRepository>();
+        return new ScoringDifficultySaga(charts.Object, scores.Object, playerStats.Object);
+    }
+
+    private static ConsumeContext<T> ContextOf<T>(T message) where T : class
+    {
+        var ctx = new Mock<ConsumeContext<T>>();
+        ctx.SetupGet(c => c.Message).Returns(message);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    [Theory]
+    [InlineData(new double[] { 1, 1, 1, 1 }, false, 0)]
+    [InlineData(new double[] { 1, 2, 3, 4 }, false, 1.118033988749895)]
+    public void StdDevReturnsExpectedPopulationDeviation(double[] values, bool asSample, double expected)
+    {
+        Assert.Equal(expected, ScoringDifficultySaga.StdDev(values, asSample), 6);
+    }
+
+    [Fact]
+    public void StdDevAsSampleDiffersFromPopulation()
+    {
+        double[] values = { 1, 2, 3, 4, 5 };
+        var population = ScoringDifficultySaga.StdDev(values, false);
+        var sample = ScoringDifficultySaga.StdDev(values, true);
+        Assert.True(sample > population);
+    }
+
+    [Fact]
+    public async Task CalculateChartLetterDifficultiesUpdatesNothingWhenNoChartsExist()
+    {
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetCharts(It.IsAny<MixEnum>(), It.IsAny<DifficultyLevel?>(), It.IsAny<ChartType?>(),
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Chart>());
+        var saga = Build(charts: charts);
+
+        await saga.Consume(ContextOf(new CalculateChartLetterDifficultiesEvent()));
+
+        charts.Verify(c => c.UpdateChartLetterDifficulties(It.IsAny<IEnumerable<ChartLetterGradeDifficulty>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CalculateScoringDifficultyDoesNotUpdateScoreLevelsWhenNoScoresExist()
+    {
+        var charts = new Mock<IChartRepository>();
+        charts.Setup(c => c.GetCharts(It.IsAny<MixEnum>(), It.IsAny<DifficultyLevel?>(), It.IsAny<ChartType?>(),
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Chart>());
+        var saga = Build(charts: charts);
+
+        await saga.Consume(ContextOf(new CalculateScoringDifficultyEvent()));
+
+        charts.Verify(c => c.UpdateScoreLevel(It.IsAny<MixEnum>(), It.IsAny<Guid>(), It.IsAny<double>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TierListSagaStaticsTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TierListSagaStaticsTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ScoreTracker.Application.Handlers;
 using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.ValueTypes;
 using Xunit;
 
 namespace ScoreTracker.Tests.ApplicationTests;
@@ -95,5 +96,88 @@ public sealed class TierListSagaStaticsTests
         var dict = new Dictionary<Guid, int>();
         for (var i = 0; i < count; i++) dict[Guid.NewGuid()] = weightFor(i);
         return dict;
+    }
+
+    // ---- Multi-user ProcessIntoTierList(IDictionary<string, IDictionary<Guid, PhoenixScore>>, ...) ----
+    //
+    // Each user's group is skipped when scoresDict.Count < 5, so test users must score
+    // at least 5 distinct charts. Three filler charts at the median bracket the two
+    // charts under examination so per-user mean/stddev is stable.
+
+    private static (Guid extreme, Guid mid1, Guid mid2, Guid mid3) FillerChartIds() =>
+        (Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+
+    private static IDictionary<Guid, PhoenixScore> UserBoard(Guid easyChart, Guid hardChart,
+        Guid c, Guid d, Guid e, int easyScore = 1000000, int hardScore = 0, int fillerScore = 500000) =>
+        new Dictionary<Guid, PhoenixScore>
+        {
+            [easyChart] = (PhoenixScore)easyScore,
+            [hardChart] = (PhoenixScore)hardScore,
+            [c] = (PhoenixScore)fillerScore,
+            [d] = (PhoenixScore)fillerScore,
+            [e] = (PhoenixScore)fillerScore
+        };
+
+    [Fact]
+    public void MultiUserProcessIntoTierListClassifiesUnanimouslyHighScoresAsVeryEasyAndLowAsVeryHard()
+    {
+        var easy = Guid.NewGuid();
+        var hard = Guid.NewGuid();
+        var (_, c, d, e) = FillerChartIds();
+        var userScores = Enumerable.Range(0, 5).ToDictionary(
+            i => $"u{i}",
+            i => (IDictionary<Guid, PhoenixScore>)UserBoard(easy, hard, c, d, e));
+
+        var entries = TierListSaga.ProcessIntoTierList(userScores, DifficultyLevel.From(20), "Scores").ToArray();
+
+        Assert.Equal(TierListCategory.VeryEasy, entries.Single(en => en.ChartId == easy).Category);
+        Assert.Equal(TierListCategory.VeryHard, entries.Single(en => en.ChartId == hard).Category);
+        Assert.All(entries, en => Assert.Equal("Scores", (string)en.TierListName));
+    }
+
+    [Fact]
+    public void MultiUserProcessIntoTierListSkipsUsersWhoScoredFewerThanFiveCharts()
+    {
+        // Each user has only 2 charts (< 5), so every group is skipped, chartCount stays 0,
+        // averages are NaN, and every chart falls through to the default Underrated bucket.
+        var chartA = Guid.NewGuid();
+        var chartB = Guid.NewGuid();
+        var userScores = Enumerable.Range(0, 5).ToDictionary(
+            i => $"u{i}",
+            i => (IDictionary<Guid, PhoenixScore>)new Dictionary<Guid, PhoenixScore>
+            {
+                [chartA] = (PhoenixScore)990000,
+                [chartB] = (PhoenixScore)100000
+            });
+
+        var entries = TierListSaga.ProcessIntoTierList(userScores, DifficultyLevel.From(20), "Scores").ToArray();
+
+        Assert.All(entries, en => Assert.Equal(TierListCategory.Underrated, en.Category));
+    }
+
+    [Fact]
+    public void MultiUserProcessIntoTierListWeightsHeavyGroupsHigherThanLightGroups()
+    {
+        // 5 light users + 5 heavy users with reversed score profiles. The heavy group's 100x
+        // weight should drive the final classification toward what *they* saw — chartA hard,
+        // chartB easy — rather than the opposing light view.
+        var chartA = Guid.NewGuid();
+        var chartB = Guid.NewGuid();
+        var (_, c, d, e) = FillerChartIds();
+
+        var light = Enumerable.Range(0, 5).ToDictionary(
+            i => $"light{i}",
+            i => (IDictionary<Guid, PhoenixScore>)UserBoard(chartA, chartB, c, d, e));
+        var heavy = Enumerable.Range(0, 5).ToDictionary(
+            i => $"heavy{i}",
+            i => (IDictionary<Guid, PhoenixScore>)UserBoard(chartB, chartA, c, d, e));
+
+        var combined = light.Concat(heavy).ToDictionary(kv => kv.Key, kv => kv.Value);
+        var weights = combined.ToDictionary(kv => kv.Key, kv => kv.Key.StartsWith("heavy") ? 100.0 : 1.0);
+
+        var entries = TierListSaga.ProcessIntoTierList(combined, DifficultyLevel.From(20), "Scores", weights).ToArray();
+
+        Assert.Equal(TierListCategory.VeryHard, entries.Single(en => en.ChartId == chartA).Category);
+        Assert.Equal(TierListCategory.VeryEasy, entries.Single(en => en.ChartId == chartB).Category);
     }
 }

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/UserQualifiersTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/UserQualifiersTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class UserQualifiersTests
+{
+    private static QualifiersConfiguration Config(IEnumerable<Chart> charts, string scoringType, int playCount = 2,
+        IDictionary<Guid, int>? adjustments = null) =>
+        new(charts, adjustments ?? new Dictionary<Guid, int>(), Name.From(scoringType), 0, playCount, null, false);
+
+    private static UserQualifiers New(QualifiersConfiguration config) =>
+        new(config, false, Name.From("player"), Guid.NewGuid(), new Dictionary<Guid, UserQualifiers.Submission>());
+
+    [Fact]
+    public void ApproveFlipsIsApprovedToTrue()
+    {
+        var qualifiers = New(Config(Array.Empty<Chart>(), "Score"));
+
+        qualifiers.Approve();
+
+        Assert.True(qualifiers.IsApproved);
+    }
+
+    [Fact]
+    public void AddPhoenixScoreRecordsSubmissionForChart()
+    {
+        var qualifiers = New(Config(Array.Empty<Chart>(), "Score"));
+        var chartId = Guid.NewGuid();
+        var photo = new Uri("https://example.invalid/proof.png");
+
+        var added = qualifiers.AddPhoenixScore(chartId, 950000, photo);
+
+        Assert.True(added);
+        Assert.True(qualifiers.Submissions.ContainsKey(chartId));
+        Assert.Equal((PhoenixScore)950000, qualifiers.Submissions[chartId].Score);
+        Assert.Equal(photo, qualifiers.Submissions[chartId].PhotoUrl);
+    }
+
+    [Fact]
+    public void RatingForScoreScoringTypeReturnsRawScore()
+    {
+        var qualifiers = New(Config(Array.Empty<Chart>(), "Score"));
+
+        var rating = qualifiers.Rating(DifficultyLevel.From(20), 980000);
+
+        Assert.Equal(980000.0, rating);
+    }
+
+    [Theory]
+    [InlineData("Fungpapi")]
+    [InlineData("Competitive Level")]
+    public void RatingForFungpapiTypesReturnsLevelPlusScoreOffset(string scoringType)
+    {
+        var qualifiers = New(Config(Array.Empty<Chart>(), scoringType));
+
+        // 965,000 is the formula's zero point: level + (965000 - 965000) / 17500 = level
+        var atZeroPoint = qualifiers.Rating(DifficultyLevel.From(20), 965000);
+        var oneLevelHigher = qualifiers.Rating(DifficultyLevel.From(20), 965000 + 17500);
+
+        Assert.Equal(20.0, atZeroPoint);
+        Assert.Equal(21.0, oneLevelHigher);
+    }
+
+    [Fact]
+    public void RatingForChartIdReturnsZeroWhenNoSubmissionExists()
+    {
+        var chart = new ChartBuilder().WithLevel(15).Build();
+        var qualifiers = New(Config(new[] { chart }, "Score"));
+
+        Assert.Equal(0.0, qualifiers.Rating(chart.Id));
+    }
+
+    [Fact]
+    public void RatingForChartIdUsesChartDifficultyAndSubmissionScore()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var qualifiers = New(Config(new[] { chart }, "Fungpapi"));
+        qualifiers.AddPhoenixScore(chart.Id, 965000, null);
+
+        // Fungpapi at 965,000 → level (20)
+        Assert.Equal(20.0, qualifiers.Rating(chart.Id));
+    }
+
+    [Fact]
+    public void BestChartsReturnsTopPlayCountOrderedByRatingDescending()
+    {
+        var chartA = new ChartBuilder().WithLevel(20).Build();
+        var chartB = new ChartBuilder().WithLevel(20).Build();
+        var chartC = new ChartBuilder().WithLevel(20).Build();
+        var config = Config(new[] { chartA, chartB, chartC }, "Score", playCount: 2);
+        var qualifiers = New(config);
+
+        qualifiers.AddPhoenixScore(chartA.Id, 900000, null);
+        qualifiers.AddPhoenixScore(chartB.Id, 950000, null);
+        qualifiers.AddPhoenixScore(chartC.Id, 980000, null);
+
+        var best = qualifiers.BestCharts().ToArray();
+
+        Assert.Equal(2, best.Length);
+        Assert.Equal(chartC.Id, best[0].Chart.Id);
+        Assert.Equal(chartB.Id, best[1].Chart.Id);
+    }
+
+    [Fact]
+    public void CalculateScoreSumsBestChartsForNonFungpapiScoring()
+    {
+        var chartA = new ChartBuilder().WithLevel(20).Build();
+        var chartB = new ChartBuilder().WithLevel(20).Build();
+        var qualifiers = New(Config(new[] { chartA, chartB }, "Score", playCount: 2));
+        qualifiers.AddPhoenixScore(chartA.Id, 900000, null);
+        qualifiers.AddPhoenixScore(chartB.Id, 950000, null);
+
+        Assert.Equal(900000.0 + 950000.0, qualifiers.CalculateScore());
+    }
+
+    [Fact]
+    public void CalculateScoreAveragesByPlayCountForFungpapiScoring()
+    {
+        var chartA = new ChartBuilder().WithLevel(20).Build();
+        var chartB = new ChartBuilder().WithLevel(20).Build();
+        var qualifiers = New(Config(new[] { chartA, chartB }, "Fungpapi", playCount: 4));
+        qualifiers.AddPhoenixScore(chartA.Id, 965000, null); // → 20
+        qualifiers.AddPhoenixScore(chartB.Id, 965000 + 17500, null); // → 21
+
+        // Fungpapi divides by configured PlayCount (4) even when fewer charts are submitted
+        Assert.Equal((20.0 + 21.0) / 4.0, qualifiers.CalculateScore());
+    }
+
+    [Fact]
+    public void CalculateScoreReturnsZeroForFungpapiWithNoSubmissions()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var qualifiers = New(Config(new[] { chart }, "Fungpapi", playCount: 4));
+
+        Assert.Equal(0.0, qualifiers.CalculateScore());
+    }
+
+    [Fact]
+    public void AddXXScoreAppliesNoteCountAdjustmentBeforeCalculatingPhoenixScore()
+    {
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var adjustments = new Dictionary<Guid, int> { [chart.Id] = 10 };
+        var qualifiers = New(Config(new[] { chart }, "Score", adjustments: adjustments));
+        var baseline = New(Config(new[] { chart }, "Score"));
+        var photo = new Uri("https://example.invalid/x.png");
+
+        // Use a step screen with greats so the score is below the 1M ceiling and the
+        // adjustment (which lifts perfects + maxCombo) produces a measurably higher score.
+        baseline.AddXXScore(chart.Id, 90, 10, 0, 0, 0, 90, photo);
+        qualifiers.AddXXScore(chart.Id, 90, 10, 0, 0, 0, 90, photo);
+
+        Assert.True(qualifiers.Submissions[chart.Id].Score > baseline.Submissions[chart.Id].Score);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 43 tests covering the highest-priority gaps from the latest coverage XML — five Application handlers/sagas at 0%, the `UserQualifiers` Domain aggregate at 0%, and the multi-user `TierListSaga.ProcessIntoTierList` overload that the existing `*Statics` tests skipped. Largest single gap was `RandomizerSaga` (187 uncovered blocks); also covers the `StdDev` helper duplicated in `ScoringDifficultySaga`.

Tests follow the canonical `CreateUserHandlerTests` pattern: mock the Domain ports, instantiate the real handler, assert returned values where applicable, and `Verify` side-effect calls. MassTransit consumers use a mocked `ConsumeContext<T>`; `ScoreQualitySaga` uses a real in-process `MemoryCache` as a fake (`InMemory` per `ENTERPRISE-TESTING.md`).

## Tests added

| File | Count | Subject |
|---|---|---|
| `DomainTests/UserQualifiersTests.cs` | 12 | Approve, AddPhoenixScore, AddXXScore, all 4 Rating scoring types, BestCharts, CalculateScore |
| `ApplicationTests/SaveQualifiersHandlerTests.cs` | 3 | new-challenger / progression / suppression-below-PlayCount |
| `ApplicationTests/AutoBuildSessionHandlerTests.cs` | 3 | session build, skips no-Score/no-Plate records, MinimumRestPerChart |
| `ApplicationTests/MarchOfMurlocsHandlerTests.cs` | 4 | TryScheduleMoM (3 paths) + CycleMoM creates tournaments + unhighlights prior |
| `ApplicationTests/QualifiersSagaTests.cs` | 4 | improvement → save, no improvement → skip, new entry, missing user → skip |
| `ApplicationTests/ScoreQualitySagaTests.cs` | 3 | competitive-players delegation, top-percentile branches |
| `ApplicationTests/ScoringDifficultySagaTests.cs` | 5 | StdDev (pop vs sample), empty-input no-op |
| `ApplicationTests/RandomizerSagaTests.cs` | 9 | Save/Delete delegation, GetIncluded filters (level weight / ScoringLevel / LetterGrade / ClearStatus), GetRandom count + AllowRepeats + DecreasingLevel |
| `ApplicationTests/TierListSagaStaticsTests.cs` *(appended)* | 3 | multi-user `ProcessIntoTierList` overload |

## Production change

Deleted `private static WorldRankingService.AvgOr0` — zero call sites in its declaring class; the only `AvgOr0` references are in `PlayerRatingSaga`, which has its own private copy. Per CLAUDE.md, dead code is removed rather than tested.

## Notes for the reviewer

- While writing the multi-user `ProcessIntoTierList` tests I noticed the per-user-count guard `if (scoreInts.Length < 5 || (level > 23 && scoreInts.Length < 3))` makes the level-23 relaxation unreachable (the `||` short-circuits true at `length < 5`). The new tests document the *current* behavior; flagged as a follow-up rather than fixed in this PR.
- 457/457 tests pass; `dotnet build -c Release` is clean (existing warnings only, no new ones).

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release`
- [x] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)