### PR TITLE
Run leaderboard import weekly instead of daily

### DIFF
--- a/ScoreTracker/ScoreTracker/Program.cs
+++ b/ScoreTracker/ScoreTracker/Program.cs
@@ -211,7 +211,7 @@ var recurringJobs = new (string Id, System.Linq.Expressions.Expression<Func<Recu
     ("update-weekly-charts",             r => r.PublishUpdateWeeklyCharts(),              "0 9 * * *"),  // 04:00 ET
     ("process-pass-tier-list",           r => r.PublishProcessPassTierList(),             "30 9 * * *"), // 04:30 ET
     ("calculate-chart-letter-difficulties", r => r.PublishCalculateChartLetterDifficulties(), "0 10 * * *"), // 05:00 ET
-    ("start-leaderboard-import",         r => r.PublishStartLeaderboardImport(),          "30 10 * * *") // 05:30 ET
+    ("start-leaderboard-import",         r => r.PublishStartLeaderboardImport(),          "30 10 * * 0") // Sundays 05:30 ET
 };
 if (builder.Configuration["PreventRecurringJobs"] == "true")
 {


### PR DESCRIPTION
## Summary

- Changes the `start-leaderboard-import` Hangfire recurring job from daily to weekly (Sundays 05:30 ET / 10:30 UTC) by changing the cron expression's day-of-week field from `*` to `0`.
- The import is heavier than the other recurring jobs and doesn't need to refresh daily.

## Notes for the reviewer

- One-character cron change in [Program.cs](ScoreTracker/ScoreTracker/Program.cs). No other behavior changes.
- Hangfire's `RecurringJob.AddOrUpdate` reconciles on next boot, so deploying this is enough — no manual cleanup of the existing daily registration needed.

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` (clean)
- [ ] After deploy, confirm the `start-leaderboard-import` entry in `/hangfire` shows the next fire time on the upcoming Sunday at 10:30 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)