### PR TITLE
Re-enable March of Murlocs with runaway-loop fix

### DIFF
--- a/ScoreTracker/ScoreTracker.Application/Handlers/MarchOfMurlocsHandler.cs
+++ b/ScoreTracker/ScoreTracker.Application/Handlers/MarchOfMurlocsHandler.cs
@@ -37,7 +37,13 @@ namespace ScoreTracker.Application.Handlers
 
         public async Task Consume(ConsumeContext<TryScheduleMoM> context)
         {
-            var mom = (await _tournaments.GetAllTournaments(context.CancellationToken)).FirstOrDefault(e => e.IsMoM);
+            // Pick the most recent MoM, not any-old-MoM. The previous FirstOrDefault was the
+            // root cause of the runaway: once any expired MoM existed, every TryScheduleMoM tick
+            // saw it and immediately fired CycleMoM, regardless of whether a current MoM was active.
+            var mom = (await _tournaments.GetAllTournaments(context.CancellationToken))
+                .Where(e => e.IsMoM)
+                .OrderByDescending(e => e.EndDate)
+                .FirstOrDefault();
             if (mom?.EndDate == null || mom.EndDate < _dateTime.Now)
                 await _bus.Publish(new CycleMoM());
             else
@@ -47,7 +53,15 @@ namespace ScoreTracker.Application.Handlers
 
         public async Task Consume(ConsumeContext<CycleMoM> context)
         {
-            var moms = (await _tournaments.GetAllTournaments(context.CancellationToken)).Where(e => e.IsMoM).ToArray();
+            var moms = (await _tournaments.GetAllTournaments(context.CancellationToken))
+                .Where(e => e.IsMoM)
+                .OrderByDescending(e => e.EndDate)
+                .ToArray();
+            // Idempotency: if a future-dated MoM already exists, this cycle has nothing to do.
+            // Protects against duplicate CycleMoM messages (in-memory transport replay, double-publish, etc.)
+            // landing back-to-back and creating extra tournaments.
+            if (moms.Any(m => m.EndDate != null && m.EndDate > _dateTime.Now))
+                return;
             var oldEnd = moms.FirstOrDefault()?.EndDate ?? _dateTime.Now - TimeSpan.FromMinutes(1);
             var year = _dateTime.Now.Year;
 

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/MarchOfMurlocsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/MarchOfMurlocsHandlerTests.cs
@@ -157,4 +157,67 @@ public sealed class MarchOfMurlocsHandlerTests
 
         Assert.Contains(savedRecords, r => r.Id == previousMoM.Id && !r.IsHighlighted);
     }
+
+    [Fact]
+    public async Task TrySchedulePostponesCycleWhenLatestMoMIsActiveEvenIfExpiredOldMoMExists()
+    {
+        // Regression: pre-fix, FirstOrDefault(IsMoM) could return an old expired MoM and trigger
+        // CycleMoM on every tick — the runaway that filled the DB with garbage tournaments. The
+        // handler must now pick the latest MoM by EndDate.
+        var tournaments = new Mock<ITournamentRepository>();
+        var charts = new Mock<IChartRepository>();
+        var bus = new Mock<IBus>();
+        var scheduler = new Mock<IMessageScheduler>();
+        var now = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+        var activeEnd = now + TimeSpan.FromDays(30);
+        var dateTime = FakeDateTime.At(now);
+
+        var expiredOld = MoM(now - TimeSpan.FromDays(365));
+        var active = MoM(activeEnd);
+        // Return the expired one first so an unordered FirstOrDefault would pick it.
+        tournaments.Setup(t => t.GetAllTournaments(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { expiredOld, active });
+
+        var handler = new MarchOfMurlocsHandler(tournaments.Object, charts.Object, bus.Object,
+            scheduler.Object, dateTime.Object);
+
+        await handler.Consume(ContextOf(new MarchOfMurlocsHandler.TryScheduleMoM()).Object);
+
+        bus.Verify(b => b.Publish(It.IsAny<MarchOfMurlocsHandler.CycleMoM>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        scheduler.Verify(s => s.SchedulePublish(
+                (activeEnd + TimeSpan.FromMinutes(1)).DateTime,
+                It.IsAny<MarchOfMurlocsHandler.CycleMoM>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CycleDoesNothingWhenFutureDatedMoMAlreadyExists()
+    {
+        // Idempotency: a duplicate CycleMoM (e.g. from in-memory transport replay or a double
+        // publish) must not create another pair of tournaments when one is already active.
+        var tournaments = new Mock<ITournamentRepository>();
+        var charts = new Mock<IChartRepository>();
+        var bus = new Mock<IBus>();
+        var scheduler = new Mock<IMessageScheduler>();
+        var now = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+        var dateTime = FakeDateTime.At(now);
+        var active = MoM(now + TimeSpan.FromDays(30));
+
+        tournaments.Setup(t => t.GetAllTournaments(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { active });
+
+        var handler = new MarchOfMurlocsHandler(tournaments.Object, charts.Object, bus.Object,
+            scheduler.Object, dateTime.Object);
+
+        await handler.Consume(ContextOf(new MarchOfMurlocsHandler.CycleMoM()).Object);
+
+        tournaments.Verify(t => t.CreateOrSaveTournament(It.IsAny<TournamentConfiguration>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        tournaments.Verify(t => t.CreateScoringLevelSnapshots(It.IsAny<Guid>(),
+                It.IsAny<IEnumerable<(Guid, double)>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/ScoreTracker/ScoreTracker/HostedServices/RecurringJobRunner.cs
+++ b/ScoreTracker/ScoreTracker/HostedServices/RecurringJobRunner.cs
@@ -1,4 +1,5 @@
 using MassTransit;
+using ScoreTracker.Application.Handlers;
 using ScoreTracker.Domain.Events;
 
 namespace ScoreTracker.Web.HostedServices;
@@ -32,4 +33,7 @@ public sealed class RecurringJobRunner
 
     public Task PublishStartLeaderboardImport() =>
         _bus.Publish(new StartLeaderboardImportEvent());
+
+    public Task PublishTryScheduleMoM() =>
+        _bus.Publish(new MarchOfMurlocsHandler.TryScheduleMoM());
 }

--- a/ScoreTracker/ScoreTracker/Program.cs
+++ b/ScoreTracker/ScoreTracker/Program.cs
@@ -211,7 +211,8 @@ var recurringJobs = new (string Id, System.Linq.Expressions.Expression<Func<Recu
     ("update-weekly-charts",             r => r.PublishUpdateWeeklyCharts(),              "0 9 * * *"),  // 04:00 ET
     ("process-pass-tier-list",           r => r.PublishProcessPassTierList(),             "30 9 * * *"), // 04:30 ET
     ("calculate-chart-letter-difficulties", r => r.PublishCalculateChartLetterDifficulties(), "0 10 * * *"), // 05:00 ET
-    ("start-leaderboard-import",         r => r.PublishStartLeaderboardImport(),          "30 10 * * 0") // Sundays 05:30 ET
+    ("start-leaderboard-import",         r => r.PublishStartLeaderboardImport(),          "30 10 * * 0"), // Sundays 05:30 ET
+    ("try-schedule-mom",                 r => r.PublishTryScheduleMoM(),                  "0 11 * * *")  // 06:00 ET
 };
 if (builder.Configuration["PreventRecurringJobs"] == "true")
 {


### PR DESCRIPTION
## Summary

Re-enables the March of Murlocs auto-cycling that was silently disabled during the .NET 10 upgrade after it filled the DB with garbage tournaments. Fixes the underlying handler bug, adds regression tests for the runaway scenario, and wires the trigger back up as a Hangfire recurring job.

## What was wrong

`MarchOfMurlocsHandler.Consume(TryScheduleMoM)` did:

```csharp
var mom = (await _tournaments.GetAllTournaments(...)).FirstOrDefault(e => e.IsMoM);
if (mom?.EndDate == null || mom.EndDate < _dateTime.Now)
    await _bus.Publish(new CycleMoM());
```

`FirstOrDefault(IsMoM)` returned *any* MoM — likely the oldest by insertion order. Once any MoM expired (which happens at the end of every season), every subsequent `TryScheduleMoM` tick found that expired record at the top of the list and immediately fired `CycleMoM`, regardless of whether an active MoM was already present. `CycleMoM` then created a fresh pair on every fire. With the trigger publishing on every daily reschedule and every app boot, the table accumulated quickly.

The existing tests didn't catch this — they only covered "no MoM" and "single ended MoM," never the "expired-old coexists with active-new" state that's the actual day-to-day reality.

## What changed

- **[MarchOfMurlocsHandler.cs](ScoreTracker/ScoreTracker.Application/Handlers/MarchOfMurlocsHandler.cs)**:
  - `TryScheduleMoM` now picks the latest MoM via `.OrderByDescending(EndDate).FirstOrDefault()` so it can't be tripped by ancient expired records.
  - `CycleMoM` early-returns when a future-dated MoM already exists (idempotency — protects against duplicate publishes from in-memory transport replay or repeated Hangfire fires while a previous one is still in flight).
- **[MarchOfMurlocsHandlerTests.cs](ScoreTracker/ScoreTracker.Tests/ApplicationTests/MarchOfMurlocsHandlerTests.cs)**: two new tests covering both fixes — `TrySchedulePostponesCycleWhenLatestMoMIsActiveEvenIfExpiredOldMoMExists` (the runaway regression) and `CycleDoesNothingWhenFutureDatedMoMAlreadyExists` (idempotency).
- **[RecurringJobRunner.cs](ScoreTracker/ScoreTracker/HostedServices/RecurringJobRunner.cs)**: new `PublishTryScheduleMoM()` method, same one-line shape as the others.
- **[Program.cs](ScoreTracker/ScoreTracker/Program.cs)**: registers `try-schedule-mom` at `0 11 * * *` UTC (06:00 ET) — outside the 02:00–05:30 batch window so it doesn't pile onto the heavy nightly jobs.

## Notes for the reviewer

- I left `IsMoM` flag on old tournaments unchanged — the [MarchOfMurlocs.razor](ScoreTracker/ScoreTracker/Pages/Competition/MarchOfMurlocs.razor) page filters by `IsMoM = true` to populate the "Previous Tournaments" section, so flipping it would erase history from the UI. The fix doesn't need it; bounding the candidate set via `OrderByDescending(EndDate)` is enough.
- The page still calls `GetAllTournamentsQuery` and filters client-side. A `GetMoMs()` repo port would be a nice follow-up for performance but isn't blocking re-enable now that the garbage data has been purged.
- Garbage data was already cleaned up out-of-band, per chat.

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` (clean)
- [x] `dotnet test` (586/586 pass — 4 existing MoM tests + 2 new regression tests + the rest of the suite)
- [ ] After deploy, confirm `try-schedule-mom` shows up in `/hangfire` → Recurring Jobs with next-fire ~06:00 ET tomorrow.
- [ ] "Trigger now" once from the dashboard; verify on `/Tournaments/MarchOfMurlocs`:
  - if no active MoM exists: a Singles + Doubles pair appears for the upcoming season;
  - if an active MoM already exists: nothing changes (idempotency).
- [ ] Trigger a second time within minutes; verify *no* duplicate tournaments are created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)