### PR TITLE
Cover Tier 3 ValueTypes and JSON converters

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/BpmTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/BpmTests.cs
@@ -125,4 +125,43 @@ public sealed class BpmTests
     {
         Assert.False(Bpm.TryParse(input, out _));
     }
+
+    // ---- Implicit conversions ----
+
+    [Fact]
+    public void ImplicitConversionFromDecimalDelegatesToFrom()
+    {
+        Bpm bpm = 120m;
+        Assert.Equal(120m, bpm.Min);
+        Assert.Equal(120m, bpm.Max);
+    }
+
+    [Fact]
+    public void ImplicitConversionFromNonPositiveDecimalThrows()
+    {
+        Assert.Throws<InvalidBpmException>(() =>
+        {
+            Bpm bpm = 0m;
+        });
+    }
+
+    [Theory]
+    [InlineData("120", 120, 120)]
+    [InlineData("99.5", 99.5, 99.5)]
+    [InlineData("120 ~ 200", 120, 200)]
+    public void ImplicitConversionFromStringDelegatesToTryParse(string input, decimal expectedMin, decimal expectedMax)
+    {
+        Bpm bpm = input;
+        Assert.Equal(expectedMin, bpm.Min);
+        Assert.Equal(expectedMax, bpm.Max);
+    }
+
+    [Fact]
+    public void ImplicitConversionFromMalformedStringThrows()
+    {
+        Assert.Throws<InvalidBpmException>(() =>
+        {
+            Bpm bpm = "not-a-number";
+        });
+    }
 }

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/DifficultyLevelTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/DifficultyLevelTests.cs
@@ -1,4 +1,5 @@
-﻿using ScoreTracker.Domain.Exceptions;
+﻿using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Exceptions;
 using ScoreTracker.Domain.ValueTypes;
 using Xunit;
 
@@ -26,5 +27,106 @@ public sealed class DifficultyLevelTests
     {
         var difficultyLevel = DifficultyLevel.From(level);
         Assert.Equal(level, (int)difficultyLevel);
+    }
+
+    // ---- CompareTo(object) ----
+
+    [Fact]
+    public void CompareToObjectWithDifficultyLevelDelegatesToTypedCompareTo()
+    {
+        DifficultyLevel a = DifficultyLevel.From(15);
+        object b = DifficultyLevel.From(20);
+
+        Assert.True(a.CompareTo(b) < 0);
+        Assert.True(((DifficultyLevel)20).CompareTo((object)DifficultyLevel.From(20)) == 0);
+    }
+
+    [Fact]
+    public void CompareToObjectWithIntDelegatesToIntCompareTo()
+    {
+        DifficultyLevel a = DifficultyLevel.From(15);
+
+        Assert.True(a.CompareTo((object)20) < 0);
+        Assert.True(a.CompareTo((object)15) == 0);
+        Assert.True(a.CompareTo((object)10) > 0);
+    }
+
+    [Fact]
+    public void CompareToObjectReturnsZeroForUnrelatedTypes()
+    {
+        DifficultyLevel a = DifficultyLevel.From(15);
+
+        Assert.Equal(0, a.CompareTo((object)"15"));
+        Assert.Equal(0, a.CompareTo((object?)null));
+    }
+
+    // ---- ParseShortHand / TryParseShortHand / ToShorthand ----
+
+    [Theory]
+    [InlineData("S20", ChartType.Single, 20)]
+    [InlineData("D15", ChartType.Double, 15)]
+    [InlineData("CoOp3", ChartType.CoOp, 3)]
+    [InlineData("  S20  ", ChartType.Single, 20)] // regex tolerates whitespace
+    public void ParseShortHandReturnsChartTypeAndLevel(string input, ChartType expectedType, int expectedLevel)
+    {
+        var (type, level) = DifficultyLevel.ParseShortHand(input);
+
+        Assert.Equal(expectedType, type);
+        Assert.Equal(expectedLevel, (int)level);
+    }
+
+    [Theory]
+    [InlineData("not-a-shorthand")] // fails the regex entirely
+    [InlineData("12")]               // matches no letter group
+    [InlineData("")]                 // empty input
+    public void ParseShortHandThrowsForMalformedInput(string input)
+    {
+        Assert.Throws<InvalidDifficultyLevelException>(() => DifficultyLevel.ParseShortHand(input));
+    }
+
+    [Fact]
+    public void ParseShortHandThrowsWhenLevelIsOutOfRange()
+    {
+        // 30 is past Max; the regex matches but TryParse fails.
+        Assert.Throws<InvalidDifficultyLevelException>(() => DifficultyLevel.ParseShortHand("S30"));
+    }
+
+    [Fact]
+    public void TryParseShortHandReturnsTrueAndOutValuesOnSuccess()
+    {
+        var ok = DifficultyLevel.TryParseShortHand("D22", out var type, out var level);
+
+        Assert.True(ok);
+        Assert.Equal(ChartType.Double, type);
+        Assert.Equal(22, (int)level);
+    }
+
+    [Fact]
+    public void TryParseShortHandReturnsFalseAndDefaultsOnFailure()
+    {
+        var ok = DifficultyLevel.TryParseShortHand("garbage", out var type, out var level);
+
+        Assert.False(ok);
+        Assert.Equal(ChartType.Single, type);
+        Assert.Equal(1, (int)level);
+    }
+
+    [Theory]
+    [InlineData(ChartType.Single, 20, "S20")]
+    [InlineData(ChartType.Double, 15, "D15")]
+    [InlineData(ChartType.CoOp, 3, "CoOp3")]
+    public void ToShorthandFormatsChartTypeAndLevel(ChartType type, int level, string expected)
+    {
+        Assert.Equal(expected, DifficultyLevel.ToShorthand(type, DifficultyLevel.From(level)));
+    }
+
+    [Fact]
+    public void ToShorthandRoundTripsThroughParseShortHand()
+    {
+        var encoded = DifficultyLevel.ToShorthand(ChartType.Double, DifficultyLevel.From(22));
+        var (type, level) = DifficultyLevel.ParseShortHand(encoded);
+
+        Assert.Equal(ChartType.Double, type);
+        Assert.Equal(22, (int)level);
     }
 }

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/NameTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/NameTests.cs
@@ -31,4 +31,92 @@ public sealed class NameTests
         var lowerCase = Name.From(name.ToLower());
         Assert.Equal(upperCase, lowerCase);
     }
+
+    // ---- Implicit conversions ----
+
+    [Fact]
+    public void ImplicitConversionFromStringDelegatesToFrom()
+    {
+        Name name = "Hello";
+        Assert.Equal("Hello", (string)name);
+    }
+
+    [Fact]
+    public void ImplicitConversionFromEmptyStringThrows()
+    {
+        Assert.Throws<InvalidNameException>(() =>
+        {
+            Name name = "";
+        });
+    }
+
+    [Fact]
+    public void ImplicitConversionFromNullableStringReturnsNullForNullInput()
+    {
+        Name? name = (string?)null;
+        Assert.Null(name);
+    }
+
+    [Fact]
+    public void ImplicitConversionFromNullableStringReturnsValueForNonNullInput()
+    {
+        Name? name = (string?)"Hello";
+        Assert.NotNull(name);
+        Assert.Equal("Hello", (string)name!.Value);
+    }
+
+    [Fact]
+    public void ImplicitConversionToStringExposesUnderlyingName()
+    {
+        var name = Name.From("Hello");
+        string back = name;
+        Assert.Equal("Hello", back);
+    }
+
+    // ---- TryParse ----
+
+    [Fact]
+    public void TryParseReturnsTrueAndOutValueForValidInput()
+    {
+        Assert.True(Name.TryParse("Hello", out var result));
+        Assert.Equal("Hello", (string)result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryParseReturnsFalseForInvalidInput(string input)
+    {
+        Assert.False(Name.TryParse(input, out _));
+    }
+
+    // ---- Contains ----
+
+    [Fact]
+    public void ContainsReturnsTrueForCaseInsensitiveSubstring()
+    {
+        var name = Name.From("Hello World");
+
+        Assert.True(name.Contains("WORLD"));
+        Assert.True(name.Contains("hello"));
+        Assert.True(name.Contains("o W"));
+    }
+
+    [Fact]
+    public void ContainsReturnsFalseForNonMatchingSubstring()
+    {
+        var name = Name.From("Hello World");
+
+        Assert.False(name.Contains("Goodbye"));
+    }
+
+    // ---- CompareTo ----
+
+    [Fact]
+    public void CompareToOrdersAlphabeticallyIgnoringCase()
+    {
+        Assert.True(Name.From("apple").CompareTo(Name.From("Banana")) < 0);
+        Assert.True(Name.From("BANANA").CompareTo(Name.From("apple")) > 0);
+        Assert.Equal(0, Name.From("Same").CompareTo(Name.From("SAME")));
+    }
 }

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixTitleTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixTitleTests.cs
@@ -1,0 +1,58 @@
+using System;
+using ScoreTracker.Domain.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Models.Titles.Phoenix;
+using ScoreTracker.Domain.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class PhoenixTitleTests
+{
+    // PhoenixBasicTitle is the lightest concrete subclass and inherits all PhoenixTitle base
+    // behavior (default CompletionProgress and PopulatesFromDatabase) without overriding it.
+
+    [Fact]
+    public void DefaultCompletionProgressIsZero()
+    {
+        var title = new PhoenixBasicTitle(Name.From("Welcome"), "Welcome to Phoenix");
+        var chart = new ChartBuilder().WithLevel(20).Build();
+        var attempt = new RecordedPhoenixScore(Guid.NewGuid(), 990000, PhoenixPlate.PerfectGame, false,
+            DateTimeOffset.UtcNow);
+
+        Assert.Equal(0, title.CompletionProgress(chart, attempt));
+    }
+
+    [Fact]
+    public void DefaultPopulatesFromDatabaseIsTrue()
+    {
+        var title = new PhoenixBasicTitle(Name.From("Welcome"), "Welcome");
+
+        Assert.True(title.PopulatesFromDatabase);
+    }
+
+    [Fact]
+    public void TwoArgConstructorDefaultsCategoryToMisc()
+    {
+        var title = new PhoenixBasicTitle(Name.From("Welcome"), "Welcome");
+
+        Assert.Equal("Misc.", (string)title.Category);
+    }
+
+    [Fact]
+    public void ThreeArgConstructorAcceptsExplicitCategory()
+    {
+        var title = new PhoenixBasicTitle(Name.From("Welcome"), "Welcome", Name.From("Onboarding"));
+
+        Assert.Equal("Onboarding", (string)title.Category);
+    }
+
+    [Fact]
+    public void BasicTitleHasZeroCompletionRequired()
+    {
+        var title = new PhoenixBasicTitle(Name.From("Welcome"), "Welcome");
+
+        Assert.Equal(0, title.CompletionRequired);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/ValueTypeJsonConverterTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/ValueTypeJsonConverterTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using ScoreTracker.Domain.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+public sealed class ValueTypeJsonConverterTests
+{
+    private static JsonSerializerOptions OptionsFor(System.Text.Json.Serialization.JsonConverter converter)
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(converter);
+        return options;
+    }
+
+    // ---- Name ----
+
+    [Fact]
+    public void NameConverterRoundTripsAValidName()
+    {
+        var options = OptionsFor(Name.Converter);
+        var original = Name.From("Hello World");
+
+        var json = JsonSerializer.Serialize(original, options);
+        var roundTripped = JsonSerializer.Deserialize<Name>(json, options);
+
+        Assert.Equal("\"Hello World\"", json);
+        Assert.Equal(original, roundTripped);
+    }
+
+    [Fact]
+    public void NameConverterReadingEmptyStringThrows()
+    {
+        var options = OptionsFor(Name.Converter);
+        Assert.Throws<ScoreTracker.Domain.Exceptions.InvalidNameException>(
+            () => JsonSerializer.Deserialize<Name>("\"\"", options));
+    }
+
+    // ---- LevelBucket ----
+
+    [Fact]
+    public void LevelBucketConverterRoundTripsAValidBucket()
+    {
+        var options = OptionsFor(LevelBucket.Converter);
+        var original = LevelBucket.From("S20");
+
+        var json = JsonSerializer.Serialize(original, options);
+        var roundTripped = JsonSerializer.Deserialize<LevelBucket>(json, options);
+
+        Assert.Equal("\"S20\"", json);
+        Assert.Equal(original.ToString(), roundTripped.ToString());
+    }
+
+    // ---- PhoenixScore ----
+
+    [Fact]
+    public void PhoenixScoreConverterRoundTripsScoreAsInteger()
+    {
+        var options = OptionsFor(PhoenixScore.Converter);
+        var original = (PhoenixScore)950000;
+
+        var json = JsonSerializer.Serialize(original, options);
+        var roundTripped = JsonSerializer.Deserialize<PhoenixScore>(json, options);
+
+        Assert.Equal("950000", json);
+        Assert.Equal(original, roundTripped);
+    }
+
+    [Fact]
+    public void PhoenixScoreConverterRejectsScoresAboveMax()
+    {
+        var options = OptionsFor(PhoenixScore.Converter);
+        Assert.Throws<ScoreTracker.Domain.Exceptions.InvalidScoreException>(
+            () => JsonSerializer.Deserialize<PhoenixScore>("1500000", options));
+    }
+
+    // ---- Rating ----
+
+    [Fact]
+    public void RatingConverterRoundTripsRatingAsInteger()
+    {
+        var options = OptionsFor(Rating.Converter);
+        var original = (Rating)1234;
+
+        var json = JsonSerializer.Serialize(original, options);
+        var roundTripped = JsonSerializer.Deserialize<Rating>(json, options);
+
+        Assert.Equal("1234", json);
+        Assert.Equal(original, roundTripped);
+    }
+
+    [Fact]
+    public void RatingConverterRejectsNegativeRatings()
+    {
+        var options = OptionsFor(Rating.Converter);
+        Assert.Throws<ScoreTracker.Domain.Exceptions.InvalidScoreException>(
+            () => JsonSerializer.Deserialize<Rating>("-1", options));
+    }
+}


### PR DESCRIPTION
## Summary

Adds 46 unit tests in `DomainTests/` covering the Tier 3 priorities from the coverage report — the remaining sub-80% `Domain.ValueTypes` branches and the four JSON converters at 0%.

Final piece of the coverage work started in [#82](https://github.com/DrMurloc/PumpItUpScoreTracker/pull/82) and continued in [#83](https://github.com/DrMurloc/PumpItUpScoreTracker/pull/83).

## Tests added

| File | Count | Subject |
|---|---|---|
| `DifficultyLevelTests.cs` *(extended)* | +19 | `CompareTo(object)` for typed/int/unrelated; `ParseShortHand` success + throw paths (malformed regex, out-of-range level); `TryParseShortHand` success + failure defaults; `ToShorthand` formatting + round-trip via `ParseShortHand` |
| `BpmTests.cs` *(extended)* | +5 | Implicit `decimal → Bpm` (success + non-positive throws); implicit `string → Bpm` (single value, range, malformed throws) |
| `NameTests.cs` *(extended)* | +10 | Implicit `string → Name` (success + empty throws); nullable `string? → Name?` (null + non-null branches); implicit `Name → string`; `TryParse` success + failure; case-insensitive `Contains`; `CompareTo` |
| `ValueTypeJsonConverterTests.cs` | 7 | Round-trip JSON for `Name`, `LevelBucket`, `PhoenixScore`, `Rating` converters; reject paths for empty `Name`, out-of-range `PhoenixScore`, negative `Rating` |
| `PhoenixTitleTests.cs` | 5 | Default base-class `CompletionProgress = 0` and `PopulatesFromDatabase = true` (covered through `PhoenixBasicTitle`, which inherits both); two-arg ctor defaults `Category` to `"Misc."`; three-arg ctor accepts explicit category |

## Notes for the reviewer

- One behavior detail surfaced while writing the `ParseShortHand` tests: `ParseShortHand(\"Q15\")` throws `ArgumentException` (bubbled from [`ChartTypeHelperMethods.ParseChartTypeShortHand`](ScoreTracker/ScoreTracker.Domain/Enums/ChartType.cs:35)), not `InvalidDifficultyLevelException`. The wrapping is partial — only regex and level failures get the domain-exception treatment. `TryParseShortHand` catches everything so try-pattern consumers see uniform behavior. The `Theory` in `DifficultyLevelTests` intentionally only covers the `InvalidDifficultyLevelException` branches; flagged as a possible follow-up rather than fixed.
- 584/584 tests pass (up from the post-#83 baseline of 538); `dotnet build -c Release` clean.

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release`
- [x] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)