### PR TITLE
Cover Tier 2 Domain.Models behavior (Titles + ScoringConfiguration)

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixBossBreakerTitleTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixBossBreakerTitleTests.cs
@@ -1,0 +1,81 @@
+using System;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Models.Titles.Phoenix;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class PhoenixBossBreakerTitleTests
+{
+    private const string Song = "Conflict";
+
+    private static PhoenixBossBreakerTitle Title(string songName = Song,
+        ChartType type = ChartType.Single, int level = 26) =>
+        new(Name.From("Phoenix"), Name.From(songName), type, DifficultyLevel.From(level));
+
+    private static RecordedPhoenixScore Attempt(bool isBroken, PhoenixScore? score = null) =>
+        new(Guid.NewGuid(), score, PhoenixPlate.PerfectGame, isBroken, DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void AppliesToChartReturnsTrueWhenSongTypeAndLevelMatch()
+    {
+        var title = Title();
+        var chart = new ChartBuilder().WithSongName(Song).WithType(ChartType.Single).WithLevel(26).Build();
+
+        Assert.True(title.AppliesToChart(chart));
+    }
+
+    [Theory]
+    [InlineData("Other Song", ChartType.Single, 26)]
+    [InlineData(Song, ChartType.Double, 26)]
+    [InlineData(Song, ChartType.Single, 25)]
+    public void AppliesToChartReturnsFalseWhenAnyAttributeDiffers(string songName, ChartType type, int level)
+    {
+        var title = Title();
+        var chart = new ChartBuilder().WithSongName(songName).WithType(type).WithLevel(level).Build();
+
+        Assert.False(title.AppliesToChart(chart));
+    }
+
+    [Fact]
+    public void CompletionProgressIsOneWhenAttemptIsClearedOnTheBossChart()
+    {
+        var title = Title();
+        var chart = new ChartBuilder().WithSongName(Song).WithType(ChartType.Single).WithLevel(26).Build();
+
+        Assert.Equal(1, title.CompletionProgress(chart, Attempt(isBroken: false)));
+    }
+
+    [Fact]
+    public void CompletionProgressIsZeroWhenAttemptIsBrokenEvenOnMatchingChart()
+    {
+        var title = Title();
+        var chart = new ChartBuilder().WithSongName(Song).WithType(ChartType.Single).WithLevel(26).Build();
+
+        Assert.Equal(0, title.CompletionProgress(chart, Attempt(isBroken: true)));
+    }
+
+    [Fact]
+    public void CompletionProgressIsZeroForNonMatchingChart()
+    {
+        var title = Title();
+        var otherChart = new ChartBuilder().WithSongName("Other").WithType(ChartType.Single).WithLevel(26).Build();
+
+        Assert.Equal(0, title.CompletionProgress(otherChart, Attempt(isBroken: false)));
+    }
+
+    [Fact]
+    public void PopulatesFromDatabaseIsFalse()
+    {
+        Assert.False(Title().PopulatesFromDatabase);
+    }
+
+    [Fact]
+    public void RequiresExactlyOneCompletion()
+    {
+        Assert.Equal(1, Title().CompletionRequired);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixDifficultyTitleTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixDifficultyTitleTests.cs
@@ -1,0 +1,81 @@
+using System;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Models.Titles.Phoenix;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class PhoenixDifficultyTitleTests
+{
+    private static PhoenixDifficultyTitle Title(int level = 20, int requiredRating = 5000) =>
+        new(Name.From($"Lv.{level}"), DifficultyLevel.From(level), requiredRating);
+
+    private static RecordedPhoenixScore Attempt(PhoenixScore? score, bool isBroken = false) =>
+        new(Guid.NewGuid(), score, PhoenixPlate.PerfectGame, isBroken, DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void ExposesLevelAndRequiredRating()
+    {
+        var title = Title(level: 22, requiredRating: 7500);
+
+        Assert.Equal(DifficultyLevel.From(22), title.Level);
+        Assert.Equal(7500, title.RequiredRating);
+        Assert.Equal(7500, title.CompletionRequired);
+    }
+
+    [Fact]
+    public void CompletionProgressReturnsZeroWhenChartLevelDiffers()
+    {
+        var title = Title(level: 20);
+        var offLevel = new ChartBuilder().WithLevel(19).Build();
+
+        Assert.Equal(0, title.CompletionProgress(offLevel, Attempt(990000)));
+    }
+
+    [Fact]
+    public void CompletionProgressReturnsZeroWhenAttemptIsBroken()
+    {
+        var title = Title(level: 20);
+        var chart = new ChartBuilder().WithLevel(20).Build();
+
+        Assert.Equal(0, title.CompletionProgress(chart, Attempt(990000, isBroken: true)));
+    }
+
+    [Fact]
+    public void CompletionProgressReturnsZeroWhenScoreIsNull()
+    {
+        var title = Title(level: 20);
+        var chart = new ChartBuilder().WithLevel(20).Build();
+
+        Assert.Equal(0, title.CompletionProgress(chart, Attempt(null)));
+    }
+
+    [Fact]
+    public void CompletionProgressIsBaseRatingTimesLetterGradeModifier()
+    {
+        var level = DifficultyLevel.From(20);
+        var title = Title(level: 20);
+        var chart = new ChartBuilder().WithLevel(20).Build();
+
+        // 950000 falls in the AAA bracket; modifier is the static value the enum reports.
+        var attempt = Attempt(950000);
+        var expected = level.BaseRating * PhoenixLetterGrade.AAA.GetModifier();
+
+        Assert.Equal(expected, title.CompletionProgress(chart, attempt));
+    }
+
+    [Fact]
+    public void PopulatesFromDatabaseIsFalse()
+    {
+        Assert.False(Title().PopulatesFromDatabase);
+    }
+
+    [Fact]
+    public void CategoryIsDifficulty()
+    {
+        Assert.Equal("Difficulty", (string)Title().Category);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixSkillTitleTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixSkillTitleTests.cs
@@ -1,0 +1,81 @@
+using System;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Models.Titles.Phoenix;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class PhoenixSkillTitleTests
+{
+    private const string Song = "Conflict";
+
+    private static PhoenixSkillTitle Title(string songName = Song,
+        ChartType type = ChartType.Single, int level = 26) =>
+        new(Name.From("Speed"), 1, Name.From(songName), type, DifficultyLevel.From(level));
+
+    private static RecordedPhoenixScore Attempt(PhoenixScore? score) =>
+        new(Guid.NewGuid(), score, PhoenixPlate.PerfectGame, false, DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void AppliesToChartReturnsTrueWhenSongTypeAndLevelMatch()
+    {
+        var title = Title();
+        var chart = new ChartBuilder().WithSongName(Song).WithType(ChartType.Single).WithLevel(26).Build();
+
+        Assert.True(title.AppliesToChart(chart));
+    }
+
+    [Theory]
+    [InlineData("Other Song", ChartType.Single, 26)]
+    [InlineData(Song, ChartType.Double, 26)]
+    [InlineData(Song, ChartType.Single, 25)]
+    public void AppliesToChartReturnsFalseWhenAnyAttributeDiffers(string songName, ChartType type, int level)
+    {
+        var title = Title();
+        var chart = new ChartBuilder().WithSongName(songName).WithType(type).WithLevel(level).Build();
+
+        Assert.False(title.AppliesToChart(chart));
+    }
+
+    [Fact]
+    public void CompletionProgressReturnsScoreValueWhenChartMatchesAndScoreRecorded()
+    {
+        var title = Title();
+        var chart = new ChartBuilder().WithSongName(Song).WithType(ChartType.Single).WithLevel(26).Build();
+
+        Assert.Equal(995000, title.CompletionProgress(chart, Attempt(995000)));
+    }
+
+    [Fact]
+    public void CompletionProgressReturnsZeroWhenScoreIsNullEvenOnMatchingChart()
+    {
+        var title = Title();
+        var chart = new ChartBuilder().WithSongName(Song).WithType(ChartType.Single).WithLevel(26).Build();
+
+        Assert.Equal(0, title.CompletionProgress(chart, Attempt(null)));
+    }
+
+    [Fact]
+    public void CompletionProgressReturnsZeroForNonMatchingChart()
+    {
+        var title = Title();
+        var otherChart = new ChartBuilder().WithSongName("Other").WithType(ChartType.Single).WithLevel(26).Build();
+
+        Assert.Equal(0, title.CompletionProgress(otherChart, Attempt(995000)));
+    }
+
+    [Fact]
+    public void PopulatesFromDatabaseIsFalse()
+    {
+        Assert.False(Title().PopulatesFromDatabase);
+    }
+
+    [Fact]
+    public void RequiresSssScoreToComplete()
+    {
+        Assert.Equal(990000, Title().CompletionRequired);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixTitleProgressTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixTitleProgressTests.cs
@@ -1,0 +1,172 @@
+using System;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Models.Titles.Phoenix;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class PhoenixTitleProgressTests
+{
+    private static PhoenixDifficultyTitle DifficultyTitle(int level = 20, int requiredRating = 1000) =>
+        new(Name.From($"Lv.{level}"), DifficultyLevel.From(level), requiredRating);
+
+    private static RecordedPhoenixScore Attempt(PhoenixScore? score, bool isBroken = false) =>
+        new(Guid.NewGuid(), score, PhoenixPlate.PerfectGame, isBroken, DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void RequiredAaCountForDifficultyTitleIsCeilingOfRequiredRatingOverBaseRating()
+    {
+        var level = DifficultyLevel.From(20);
+        // Pick a required rating that doesn't divide cleanly so the ceiling is exercised.
+        var title = new PhoenixDifficultyTitle(Name.From("Lv.20"), level, level.BaseRating * 3 + 1);
+
+        var progress = new PhoenixTitleProgress(title);
+
+        Assert.Equal(4, progress.RequiredAaCount);
+    }
+
+    [Fact]
+    public void RequiredAaCountIsZeroForNonDifficultyTitles()
+    {
+        var title = new PhoenixBasicTitle(Name.From("Welcome"), "Welcome to Phoenix");
+
+        var progress = new PhoenixTitleProgress(title);
+
+        Assert.Equal(0, progress.RequiredAaCount);
+    }
+
+    [Fact]
+    public void ApplyAttemptAccumulatesCompletionCountFromTitleProgress()
+    {
+        var progress = new PhoenixTitleProgress(DifficultyTitle());
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var rating = DifficultyLevel.From(20).BaseRating;
+
+        progress.ApplyAttempt(chart, Attempt(950000)); // AAA bracket
+        var afterFirst = progress.CompletionCount;
+        progress.ApplyAttempt(chart, Attempt(950000));
+
+        Assert.Equal(rating * PhoenixLetterGrade.AAA.GetModifier(), afterFirst);
+        Assert.Equal(afterFirst * 2, progress.CompletionCount);
+    }
+
+    [Fact]
+    public void ApplyAttemptDoesNotIncrementWhenAttemptScoreIsNull()
+    {
+        var progress = new PhoenixTitleProgress(DifficultyTitle());
+        var chart = new ChartBuilder().WithLevel(20).Build();
+
+        progress.ApplyAttempt(chart, Attempt(null));
+
+        Assert.Equal(0, progress.CompletionCount);
+        Assert.Equal(ParagonLevel.None, progress.ParagonLevel);
+    }
+
+    [Fact]
+    public void ParagonLevelIsNoneForNonDifficultyTitlesEvenAfterAttempts()
+    {
+        var basicTitle = new PhoenixBasicTitle(Name.From("Welcome"), "Welcome");
+        var progress = new PhoenixTitleProgress(basicTitle);
+        var chart = new ChartBuilder().WithLevel(20).Build();
+
+        progress.ApplyAttempt(chart, Attempt(990000));
+
+        Assert.Equal(ParagonLevel.None, progress.ParagonLevel);
+    }
+
+    [Fact]
+    public void ParagonLevelClimbsAsAaPlusAttemptsAccumulate()
+    {
+        // RequiredRating = BaseRating * 1 → RequiredAaCount = 1, so a single AA attempt
+        // is enough to reach the AA paragon level.
+        var level = DifficultyLevel.From(20);
+        var title = new PhoenixDifficultyTitle(Name.From("Lv.20"), level, level.BaseRating);
+        var progress = new PhoenixTitleProgress(title);
+        var chart = new ChartBuilder().WithLevel(20).Build();
+
+        Assert.Equal(ParagonLevel.None, progress.ParagonLevel);
+
+        progress.ApplyAttempt(chart, Attempt(900000)); // AA bracket → bumps F..AA all to 1
+
+        Assert.Equal(ParagonLevel.AA, progress.ParagonLevel);
+    }
+
+    [Fact]
+    public void NextParagonProgressReportsBucketAtNextHigherParagonLevel()
+    {
+        var level = DifficultyLevel.From(20);
+        // RequiredAaCount = 2 keeps us at AA after two AA attempts; next level (AA+) sits at 0.
+        var title = new PhoenixDifficultyTitle(Name.From("Lv.20"), level, level.BaseRating * 2);
+        var progress = new PhoenixTitleProgress(title);
+        var chart = new ChartBuilder().WithLevel(20).Build();
+
+        progress.ApplyAttempt(chart, Attempt(900000)); // AA
+        progress.ApplyAttempt(chart, Attempt(900000)); // AA
+        // Now F..AA each have count 2, AA+ has 0.
+
+        Assert.Equal(ParagonLevel.AA, progress.ParagonLevel);
+        Assert.Equal(0, progress.NextParagonProgress);
+    }
+
+    [Fact]
+    public void NextParagonProgressIsNegativeOneAtParagonGrade()
+    {
+        var level = DifficultyLevel.From(20);
+        var title = new PhoenixDifficultyTitle(Name.From("Lv.20"), level, level.BaseRating);
+        var progress = new PhoenixTitleProgress(title);
+        var chart = new ChartBuilder().WithLevel(20).Build();
+
+        progress.ApplyAttempt(chart, Attempt(1000000)); // PG promotes every paragon bucket including PG
+
+        Assert.Equal(ParagonLevel.PG, progress.ParagonLevel);
+        Assert.Equal(-1, progress.NextParagonProgress);
+    }
+
+    [Fact]
+    public void AdditionalNoteIsEmptyForNonDifficultyAndNonCoOpTitles()
+    {
+        var basicTitle = new PhoenixBasicTitle(Name.From("Welcome"), "Welcome");
+        var progress = new PhoenixTitleProgress(basicTitle);
+
+        Assert.Equal(string.Empty, progress.AdditionalNote);
+    }
+
+    [Fact]
+    public void AdditionalNoteIsEmptyOnceCompletionCountReachesRequired()
+    {
+        var level = DifficultyLevel.From(20);
+        var title = new PhoenixDifficultyTitle(Name.From("Lv.20"), level, level.BaseRating);
+        var progress = new PhoenixTitleProgress(title);
+        var chart = new ChartBuilder().WithLevel(20).Build();
+
+        // PG attempt awards BaseRating * 1.6 (PgLetterGradeModifier handled in helper). For
+        // any score that fully covers RequiredRating, CompletionCount >= CompletionRequired.
+        progress.ApplyAttempt(chart, Attempt(990000));
+        progress.ApplyAttempt(chart, Attempt(990000));
+
+        Assert.True(progress.CompletionCount >= title.CompletionRequired);
+        Assert.Equal(string.Empty, progress.AdditionalNote);
+    }
+
+    [Fact]
+    public void AdditionalNoteReportsPassRangeForIncompleteDifficultyTitle()
+    {
+        var level = DifficultyLevel.From(20);
+        var title = new PhoenixDifficultyTitle(Name.From("Lv.20"), level, level.BaseRating * 4);
+        var progress = new PhoenixTitleProgress(title);
+
+        Assert.Contains("Passes", progress.AdditionalNote);
+    }
+
+    [Fact]
+    public void AdditionalNoteReportsPassRangeForCoOpTitle()
+    {
+        var coOpTitle = new PhoenixCoOpTitle(Name.From("CoOp Hero"), 4000);
+        var progress = new PhoenixTitleProgress(coOpTitle);
+
+        Assert.Contains("Passes", progress.AdditionalNote);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/ScoringConfigurationTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/ScoringConfigurationTests.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class ScoringConfigurationTests
+{
+    private static readonly TimeSpan BaseAverage = TimeSpan.FromMinutes(2);
+
+    private static Chart ChartAt(int level, ChartType type = ChartType.Single,
+        TimeSpan? duration = null, SongType songType = SongType.Arcade) =>
+        new ChartBuilder()
+            .WithLevel(level)
+            .WithType(type)
+            .WithSong(new Song(Name.From($"song-{Guid.NewGuid()}"), songType,
+                new Uri("https://example.invalid/s.png"), duration ?? BaseAverage,
+                Name.From("artist"), Bpm: null))
+            .Build();
+
+    // ---- Public GetScore overloads / Default formula ----
+
+    [Fact]
+    public void GetScoreReturnsZeroWhenScoreBelowMinimumScore()
+    {
+        var config = new ScoringConfiguration { MinimumScore = 800000 };
+
+        Assert.Equal(0, config.GetScore(DifficultyLevel.From(20), 700000));
+    }
+
+    [Fact]
+    public void GetScoreInDefaultFormulaIsLevelRatingTimesLetterGradeModifier()
+    {
+        var config = new ScoringConfiguration();
+        var level = DifficultyLevel.From(20);
+
+        // Default config: BaseAverage duration ⇒ time multiplier 1.0; ChartTypeModifier[Single]=1.0;
+        // SongType[Arcade]=1.0; SuperbGame plate=1.0; no chart modifier. So result reduces to
+        // LevelRatings[level] * LetterGradeModifier.
+        var expected = config.LevelRatings[level] * PhoenixLetterGrade.AAA.GetModifier();
+
+        Assert.Equal(expected, config.GetScore(level, 950000));
+    }
+
+    [Fact]
+    public void GetScoreUsesPgLetterGradeModifierForPerfectGameScore()
+    {
+        var config = new ScoringConfiguration { PgLetterGradeModifier = 2.0 };
+        var level = DifficultyLevel.From(20);
+
+        Assert.Equal(config.LevelRatings[level] * 2.0, config.GetScore(level, 1000000));
+    }
+
+    [Fact]
+    public void GetScoreAppliesStageBreakModifierWhenAttemptIsBroken()
+    {
+        var config = new ScoringConfiguration { StageBreakModifier = 0.5 };
+        var chart = ChartAt(20);
+
+        var clean = config.GetScore(chart, 950000, PhoenixPlate.SuperbGame, false);
+        var broken = config.GetScore(chart, 950000, PhoenixPlate.SuperbGame, true);
+
+        Assert.Equal(clean * 0.5, broken);
+    }
+
+    [Fact]
+    public void GetScoreAppliesChartModifierKeyedByChartId()
+    {
+        var chart = ChartAt(20);
+        var config = new ScoringConfiguration
+        {
+            ChartModifiers = new Dictionary<Guid, double> { [chart.Id] = 1.5 }
+        };
+
+        var unmodified = new ScoringConfiguration();
+        var baseScore = unmodified.GetScore(chart, 950000, PhoenixPlate.SuperbGame, false);
+
+        // Default formula multiplies the chart modifier in twice (once via GetScorelessScore, once
+        // again on the result), so the effective multiplier is 1.5 * 1.5 = 2.25.
+        Assert.Equal(baseScore * 1.5 * 1.5, config.GetScore(chart, 950000, PhoenixPlate.SuperbGame, false), 6);
+    }
+
+    // ---- AdjustToTime / SongType / ChartType ----
+
+    [Fact]
+    public void GetScoreScalesLinearlyWithDurationWhenAdjustToTimeIsTrue()
+    {
+        var config = new ScoringConfiguration { AdjustToTime = true };
+        var shortChart = ChartAt(20, duration: TimeSpan.FromMinutes(1));
+        var standardChart = ChartAt(20, duration: BaseAverage);
+
+        var shortScore = config.GetScore(shortChart, 950000, PhoenixPlate.SuperbGame, false);
+        var standardScore = config.GetScore(standardChart, 950000, PhoenixPlate.SuperbGame, false);
+
+        Assert.Equal(standardScore * 0.5, shortScore, 6);
+    }
+
+    [Fact]
+    public void GetScoreIgnoresDurationWhenAdjustToTimeIsFalse()
+    {
+        var config = new ScoringConfiguration { AdjustToTime = false };
+        var shortChart = ChartAt(20, duration: TimeSpan.FromMinutes(1));
+        var longChart = ChartAt(20, duration: TimeSpan.FromMinutes(4));
+
+        var shortScore = config.GetScore(shortChart, 950000, PhoenixPlate.SuperbGame, false);
+        var longScore = config.GetScore(longChart, 950000, PhoenixPlate.SuperbGame, false);
+
+        Assert.Equal(shortScore, longScore);
+    }
+
+    [Fact]
+    public void GetScoreAppliesSongTypeModifier()
+    {
+        var config = new ScoringConfiguration();
+        config.SongTypeModifiers[SongType.Remix] = 0.5;
+
+        var arcade = ChartAt(20, songType: SongType.Arcade);
+        var remix = ChartAt(20, songType: SongType.Remix);
+
+        var arcadeScore = config.GetScore(arcade, 950000, PhoenixPlate.SuperbGame, false);
+        var remixScore = config.GetScore(remix, 950000, PhoenixPlate.SuperbGame, false);
+
+        Assert.Equal(arcadeScore * 0.5, remixScore);
+    }
+
+    [Fact]
+    public void GetScoreAppliesChartTypeModifier()
+    {
+        var config = new ScoringConfiguration();
+        config.ChartTypeModifiers[ChartType.Double] = 1.25;
+
+        var single = ChartAt(20, ChartType.Single);
+        var dub = ChartAt(20, ChartType.Double);
+
+        var singleScore = config.GetScore(single, 950000, PhoenixPlate.SuperbGame, false);
+        var doubleScore = config.GetScore(dub, 950000, PhoenixPlate.SuperbGame, false);
+
+        Assert.Equal(singleScore * 1.25, doubleScore, 6);
+    }
+
+    // ---- ContinuousLetterGradeScale ----
+
+    [Fact]
+    public void ContinuousLetterGradeScaleInterpolatesBetweenAdjacentBrackets()
+    {
+        var config = new ScoringConfiguration { ContinuousLetterGradeScale = true };
+        var level = DifficultyLevel.From(20);
+
+        // 950000 sits at the start of the AAA bracket (1.10) and 960000 at the start of the next
+        // (AAA+, 1.15). With continuous scaling, a midpoint score should yield the midpoint
+        // modifier between those two — strictly higher than the AAA-only rate.
+        var bracketStart = config.GetScore(level, 950000);
+        var middle = config.GetScore(level, 955000);
+        var bracketAbove = config.GetScore(level, 960000);
+
+        Assert.True(middle > bracketStart);
+        Assert.True(middle < bracketAbove);
+    }
+
+    // ---- Avalanche formula ----
+
+    [Fact]
+    public void AvalancheFormulaSubtractsStageBreakModifierFromLetterGradeModifier()
+    {
+        var config = new ScoringConfiguration
+        {
+            Formula = ScoringConfiguration.CalculationType.Avalanche,
+            StageBreakModifier = 0.1
+        };
+        var chart = ChartAt(20);
+
+        var clean = config.GetScore(chart, 950000, PhoenixPlate.SuperbGame, false);
+        var broken = config.GetScore(chart, 950000, PhoenixPlate.SuperbGame, true);
+
+        // clean = scoreless * letterMod ; broken = scoreless * (letterMod - 0.1)
+        // ratio: broken/clean = (letterMod - 0.1) / letterMod
+        var letterMod = PhoenixLetterGrade.AAA.GetModifier();
+        Assert.Equal(clean * (letterMod - 0.1) / letterMod, broken, 6);
+    }
+
+    // ---- Custom formula ----
+
+    [Fact]
+    public void CustomFormulaEvaluatesUserAlgorithmAgainstSubstitutedTokens()
+    {
+        var config = new ScoringConfiguration
+        {
+            Formula = ScoringConfiguration.CalculationType.Custom,
+            CustomAlgorithm = "LVL + LTTR"
+        };
+        var level = DifficultyLevel.From(20);
+
+        // LVL = LevelRatings[20] = 650; LTTR = AAA modifier = 1.10
+        var expected = config.LevelRatings[level] + PhoenixLetterGrade.AAA.GetModifier();
+
+        Assert.Equal(expected, config.GetScore(level, 950000), 6);
+    }
+
+    // ---- GetBaseRating (reached via GetScorelessScore) ----
+
+    [Fact]
+    public void GetBaseRatingReturnsTwoThousandForCoOpRegardlessOfLevelRatings()
+    {
+        var config = new ScoringConfiguration { AdjustToTime = false };
+        config.LevelRatings[DifficultyLevel.From(20)] = 99999; // would dominate if it leaked through
+        var coOpChart = ChartAt(20, type: ChartType.CoOp);
+
+        // CoOp returns 2000 from GetBaseRating; default ChartTypeModifier[CoOp]=1.0,
+        // SongType[Arcade]=1.0 ⇒ scoreless score is 2000.
+        Assert.Equal(2000, config.GetScorelessScore(coOpChart));
+    }
+
+    [Fact]
+    public void GetBaseRatingUsesLevelRatingsWhenNoChartLevelSnapshotIsSet()
+    {
+        var config = new ScoringConfiguration { AdjustToTime = false };
+        var chart = ChartAt(20);
+
+        Assert.Equal(config.LevelRatings[DifficultyLevel.From(20)], config.GetScorelessScore(chart));
+    }
+
+    [Fact]
+    public void GetBaseRatingInterpolatesFromChartLevelSnapshotBetweenAdjacentLevels()
+    {
+        var chart = ChartAt(20);
+        var config = new ScoringConfiguration
+        {
+            AdjustToTime = false,
+            ChartLevelSnapshot = new Dictionary<Guid, double> { [chart.Id] = 20.5 }
+        };
+        config.LevelRatings[DifficultyLevel.From(20)] = 1000;
+        config.LevelRatings[DifficultyLevel.From(21)] = 2000;
+
+        // Snapshot at 20.5 means: floor=20, ceil=21, fraction = 20.5 - 0.5 - 20 = 0.0 ⇒ rating = 1000.
+        // Snapshot at 21.0 ⇒ fraction = 21.0 - 0.5 - 20 = 0.5 ⇒ rating = 1000 + 0.5*(2000-1000) = 1500.
+        // Stick with 20.5 case here: expect exactly 1000 from the formula.
+        Assert.Equal(1000, config.GetScorelessScore(chart));
+    }
+
+    [Fact]
+    public void GetBaseRatingIgnoresSnapshotWhenIncludeLevelOverrideIsFalse()
+    {
+        var chart = ChartAt(20);
+        var config = new ScoringConfiguration
+        {
+            AdjustToTime = false,
+            ChartLevelSnapshot = new Dictionary<Guid, double> { [chart.Id] = 25.0 }
+        };
+        config.LevelRatings[DifficultyLevel.From(20)] = 1000;
+
+        Assert.Equal(1000, config.GetScorelessScore(chart, includeLevelOverride: false));
+    }
+
+    [Fact]
+    public void GetBaseRatingIgnoresSnapshotForLevelTwentyNineAndAbove()
+    {
+        // The override does not apply when chart.Level >= 29, so the level-29 LevelRating is used directly.
+        var chart = ChartAt(29);
+        var config = new ScoringConfiguration
+        {
+            AdjustToTime = false,
+            ChartLevelSnapshot = new Dictionary<Guid, double> { [chart.Id] = 27.5 }
+        };
+        var expected = config.LevelRatings[DifficultyLevel.From(29)];
+
+        Assert.Equal(expected, config.GetScorelessScore(chart));
+    }
+
+    [Fact]
+    public void GetBaseRatingIgnoresSnapshotForChartIdsNotPresentInTheSnapshot()
+    {
+        var chart = ChartAt(20);
+        var otherId = Guid.NewGuid();
+        var config = new ScoringConfiguration
+        {
+            AdjustToTime = false,
+            ChartLevelSnapshot = new Dictionary<Guid, double> { [otherId] = 25.0 }
+        };
+
+        Assert.Equal(config.LevelRatings[DifficultyLevel.From(20)], config.GetScorelessScore(chart));
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/TitleHelpersTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/TitleHelpersTests.cs
@@ -1,0 +1,79 @@
+using System;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Models.Titles;
+using ScoreTracker.Domain.Models.Titles.Phoenix;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class TitleHelpersTests
+{
+    private static PhoenixTitleProgress DifficultyProgress(int level, int requiredRating, bool complete)
+    {
+        var title = new PhoenixDifficultyTitle(Name.From($"Lv.{level}"), DifficultyLevel.From(level), requiredRating);
+        var progress = new PhoenixTitleProgress(title);
+        if (complete)
+        {
+            // GetPushingTitle compares CompletionCount to CompletionRequired, not IsComplete,
+            // so push enough rating in to actually meet the bar.
+            var chart = new ChartBuilder().WithLevel(level).Build();
+            var attempt = new RecordedPhoenixScore(Guid.NewGuid(), 1000000, PhoenixPlate.PerfectGame, false,
+                DateTimeOffset.UtcNow);
+            while (progress.CompletionCount < title.CompletionRequired)
+                progress.ApplyAttempt(chart, attempt);
+        }
+        return progress;
+    }
+
+    [Fact]
+    public void GetPushingTitleReturnsLowestDifficultyTitleWhenNoneAreComplete()
+    {
+        var lvl15 = DifficultyProgress(15, 1000, complete: false);
+        var lvl20 = DifficultyProgress(20, 5000, complete: false);
+        var lvl25 = DifficultyProgress(25, 10000, complete: false);
+
+        var pushing = new TitleProgress[] { lvl25, lvl15, lvl20 }.GetPushingTitle();
+
+        Assert.Same(lvl15, pushing);
+    }
+
+    [Fact]
+    public void GetPushingTitleReturnsTitleAboveTheHighestCompletedDifficultyTitle()
+    {
+        var lvl15 = DifficultyProgress(15, 1000, complete: true);
+        var lvl20 = DifficultyProgress(20, 5000, complete: true);
+        var lvl25 = DifficultyProgress(25, 10000, complete: false);
+
+        var pushing = new TitleProgress[] { lvl15, lvl25, lvl20 }.GetPushingTitle();
+
+        Assert.Same(lvl25, pushing);
+    }
+
+    [Fact]
+    public void GetPushingTitleIgnoresNonDifficultyTitles()
+    {
+        var lvl15 = DifficultyProgress(15, 1000, complete: true);
+        var lvl20 = DifficultyProgress(20, 5000, complete: false);
+        var basicTitle = new PhoenixTitleProgress(new PhoenixBasicTitle(Name.From("Welcome"), "Welcome"));
+
+        var pushing = new TitleProgress[] { basicTitle, lvl15, lvl20 }.GetPushingTitle();
+
+        Assert.Same(lvl20, pushing);
+    }
+
+    [Fact]
+    public void GetPushingTitleSortsBySameLevelByCompletionRequired()
+    {
+        // Two level-20 difficulty titles with different completion requirements; the easier
+        // one is incomplete and should be the pushing target.
+        var easyAtLvl20 = DifficultyProgress(20, 1000, complete: false);
+        var hardAtLvl20 = DifficultyProgress(20, 5000, complete: false);
+
+        var pushing = new TitleProgress[] { hardAtLvl20, easyAtLvl20 }.GetPushingTitle();
+
+        Assert.Same(easyAtLvl20, pushing);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/XXDifficultyLevelTitleTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/XXDifficultyLevelTitleTests.cs
@@ -1,0 +1,87 @@
+using System;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Models.Titles.XX;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class XXDifficultyLevelTitleTests
+{
+    private static BestXXChartAttempt Attempt(int level, bool isBroken = false)
+    {
+        var chart = new ChartBuilder().WithLevel(level).Build();
+        var bestAttempt = new XXChartAttempt(XXLetterGrade.A, isBroken, null, DateTimeOffset.UtcNow);
+        return new BestXXChartAttempt(chart, bestAttempt);
+    }
+
+    [Fact]
+    public void DoesAttemptApplyReturnsFalseWhenBestAttemptIsNull()
+    {
+        var title = new XXDifficultyLevelTitle(Name.From("Lv.20"), DifficultyLevel.From(20), 100);
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var attempt = new BestXXChartAttempt(chart, null);
+
+        Assert.False(title.DoesAttemptApply(attempt));
+    }
+
+    [Fact]
+    public void DoesAttemptApplyReturnsFalseWhenAttemptIsBroken()
+    {
+        var title = new XXDifficultyLevelTitle(Name.From("Lv.20"), DifficultyLevel.From(20), 100);
+
+        Assert.False(title.DoesAttemptApply(Attempt(level: 20, isBroken: true)));
+    }
+
+    [Theory]
+    [InlineData(20, true)]
+    [InlineData(21, false)]
+    [InlineData(19, false)]
+    public void SingleLevelConstructorMatchesOnlyExactLevel(int chartLevel, bool expected)
+    {
+        var title = new XXDifficultyLevelTitle(Name.From("Lv.20"), DifficultyLevel.From(20), 100);
+
+        Assert.Equal(expected, title.DoesAttemptApply(Attempt(level: chartLevel)));
+    }
+
+    [Theory]
+    [InlineData(18, false)]
+    [InlineData(19, true)]
+    [InlineData(20, true)]
+    [InlineData(21, true)]
+    [InlineData(22, false)]
+    public void RangeConstructorMatchesAnyLevelInsideTheRangeInclusive(int chartLevel, bool expected)
+    {
+        var title = new XXDifficultyLevelTitle(Name.From("19-21"), DifficultyLevel.From(19),
+            DifficultyLevel.From(21), 100);
+
+        Assert.Equal(expected, title.DoesAttemptApply(Attempt(level: chartLevel)));
+    }
+
+    [Fact]
+    public void AdditionalRequirementsConstructorIncludesNoteInDescription()
+    {
+        var title = new XXDifficultyLevelTitle(Name.From("Lv.20"), DifficultyLevel.From(20), 100,
+            "Stage breaks not counted");
+
+        Assert.Contains("Stage breaks not counted", title.Description);
+    }
+
+    [Fact]
+    public void RequiredCountFlowsThroughToCompletionRequired()
+    {
+        var title = new XXDifficultyLevelTitle(Name.From("Lv.20"), DifficultyLevel.From(20), 250);
+
+        Assert.Equal(250, title.CompletionRequired);
+    }
+
+    [Fact]
+    public void CategoryIsDifficulty()
+    {
+        var title = new XXDifficultyLevelTitle(Name.From("Lv.20"), DifficultyLevel.From(20), 100);
+
+        Assert.Equal("Difficulty", (string)title.Category);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/XXSkillTitleTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/XXSkillTitleTests.cs
@@ -1,0 +1,80 @@
+using System;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Models.Titles.XX;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class XXSkillTitleTests
+{
+    private const string Song = "Conflict";
+
+    private static XXSkillTitle Title(XXLetterGrade required = XXLetterGrade.SS) =>
+        new(Name.From("Speed Hero"), Name.From(Song), ChartType.Single, DifficultyLevel.From(20), required);
+
+    private static BestXXChartAttempt Attempt(string song = Song, ChartType type = ChartType.Single,
+        int level = 20, XXLetterGrade letter = XXLetterGrade.SS, bool isBroken = false)
+    {
+        var chart = new ChartBuilder().WithSongName(song).WithType(type).WithLevel(level).Build();
+        var bestAttempt = new XXChartAttempt(letter, isBroken, null, DateTimeOffset.UtcNow);
+        return new BestXXChartAttempt(chart, bestAttempt);
+    }
+
+    [Fact]
+    public void DefaultLetterGradeRequirementIsSS()
+    {
+        // The two-arg constructor delegates to SS as the default required grade.
+        var defaultTitle = new XXSkillTitle(Name.From("Default"), Name.From(Song), ChartType.Single,
+            DifficultyLevel.From(20));
+
+        Assert.True(defaultTitle.DoesAttemptApply(Attempt(letter: XXLetterGrade.SS)));
+        Assert.False(defaultTitle.DoesAttemptApply(Attempt(letter: XXLetterGrade.S)));
+    }
+
+    [Fact]
+    public void DoesAttemptApplyReturnsFalseWhenBestAttemptIsNull()
+    {
+        var chart = new ChartBuilder().WithSongName(Song).WithType(ChartType.Single).WithLevel(20).Build();
+        var attempt = new BestXXChartAttempt(chart, null);
+
+        Assert.False(Title().DoesAttemptApply(attempt));
+    }
+
+    [Theory]
+    [InlineData("Other Song", ChartType.Single, 20, XXLetterGrade.SS)]
+    [InlineData(Song, ChartType.Double, 20, XXLetterGrade.SS)]
+    [InlineData(Song, ChartType.Single, 19, XXLetterGrade.SS)]
+    public void DoesAttemptApplyReturnsFalseWhenChartAttributesDiffer(string song, ChartType type, int level,
+        XXLetterGrade letter)
+    {
+        Assert.False(Title().DoesAttemptApply(Attempt(song, type, level, letter)));
+    }
+
+    [Fact]
+    public void DoesAttemptApplyReturnsFalseWhenLetterGradeBelowRequirement()
+    {
+        Assert.False(Title(required: XXLetterGrade.SS).DoesAttemptApply(Attempt(letter: XXLetterGrade.S)));
+    }
+
+    [Fact]
+    public void DoesAttemptApplyReturnsTrueWhenLetterGradeMeetsRequirement()
+    {
+        Assert.True(Title(required: XXLetterGrade.SS).DoesAttemptApply(Attempt(letter: XXLetterGrade.SS)));
+    }
+
+    [Fact]
+    public void DoesAttemptApplyReturnsTrueWhenLetterGradeExceedsRequirement()
+    {
+        Assert.True(Title(required: XXLetterGrade.SS).DoesAttemptApply(Attempt(letter: XXLetterGrade.SSS)));
+    }
+
+    [Fact]
+    public void DoesAttemptApplyDoesNotConsiderBrokenFlag()
+    {
+        // The skill title only checks song/type/level/letter — broken state is unrelated.
+        Assert.True(Title().DoesAttemptApply(Attempt(letter: XXLetterGrade.SS, isBroken: true)));
+    }
+}


### PR DESCRIPTION
## Summary

Adds 81 unit tests in `DomainTests/` covering the Tier 2 priorities from the coverage report — the Title hierarchy (7 classes, all at 0% in the snapshot) and `ScoringConfiguration.GetScore` / `GetBaseRating` (Pumbility math at 37% / 20%).

Follow-up to [#82](https://github.com/DrMurloc/PumpItUpScoreTracker/pull/82). Same approach: real domain objects, no mocks, behavior-first naming.

## Tests added

| File | Count | Subject |
|---|---|---|
| `PhoenixBossBreakerTitleTests.cs` | 9 | `AppliesToChart` song/type/level matching, `CompletionProgress` broken/null guards |
| `PhoenixSkillTitleTests.cs` | 9 | Score-value progress when chart matches, null/non-matching guards |
| `PhoenixDifficultyTitleTests.cs` | 7 | `BaseRating × LetterGradeModifier`, broken/null/wrong-level guards |
| `PhoenixTitleProgressTests.cs` | 12 | `RequiredAaCount` derivation, `ApplyAttempt` accumulation, paragon ladder (None → AA → … → PG → -1), `AdditionalNote` for difficulty/CoOp/basic titles |
| `TitleHelpersTests.cs` | 4 | `GetPushingTitle` returns lowest when none complete, next-above when prior complete, ignores non-difficulty, ties broken by `CompletionRequired` |
| `XXSkillTitleTests.cs` | 9 | `DoesAttemptApply` null-attempt, mismatch guards, letter-grade threshold, broken-state ignored, default ctor uses `SS` |
| `XXDifficultyLevelTitleTests.cs` | 13 | All three constructors (single-level / range / additional-requirements), broken excluded, range bounds inclusive |
| `ScoringConfigurationTests.cs` | 18 | Pumbility math: `MinimumScore` guard, default formula, PG modifier, stage-break + chart modifier, `AdjustToTime` on/off, song/chart-type modifiers, `ContinuousLetterGradeScale` interpolation, Avalanche formula, Custom formula token substitution; `GetBaseRating` covering CoOp constant, snapshot interpolation, level-29 cap, snapshot opt-out, missing-chart fallback |

## Notes for the reviewer

- Where possible, expected modifiers are computed via `PhoenixLetterGrade.<X>.GetModifier()` rather than hard-coded — the tests track [`PhoenixLetterGrade.cs`](ScoreTracker/ScoreTracker.Domain/Enums/PhoenixLetterGrade.cs) as the source of truth for the bracket math.
- `TitleProgress.Complete()` only flips an internal `_forcedComplete` flag; `GetPushingTitle` (and most other helpers) checks `CompletionCount` against `CompletionRequired`. The test helper for "completed" titles in `TitleHelpersTests.cs` reflects this — it loops `ApplyAttempt` with PG attempts until `CompletionCount` actually clears the bar.
- 538/538 tests pass (up from the post-#82 baseline of 457); `dotnet build -c Release` clean.

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release`
- [x] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)