### PR TITLE
Add user-initiated score wipe from Account Settings

### DIFF
--- a/ScoreTracker/ScoreTracker.Application/Commands/WipeUserScoresCommand.cs
+++ b/ScoreTracker/ScoreTracker.Application/Commands/WipeUserScoresCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace ScoreTracker.Application.Commands;
+
+[ExcludeFromCodeCoverage]
+public sealed record WipeUserScoresCommand(Guid UserId, bool IncludeHistory) : IRequest
+{
+}

--- a/ScoreTracker/ScoreTracker.Application/Handlers/WipeUserScoresHandler.cs
+++ b/ScoreTracker/ScoreTracker.Application/Handlers/WipeUserScoresHandler.cs
@@ -1,0 +1,46 @@
+using MassTransit;
+using MediatR;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.SecondaryPorts;
+
+namespace ScoreTracker.Application.Handlers;
+
+public sealed class WipeUserScoresHandler : IRequestHandler<WipeUserScoresCommand>
+{
+    private readonly IPhoenixRecordRepository _phoenixScores;
+    private readonly IXXChartAttemptRepository _xxScores;
+    private readonly IPlayerStatsRepository _playerStats;
+    private readonly ITitleRepository _titles;
+    private readonly IPlayerHistoryRepository _playerHistory;
+    private readonly IBus _bus;
+
+    public WipeUserScoresHandler(IPhoenixRecordRepository phoenixScores,
+        IXXChartAttemptRepository xxScores,
+        IPlayerStatsRepository playerStats,
+        ITitleRepository titles,
+        IPlayerHistoryRepository playerHistory,
+        IBus bus)
+    {
+        _phoenixScores = phoenixScores;
+        _xxScores = xxScores;
+        _playerStats = playerStats;
+        _titles = titles;
+        _playerHistory = playerHistory;
+        _bus = bus;
+    }
+
+    public async Task Handle(WipeUserScoresCommand request, CancellationToken cancellationToken)
+    {
+        await _phoenixScores.DeleteAllForUser(request.UserId, cancellationToken);
+        await _xxScores.DeleteAllForUser(request.UserId, cancellationToken);
+        await _playerStats.DeleteStats(request.UserId, cancellationToken);
+        await _titles.DeleteHighestTitle(request.UserId, cancellationToken);
+        if (request.IncludeHistory)
+            await _playerHistory.DeleteHistoryForUser(request.UserId, cancellationToken);
+
+        await _bus.Publish(
+            new PlayerScoreUpdatedEvent(request.UserId, Array.Empty<Guid>(), new Dictionary<Guid, int>()),
+            cancellationToken);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Data/Repositories/EFPhoenixRecordsRepository.cs
+++ b/ScoreTracker/ScoreTracker.Data/Repositories/EFPhoenixRecordsRepository.cs
@@ -348,4 +348,15 @@ public sealed class EFPhoenixRecordsRepository : IPhoenixRecordRepository,
                 (int)g.Average(e => e.pr.Score ?? 0),
                 g.Sum(e => e.prs.Pumbility), g.Sum(e => e.prs.PumbilityPlus))).ToArrayAsync(cancellationToken);
     }
+
+    public async Task DeleteAllForUser(Guid userId, CancellationToken cancellationToken = default)
+    {
+        await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+        var scores = await database.PhoenixBestAttempt.Where(p => p.UserId == userId).ToArrayAsync(cancellationToken);
+        var stats = await database.PhoenixRecordStats.Where(p => p.UserId == userId).ToArrayAsync(cancellationToken);
+        database.PhoenixBestAttempt.RemoveRange(scores);
+        database.PhoenixRecordStats.RemoveRange(stats);
+        await database.SaveChangesAsync(cancellationToken);
+        _cache.Remove(ScoreCache(userId));
+    }
 }

--- a/ScoreTracker/ScoreTracker.Data/Repositories/EFPlayerHistoryRepository.cs
+++ b/ScoreTracker/ScoreTracker.Data/Repositories/EFPlayerHistoryRepository.cs
@@ -37,5 +37,13 @@ namespace ScoreTracker.Data.Repositories
                 .Select(r => new PlayerRatingRecord(r.UserId, r.Date, r.CompetitiveLevel, r.SinglesLevel,
                     r.DoublesLevel, r.CoOpRating, r.PassCount)).ToArrayAsync(cancellationToken);
         }
+
+        public async Task DeleteHistoryForUser(Guid userId, CancellationToken cancellationToken)
+        {
+            await using var database = await factory.CreateDbContextAsync(cancellationToken);
+            var entries = await database.PlayerHistory.Where(r => r.UserId == userId).ToArrayAsync(cancellationToken);
+            database.PlayerHistory.RemoveRange(entries);
+            await database.SaveChangesAsync(cancellationToken);
+        }
     }
 }

--- a/ScoreTracker/ScoreTracker.Data/Repositories/EFPlayerStatsRepository.cs
+++ b/ScoreTracker/ScoreTracker.Data/Repositories/EFPlayerStatsRepository.cs
@@ -138,5 +138,18 @@ namespace ScoreTracker.Data.Repositories
         {
             return await GetStats(request.UserId, cancellationToken);
         }
+
+        public async Task DeleteStats(Guid userId, CancellationToken cancellationToken)
+        {
+            await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+            var entity = await database.PlayerStats.FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken);
+            if (entity != null)
+            {
+                database.PlayerStats.Remove(entity);
+                await database.SaveChangesAsync(cancellationToken);
+            }
+
+            _cache.Remove(CacheKey(userId));
+        }
     }
 }

--- a/ScoreTracker/ScoreTracker.Data/Repositories/EFTitleRepository.cs
+++ b/ScoreTracker/ScoreTracker.Data/Repositories/EFTitleRepository.cs
@@ -126,5 +126,20 @@ namespace ScoreTracker.Data.Repositories
                     new TitleAchievedRecord(u.UserId, title, Enum.Parse<ParagonLevel>(u.ParagonLevel)))
                 .ToArrayAsync(cancellationToken);
         }
+
+        public async Task DeleteHighestTitle(Guid userId, CancellationToken cancellationToken)
+        {
+            await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+            var entity =
+                await database.UserHighestTitle.FirstOrDefaultAsync(u => u.UserId == userId, cancellationToken);
+            if (entity != null)
+            {
+                database.UserHighestTitle.Remove(entity);
+                await database.SaveChangesAsync(cancellationToken);
+            }
+
+            _cache.Remove(CacheKey);
+            _cache.Remove(CacheKey + "__UserCount");
+        }
     }
 }

--- a/ScoreTracker/ScoreTracker.Data/Repositories/EFXXChartAttemptRepository.cs
+++ b/ScoreTracker/ScoreTracker.Data/Repositories/EFXXChartAttemptRepository.cs
@@ -129,4 +129,12 @@ public sealed class EFXXChartAttemptRepository : IXXChartAttemptRepository
                             ba.RecordedDate)))
             .ToArrayAsync(cancellationToken);
     }
+
+    public async Task DeleteAllForUser(Guid userId, CancellationToken cancellationToken = default)
+    {
+        await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+        var attempts = await database.BestAttempt.Where(b => b.UserId == userId).ToArrayAsync(cancellationToken);
+        database.BestAttempt.RemoveRange(attempts);
+        await database.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPhoenixRecordRepository.cs
+++ b/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPhoenixRecordRepository.cs
@@ -49,4 +49,6 @@ public interface IPhoenixRecordRepository
 
     Task<int> GetClearCount(Guid userId, ChartType chartType, DifficultyLevel level,
         CancellationToken cancellationToken = default);
+
+    Task DeleteAllForUser(Guid userId, CancellationToken cancellationToken = default);
 }

--- a/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPlayerHistoryRepository.cs
+++ b/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPlayerHistoryRepository.cs
@@ -5,4 +5,5 @@ namespace ScoreTracker.Domain.SecondaryPorts;
 public interface IPlayerHistoryRepository
 {
     Task WriteHistory(PlayerRatingRecord record, CancellationToken cancellationToken);
+    Task DeleteHistoryForUser(Guid userId, CancellationToken cancellationToken);
 }

--- a/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPlayerStatsRepository.cs
+++ b/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPlayerStatsRepository.cs
@@ -11,4 +11,6 @@ public interface IPlayerStatsRepository
 
     Task<IEnumerable<Guid>> GetPlayersByCompetitiveRange(ChartType? chartType, double competitiveLevel, double range,
         CancellationToken cancellationToken);
+
+    Task DeleteStats(Guid userId, CancellationToken cancellationToken);
 }

--- a/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/ITitleRepository.cs
+++ b/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/ITitleRepository.cs
@@ -16,5 +16,7 @@ namespace ScoreTracker.Domain.SecondaryPorts
         Task<IEnumerable<TitleAggregationRecord>> GetTitleAggregations(CancellationToken cancellationToken);
         Task<int> CountTitledUsers(CancellationToken cancellationToken);
         Task<IEnumerable<TitleAchievedRecord>> GetUsersWithTitle(Name title, CancellationToken cancellationToken);
+
+        Task DeleteHighestTitle(Guid userId, CancellationToken cancellationToken);
     }
 }

--- a/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IXXChartAttemptRepository.cs
+++ b/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IXXChartAttemptRepository.cs
@@ -14,4 +14,6 @@ public interface IXXChartAttemptRepository
         CancellationToken cancellationToken);
 
     Task<IEnumerable<BestXXChartAttempt>> GetBestAttempts(Guid userId, CancellationToken cancellationToken = default);
+
+    Task DeleteAllForUser(Guid userId, CancellationToken cancellationToken = default);
 }

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/WipeUserScoresHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/WipeUserScoresHandlerTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Moq;
+using ScoreTracker.Application.Commands;
+using ScoreTracker.Application.Handlers;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.SecondaryPorts;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+public sealed class WipeUserScoresHandlerTests
+{
+    private static (WipeUserScoresHandler handler,
+        Mock<IPhoenixRecordRepository> phoenix,
+        Mock<IXXChartAttemptRepository> xx,
+        Mock<IPlayerStatsRepository> stats,
+        Mock<ITitleRepository> titles,
+        Mock<IPlayerHistoryRepository> history,
+        Mock<IBus> bus) BuildHandler()
+    {
+        var phoenix = new Mock<IPhoenixRecordRepository>();
+        var xx = new Mock<IXXChartAttemptRepository>();
+        var stats = new Mock<IPlayerStatsRepository>();
+        var titles = new Mock<ITitleRepository>();
+        var history = new Mock<IPlayerHistoryRepository>();
+        var bus = new Mock<IBus>();
+        var handler = new WipeUserScoresHandler(phoenix.Object, xx.Object, stats.Object, titles.Object, history.Object,
+            bus.Object);
+        return (handler, phoenix, xx, stats, titles, history, bus);
+    }
+
+    [Fact]
+    public async Task DeletesScoresStatsTitlesAndPublishesRecomputeEventWhenHistoryNotIncluded()
+    {
+        var (handler, phoenix, xx, stats, titles, history, bus) = BuildHandler();
+        var userId = Guid.NewGuid();
+
+        await handler.Handle(new WipeUserScoresCommand(userId, false), CancellationToken.None);
+
+        phoenix.Verify(p => p.DeleteAllForUser(userId, It.IsAny<CancellationToken>()), Times.Once);
+        xx.Verify(p => p.DeleteAllForUser(userId, It.IsAny<CancellationToken>()), Times.Once);
+        stats.Verify(p => p.DeleteStats(userId, It.IsAny<CancellationToken>()), Times.Once);
+        titles.Verify(p => p.DeleteHighestTitle(userId, It.IsAny<CancellationToken>()), Times.Once);
+        history.Verify(p => p.DeleteHistoryForUser(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        bus.Verify(
+            b => b.Publish(
+                It.Is<PlayerScoreUpdatedEvent>(e =>
+                    e.UserId == userId && e.NewChartIds.Length == 0 && e.UpscoredChartIds.Count == 0),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AlsoDeletesPlayerHistoryWhenHistoryIncluded()
+    {
+        var (handler, _, _, _, _, history, _) = BuildHandler();
+        var userId = Guid.NewGuid();
+
+        await handler.Handle(new WipeUserScoresCommand(userId, true), CancellationToken.None);
+
+        history.Verify(p => p.DeleteHistoryForUser(userId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker/Pages/Account.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Account.razor
@@ -80,7 +80,8 @@
         <MudButton Icon="@Icons.Material.Filled.Download" Variant="Variant.Filled" Color="Color.Primary" OnClick="DownloadScores">@L["Download Scores"]</MudButton>
         <MudButton Href="/UploadXXScores" Icon="@Icons.Material.Filled.UploadFile" Variant="Variant.Filled" Color="Color.Primary">@L["Upload XX Scores"]</MudButton>
         <MudButton Href="/UploadPhoenixScores" Icon="@Icons.Material.Filled.UploadFile" Variant="Variant.Filled" Color="Color.Primary">@L["Import Phoenix Scores"]</MudButton>
-        
+        <MudButton Icon="@Icons.Material.Filled.DeleteForever" Variant="Variant.Filled" Color="Color.Error" OnClick="OpenWipeDialog">@L["Delete All Scores"]</MudButton>
+
         <MudButton Href="/Logout" Icon="@Icons.Material.Filled.Logout" Variant="Variant.Filled" Color="Color.Primary">@L["Logout"]</MudButton>
     </MudCardActions>
 </MudCard>
@@ -90,7 +91,7 @@
         @if (_isPublic)
         {
             <MudText>@L["Make Not Public Disclaimer"]</MudText>
-            
+
         }
         else
         {
@@ -110,6 +111,31 @@
     </DialogActions>
 </MudDialog>
 
+<MudDialog @bind-Visible="_showWipeScoresDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">@L["Delete All Scores"]</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudCheckBox T="bool" @bind-Value="_wipeAcknowledged" Color="Color.Error" Disabled="_isWiping">
+            @L["This will delete all of your scores and reset your player stats and title progress"]
+        </MudCheckBox>
+        <MudCheckBox T="bool" @bind-Value="_wipeIncludeHistory" Color="Color.Error" Disabled="_isWiping">
+            @L["(Optional) Also delete historical data"]
+        </MudCheckBox>
+    </DialogContent>
+    <DialogActions>
+        <MudSpacer></MudSpacer>
+        <MudButton Variant="Variant.Text"
+                   OnClick="CancelWipeDialog"
+                   Disabled="_isWiping"
+                   Color="Color.Primary">@L["Cancel"]</MudButton>
+        <MudButton Variant="Variant.Filled"
+                   OnClick="ConfirmWipeScores"
+                   Disabled="@(!_wipeAcknowledged || _isWiping)"
+                   Color="Color.Error">@L["Confirm"]</MudButton>
+    </DialogActions>
+</MudDialog>
+
 @inject NavigationManager NavManager
 @inject ICurrentUserAccessor CurrentUser;
 @inject IMediator Mediator;
@@ -125,6 +151,10 @@
     private bool _isPublic = false;
     private bool _isContentLocked = false;
     private bool _showPublicConfirmDialog = false;
+    private bool _showWipeScoresDialog = false;
+    private bool _wipeAcknowledged = false;
+    private bool _wipeIncludeHistory = false;
+    private bool _isWiping = false;
     private bool _isUpdatingUser = false;
     private IEnumerable<CountryRecord> _countries = Array.Empty<CountryRecord>();
     private string _countryName = null;
@@ -220,6 +250,33 @@
         else
         {
             Snackbar.Add("Invalid Name",Severity.Error);
+        }
+    }
+
+    private void OpenWipeDialog()
+    {
+        _wipeAcknowledged = false;
+        _wipeIncludeHistory = false;
+        _showWipeScoresDialog = true;
+    }
+
+    private void CancelWipeDialog()
+    {
+        _showWipeScoresDialog = false;
+    }
+
+    private async Task ConfirmWipeScores()
+    {
+        _isWiping = true;
+        try
+        {
+            await Mediator.Send(new WipeUserScoresCommand(CurrentUser.User.Id, _wipeIncludeHistory));
+            Snackbar.Add(L["Your scores have been deleted"], Severity.Success);
+            _showWipeScoresDialog = false;
+        }
+        finally
+        {
+            _isWiping = false;
         }
     }
 

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -1987,4 +1987,19 @@
   <data name="Your account is content-locked. Message an admin if you have questions." xml:space="preserve">
 	  <value>Your account is content-locked. Message an admin if you have questions.</value>
   </data>
+  <data name="Delete All Scores" xml:space="preserve">
+	  <value>Delete All Scores</value>
+  </data>
+  <data name="This will delete all of your scores and reset your player stats and title progress" xml:space="preserve">
+	  <value>This will delete all of your scores and reset your player stats and title progress</value>
+  </data>
+  <data name="(Optional) Also delete historical data" xml:space="preserve">
+	  <value>(Optional) Also delete historical data</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+	  <value>Confirm</value>
+  </data>
+  <data name="Your scores have been deleted" xml:space="preserve">
+	  <value>Your scores have been deleted</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1938,4 +1938,19 @@
   <data name="Your account is content-locked. Message an admin if you have questions." xml:space="preserve">
     <value>Sua conta está com bloqueio de conteúdo. Envie uma mensagem a um administrador em caso de dúvidas.</value>
   </data>
+  <data name="Delete All Scores" xml:space="preserve">
+    <value>Excluir Todas as Pontuações</value>
+  </data>
+  <data name="This will delete all of your scores and reset your player stats and title progress" xml:space="preserve">
+    <value>Isso excluirá todas as suas pontuações e redefinirá suas estatísticas de jogador e progresso de títulos</value>
+  </data>
+  <data name="(Optional) Also delete historical data" xml:space="preserve">
+    <value>(Opcional) Também excluir dados históricos</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirmar</value>
+  </data>
+  <data name="Your scores have been deleted" xml:space="preserve">
+    <value>Suas pontuações foram excluídas</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- New "Delete All Scores" button + confirmation dialog on the Account page. Required-acknowledgement checkbox gates the Confirm button; optional second checkbox extends the wipe to player history.
- Wipes `PhoenixBestAttempt`, `PhoenixRecordStats`, `BestAttempt` (XX), `PlayerStats`, and `UserHighestTitle` for the current user; with the optional checkbox, also `PlayerHistory`. `UserTitle` rows are cleared automatically by the existing `TitleSaga` when the post-wipe `PlayerScoreUpdatedEvent` fires (`SaveTitles([])` reconciles to empty). The same event triggers `PlayerRatingSaga.RecalculateStats` to re-save zeroed `PlayerStats`. Cache eviction is included in the Phoenix-score and player-stats repos so the recompute reads fresh data.

## Test plan
- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` clean (0 errors)
- [x] `dotnet test` — 599 pass / 0 fail (2 new `WipeUserScoresHandlerTests`)
- [ ] Manually verify in browser: button renders red, dialog opens, Confirm disabled until required checkbox ticked, snackbar fires on success, scores/stats/titles clear in UI
- [ ] Manually verify with `Also delete historical data` ticked, the player history graph empties

🤖 Generated with [Claude Code](https://claude.com/claude-code)