### PR TITLE
Add Japanese (ja-JP) localization

### DIFF
--- a/LOCALIZATION-ja-JP.md
+++ b/LOCALIZATION-ja-JP.md
@@ -1,0 +1,205 @@
+# ja-JP localization glossary
+
+Working reference for translating `App.en-US.resx` into `App.ja-JP.resx`. Captures the conventions established by nabulator's seed translations (PR #44) and the machine-translation sweep that followed (PR #90), plus the deviations and known-bad strings a future native-speaker pass should clean up.
+
+For the localization mechanism itself (resx layout, `L["..."]` usage, key conventions), see [ARCHITECTURE.md](ARCHITECTURE.md#cross-cutting-concerns). For PIU domain terms in English, see [DOMAIN.md](DOMAIN.md). For the parallel pt-BR conventions, see [LOCALIZATION-pt-BR.md](LOCALIZATION-pt-BR.md).
+
+## Style conventions
+
+- **Polite register (です／ます).** ~60 entries use `〜ます／〜ません／〜です／〜ください`; only a handful of older nabulator strings drop into plain form (`変更できる`, `ロールバック出来ません` — see Known issues). New translations should be polite throughout. Avoid keigo (尊敬語/謙譲語) except in the few stock phrases that already use it (`ご連絡ください`).
+- **Sentence case is not a thing in Japanese.** Ignore the en-US Title Case in keys; values just use natural Japanese without capitalization rules. (English brand names embedded mid-sentence — `Phoenix`, `PIU`, `Score Tracker`, `XX`, `Discord` — keep their original casing.)
+- **Punctuation is full-width.** Established split: `（）` not `()`, `：` not `:`, `。` not `.` for sentence-final periods, `、` not `,` for in-sentence commas. Counts in the current resx: 31 full-width parens vs 3 half-width; 22 full-width `：` vs 2 half-width. Stay consistent.
+- **Numerals are half-width** except in three legacy nabulator strings (`１レベル`, `１－４ポイント`). New translations use `1`, `2`, `10`, etc. Don't introduce more full-width numerals.
+- **Preserve positional placeholders verbatim.** `{0}`, `{1}` go into the value untouched, in whatever order Japanese grammar wants. Example: key `Welcome to Score Tracker, X!` → value `Score Trackerへようこそ、{0}さん！`. The `さん` honorific suffix is appended after `{0}` because the placeholder is a name.
+- **Skip prose with inline markup.** Per CLAUDE.md, `<MudText>` bodies with embedded `<MudLink>`/other elements stay hardcoded English. Don't extract them, don't translate them.
+- **No `〜だ／である` written-style endings.** The app's voice is conversational-polite, not formal-written.
+
+## Established term mappings
+
+These have at least one existing translation in `App.ja-JP.resx`. New translations of the same term must reuse the established form unless there's a documented reason to change it.
+
+### App / generic UI
+
+| English | ja-JP | Notes |
+|---|---|---|
+| Score Tracker (the app) | Score Tracker | Brand name, kept English. Used inside Japanese sentences as-is. |
+| Account | アカウント | |
+| About | 概要 | "About The Site" → このサイトについて. |
+| Actions | 操作 | |
+| Add | 追加 | Suru-verb usage: `〜追加` for noun, `〜を追加` for verb objects. |
+| Average | 平均 | |
+| Cancel | キャンセル | |
+| Close | 閉じる | |
+| Confirm | 確認 | Also used for "Verification". |
+| Completed | 完了 | Used for "Done" too. |
+| Copy | コピー | "Copy Script" / "Copy to Clipboard" both → コピー. |
+| Country | Country | **Untranslated** in nabulator's seed. See Known issues. |
+| Create | 作成 | |
+| Default | デフォルト | |
+| Delete | 削除 | |
+| Description | 説明 | |
+| Difficulty | 難度 / 難しさ | Both forms appear; 難度 is preferred for compounds (`平均難度`, `難度カテゴリー分類`), 難しさ for the bare-level concept (`難しさレベル`). |
+| Done | 完了 | |
+| Download | ダウンロード | |
+| Easy / Hard | 簡単 / 難しい | Plain adjective forms. |
+| Easiest / Hardest Player | 下級プレーヤー / 上級プレーヤー | Note: rendered as "low-rank/high-rank" rather than literal -est. |
+| Edit | 編集 | |
+| Hide | 隠す | |
+| Home | ホームページ | |
+| Image | 画像 | "Upload Image" → 画像アップロード. |
+| Language | 言語 | |
+| Last Updated | 最近更新 | |
+| Login | ログイン | |
+| Logout | ログアウト | |
+| Make Public / Private | 公開する / 非公開する | |
+| Max / Min | 最大 / 最小 | "Max Level" → 最大レベル, "Min Score" → 最低スコア (注: 最低 is also used for ranges with a floor like Min BPM → 最低BPM). |
+| Median | 中央値 | |
+| Medium | 中 | |
+| Name | 名前 | |
+| Next | 次の | "Next Letter" → 次のランク. |
+| Open | Open | **Untranslated** in nabulator's seed. See Known issues. |
+| Page | ページ | "Starting Page" → 再開のページ, "Ending Page" → 最後のページ. |
+| Pending | 未決定 | |
+| Permissions | 権限 | |
+| Place (rank, "1st place") | 場所 | |
+| Public / Private | 公開 / 非公開 | |
+| Reason | 理由 | |
+| Recorded Date | 記録日 | |
+| Recorded On X | {0}にき記録した | nabulator. Note "き" appears to be a typo before 記録した. |
+| Restart | 再起動 | |
+| Rules | 規則 | |
+| Save | 保存 | |
+| Search | 捜索 / 検索 | nabulator uses 捜索 ("Official Leaderboard Search" → 公開ランキング捜索); newer entries use 検索 ("Search User" → ユーザー検索). Pick one going forward — 検索 is the more common UI word. |
+| Settings | 設定 | "Admin Settings" → 管理設定, "Extra Settings" → 追加設定. |
+| Show | 表示 | "Show Age" → 歳表示, "Show Difficulty" → 難度表示. Suffix pattern. |
+| Source | 出典 | |
+| Source Code | ソースコード | |
+| Start | 開始 | "Start Date" → 開始日, "Starting Life" → 開始体力. |
+| Stats / Statistics | 統計 | "Player Stats" → 進捗中の譜面 (note: nabulator interpreted this as in-progress charts, not literal stats — see Known issues). "Game Stats" → ゲーム統計. |
+| Submit | 登録 | Also used for "Submission". |
+| Tag(s) | タグ | |
+| Title (in-game title award) | タイトル | "Title Progress" → タイトル進捗, "Titles" → タイトル. |
+| To Do | やりこと | **Typo** of やること. See Known issues. |
+| Tools | ツルー | **Typo** of ツール. See Known issues. |
+| Total | 総計 | |
+| Type | 種類 | "Chart Type" → 譜面タイプ (Type rendered as タイプ here, but as 種類 elsewhere — context-dependent). |
+| Ungraded / Not Graded | 未ランク / 未ランク数 | |
+| Unknown | 不明 | |
+| Update | 更新 | "Upload Scores" → スコア更新 (so 更新 doubles for "upload" in some contexts — see Upload below). |
+| Upload | アップロード or 更新 | Inconsistent. "Upload Image" → 画像アップロード; "Upload Scores" → スコア更新; "アップロード" appears in disclaimers. Lean on context, prefer アップロード for new entries. |
+| Username | ユーザ名 / ユーザー名 | nabulator uses ユーザ (no 長音); newer entries use ユーザー (with 長音). Inconsistent — see Known issues. |
+| Validation | 確認 | |
+| Very Easy / Very Hard | とても簡単 / とても難しい | |
+| Video | ビデオ | "Video URL" → ビデオURL, "Open Video" → ビデオリンク開く. |
+| Welcome | ようこそ | "Welcome to Score Tracker, X!" → Score Trackerへようこそ、{0}さん！ (placeholder takes さん). |
+
+### PIU domain
+
+| English | ja-JP | Notes |
+|---|---|---|
+| Chart(s) | 譜面 | nabulator's choice — translated, not loanword. Used compositionally: 譜面リスト, 譜面タイプ, 譜面作者, 譜面くじ引き, 譜面残り, 譜面比較. **Don't switch to チャート mid-file.** |
+| CoOp | CoOp | Untranslated. "CoOp Aggregation" → CoOp集合 (see Known issues — 集合 is "set", not "aggregate"). |
+| Co-Op | Co-Op | Distinct from "CoOp" — used as a select-item label on /WeeklyCharts. Both spellings appear in source verbatim. |
+| Singles / Doubles | Singles / Doubles | Untranslated. "Singles Level" → Singlesレベル, "Doubles Level" → Doublesレベル. |
+| Difficulty Level | 難しさレベル | |
+| Letter Grade | ランク | Loanword, katakana. "Min/Max Letter Grade" → 最低/最高ランク. "Next Letter" → 次のランク. |
+| Letter Difficulty | ランク難度 | |
+| Mix | ベーション | **Typo** of バージョン. See Known issues. |
+| Phoenix / XX | Phoenix / XX | Game versions, untranslated proper nouns. "Phoenix Score Calculator" → Phoenixスコア計算; "Upload XX Scores" → XXスコア更新. |
+| Plate | プレート | Loanword, katakana. (Compare pt-BR which keeps it English.) |
+| Pass (verb / noun for clearing a chart) | クリア | Semantic translation. "Hide Completed Charts" → 完了譜面隠す (uses 完了 for "completed"); "Passed Count" → クリア数; "Not Passed" → 未クリア数; "Stage Pass" → Stageクリア (Stage left English mid-word). |
+| Score (singular) | スコア | "Score" → スコア, "Score State" → スコア状態, "My Score" → 自己スコア. |
+| Scores (plural / collection) | スコア | Same word — Japanese doesn't grammatically distinguish. |
+| Score (Data Backed) | スコア(データあり) | Half-width parens here are nabulator's choice — note inconsistency with the full-width-parens convention. |
+| Note Count | ノーツ数 | "Min/Max Note Count" → 最低/最高ノーツ数. "Notes" → ノーツ. |
+| Step Artist | 譜面作者 | "Step Artist: X" → 譜面作者：{0}. |
+| BPM | BPM | Untranslated. "Min/Max BPM" → 最低/最高BPM. |
+| Tier List | ティアリスト | Loanword, katakana. "PIU Tier List" → PIUティアリスト, "Calculated Tier List" → 計算ティアリスト. |
+| Leaderboard | ランキング | Loanword. "World Rankings" → 世界ランキング, "UCS Leaderboard" → UCSランキング, "Bounty Leaderboard" → バウンティランキング, "Monthly Leaderboard" → 月間ランキング, "Score Rankings" → スコアランキング. |
+| Communities | 地域ランキング | nabulator's choice — literally "regional rankings". Loses some social/community meaning. See Known issues. |
+| Bounty / Bounties | バウンティ | Loanword. "Bounty Leaderboard" → バウンティランキング. |
+| UCS | UCS | Untranslated acronym. "Add UCS" → UCS追加, "UCS Leaderboard" → UCSランキング. |
+| Player | プレーヤー | Long-vowel ー retained (not プレイヤー). |
+| Players | プレーヤー達 | nabulator added the 達 plural marker. Slightly unusual for game UI; see Known issues. |
+| Player Count | プレーヤー数 | Drops 達 in compounds. |
+| Player Level | プレーヤーレベル | |
+| Tournament(s) | 大会 | "Tournament" → 大会, "Tournament Name" → 大会名, "Tournament Settings" → 大会設定. |
+| Qualifiers | 資格 | "{0} Qualifiers Leaderboard" → {0}資格ランキング. |
+| Rating | 評定 | "Max Rating" → 最高評定, "Rating Calculator" → 評定の計算. |
+| Pumbility | (none) | Not yet translated; no current entries. Recommend leaving as `Pumbility` (loanword for proper-noun rating system). |
+| Phoenix Score Calculator | Phoenixスコア計算 | |
+| Score Loss | {0}スコア低下 | (in the X-form key "X Score Loss") |
+| Song | 曲 | "Song Name" → 曲名, "Song Artist" → アーティスト, "Song Duration" → 曲時間, "Song Type" → 曲種類, "Song Image" → 曲画像. |
+| Avatar | アバター | |
+| Favorites | お気に入り / 気に入れ | "Add to Favorites" → お気に入りを追加 (canonical); "Favorites" bare → 気に入れ (nabulator, slightly off). Prefer お気に入り for new entries. |
+| Weekly Charts | 週間譜面 | |
+
+### Game-mechanic vocabulary (PIU Life Calculator etc.)
+
+| English | ja-JP | Notes |
+|---|---|---|
+| Life / Health | 体力 | "Life Threshold" → 体力閾値, "Max Life" → 最大体力, "Starting Life" → 開始体力. |
+| Lifebar | ライフバー | "Lifebar Description" → ライフバー説明. |
+| Visible Life / Rainbow Life | 視覚体力 / 虹色ライフ | |
+| Combo | コンボ | |
+| Perfect / Great / Good / Bad / Miss | Perfect / Great / Good / Bad / Miss | All untranslated, kept English in mid-sentence. "Greats" → Great数, "Perfects" → Perfect数. |
+| Multiplier | 倍率 | "Stage Break Modifier" → Stage失敗倍率. |
+| Modifier | 倍率 | Same as multiplier. |
+| Break / Broken | 失敗 / Break Off | "Stage Break" → not present, but "Broken" → "Break Off" (nabulator left English — see Known issues); "Bad Break" / "Miss Break" → Bad失敗 / Miss失敗. |
+
+### Phrasing patterns to copy
+
+- **Polite request**: `〜してください` for instructions to the user. Examples: `下のコピーバトン使ってください`, `ロック前にユーザー名を割り当ててください`, `ページを再読み込みして再試行してください`.
+- **`注意：` prefix for warnings/disclaimers.** Used by nabulator and continued in the new batch: `注意：このスクリプトが壊しやすい...`, `注意：このデータはNX2とPrimeから抽出したもので...`. Place at sentence start, full-width colon.
+- **Honorific `さん` for proper names in placeholders.** `Welcome to Score Tracker, {0}!` → `Score Trackerへようこそ、{0}さん！`. Same pattern for credit-style strings (`MR_WEQさん`, `daryenさん`, `KyleTTさん`, `FEFEMZさん`).
+- **`〜について` for "about / regarding"**: `Life gain description` → 体力回復について, `Life loss description` → 体力減少について.
+- **Show/hide as compound noun-suffix**: `Show Age` → 歳表示, `Show Difficulty` → 難度表示, `Hide Completed Charts` → 完了譜面隠す.
+
+## Known issues / native review needed
+
+These were carried over from nabulator's seed translations (PR #44) and intentionally **not** corrected during the machine-translation sweep, to keep structural and quality changes separate. A native-speaker pass should fold these in.
+
+### Typos
+
+- **`Mix` → `ベーション`** (line ≈ resx). Should be `バージョン` or — more accurately for this game — `ミックス` since "Mix" in PIU refers to game versions/iterations rather than a generic version number.
+- **`Filters` → `フィアルた`**. Should be `フィルター`. The reordered characters are clearly a typo.
+- **`Tools` → `ツルー`**. Should be `ツール`.
+- **`To Do` → `やりこと`** (and downstream `やりことリスト`). Should be `やること` (and `やることリスト`). The typo propagates through "Add to ToDo", "Remove from To Do List", "Show Only ToDo Charts", "Toggle ToDo".
+- **`Recorded On X` → `{0}にき記録した`**. Stray `き` — should be `{0}に記録した` or `{0}に記録されました` (polite-passive).
+- **`一部のスコアダウンロードが失敗しまいました`** (Phoenix Import Saving Failures). `失敗しまいました` is non-standard — should be `失敗してしまいました` or just `失敗しました`.
+- **`まえ` (Make Public Disclaimer 2)** — should be `前` (kanji) or `以前` for register consistency.
+
+### Untranslated where translation is expected
+
+- **`Country` → `Country`**. Should be `国`. nabulator left the dropdown label English; everywhere else the file uses Japanese for similar labels.
+- **`Open` → `Open`**. Should be `オープン` or context-appropriate.
+- **`Broken` → `Break Off`**. Left as English (and a different English phrase from the source). Should likely be `失敗` to match the rest of the break/fail vocabulary, or `Stage Break` to match the original PIU term.
+
+### Questionable word choices
+
+- **`CoOp Aggregation` → `CoOp集合`**. `集合` means "set/gathering", not "aggregation". Should be `集計` (which is what the new translation pass uses for similar concepts).
+- **`Communities` → `地域ランキング`** ("regional rankings"). Loses the social-community connotation; the feature is about player groups, not just regions. Reasonable candidate: `コミュニティ`.
+- **`Players` → `プレーヤー達`**. The `達` plural marker is grammatically valid but unusual in game UI, where bare `プレーヤー` is the norm. Compounds drop it correctly (`プレーヤー数`, `プレーヤーレベル`).
+- **`Player Stats` → `進捗中の譜面`** ("in-progress charts"). nabulator interpreted "Stats" as the in-progress chart list this label is associated with on the page; not a literal translation. May or may not be the right call — depends on how the label reads in context.
+- **`スコア(データあり)`** uses half-width parens, breaking the full-width convention. nabulator's choice; consistency-wise should be `スコア（データあり）`.
+- **`シェアー`** (Chart List Share Description) — `シェアー` is non-standard katakana; standard would be `シェア`.
+- **`捜索` vs `検索`** for "Search". Two forms in use; pick one (recommend `検索`).
+- **`ユーザ` vs `ユーザー` / `プレーヤー`** — long-vowel mark inconsistency. nabulator uses `ユーザ`; the new batch uses `ユーザー`. Pick one and sweep.
+
+### Machine-translation review priority
+
+The 396 entries added in PR #90 were generated against nabulator's domain glossary. Dense paragraph strings are the highest review priority because subtle word-choice and sentence-flow issues hurt them most:
+
+- **Life-bar mechanics paragraphs** (PIU Life Calculator page): `Bads at low health let you live...`, `Misses lose LESS health the further beneath 1000 health you are at...`, `Effectively, this means that your life gain is heavily affected by combo...`, `When at 12% or lower visual life, a miss gives less life loss than a bad...` — translations are technically correct but read mechanically.
+- **Scoring-algorithm explainers** (ChartScoring page): `All players with scores within the target folder are assigned weights...`, `These averages are shifted away from the level in question by .5 of a standard deviation...`, `In this case, the chart is determined to be above by X utilizing standard deviations in the Y folder.` — same caveat, dense statistics prose.
+- **Disclaimer/explainer paragraphs**: `Disclaimer: This data was data-mined in NX2 and Prime...`, `Disclaimer: This list is being refined...`.
+
+For short labels (column headers, button text, single-noun keys), the machine pass is generally fine.
+
+## Process for future batches
+
+1. Pick a feature folder (Tournaments, Tier Lists, Progress, Admin, Tools, etc.) or a category from the Known issues list above.
+2. Translate using this glossary. **If a new term needs a decision, add a row to "Established term mappings" before translating.**
+3. For typo / questionable-word fixes, prefer one batch per category (e.g. "Fix yarikoto → yarukoto across the file") so the diff is reviewable.
+4. `dotnet build ScoreTracker/ScoreTracker.sln -c Release` to confirm resx well-formedness.
+5. PR titled like `Translate <Folder> to ja-JP` or `Fix ja-JP <typo / inconsistency>`.

--- a/ScoreTracker/ScoreTracker/Controllers/CultureController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/CultureController.cs
@@ -8,7 +8,7 @@ namespace ScoreTracker.Web.Controllers;
 public class CultureController : Controller
 {
     private static readonly ISet<string> SupportedCultures =
-        new[] { "en-US", "pt-BR", "ko-KR", "es-MX", "en-ZW" }.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        new[] { "en-US", "pt-BR", "ko-KR", "es-MX", "en-ZW", "fr-FR", "ja-JP" }.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     [HttpGet("Set")]
     public IActionResult Set([FromQuery(Name = "culture")] string culture,

--- a/ScoreTracker/ScoreTracker/Pages/Account.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Account.razor
@@ -51,6 +51,7 @@
                     <MudSelectItem T="string" Value=@("es-MX")>Español</MudSelectItem>
                     <MudSelectItem T="string" Value=@("pt-BR")>Português</MudSelectItem>
                     <MudSelectItem T="string" Value=@("ko-KR")>한국어</MudSelectItem>
+                    <MudSelectItem T="string" Value=@("ja-JP")>日本語</MudSelectItem>
                     <MudSelectItem T="string" Value=@("fr-FR")>Français</MudSelectItem>
                     <MudSelectItem T="string" Value=@("en-ZW")>Murloc</MudSelectItem>
                 </MudSelect>

--- a/ScoreTracker/ScoreTracker/Program.cs
+++ b/ScoreTracker/ScoreTracker/Program.cs
@@ -193,8 +193,8 @@ var app = builder.Build();
 
 
 app.UseRequestLocalization(new RequestLocalizationOptions()
-    .AddSupportedCultures("en-US", "pt-BR", "ko-KR", "en-ZW", "es-MX", "fr-FR")
-    .AddSupportedUICultures("en-US", "pt-BR", "ko-KR", "en-ZW", "es-MX", "fr-FR")
+    .AddSupportedCultures("en-US", "pt-BR", "ko-KR", "en-ZW", "es-MX", "fr-FR", "ja-JP")
+    .AddSupportedUICultures("en-US", "pt-BR", "ko-KR", "en-ZW", "es-MX", "fr-FR", "ja-JP")
     .SetDefaultCulture("en-US"));
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -2002,4 +2002,28 @@
   <data name="Your scores have been deleted" xml:space="preserve">
 	  <value>Your scores have been deleted</value>
   </data>
+  <data name="Competition" xml:space="preserve">
+    <value>Competition</value>
+  </data>
+  <data name="Completion Leaderboards" xml:space="preserve">
+    <value>Completion Leaderboards</value>
+  </data>
+  <data name="Discord" xml:space="preserve">
+    <value>Discord</value>
+  </data>
+  <data name="Lifebar Calculator" xml:space="preserve">
+    <value>Lifebar Calculator</value>
+  </data>
+  <data name="Official Leaderboards" xml:space="preserve">
+    <value>Official Leaderboards</value>
+  </data>
+  <data name="PIU Scores" xml:space="preserve">
+    <value>PIU Scores</value>
+  </data>
+  <data name="PUMBILITY" xml:space="preserve">
+    <value>PUMBILITY</value>
+  </data>
+  <data name="UCS Leaderboards" xml:space="preserve">
+    <value>UCS Leaderboards</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -118,180 +118,180 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1+ Level Easier" xml:space="preserve">
-    <value>1+ Level Easier</value>
+    <value>１レベル簡単</value>
   </data>
   <data name="1+ Level Harder" xml:space="preserve">
-    <value>1+ Level Harder</value>
+    <value>１レベル難しい</value>
   </data>
   <data name="About" xml:space="preserve">
-    <value>About</value>
+    <value>概要</value>
   </data>
   <data name="Account" xml:space="preserve">
-    <value>Account</value>
+    <value>アカウント</value>
   </data>
   <data name="Account Creation Line 1" xml:space="preserve">
-    <value>If you do not have an account with Score Tracker, one will be created when you select one of the login providers.</value>
+    <value>もし君はここのアカウント作成してない場合、ログインプロバイダーを選んで新しくアカウントが自動で作る。（パスワード不要）</value>
   </data>
   <data name="Account Creation Line 2" xml:space="preserve">
-    <value>The only information stored about your account from the login provider you select is the external ID (typically a random number or combination of letters), and the username. You can change the username at any time after account creation.</value>
+    <value>このサイトは外部アカウントの個人情報でユーザーIDとウーザーだけ読みます。自分のユーザー名いつでも変更できる。</value>
   </data>
   <data name="Account Creation Line 3" xml:space="preserve">
-    <value>No passwords are stored in Score Tracker, we don't want them, you don't want us to have them, everyone is happier this way.</value>
+    <value>このサイトパスワード利用と保存しない。もっと安全から</value>
   </data>
   <data name="Account Creation?" xml:space="preserve">
-    <value>Account Creation?</value>
-    <comment>Button that pops up explination of account creation process</comment>
+      <value>アカウント作成？</value>
+    <comment>バタンポップアップの説明</comment>
   </data>
   <data name="Actions" xml:space="preserve">
-    <value>Actions</value>
+    <value>操作</value>
   </data>
   <data name="Add to Favorites" xml:space="preserve">
-    <value>Add to Favorites</value>
+    <value>お気に入りを追加</value>
   </data>
   <data name="Add to ToDo" xml:space="preserve">
-    <value>Add to To Do List</value>
+    <value>やりたいリストを追加</value>
   </data>
   <data name="Adjusted Difficulty" xml:space="preserve">
-    <value>Adjusted Difficulty</value>
-    <comment>I.E After Player votes</comment>
+    <value>調整難しさ</value>
+    <comment>ユーザーの票を数えたら</comment>
   </data>
   <data name="Average" xml:space="preserve">
-    <value>Average</value>
+    <value>平均</value>
   </data>
   <data name="Average Rating" xml:space="preserve">
-    <value>Average Rating</value>
+    <value>平均評価</value>
   </data>
   <data name="Broken" xml:space="preserve">
-    <value>Broken</value>
+    <value>Break Off</value>
   </data>
   <data name="Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>キャンセル</value>
   </data>
   <data name="Chart List Share Description" xml:space="preserve">
-    <value>Use this link to share your chart list to other players.</value>
+    <value>この譜面リストをシェアー</value>
   </data>
   <data name="Chart Randomizer" xml:space="preserve">
-    <value>Chart Randomizer</value>
+    <value>譜面くじ引き（抽選機）</value>
   </data>
   <data name="Chart Type" xml:space="preserve">
-    <value>Chart Type</value>
-    <comment>Chart Types = single, double, co op</comment>
+    <value>譜面タイプ</value>
+    <comment>種類 = single, double, co op</comment>
   </data>
   <data name="Charts" xml:space="preserve">
-    <value>Charts</value>
+    <value>譜面</value>
   </data>
   <data name="Charts List" xml:space="preserve">
-    <value>Charts List</value>
+    <value>譜面リスト</value>
   </data>
   <data name="Close" xml:space="preserve">
-    <value>Close</value>
+    <value>閉じる</value>
   </data>
   <data name="Communities" xml:space="preserve">
-    <value>Communities</value>
+    <value>地域ランキング</value>
   </data>
   <data name="Completed" xml:space="preserve">
-    <value>Completed</value>
+    <value>完了</value>
   </data>
   <data name="CoOp" xml:space="preserve">
     <value>CoOp</value>
   </data>
   <data name="CoOp Aggregation" xml:space="preserve">
-    <value>CoOp Aggregation</value>
+    <value>CoOp集合</value>
   </data>
   <data name="Copy Script" xml:space="preserve">
-    <value>Copy Script</value>
+    <value>コピー</value>
   </data>
   <data name="Copy to Clipboard" xml:space="preserve">
-    <value>Copy to Clipboard</value>
+    <value>コピー</value>
   </data>
   <data name="Different Player Difficulties" xml:space="preserve">
-    <value>Different Player Difficulties</value>
-    <comment>Specifies if a co op chart has different difficulties per player</comment>
+    <value>難しさ分差</value>
+    <comment>CoOp譜面に各プレーヤーの難しさが違う</comment>
   </data>
   <data name="Difficulty Level" xml:space="preserve">
-    <value>Difficulty Level</value>
+    <value>難しさレベル</value>
   </data>
   <data name="Disputed Charts" xml:space="preserve">
-    <value>Disputed Charts</value>
+    <value>異説あり譜面</value>
   </data>
   <data name="Disputed Charts Disclaimer" xml:space="preserve">
-    <value>Charts with 4 or more votes, within .5 levels of adjusted rating, and more than .4 Standard Deviation</value>
+    <value>譜面の四票以上と調整難しさは０．５以内と標準偏差は０．４以内</value>
   </data>
   <data name="Doubles" xml:space="preserve">
     <value>Doubles</value>
   </data>
   <data name="Download Failures" xml:space="preserve">
-    <value>Download Failures</value>
+    <value>ダウンロード失敗</value>
   </data>
   <data name="Download Scores" xml:space="preserve">
-    <value>Download Scores</value>
+    <value>スコアダウンロード</value>
   </data>
   <data name="Easiest Player" xml:space="preserve">
-    <value>Easiest Player</value>
+    <value>下級プレーヤー</value>
   </data>
   <data name="Easy" xml:space="preserve">
-    <value>Easy</value>
+    <value>簡単</value>
   </data>
   <data name="Ending Page" xml:space="preserve">
-    <value>Ending Page</value>
+    <value>最後のページ</value>
   </data>
   <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+    <value>気に入れ</value>
   </data>
   <data name="Find Players" xml:space="preserve">
-    <value>Find Players</value>
+    <value>プレーヤー捜索</value>
   </data>
   <data name="Full Privacy Policy" xml:space="preserve">
-    <value>Full Privacy Policy</value>
+    <value>個人情報保護方針</value>
   </data>
   <data name="Hard" xml:space="preserve">
-    <value>Hard</value>
+    <value>難しい</value>
   </data>
   <data name="Hardest Player" xml:space="preserve">
-    <value>Hardest Player</value>
+    <value>上級プレーヤー</value>
   </data>
   <data name="Hide Completed Charts" xml:space="preserve">
-    <value>Hide Completed Charts</value>
+    <value>完了譜面隠す</value>
   </data>
   <data name="Import Phoenix Scores" xml:space="preserve">
-    <value>Import Phoenix Scores</value>
+    <value>スコアインポート</value>
   </data>
   <data name="Language" xml:space="preserve">
-    <value>Language</value>
+    <value>言語</value>
   </data>
   <data name="Last Updated" xml:space="preserve">
-    <value>Last Updated</value>
+    <value>最近更新</value>
   </data>
   <data name="Leaderboard" xml:space="preserve">
-    <value>Leaderboard</value>
+    <value>ランキング</value>
   </data>
   <data name="Letter Grade" xml:space="preserve">
-    <value>Letter Grade</value>
+    <value>ランク</value>
   </data>
   <data name="Log In With" xml:space="preserve">
-    <value>Log In With {0}</value>
-    <comment>I.E Log In With Discord</comment>
+    <value>{0}でログインする</value>
+    <comment>例：DISCORDでログインする</comment>
   </data>
   <data name="Login" xml:space="preserve">
-    <value>Login</value>
+    <value>ログイン</value>
   </data>
   <data name="Logout" xml:space="preserve">
-    <value>Logout</value>
+    <value>ログアウト</value>
   </data>
   <data name="Make Not Public Disclaimer" xml:space="preserve">
-    <value>Making your account private will make your scores and progress no longer be externally visible, even for anyone already following you. You will be removed from the World community.</value>
+      <value>非公開にすれば自分のスコアと進化も誰でも見えなくなります（友達も）。世界ランキングから削除されます。</value>
   </data>
   <data name="Make Private" xml:space="preserve">
-    <value>Make Private</value>
+    <value>非公開する</value>
   </data>
   <data name="Make Public" xml:space="preserve">
-    <value>Make Public</value>
+    <value>公開する</value>
   </data>
   <data name="Make Public Disclaimer 1" xml:space="preserve">
-    <value>Making your account public will make your scores and progress externally visible. You will be added to the World community as well.</value>
+    <value>公開すれば自分のスコアと進化が誰度も見えるようになります。世界ランキングを追加されます。</value>
   </data>
   <data name="Make Public Disclaimer 2" xml:space="preserve">
-    <value>If your account was previously public and you made it private, making it public again will make anyone following you able to see your progress again.</value>
+    <value>公開すれば、まえのフォローしてる友達も見えるようになります。</value>
   </data>
   <data name="Medium" xml:space="preserve">
     <value>Medium</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -1,0 +1,867 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="1+ Level Easier" xml:space="preserve">
+    <value>1+ Level Easier</value>
+  </data>
+  <data name="1+ Level Harder" xml:space="preserve">
+    <value>1+ Level Harder</value>
+  </data>
+  <data name="About" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Account" xml:space="preserve">
+    <value>Account</value>
+  </data>
+  <data name="Account Creation Line 1" xml:space="preserve">
+    <value>If you do not have an account with Score Tracker, one will be created when you select one of the login providers.</value>
+  </data>
+  <data name="Account Creation Line 2" xml:space="preserve">
+    <value>The only information stored about your account from the login provider you select is the external ID (typically a random number or combination of letters), and the username. You can change the username at any time after account creation.</value>
+  </data>
+  <data name="Account Creation Line 3" xml:space="preserve">
+    <value>No passwords are stored in Score Tracker, we don't want them, you don't want us to have them, everyone is happier this way.</value>
+  </data>
+  <data name="Account Creation?" xml:space="preserve">
+    <value>Account Creation?</value>
+    <comment>Button that pops up explination of account creation process</comment>
+  </data>
+  <data name="Actions" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="Add to Favorites" xml:space="preserve">
+    <value>Add to Favorites</value>
+  </data>
+  <data name="Add to ToDo" xml:space="preserve">
+    <value>Add to To Do List</value>
+  </data>
+  <data name="Adjusted Difficulty" xml:space="preserve">
+    <value>Adjusted Difficulty</value>
+    <comment>I.E After Player votes</comment>
+  </data>
+  <data name="Average" xml:space="preserve">
+    <value>Average</value>
+  </data>
+  <data name="Average Rating" xml:space="preserve">
+    <value>Average Rating</value>
+  </data>
+  <data name="Broken" xml:space="preserve">
+    <value>Broken</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Chart List Share Description" xml:space="preserve">
+    <value>Use this link to share your chart list to other players.</value>
+  </data>
+  <data name="Chart Randomizer" xml:space="preserve">
+    <value>Chart Randomizer</value>
+  </data>
+  <data name="Chart Type" xml:space="preserve">
+    <value>Chart Type</value>
+    <comment>Chart Types = single, double, co op</comment>
+  </data>
+  <data name="Charts" xml:space="preserve">
+    <value>Charts</value>
+  </data>
+  <data name="Charts List" xml:space="preserve">
+    <value>Charts List</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="Communities" xml:space="preserve">
+    <value>Communities</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Completed</value>
+  </data>
+  <data name="CoOp" xml:space="preserve">
+    <value>CoOp</value>
+  </data>
+  <data name="CoOp Aggregation" xml:space="preserve">
+    <value>CoOp Aggregation</value>
+  </data>
+  <data name="Copy Script" xml:space="preserve">
+    <value>Copy Script</value>
+  </data>
+  <data name="Copy to Clipboard" xml:space="preserve">
+    <value>Copy to Clipboard</value>
+  </data>
+  <data name="Different Player Difficulties" xml:space="preserve">
+    <value>Different Player Difficulties</value>
+    <comment>Specifies if a co op chart has different difficulties per player</comment>
+  </data>
+  <data name="Difficulty Level" xml:space="preserve">
+    <value>Difficulty Level</value>
+  </data>
+  <data name="Disputed Charts" xml:space="preserve">
+    <value>Disputed Charts</value>
+  </data>
+  <data name="Disputed Charts Disclaimer" xml:space="preserve">
+    <value>Charts with 4 or more votes, within .5 levels of adjusted rating, and more than .4 Standard Deviation</value>
+  </data>
+  <data name="Doubles" xml:space="preserve">
+    <value>Doubles</value>
+  </data>
+  <data name="Download Failures" xml:space="preserve">
+    <value>Download Failures</value>
+  </data>
+  <data name="Download Scores" xml:space="preserve">
+    <value>Download Scores</value>
+  </data>
+  <data name="Easiest Player" xml:space="preserve">
+    <value>Easiest Player</value>
+  </data>
+  <data name="Easy" xml:space="preserve">
+    <value>Easy</value>
+  </data>
+  <data name="Ending Page" xml:space="preserve">
+    <value>Ending Page</value>
+  </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
+  <data name="Find Players" xml:space="preserve">
+    <value>Find Players</value>
+  </data>
+  <data name="Full Privacy Policy" xml:space="preserve">
+    <value>Full Privacy Policy</value>
+  </data>
+  <data name="Hard" xml:space="preserve">
+    <value>Hard</value>
+  </data>
+  <data name="Hardest Player" xml:space="preserve">
+    <value>Hardest Player</value>
+  </data>
+  <data name="Hide Completed Charts" xml:space="preserve">
+    <value>Hide Completed Charts</value>
+  </data>
+  <data name="Import Phoenix Scores" xml:space="preserve">
+    <value>Import Phoenix Scores</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="Last Updated" xml:space="preserve">
+    <value>Last Updated</value>
+  </data>
+  <data name="Leaderboard" xml:space="preserve">
+    <value>Leaderboard</value>
+  </data>
+  <data name="Letter Grade" xml:space="preserve">
+    <value>Letter Grade</value>
+  </data>
+  <data name="Log In With" xml:space="preserve">
+    <value>Log In With {0}</value>
+    <comment>I.E Log In With Discord</comment>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Login</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Logout</value>
+  </data>
+  <data name="Make Not Public Disclaimer" xml:space="preserve">
+    <value>Making your account private will make your scores and progress no longer be externally visible, even for anyone already following you. You will be removed from the World community.</value>
+  </data>
+  <data name="Make Private" xml:space="preserve">
+    <value>Make Private</value>
+  </data>
+  <data name="Make Public" xml:space="preserve">
+    <value>Make Public</value>
+  </data>
+  <data name="Make Public Disclaimer 1" xml:space="preserve">
+    <value>Making your account public will make your scores and progress externally visible. You will be added to the World community as well.</value>
+  </data>
+  <data name="Make Public Disclaimer 2" xml:space="preserve">
+    <value>If your account was previously public and you made it private, making it public again will make anyone following you able to see your progress again.</value>
+  </data>
+  <data name="Medium" xml:space="preserve">
+    <value>Medium</value>
+  </data>
+  <data name="Mix" xml:space="preserve">
+    <value>Mix</value>
+  </data>
+  <data name="My Difficulty Adjustments" xml:space="preserve">
+    <value>My Difficulty Adjustments</value>
+    <comment>I.E chart difficulty vote</comment>
+  </data>
+  <data name="My Score" xml:space="preserve">
+    <value>My Score</value>
+  </data>
+  <data name="New Discord" xml:space="preserve">
+    <value>New Discord</value>
+  </data>
+  <data name="New Discord Disclaimer" xml:space="preserve">
+    <value>I created a discord for updates and feedback! Feel free to join:</value>
+  </data>
+  <data name="Next Letter" xml:space="preserve">
+    <value>Next Letter</value>
+  </data>
+  <data name="Not Graded Count" xml:space="preserve">
+    <value>Not Graded</value>
+  </data>
+  <data name="Not Passed Count" xml:space="preserve">
+    <value>Not Passed</value>
+  </data>
+  <data name="Official Leaderboard Search" xml:space="preserve">
+    <value>Official Leaderboard Search</value>
+  </data>
+  <data name="Official Scores" xml:space="preserve">
+    <value>Official Scores</value>
+  </data>
+  <data name="Open Video" xml:space="preserve">
+    <value>Open Video</value>
+  </data>
+  <data name="Parse Failures" xml:space="preserve">
+    <value>Parse Failures</value>
+  </data>
+  <data name="Passed Count" xml:space="preserve">
+    <value>Passed</value>
+  </data>
+  <data name="Phoenix Import Confirming" xml:space="preserve">
+    <value>Continuing will begin to save the uploaded scores over your existing records. You will not be able to undo this. You will be able to stop the saving process, but it will not roll back uploads.</value>
+  </data>
+  <data name="Phoenix Import Info 1" xml:space="preserve">
+    <value>Use the Copy Script button below</value>
+  </data>
+  <data name="Phoenix Import Info 2" xml:space="preserve">
+    <value>Use that script in the dev tools while logged in on https://piugame.com to download a CSV of your scores. (Make sure you aren't on phoenix.piugame.com)</value>
+  </data>
+  <data name="Phoenix Import Info 3" xml:space="preserve">
+    <value>You can then upload that CSV here for yoru scores to show up.</value>
+  </data>
+  <data name="Phoenix Import Info 4" xml:space="preserve">
+    <value>Note: This tool is fairly hacky and may require some debugging on your side to make work. Make sure to disable ad blockers.</value>
+  </data>
+  <data name="Phoenix Import Saving" xml:space="preserve">
+    <value>If you leave this page or cancel, the upload will stop but you will not lose any scores that have already been recorded from your upload.</value>
+  </data>
+  <data name="Phoenix Import Saving Failures" xml:space="preserve">
+    <value>You had a few charts that were not able to be downloaded. You can download a CSV of the failures to make adjustments and try again.</value>
+  </data>
+  <data name="Phoenix Import Saving Progress" xml:space="preserve">
+    <value>{0}/{1} Uploaded. {2} Remaining. {3} Failed to record</value>
+    <comment>I.E 4/192 Uploaded. 3:29 Remaining. 2 Failed to record</comment>
+  </data>
+  <data name="Phoenix Import Saving Success" xml:space="preserve">
+    <value>All charts you uploaded were successfully updated!</value>
+  </data>
+  <data name="Phoenix Import Uploading" xml:space="preserve">
+    <value>Spreadsheet is uploading and being processed...</value>
+  </data>
+  <data name="Phoenix Score Calculator" xml:space="preserve">
+    <value>Phoenix Score Calculator</value>
+  </data>
+  <data name="Plate" xml:space="preserve">
+    <value>Plate</value>
+    <comment>I.E MG, PG, UG</comment>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>Players</value>
+  </data>
+  <data name="Popularity" xml:space="preserve">
+    <value>Popularity</value>
+  </data>
+  <data name="Preference" xml:space="preserve">
+    <value>Preference</value>
+  </data>
+  <data name="Progress" xml:space="preserve">
+    <value>Progress</value>
+  </data>
+  <data name="Progress Charts" xml:space="preserve">
+    <value>Player Stats</value>
+  </data>
+  <data name="Public" xml:space="preserve">
+    <value>Public</value>
+    <comment>(on/off, if account is set to public)</comment>
+  </data>
+  <data name="Rated Difficulty Level" xml:space="preserve">
+    <value>Rated Difficulty Level</value>
+  </data>
+  <data name="Rating Count" xml:space="preserve">
+    <value>Rating Count</value>
+  </data>
+  <data name="Record Score" xml:space="preserve">
+    <value>Record Score</value>
+  </data>
+  <data name="Recorded Date" xml:space="preserve">
+    <value>Recorded Date</value>
+  </data>
+  <data name="Recorded On" xml:space="preserve">
+    <value>Recorded On {0}</value>
+    <comment>I.E Recorded on 12/6/2023 (I don't support date localization yet but will eventually)</comment>
+  </data>
+  <data name="Remaining Charts" xml:space="preserve">
+    <value>{0} (SSS+) - {1} (AA) Charts Remaining</value>
+    <comment>I.E 6 (SSA+) - 10 (AA) Charts Remaining</comment>
+  </data>
+  <data name="Remaining Charts For You" xml:space="preserve">
+    <value>{0} Charts Estimated for You</value>
+    <comment>I.E 8 Charts Estimated for You</comment>
+  </data>
+  <data name="Remove from Favorites" xml:space="preserve">
+    <value>Remove from Favorites</value>
+  </data>
+  <data name="Remove from ToDo" xml:space="preserve">
+    <value>Remove from To Do List</value>
+  </data>
+  <data name="Report Video" xml:space="preserve">
+    <value>Report Video</value>
+  </data>
+  <data name="Report Video Tooltip" xml:space="preserve">
+    <value>Report Broken, or Incorrect Video</value>
+  </data>
+  <data name="Restart" xml:space="preserve">
+    <value>Restart</value>
+  </data>
+  <data name="Save Scores" xml:space="preserve">
+    <value>Save Scores</value>
+  </data>
+  <data name="Saved Charts" xml:space="preserve">
+    <value>Saved Charts</value>
+  </data>
+  <data name="Score" xml:space="preserve">
+    <value>Score</value>
+  </data>
+  <data name="Score Formula Shoutout" xml:space="preserve">
+    <value>Shout out to MR_WEQ for reverse engineering this score formula!</value>
+  </data>
+  <data name="Score Loss" xml:space="preserve">
+    <value>{0} Score Loss</value>
+    <comment>I.E: Goods Score Loss</comment>
+  </data>
+  <data name="Score Loss Note" xml:space="preserve">
+    <value>Note: Score loss may be off by 1-4 points due to rounding</value>
+  </data>
+  <data name="Score Range Shoutout" xml:space="preserve">
+    <value>Shout out to daryen for collecting data and finalizing the score ranges for letter grades!</value>
+  </data>
+  <data name="Score State" xml:space="preserve">
+    <value>Score State</value>
+    <comment>Score States = Passed, Unpassed, Unscored</comment>
+  </data>
+  <data name="Scores Parsed" xml:space="preserve">
+    <value>Scores Parsed</value>
+  </data>
+  <data name="Search Youtube" xml:space="preserve">
+    <value>Search Youtube</value>
+  </data>
+  <data name="Show Only ToDo Charts" xml:space="preserve">
+    <value>Show Only ToDo Charts</value>
+  </data>
+  <data name="Show Score Distribution" xml:space="preserve">
+    <value>Show Score Distribution</value>
+  </data>
+  <data name="Singles" xml:space="preserve">
+    <value>Singles</value>
+  </data>
+  <data name="Song Duration" xml:space="preserve">
+    <value>Song Duration</value>
+  </data>
+  <data name="Song Image" xml:space="preserve">
+    <value>Song Image</value>
+  </data>
+  <data name="Song Name" xml:space="preserve">
+    <value>Song Name</value>
+  </data>
+  <data name="Song Type" xml:space="preserve">
+    <value>Song Type</value>
+    <comment>Song Types = Arcade, Full Song, etc.</comment>
+  </data>
+  <data name="Stage Break" xml:space="preserve">
+    <value>Stage Break</value>
+  </data>
+  <data name="Standard Deviation" xml:space="preserve">
+    <value>Standard Deviation</value>
+    <comment>I.E of chart votes</comment>
+  </data>
+  <data name="Star Rating" xml:space="preserve">
+    <value>{0} - {1} Stars</value>
+  </data>
+  <data name="Starting Page" xml:space="preserve">
+    <value>Starting Page</value>
+  </data>
+  <data name="Tier Lists" xml:space="preserve">
+    <value>Tier Lists</value>
+  </data>
+  <data name="Title Progress" xml:space="preserve">
+    <value>Title Progress</value>
+  </data>
+  <data name="Titles" xml:space="preserve">
+    <value>Titles</value>
+  </data>
+  <data name="To Do" xml:space="preserve">
+    <value>To Do</value>
+  </data>
+  <data name="Toggle ToDo" xml:space="preserve">
+    <value>Toggle ToDo</value>
+  </data>
+  <data name="Tools" xml:space="preserve">
+    <value>Tools</value>
+  </data>
+  <data name="Total Count" xml:space="preserve">
+    <value>Total</value>
+  </data>
+  <data name="Tournament Builder" xml:space="preserve">
+    <value>Tournament Builder</value>
+  </data>
+  <data name="Tournaments" xml:space="preserve">
+    <value>Tournaments</value>
+  </data>
+  <data name="Unpassed ToDos" xml:space="preserve">
+    <value>You have {0} level {1} charts marked To Do that you haven't passed.</value>
+    <comment>I.E You have 19 level 24 charts marked To Do you haven't passed</comment>
+  </data>
+  <data name="Update Grade" xml:space="preserve">
+    <value>Update Grade</value>
+  </data>
+  <data name="Upload Scores" xml:space="preserve">
+    <value>Upload Scores</value>
+  </data>
+  <data name="Upload XX Scores" xml:space="preserve">
+    <value>Upload XX Scores</value>
+  </data>
+  <data name="Use Password 1" xml:space="preserve">
+    <value>This will have PIUScores log into your account and import scores for you.</value>
+  </data>
+  <data name="Use Password 2" xml:space="preserve">
+    <value>I do not store a record of your username or password, you will have to type them in every time you use this.</value>
+  </data>
+  <data name="Use Password 3" xml:space="preserve">
+    <value>To minimize calls to https://piugame.com I will only import new or improved scores. Every user only gets one full import using Username/Password. Use the dev-tools importer if you wish to re-import older scores.</value>
+  </data>
+  <data name="Use Password 4" xml:space="preserve">
+    <value>Once started, don't leave this page or else your scores will not finish saving.</value>
+  </data>
+  <data name="Used Primarily for debugging" xml:space="preserve">
+    <value>Used primarily for debugging</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Very Easy" xml:space="preserve">
+    <value>Very Easy</value>
+  </data>
+  <data name="Very Hard" xml:space="preserve">
+    <value>Very Hard</value>
+  </data>
+  <data name="Video" xml:space="preserve">
+    <value>Video</value>
+  </data>
+  <data name="Vote Count" xml:space="preserve">
+    <value>{0} votes</value>
+  </data>
+  <data name="Your Difficulty Rating" xml:space="preserve">
+    <value>Your Difficulty Rating</value>
+  </data>
+  <data name="Photos" xml:space="preserve">
+    <value>Photos</value>
+    <comment>Photos</comment>
+  </data>
+  <data name="Qualifiers Leaderboard" xml:space="preserve">
+    <value>{0} Qualifiers Leaderboard</value>
+    <comment>Qualifiers Leaderboard</comment>
+  </data>
+  <data name="Place" xml:space="preserve">
+    <value>Place</value>
+  </data>
+  <data name="Rating" xml:space="preserve">
+    <value>Rating</value>
+    <comment>Rating</comment>
+  </data>
+  <data name="Pending" xml:space="preserve">
+    <value>Pending</value>
+    <comment>Pending</comment>
+  </data>
+  <data name="Event Links" xml:space="preserve">
+    <value>Event Links</value>
+    <comment>Event Links</comment>
+  </data>
+  <data name="Rules" xml:space="preserve">
+    <value>Rules</value>
+    <comment>Rules</comment>
+  </data>
+  <data name="Event" xml:space="preserve">
+    <value>Event</value>
+    <comment>Event</comment>
+  </data>
+  <data name="Website" xml:space="preserve">
+    <value>Website</value>
+    <comment>Website</comment>
+  </data>
+  <data name="Chart Count" xml:space="preserve">
+    <value>Chart Count</value>
+  </data>
+  <data name="Home" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="Leaderboard Player Compare" xml:space="preserve">
+    <value>Leaderboard Player Compare</value>
+  </data>
+  <data name="Max Rating" xml:space="preserve">
+    <value>Max Rating</value>
+  </data>
+  <data name="Next Place Count" xml:space="preserve">
+    <value>Next Place is ahead by {0}</value>
+  </data>
+  <data name="Qualifier Submit Phrase 1" xml:space="preserve">
+    <value>You do not need to be logged in to use this tool. Type a username to begin submitting.</value>
+  </data>
+  <data name="Qualifier Submit Phrase 2" xml:space="preserve">
+    <value>This is your first submission! Please make sure your Username is identifiable either through discord or Start.GG.</value>
+  </data>
+  <data name="Qualifiers Submission" xml:space="preserve">
+    <value>{0} Qualifiers Submission</value>
+  </data>
+  <data name="Rating Calculator" xml:space="preserve">
+    <value>Rating Calculator</value>
+  </data>
+  <data name="Song" xml:space="preserve">
+    <value>Song</value>
+  </data>
+  <data name="Song Artist" xml:space="preserve">
+    <value>Song Artist</value>
+  </data>
+  <data name="Submission Page" xml:space="preserve">
+    <value>Submission Page</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Submit</value>
+  </data>
+  <data name="Suggested Chart" xml:space="preserve">
+    <value>Suggested Chart</value>
+  </data>
+  <data name="To Leaderboard" xml:space="preserve">
+    <value>To Leaderboard</value>
+  </data>
+  <data name="Upload Image" xml:space="preserve">
+    <value>Upload Image</value>
+  </data>
+  <data name="Use Script" xml:space="preserve">
+    <value>Use  Script</value>
+  </data>
+  <data name="World Rankings" xml:space="preserve">
+    <value>World Rankings</value>
+  </data>
+  <data name="You are X place!" xml:space="preserve">
+    <value>You are {0} Place!</value>
+  </data>
+  <data name="Play Num" xml:space="preserve">
+    <value>Play at least {0}</value>
+  </data>
+  <data name="Group By Scoring Difficulty" xml:space="preserve">
+    <value>Group By Scoring Difficulty</value>
+    <comment>Group By Scoring Difficulty</comment>
+  </data>
+  <data name="Personalized" xml:space="preserve">
+    <value>Personalized</value>
+    <comment>Personalized</comment>
+  </data>
+  <data name="Text View" xml:space="preserve">
+    <value>Text View</value>
+    <comment>Text View</comment>
+  </data>
+  <data name="101 person tournament." xml:space="preserve">
+    <value>101 person tournament.</value>
+  </data>
+  <data name="8-10 estimated charts played per player." xml:space="preserve">
+    <value>8-10 estimated charts played per player.</value>
+  </data>
+  <data name="9+ PIU Cabinets Running Phoenix." xml:space="preserve">
+    <value>9+ PIU Cabinets Running Phoenix.</value>
+  </data>
+  <data name="99 matches tailored to each player's level." xml:space="preserve">
+    <value>99 matches tailored to each player's level.</value>
+  </data>
+  <data name="CoOp and No Bar Old School Tournaments." xml:space="preserve">
+    <value>CoOp and No Bar Old School Tournaments.</value>
+  </data>
+  <data name="The most Pump it Up that has ever been at one event." xml:space="preserve">
+    <value>The most Pump it Up that has ever been at one event.</value>
+  </data>
+  <data name="Why don't you just get up and dance, man?" xml:space="preserve">
+    <value>Why don't you just get up and dance, man?</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+	  <value>Open</value>
+	  <comment>Open</comment>
+  </data>
+  <data name="Country" xml:space="preserve">
+	  <value>Country</value>
+	  <comment>Country</comment>
+  </data>
+  <data name="Avatar" xml:space="preserve">
+	  <value>Avatar</value>
+	  <comment>Avatar</comment>
+  </data>
+  <data name="Name" xml:space="preserve">
+	  <value>Name</value>
+	  <comment>Name</comment>
+  </data>
+  <data name="Level" xml:space="preserve">
+	  <value>Level</value>
+	  <comment>Level</comment>
+  </data>
+  <data name="Validation" xml:space="preserve">
+	  <value>Validation</value>
+	  <comment>Validation</comment>
+  </data>
+  <data name="Add UCS" xml:space="preserve">
+	  <value>Add UCS</value>
+	  <comment>Add UCS</comment>
+  </data>
+  <data name="Uploader" xml:space="preserve">
+	  <value>Uploader</value>
+	  <comment>Uploader</comment>
+  </data>
+  <data name="Step Artist" xml:space="preserve">
+	  <value>Step Artist</value>
+	  <comment>Step Artist</comment>
+  </data>
+  <data name="Tag" xml:space="preserve">
+	  <value>Tag</value>
+	  <comment>Tag</comment>
+  </data>
+  <data name="Add" xml:space="preserve">
+	  <value>Add</value>
+	  <comment>Add</comment>
+  </data>
+  <data name="Tags" xml:space="preserve">
+	  <value>Tags</value>
+	  <comment>Tags</comment>
+  </data>
+  <data name="Link" xml:space="preserve">
+	  <value>Link</value>
+	  <comment>Link</comment>
+  </data>
+  <data name="UCS Leaderboard" xml:space="preserve">
+	  <value>UCS Leaderboard</value>
+	  <comment>UCS Leaderboard</comment>
+  </data>
+  <data name="Stage Pass" xml:space="preserve">
+	  <value>Stage Pass</value>
+	  <comment>Stage Pass</comment>
+  </data>
+  <data name="BPM" xml:space="preserve">
+	  <value>BPM</value>
+	  <comment>BPM</comment>
+  </data>
+  <data name="Note Count" xml:space="preserve">
+	  <value>Note Count</value>
+	  <comment>Note Count</comment>
+  </data>
+  <data name="Pass (Data Backed)" xml:space="preserve">
+	  <value>Pass (Data Backed)</value>
+	  <comment>Pass (Data Backed)</comment>
+  </data>
+  <data name="Score (Data Backed)" xml:space="preserve">
+	  <value>Score (Data Backed)</value>
+	  <comment>Score (Data Backed)</comment>
+  </data>
+  <data name="Popularity (PIIU Game Leaderboard)" xml:space="preserve">
+	  <value>Popularity (PIIU Game Leaderboard)</value>
+	  <comment>Popularity (PIIU Game Leaderboard)</comment>
+  </data>
+  <data name="Player Count" xml:space="preserve">
+	  <value>Player Count</value>
+	  <comment>Player Count</comment>
+  </data>
+  <data name="Difficulty Categorization" xml:space="preserve">
+	  <value>Difficulty Categorization</value>
+	  <comment>Difficulty Categorization</comment>
+  </data>
+  <data name="Scoring Level" xml:space="preserve">
+	  <value>Scoring Level</value>
+	  <comment>Scoring Level</comment>
+  </data>
+  <data name="Skill" xml:space="preserve">
+	  <value>Skill</value>
+	  <comment>Skill</comment>
+  </data>
+  <data name="Age" xml:space="preserve">
+	  <value>Age</value>
+	  <comment>Age</comment>
+  </data>
+  <data name="Score Ranking" xml:space="preserve">
+	  <value>Score Ranking</value>
+	  <comment>Score Ranking</comment>
+  </data>
+  <data name="Settings" xml:space="preserve">
+	  <value>Settings</value>
+	  <comment>Settings</comment>
+  </data>
+  <data name="Show Skills" xml:space="preserve">
+	  <value>Show Skills</value>
+	  <comment>Show Skills</comment>
+  </data>
+  <data name="Show Difficulty" xml:space="preserve">
+	  <value>Show Difficulty</value>
+	  <comment>Show Difficulty</comment>
+  </data>
+  <data name="Show Song Name" xml:space="preserve">
+	  <value>Show Song Name</value>
+	  <comment>Show Song Name</comment>
+  </data>
+  <data name="Show Step Artist" xml:space="preserve">
+	  <value>Show Step Artist</value>
+	  <comment>Show Step Artist</comment>
+  </data>
+  <data name="Personalized Difficulty" xml:space="preserve">
+	  <value>Personalized Difficulty</value>
+	  <comment>Personalized Difficulty</comment>
+  </data>
+  <data name="Show Age" xml:space="preserve">
+	  <value>Show Age</value>
+	  <comment>Show Age</comment>
+  </data>
+  <data name="Add Filters" xml:space="preserve">
+	  <value>Add Filters</value>
+	  <comment>Add Filters</comment>
+  </data>
+  <data name="Filters" xml:space="preserve">
+	  <value>Filters</value>
+	  <comment>Filters</comment>
+  </data>
+  <data name="Min BPM" xml:space="preserve">
+	  <value>Min BPM</value>
+	  <comment>Min BPM</comment>
+  </data>
+  <data name="Max BPM" xml:space="preserve">
+	  <value>Max BPM</value>
+	  <comment>Max BPM</comment>
+  </data>
+  <data name="Min Note Count" xml:space="preserve">
+	  <value>Min Note Count</value>
+	  <comment>Min Note Count</comment>
+  </data>
+  <data name="Max Note Count" xml:space="preserve">
+	  <value>Max Note Count</value>
+	  <comment>Max Note Count</comment>
+  </data>
+  <data name="Min Letter Grade" xml:space="preserve">
+	  <value>Min Letter Grade</value>
+	  <comment>Min Letter Grade</comment>
+  </data>
+  <data name="Max Letter Grade" xml:space="preserve">
+	  <value>Max Letter Grade</value>
+	  <comment>Max Letter Grade</comment>
+  </data>
+</root>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -149,11 +149,11 @@
     <value>お気に入りを追加</value>
   </data>
   <data name="Add to ToDo" xml:space="preserve">
-    <value>やりたいリストを追加</value>
+    <value>やりことリストを追加</value>
   </data>
   <data name="Adjusted Difficulty" xml:space="preserve">
     <value>調整難しさ</value>
-    <comment>ユーザーの票を数えたら</comment>
+    <comment>ユーザーの投票を数えたら</comment>
   </data>
   <data name="Average" xml:space="preserve">
     <value>平均</value>
@@ -294,470 +294,471 @@
     <value>公開すれば、まえのフォローしてる友達も見えるようになります。</value>
   </data>
   <data name="Medium" xml:space="preserve">
-    <value>Medium</value>
+    <value>中</value>
   </data>
   <data name="Mix" xml:space="preserve">
-    <value>Mix</value>
+    <value>ベーション</value>
   </data>
   <data name="My Difficulty Adjustments" xml:space="preserve">
-    <value>My Difficulty Adjustments</value>
-    <comment>I.E chart difficulty vote</comment>
+    <value>自分の難しさ調整</value>
+    <comment>譜面難しさ票</comment>
   </data>
   <data name="My Score" xml:space="preserve">
-    <value>My Score</value>
+    <value>自己スコア</value>
   </data>
   <data name="New Discord" xml:space="preserve">
-    <value>New Discord</value>
+    <value>新Discord</value>
   </data>
   <data name="New Discord Disclaimer" xml:space="preserve">
-    <value>I created a discord for updates and feedback! Feel free to join:</value>
+      <value>このサイトのDISCORD鯖、参加してお願いします！(英語)</value>
   </data>
   <data name="Next Letter" xml:space="preserve">
-    <value>Next Letter</value>
+    <value>次のランク</value>
   </data>
   <data name="Not Graded Count" xml:space="preserve">
-    <value>Not Graded</value>
+    <value>未ランク数</value>
   </data>
   <data name="Not Passed Count" xml:space="preserve">
-    <value>Not Passed</value>
+    <value>未クリア数</value>
   </data>
   <data name="Official Leaderboard Search" xml:space="preserve">
-    <value>Official Leaderboard Search</value>
+    <value>公開ランキング捜索</value>
   </data>
   <data name="Official Scores" xml:space="preserve">
-    <value>Official Scores</value>
+    <value>公開スコア</value>
   </data>
   <data name="Open Video" xml:space="preserve">
-    <value>Open Video</value>
+    <value>ビデオリンク開く</value>
   </data>
   <data name="Parse Failures" xml:space="preserve">
-    <value>Parse Failures</value>
+    <value>構文解析失敗</value>
   </data>
   <data name="Passed Count" xml:space="preserve">
-    <value>Passed</value>
+    <value>クリア数</value>
   </data>
   <data name="Phoenix Import Confirming" xml:space="preserve">
-    <value>Continuing will begin to save the uploaded scores over your existing records. You will not be able to undo this. You will be able to stop the saving process, but it will not roll back uploads.</value>
+    <value>注意：新しくスコアは古いスコアの上に書きます。元に戻せないようになります。保存の過程が止まれば、変更のロールバック出来ません。</value>
   </data>
   <data name="Phoenix Import Info 1" xml:space="preserve">
-    <value>Use the Copy Script button below</value>
+    <value>下のコピーバトン使ってください</value>
   </data>
   <data name="Phoenix Import Info 2" xml:space="preserve">
-    <value>Use that script in the dev tools while logged in on https://piugame.com to download a CSV of your scores. (Make sure you aren't on phoenix.piugame.com)</value>
+      <value>CHROMEのDEV TOOLSでhttps://piugame.comがログインしてる状態にスクリプトを走ってください。phoenix.piugame.comが使ってない状態が気をつけてください</value>
   </data>
   <data name="Phoenix Import Info 3" xml:space="preserve">
-    <value>You can then upload that CSV here for yoru scores to show up.</value>
+    <value>スクリプトが作ったCSVファイルここでアップロード出来ます。</value>
   </data>
   <data name="Phoenix Import Info 4" xml:space="preserve">
-    <value>Note: This tool is fairly hacky and may require some debugging on your side to make work. Make sure to disable ad blockers.</value>
+    <value>注意：このスクリプトが壊しやすいと気難しいですから、ちょっとデバグ必要あるかも。絶対ADBLOCKが無効してください。</value>
   </data>
   <data name="Phoenix Import Saving" xml:space="preserve">
-    <value>If you leave this page or cancel, the upload will stop but you will not lose any scores that have already been recorded from your upload.</value>
+    <value>このページを離れたら、アップロードしたスコアは失わないです。</value>
   </data>
   <data name="Phoenix Import Saving Failures" xml:space="preserve">
-    <value>You had a few charts that were not able to be downloaded. You can download a CSV of the failures to make adjustments and try again.</value>
+    <value>一部のスコアダウンロードが失敗しまいました。失敗なCSVファイルはダウンロードして編集しても一回アップロード可能です。</value>
   </data>
   <data name="Phoenix Import Saving Progress" xml:space="preserve">
-    <value>{0}/{1} Uploaded. {2} Remaining. {3} Failed to record</value>
+    <value>{0}/{1} 成功. {2} 残り. {3}登録失敗</value>
     <comment>I.E 4/192 Uploaded. 3:29 Remaining. 2 Failed to record</comment>
   </data>
   <data name="Phoenix Import Saving Success" xml:space="preserve">
-    <value>All charts you uploaded were successfully updated!</value>
+    <value>アップロードしたスコア全部更新出来ました！</value>
   </data>
   <data name="Phoenix Import Uploading" xml:space="preserve">
-    <value>Spreadsheet is uploading and being processed...</value>
+      <value>CSVファイルの処理中</value>
   </data>
   <data name="Phoenix Score Calculator" xml:space="preserve">
-    <value>Phoenix Score Calculator</value>
+    <value>Phoenixスコア計算</value>
   </data>
   <data name="Plate" xml:space="preserve">
-    <value>Plate</value>
-    <comment>I.E MG, PG, UG</comment>
+    <value>プレート</value>
+    <comment>列：MG, PG, UG</comment>
   </data>
   <data name="Players" xml:space="preserve">
-    <value>Players</value>
+    <value>プレーヤー達</value>
   </data>
   <data name="Popularity" xml:space="preserve">
-    <value>Popularity</value>
+    <value>人気</value>
   </data>
   <data name="Preference" xml:space="preserve">
-    <value>Preference</value>
+    <value>カストマイズ</value>
   </data>
   <data name="Progress" xml:space="preserve">
-    <value>Progress</value>
+    <value>進捗</value>
   </data>
   <data name="Progress Charts" xml:space="preserve">
-    <value>Player Stats</value>
+    <value>進捗中の譜面</value>
   </data>
   <data name="Public" xml:space="preserve">
-    <value>Public</value>
-    <comment>(on/off, if account is set to public)</comment>
+    <value>公開</value>
+    <comment>(on/offもしアカウントが公開が設定された)</comment>
   </data>
   <data name="Rated Difficulty Level" xml:space="preserve">
-    <value>Rated Difficulty Level</value>
+    <value>難度評定</value>
   </data>
   <data name="Rating Count" xml:space="preserve">
-    <value>Rating Count</value>
+    <value>評定数</value>
   </data>
   <data name="Record Score" xml:space="preserve">
-    <value>Record Score</value>
+    <value>自己ベスト</value>
   </data>
   <data name="Recorded Date" xml:space="preserve">
-    <value>Recorded Date</value>
+    <value>記録日</value>
   </data>
   <data name="Recorded On" xml:space="preserve">
-    <value>Recorded On {0}</value>
-    <comment>I.E Recorded on 12/6/2023 (I don't support date localization yet but will eventually)</comment>
+    <value>{0}にき記録した</value>
+    <comment>例：12/6/2023に記録した。日本の日付の局在化は未完成です。🙇/comment>
   </data>
   <data name="Remaining Charts" xml:space="preserve">
-    <value>{0} (SSS+) - {1} (AA) Charts Remaining</value>
-    <comment>I.E 6 (SSA+) - 10 (AA) Charts Remaining</comment>
+    <value>{0} (SSS+) - {1} (AA) 譜面残り</value>
+    <comment>例：6 (SSA+) - 10 (AA)譜面残り</comment>
   </data>
   <data name="Remaining Charts For You" xml:space="preserve">
-    <value>{0} Charts Estimated for You</value>
-    <comment>I.E 8 Charts Estimated for You</comment>
+    <value>{0}譜面残り（貴方の見積もり）</value>
+    <comment>例：８譜面残り（推測）</comment>
   </data>
   <data name="Remove from Favorites" xml:space="preserve">
-    <value>Remove from Favorites</value>
+    <value>お気に入りを解除</value>
   </data>
   <data name="Remove from ToDo" xml:space="preserve">
-    <value>Remove from To Do List</value>
+    <value>やりことリストから解除</value>
   </data>
   <data name="Report Video" xml:space="preserve">
-    <value>Report Video</value>
+    <value>ビデオを報告</value>
   </data>
   <data name="Report Video Tooltip" xml:space="preserve">
-    <value>Report Broken, or Incorrect Video</value>
+    <value>間違いとか壊れたビデオを報告</value>
   </data>
   <data name="Restart" xml:space="preserve">
-    <value>Restart</value>
+    <value>再起動</value>
   </data>
   <data name="Save Scores" xml:space="preserve">
-    <value>Save Scores</value>
+    <value>スコア保存</value>
   </data>
   <data name="Saved Charts" xml:space="preserve">
-    <value>Saved Charts</value>
+    <value>保存した譜面</value>
   </data>
   <data name="Score" xml:space="preserve">
-    <value>Score</value>
+    <value>スコア</value>
   </data>
   <data name="Score Formula Shoutout" xml:space="preserve">
-    <value>Shout out to MR_WEQ for reverse engineering this score formula!</value>
+      <value>このスコアの計算均等化を レバースエンジニアリングしてと提供したMR_WEQさんありがとうがします！</value>
   </data>
   <data name="Score Loss" xml:space="preserve">
-    <value>{0} Score Loss</value>
-    <comment>I.E: Goods Score Loss</comment>
+    <value>{0}スコア低下</value>
+    <comment>例：Goodsスコア低下</comment>
   </data>
   <data name="Score Loss Note" xml:space="preserve">
-    <value>Note: Score loss may be off by 1-4 points due to rounding</value>
+    <value>注意：丸めのせいから、スコアの低下が１－４ポイントの差があるかも</value>
   </data>
   <data name="Score Range Shoutout" xml:space="preserve">
-    <value>Shout out to daryen for collecting data and finalizing the score ranges for letter grades!</value>
+    <value>daryenさんはランクのスコア帯を分析してありがとうございます！</value>
   </data>
   <data name="Score State" xml:space="preserve">
-    <value>Score State</value>
-    <comment>Score States = Passed, Unpassed, Unscored</comment>
+    <value>スコア状態</value>
+    <comment>状態の種類= Passed, Unpassed, Unscored</comment>
   </data>
   <data name="Scores Parsed" xml:space="preserve">
-    <value>Scores Parsed</value>
+    <value>スコア分析数</value>
   </data>
   <data name="Search Youtube" xml:space="preserve">
-    <value>Search Youtube</value>
+    <value>youtubeを捜索</value>
   </data>
   <data name="Show Only ToDo Charts" xml:space="preserve">
-    <value>Show Only ToDo Charts</value>
+    <value>やることリストの譜面どけ示す</value>
   </data>
   <data name="Show Score Distribution" xml:space="preserve">
-    <value>Show Score Distribution</value>
+    <value>スコア分布</value>
   </data>
   <data name="Singles" xml:space="preserve">
     <value>Singles</value>
   </data>
   <data name="Song Duration" xml:space="preserve">
-    <value>Song Duration</value>
+    <value>曲時間</value>
   </data>
   <data name="Song Image" xml:space="preserve">
-    <value>Song Image</value>
+    <value>曲画像</value>
   </data>
   <data name="Song Name" xml:space="preserve">
-    <value>Song Name</value>
+    <value>曲名</value>
   </data>
   <data name="Song Type" xml:space="preserve">
-    <value>Song Type</value>
+    <value>曲種類</value>
     <comment>Song Types = Arcade, Full Song, etc.</comment>
   </data>
   <data name="Stage Break" xml:space="preserve">
     <value>Stage Break</value>
   </data>
   <data name="Standard Deviation" xml:space="preserve">
-    <value>Standard Deviation</value>
-    <comment>I.E of chart votes</comment>
+    <value>標準偏差</value>
+    <comment>譜面投票によって</comment>
   </data>
   <data name="Star Rating" xml:space="preserve">
-    <value>{0} - {1} Stars</value>
+    <value>{0} - {1}星</value>
   </data>
   <data name="Starting Page" xml:space="preserve">
-    <value>Starting Page</value>
+    <value>再開のページ</value>
   </data>
   <data name="Tier Lists" xml:space="preserve">
-    <value>Tier Lists</value>
+    <value>ティアリスト</value>
   </data>
   <data name="Title Progress" xml:space="preserve">
-    <value>Title Progress</value>
+    <value>タイトル進捗</value>
   </data>
   <data name="Titles" xml:space="preserve">
-    <value>Titles</value>
+    <value>タイトル</value>
   </data>
   <data name="To Do" xml:space="preserve">
-    <value>To Do</value>
+    <value>やりこと</value>
   </data>
   <data name="Toggle ToDo" xml:space="preserve">
-    <value>Toggle ToDo</value>
+    <value>やりことトグル</value>
   </data>
   <data name="Tools" xml:space="preserve">
-    <value>Tools</value>
+    <value>ツルー</value>
   </data>
   <data name="Total Count" xml:space="preserve">
-    <value>Total</value>
+    <value>総計</value>
   </data>
   <data name="Tournament Builder" xml:space="preserve">
-    <value>Tournament Builder</value>
+    <value>大会編成</value>
   </data>
   <data name="Tournaments" xml:space="preserve">
-    <value>Tournaments</value>
+    <value>大会</value>
   </data>
   <data name="Unpassed ToDos" xml:space="preserve">
-    <value>You have {0} level {1} charts marked To Do that you haven't passed.</value>
-    <comment>I.E You have 19 level 24 charts marked To Do you haven't passed</comment>
+      <value>やりことリストの中のレベレ{1}で譜面まだ{0}曲が残してる（クリアしてない）</value>
+    <comment>例：レベレ２４の中でまだ９譜面が残してる</comment>
   </data>
   <data name="Update Grade" xml:space="preserve">
-    <value>Update Grade</value>
+    <value>ランク更新</value>
   </data>
   <data name="Upload Scores" xml:space="preserve">
-    <value>Upload Scores</value>
+    <value>スコア更新</value>
   </data>
   <data name="Upload XX Scores" xml:space="preserve">
-    <value>Upload XX Scores</value>
+    <value>XXスコア更新</value>
   </data>
   <data name="Use Password 1" xml:space="preserve">
-    <value>This will have PIUScores log into your account and import scores for you.</value>
+    <value>このツルーはpiugame.comにログインして、自動でスコアアップロードすます。</value>
   </data>
   <data name="Use Password 2" xml:space="preserve">
-    <value>I do not store a record of your username or password, you will have to type them in every time you use this.</value>
+    <value>注意：ユーザーとパスワードを記録しないから、毎回使う場合はも一回入力必要あります。</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>To minimize calls to https://piugame.com I will only import new or improved scores. Every user only gets one full import using Username/Password. Use the dev-tools importer if you wish to re-import older scores.</value>
+      <value>https://piugame.comのAPI呼び出すのを減らすなめに、新しいとか改良スコアどけインポートする。各ユーザーは完全インポート（ユーザーとパスワード）一回だけのサービスを上げます。古いスコアが
+          も一回インポート場合、dev-toolsのスクリプト使ってください。</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
-    <value>Once started, don't leave this page or else your scores will not finish saving.</value>
+    <value>インポート始まるとこのページを離さないでください。離したら、新しくスコアが保存しない場合もあります。</value>
   </data>
   <data name="Used Primarily for debugging" xml:space="preserve">
-    <value>Used primarily for debugging</value>
+    <value>デバッグ用</value>
   </data>
   <data name="Username" xml:space="preserve">
-    <value>Username</value>
+    <value>ユーザ名</value>
   </data>
   <data name="Very Easy" xml:space="preserve">
-    <value>Very Easy</value>
+    <value>とても簡単</value>
   </data>
   <data name="Very Hard" xml:space="preserve">
-    <value>Very Hard</value>
+    <value>とても難しい</value>
   </data>
   <data name="Video" xml:space="preserve">
-    <value>Video</value>
+    <value>ビデオ</value>
   </data>
   <data name="Vote Count" xml:space="preserve">
-    <value>{0} votes</value>
+    <value>{0}票</value>
   </data>
   <data name="Your Difficulty Rating" xml:space="preserve">
-    <value>Your Difficulty Rating</value>
+    <value>君の難度評定</value>
   </data>
   <data name="Photos" xml:space="preserve">
-    <value>Photos</value>
-    <comment>Photos</comment>
+    <value>写真</value>
+    <comment>写真</comment>
   </data>
   <data name="Qualifiers Leaderboard" xml:space="preserve">
-    <value>{0} Qualifiers Leaderboard</value>
-    <comment>Qualifiers Leaderboard</comment>
+    <value>{0}資格ランキング</value>
+    <comment>資格ランキング</comment>
   </data>
   <data name="Place" xml:space="preserve">
-    <value>Place</value>
+    <value>場所</value>
   </data>
   <data name="Rating" xml:space="preserve">
-    <value>Rating</value>
-    <comment>Rating</comment>
+    <value>評定</value>
+    <comment>レーティング</comment>
   </data>
   <data name="Pending" xml:space="preserve">
-    <value>Pending</value>
-    <comment>Pending</comment>
+    <value>未決定</value>
+    <comment>未決定</comment>
   </data>
   <data name="Event Links" xml:space="preserve">
-    <value>Event Links</value>
-    <comment>Event Links</comment>
+    <value>イベントリンク</value>
+    <comment>イベントリンク</comment>
   </data>
   <data name="Rules" xml:space="preserve">
-    <value>Rules</value>
-    <comment>Rules</comment>
+    <value>規則</value>
+    <comment>ルール</comment>
   </data>
   <data name="Event" xml:space="preserve">
-    <value>Event</value>
-    <comment>Event</comment>
+    <value>イベント</value>
+    <comment>イベント</comment>
   </data>
   <data name="Website" xml:space="preserve">
-    <value>Website</value>
-    <comment>Website</comment>
+    <value>サイト</value>
+    <comment>ウエブサイト</comment>
   </data>
   <data name="Chart Count" xml:space="preserve">
-    <value>Chart Count</value>
+    <value>譜面数</value>
   </data>
   <data name="Home" xml:space="preserve">
-    <value>Home</value>
+    <value>ホームページ</value>
   </data>
   <data name="Leaderboard Player Compare" xml:space="preserve">
-    <value>Leaderboard Player Compare</value>
+    <value>各プレーヤーランキング（比較）</value>
   </data>
   <data name="Max Rating" xml:space="preserve">
-    <value>Max Rating</value>
+    <value>最高評定</value>
   </data>
   <data name="Next Place Count" xml:space="preserve">
-    <value>Next Place is ahead by {0}</value>
+    <value>次の位の差{0}</value>
   </data>
   <data name="Qualifier Submit Phrase 1" xml:space="preserve">
-    <value>You do not need to be logged in to use this tool. Type a username to begin submitting.</value>
+    <value>このツルーはログイン必要ありません。登録前、ユーザ名を入力お願いします。/value>
   </data>
   <data name="Qualifier Submit Phrase 2" xml:space="preserve">
-    <value>This is your first submission! Please make sure your Username is identifiable either through discord or Start.GG.</value>
+      <value>初めての登録！ユーザ名はdiscordとかstart.ggで同じく確認してください</value>
   </data>
   <data name="Qualifiers Submission" xml:space="preserve">
-    <value>{0} Qualifiers Submission</value>
+    <value>{0}資格の登録</value>
   </data>
   <data name="Rating Calculator" xml:space="preserve">
-    <value>Rating Calculator</value>
+    <value>評定の計算</value>
   </data>
   <data name="Song" xml:space="preserve">
-    <value>Song</value>
+    <value>曲</value>
   </data>
   <data name="Song Artist" xml:space="preserve">
-    <value>Song Artist</value>
+    <value>アーティスト</value>
   </data>
   <data name="Submission Page" xml:space="preserve">
-    <value>Submission Page</value>
+    <value>登録ページ</value>
   </data>
   <data name="Submit" xml:space="preserve">
-    <value>Submit</value>
+    <value>登録</value>
   </data>
   <data name="Suggested Chart" xml:space="preserve">
-    <value>Suggested Chart</value>
+    <value>おすすめ譜面</value>
   </data>
   <data name="To Leaderboard" xml:space="preserve">
-    <value>To Leaderboard</value>
+    <value>ランキングチェック</value>
   </data>
   <data name="Upload Image" xml:space="preserve">
-    <value>Upload Image</value>
+    <value>画像アップロード</value>
   </data>
   <data name="Use Script" xml:space="preserve">
-    <value>Use  Script</value>
+    <value>スクリプト使用</value>
   </data>
   <data name="World Rankings" xml:space="preserve">
-    <value>World Rankings</value>
+    <value>世界ランキング</value>
   </data>
   <data name="You are X place!" xml:space="preserve">
-    <value>You are {0} Place!</value>
+    <value>君は{0}位!</value>
   </data>
   <data name="Play Num" xml:space="preserve">
-    <value>Play at least {0}</value>
+    <value>せめて{0}曲遊んで</value>
   </data>
   <data name="Group By Scoring Difficulty" xml:space="preserve">
-    <value>Group By Scoring Difficulty</value>
-    <comment>Group By Scoring Difficulty</comment>
+    <value>難度評定で分類</value>
+    <comment>スコアの難度評定でグルーポ分けする</comment>
   </data>
   <data name="Personalized" xml:space="preserve">
-    <value>Personalized</value>
-    <comment>Personalized</comment>
+    <value>個別化</value>
+    <comment>個別化</comment>
   </data>
   <data name="Text View" xml:space="preserve">
-    <value>Text View</value>
-    <comment>Text View</comment>
+    <value>テキストで表示</value>
+    <comment>文字示す</comment>
   </data>
   <data name="101 person tournament." xml:space="preserve">
-    <value>101 person tournament.</value>
+    <value>101名大会</value>
   </data>
   <data name="8-10 estimated charts played per player." xml:space="preserve">
-    <value>8-10 estimated charts played per player.</value>
+    <value>各プレーヤーは８から１０の見積もり譜面。</value>
   </data>
   <data name="9+ PIU Cabinets Running Phoenix." xml:space="preserve">
-    <value>9+ PIU Cabinets Running Phoenix.</value>
+      <value>9+ PHONEXの筐体</value>
   </data>
   <data name="99 matches tailored to each player's level." xml:space="preserve">
-    <value>99 matches tailored to each player's level.</value>
+    <value>99の試合</value>
   </data>
   <data name="CoOp and No Bar Old School Tournaments." xml:space="preserve">
-    <value>CoOp and No Bar Old School Tournaments.</value>
+    <value>CoOpとノーバー大会</value>
   </data>
   <data name="The most Pump it Up that has ever been at one event." xml:space="preserve">
-    <value>The most Pump it Up that has ever been at one event.</value>
+    <value>世界一番PUMP IT UP</value>
   </data>
   <data name="Why don't you just get up and dance, man?" xml:space="preserve">
     <value>Why don't you just get up and dance, man?</value>
   </data>
   <data name="Open" xml:space="preserve">
 	  <value>Open</value>
-	  <comment>Open</comment>
+	  <comment>開く</comment>
   </data>
   <data name="Country" xml:space="preserve">
 	  <value>Country</value>
-	  <comment>Country</comment>
+	  <comment>国</comment>
   </data>
   <data name="Avatar" xml:space="preserve">
-	  <value>Avatar</value>
-	  <comment>Avatar</comment>
+	  <value>アバター</value>
+	  <comment>自分のアイコン</comment>
   </data>
   <data name="Name" xml:space="preserve">
-	  <value>Name</value>
-	  <comment>Name</comment>
+	  <value>名前</value>
+	  <comment>名</comment>
   </data>
   <data name="Level" xml:space="preserve">
-	  <value>Level</value>
-	  <comment>Level</comment>
+	  <value>レベル</value>
+	  <comment>レベル</comment>
   </data>
   <data name="Validation" xml:space="preserve">
-	  <value>Validation</value>
-	  <comment>Validation</comment>
+	  <value>確認</value>
+	  <comment>確認</comment>
   </data>
   <data name="Add UCS" xml:space="preserve">
-	  <value>Add UCS</value>
-	  <comment>Add UCS</comment>
+	  <value>UCS追加</value>
+      <comment>UCS追加</comment>
   </data>
   <data name="Uploader" xml:space="preserve">
-	  <value>Uploader</value>
-	  <comment>Uploader</comment>
+	  <value>作者</value>
+	  <comment>アップロードの人</comment>
   </data>
   <data name="Step Artist" xml:space="preserve">
-	  <value>Step Artist</value>
+	  <value>譜面作者</value>
 	  <comment>Step Artist</comment>
   </data>
   <data name="Tag" xml:space="preserve">
-	  <value>Tag</value>
+	  <value>タグ</value>
 	  <comment>Tag</comment>
   </data>
   <data name="Add" xml:space="preserve">
-	  <value>Add</value>
+	  <value>追加</value>
 	  <comment>Add</comment>
   </data>
   <data name="Tags" xml:space="preserve">
-	  <value>Tags</value>
+	  <value>タグ</value>
 	  <comment>Tags</comment>
   </data>
   <data name="Link" xml:space="preserve">
-	  <value>Link</value>
+	  <value>リンク</value>
 	  <comment>Link</comment>
   </data>
   <data name="UCS Leaderboard" xml:space="preserve">
-	  <value>UCS Leaderboard</value>
+	  <value>UCSランキング</value>
 	  <comment>UCS Leaderboard</comment>
   </data>
   <data name="Stage Pass" xml:space="preserve">
-	  <value>Stage Pass</value>
+	  <value>Stageクリア</value>
 	  <comment>Stage Pass</comment>
   </data>
   <data name="BPM" xml:space="preserve">
@@ -765,103 +766,103 @@
 	  <comment>BPM</comment>
   </data>
   <data name="Note Count" xml:space="preserve">
-	  <value>Note Count</value>
+	  <value>ノーツ数</value>
 	  <comment>Note Count</comment>
   </data>
   <data name="Pass (Data Backed)" xml:space="preserve">
-	  <value>Pass (Data Backed)</value>
+      <value>クリア(データあり)</value>
 	  <comment>Pass (Data Backed)</comment>
   </data>
   <data name="Score (Data Backed)" xml:space="preserve">
-	  <value>Score (Data Backed)</value>
+	  <value>スコア(データあり)</value>
 	  <comment>Score (Data Backed)</comment>
   </data>
   <data name="Popularity (PIIU Game Leaderboard)" xml:space="preserve">
-	  <value>Popularity (PIIU Game Leaderboard)</value>
+	  <value>人気さ(PIIU Game 公開ランキング)</value>
 	  <comment>Popularity (PIIU Game Leaderboard)</comment>
   </data>
   <data name="Player Count" xml:space="preserve">
-	  <value>Player Count</value>
+	  <value>プレーヤー数</value>
 	  <comment>Player Count</comment>
   </data>
   <data name="Difficulty Categorization" xml:space="preserve">
-	  <value>Difficulty Categorization</value>
+	  <value>難度カテゴリー分類</value>
 	  <comment>Difficulty Categorization</comment>
   </data>
   <data name="Scoring Level" xml:space="preserve">
-	  <value>Scoring Level</value>
+	  <value>スコアのレベル</value>
 	  <comment>Scoring Level</comment>
   </data>
   <data name="Skill" xml:space="preserve">
-	  <value>Skill</value>
+	  <value>スキル</value>
 	  <comment>Skill</comment>
   </data>
   <data name="Age" xml:space="preserve">
-	  <value>Age</value>
+	  <value>歳</value>
 	  <comment>Age</comment>
   </data>
   <data name="Score Ranking" xml:space="preserve">
-	  <value>Score Ranking</value>
+	  <value>スコアランキング</value>
 	  <comment>Score Ranking</comment>
   </data>
   <data name="Settings" xml:space="preserve">
-	  <value>Settings</value>
+	  <value>設定</value>
 	  <comment>Settings</comment>
   </data>
   <data name="Show Skills" xml:space="preserve">
-	  <value>Show Skills</value>
+	  <value>スキル表示</value>
 	  <comment>Show Skills</comment>
   </data>
   <data name="Show Difficulty" xml:space="preserve">
-	  <value>Show Difficulty</value>
+	  <value>難度表示</value>
 	  <comment>Show Difficulty</comment>
   </data>
   <data name="Show Song Name" xml:space="preserve">
-	  <value>Show Song Name</value>
+	  <value>曲名表示</value>
 	  <comment>Show Song Name</comment>
   </data>
   <data name="Show Step Artist" xml:space="preserve">
-	  <value>Show Step Artist</value>
+	  <value>譜面作者表示</value>
 	  <comment>Show Step Artist</comment>
   </data>
   <data name="Personalized Difficulty" xml:space="preserve">
-	  <value>Personalized Difficulty</value>
+	  <value>個別化難度</value>
 	  <comment>Personalized Difficulty</comment>
   </data>
   <data name="Show Age" xml:space="preserve">
-	  <value>Show Age</value>
+	  <value>歳表示</value>
 	  <comment>Show Age</comment>
   </data>
   <data name="Add Filters" xml:space="preserve">
-	  <value>Add Filters</value>
+	  <value>フィルター追加</value>
 	  <comment>Add Filters</comment>
   </data>
   <data name="Filters" xml:space="preserve">
-	  <value>Filters</value>
+	  <value>フィアルた</value>
 	  <comment>Filters</comment>
   </data>
   <data name="Min BPM" xml:space="preserve">
-	  <value>Min BPM</value>
+	  <value>最低BPM</value>
 	  <comment>Min BPM</comment>
   </data>
   <data name="Max BPM" xml:space="preserve">
-	  <value>Max BPM</value>
+	  <value>最高BPM</value>
 	  <comment>Max BPM</comment>
   </data>
   <data name="Min Note Count" xml:space="preserve">
-	  <value>Min Note Count</value>
+      <value>最低ノーツ数</value>
 	  <comment>Min Note Count</comment>
   </data>
   <data name="Max Note Count" xml:space="preserve">
-	  <value>Max Note Count</value>
+	  <value>最高ノーツ数</value>
 	  <comment>Max Note Count</comment>
   </data>
   <data name="Min Letter Grade" xml:space="preserve">
-	  <value>Min Letter Grade</value>
+	  <value>最低ランク</value>
 	  <comment>Min Letter Grade</comment>
   </data>
   <data name="Max Letter Grade" xml:space="preserve">
-	  <value>Max Letter Grade</value>
+	  <value>最高ランク</value>
 	  <comment>Max Letter Grade</comment>
   </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -407,7 +407,7 @@
   </data>
   <data name="Recorded On" xml:space="preserve">
     <value>{0}にき記録した</value>
-    <comment>例：12/6/2023に記録した。日本の日付の局在化は未完成です。🙇/comment>
+    <comment>例：12/6/2023に記録した。日本の日付の局在化は未完成です。🙇</comment>
   </data>
   <data name="Remaining Charts" xml:space="preserve">
     <value>{0} (SSS+) - {1} (AA) 譜面残り</value>
@@ -624,7 +624,7 @@
     <value>次の位の差{0}</value>
   </data>
   <data name="Qualifier Submit Phrase 1" xml:space="preserve">
-    <value>このツルーはログイン必要ありません。登録前、ユーザ名を入力お願いします。/value>
+    <value>このツルーはログイン必要ありません。登録前、ユーザ名を入力お願いします。</value>
   </data>
   <data name="Qualifier Submit Phrase 2" xml:space="preserve">
       <value>初めての登録！ユーザ名はdiscordとかstart.ggで同じく確認してください</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -2003,4 +2003,28 @@
   <data name="Your scores have been deleted" xml:space="preserve">
 	  <value>スコアを削除しました</value>
   </data>
+  <data name="Competition" xml:space="preserve">
+    <value>競技</value>
+  </data>
+  <data name="Completion Leaderboards" xml:space="preserve">
+    <value>達成ランキング</value>
+  </data>
+  <data name="Discord" xml:space="preserve">
+    <value>Discord</value>
+  </data>
+  <data name="Lifebar Calculator" xml:space="preserve">
+    <value>ライフバー計算</value>
+  </data>
+  <data name="Official Leaderboards" xml:space="preserve">
+    <value>公開ランキング</value>
+  </data>
+  <data name="PIU Scores" xml:space="preserve">
+    <value>PIU Scores</value>
+  </data>
+  <data name="PUMBILITY" xml:space="preserve">
+    <value>PUMBILITY</value>
+  </data>
+  <data name="UCS Leaderboards" xml:space="preserve">
+    <value>UCSランキング</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -139,9 +139,9 @@
     <value>このサイトパスワード利用と保存しない。もっと安全から</value>
   </data>
   <data name="Account Creation?" xml:space="preserve">
-      <value>アカウント作成？</value>
-    <comment>バタンポップアップの説明</comment>
-  </data>
+    <value>アカウント作成？</value>
+    
+  <comment>バタンポップアップの説明</comment></data>
   <data name="Actions" xml:space="preserve">
     <value>操作</value>
   </data>
@@ -151,15 +151,8 @@
   <data name="Add to ToDo" xml:space="preserve">
     <value>やりことリストを追加</value>
   </data>
-  <data name="Adjusted Difficulty" xml:space="preserve">
-    <value>調整難しさ</value>
-    <comment>ユーザーの投票を数えたら</comment>
-  </data>
   <data name="Average" xml:space="preserve">
     <value>平均</value>
-  </data>
-  <data name="Average Rating" xml:space="preserve">
-    <value>平均評価</value>
   </data>
   <data name="Broken" xml:space="preserve">
     <value>Break Off</value>
@@ -175,8 +168,8 @@
   </data>
   <data name="Chart Type" xml:space="preserve">
     <value>譜面タイプ</value>
-    <comment>種類 = single, double, co op</comment>
-  </data>
+    
+  <comment>種類 = single, double, co op</comment></data>
   <data name="Charts" xml:space="preserve">
     <value>譜面</value>
   </data>
@@ -204,18 +197,8 @@
   <data name="Copy to Clipboard" xml:space="preserve">
     <value>コピー</value>
   </data>
-  <data name="Different Player Difficulties" xml:space="preserve">
-    <value>難しさ分差</value>
-    <comment>CoOp譜面に各プレーヤーの難しさが違う</comment>
-  </data>
   <data name="Difficulty Level" xml:space="preserve">
     <value>難しさレベル</value>
-  </data>
-  <data name="Disputed Charts" xml:space="preserve">
-    <value>異説あり譜面</value>
-  </data>
-  <data name="Disputed Charts Disclaimer" xml:space="preserve">
-    <value>譜面の四票以上と調整難しさは０．５以内と標準偏差は０．４以内</value>
   </data>
   <data name="Doubles" xml:space="preserve">
     <value>Doubles</value>
@@ -237,9 +220,6 @@
   </data>
   <data name="Favorites" xml:space="preserve">
     <value>気に入れ</value>
-  </data>
-  <data name="Find Players" xml:space="preserve">
-    <value>プレーヤー捜索</value>
   </data>
   <data name="Full Privacy Policy" xml:space="preserve">
     <value>個人情報保護方針</value>
@@ -270,8 +250,8 @@
   </data>
   <data name="Log In With" xml:space="preserve">
     <value>{0}でログインする</value>
-    <comment>例：DISCORDでログインする</comment>
-  </data>
+    
+  <comment>例：DISCORDでログインする</comment></data>
   <data name="Login" xml:space="preserve">
     <value>ログイン</value>
   </data>
@@ -279,7 +259,7 @@
     <value>ログアウト</value>
   </data>
   <data name="Make Not Public Disclaimer" xml:space="preserve">
-      <value>非公開にすれば自分のスコアと進化も誰でも見えなくなります（友達も）。世界ランキングから削除されます。</value>
+    <value>非公開にすれば自分のスコアと進化も誰でも見えなくなります（友達も）。世界ランキングから削除されます。</value>
   </data>
   <data name="Make Private" xml:space="preserve">
     <value>非公開する</value>
@@ -299,18 +279,8 @@
   <data name="Mix" xml:space="preserve">
     <value>ベーション</value>
   </data>
-  <data name="My Difficulty Adjustments" xml:space="preserve">
-    <value>自分の難しさ調整</value>
-    <comment>譜面難しさ票</comment>
-  </data>
   <data name="My Score" xml:space="preserve">
     <value>自己スコア</value>
-  </data>
-  <data name="New Discord" xml:space="preserve">
-    <value>新Discord</value>
-  </data>
-  <data name="New Discord Disclaimer" xml:space="preserve">
-      <value>このサイトのDISCORD鯖、参加してお願いします！(英語)</value>
   </data>
   <data name="Next Letter" xml:space="preserve">
     <value>次のランク</value>
@@ -343,7 +313,7 @@
     <value>下のコピーバトン使ってください</value>
   </data>
   <data name="Phoenix Import Info 2" xml:space="preserve">
-      <value>CHROMEのDEV TOOLSでhttps://piugame.comがログインしてる状態にスクリプトを走ってください。phoenix.piugame.comが使ってない状態が気をつけてください</value>
+    <value>CHROMEのDEV TOOLSでhttps://piugame.comがログインしてる状態にスクリプトを走ってください。phoenix.piugame.comが使ってない状態が気をつけてください</value>
   </data>
   <data name="Phoenix Import Info 3" xml:space="preserve">
     <value>スクリプトが作ったCSVファイルここでアップロード出来ます。</value>
@@ -359,29 +329,26 @@
   </data>
   <data name="Phoenix Import Saving Progress" xml:space="preserve">
     <value>{0}/{1} 成功. {2} 残り. {3}登録失敗</value>
-    <comment>I.E 4/192 Uploaded. 3:29 Remaining. 2 Failed to record</comment>
-  </data>
+    
+  <comment>I.E 4/192 Uploaded. 3:29 Remaining. 2 Failed to record</comment></data>
   <data name="Phoenix Import Saving Success" xml:space="preserve">
     <value>アップロードしたスコア全部更新出来ました！</value>
   </data>
   <data name="Phoenix Import Uploading" xml:space="preserve">
-      <value>CSVファイルの処理中</value>
+    <value>CSVファイルの処理中</value>
   </data>
   <data name="Phoenix Score Calculator" xml:space="preserve">
     <value>Phoenixスコア計算</value>
   </data>
   <data name="Plate" xml:space="preserve">
     <value>プレート</value>
-    <comment>列：MG, PG, UG</comment>
-  </data>
+    
+  <comment>列：MG, PG, UG</comment></data>
   <data name="Players" xml:space="preserve">
     <value>プレーヤー達</value>
   </data>
   <data name="Popularity" xml:space="preserve">
     <value>人気</value>
-  </data>
-  <data name="Preference" xml:space="preserve">
-    <value>カストマイズ</value>
   </data>
   <data name="Progress" xml:space="preserve">
     <value>進捗</value>
@@ -391,35 +358,23 @@
   </data>
   <data name="Public" xml:space="preserve">
     <value>公開</value>
-    <comment>(on/offもしアカウントが公開が設定された)</comment>
-  </data>
-  <data name="Rated Difficulty Level" xml:space="preserve">
-    <value>難度評定</value>
-  </data>
-  <data name="Rating Count" xml:space="preserve">
-    <value>評定数</value>
-  </data>
-  <data name="Record Score" xml:space="preserve">
-    <value>自己ベスト</value>
-  </data>
+    
+  <comment>(on/offもしアカウントが公開が設定された)</comment></data>
   <data name="Recorded Date" xml:space="preserve">
     <value>記録日</value>
   </data>
   <data name="Recorded On" xml:space="preserve">
     <value>{0}にき記録した</value>
-    <comment>例：12/6/2023に記録した。日本の日付の局在化は未完成です。🙇</comment>
-  </data>
+    
+  <comment>例：12/6/2023に記録した。日本の日付の局在化は未完成です。🙇</comment></data>
   <data name="Remaining Charts" xml:space="preserve">
     <value>{0} (SSS+) - {1} (AA) 譜面残り</value>
-    <comment>例：6 (SSA+) - 10 (AA)譜面残り</comment>
-  </data>
+    
+  <comment>例：6 (SSA+) - 10 (AA)譜面残り</comment></data>
   <data name="Remaining Charts For You" xml:space="preserve">
     <value>{0}譜面残り（貴方の見積もり）</value>
-    <comment>例：８譜面残り（推測）</comment>
-  </data>
-  <data name="Remove from Favorites" xml:space="preserve">
-    <value>お気に入りを解除</value>
-  </data>
+    
+  <comment>例：８譜面残り（推測）</comment></data>
   <data name="Remove from ToDo" xml:space="preserve">
     <value>やりことリストから解除</value>
   </data>
@@ -442,12 +397,12 @@
     <value>スコア</value>
   </data>
   <data name="Score Formula Shoutout" xml:space="preserve">
-      <value>このスコアの計算均等化を レバースエンジニアリングしてと提供したMR_WEQさんありがとうがします！</value>
+    <value>このスコアの計算均等化を レバースエンジニアリングしてと提供したMR_WEQさんありがとうがします！</value>
   </data>
   <data name="Score Loss" xml:space="preserve">
     <value>{0}スコア低下</value>
-    <comment>例：Goodsスコア低下</comment>
-  </data>
+    
+  <comment>例：Goodsスコア低下</comment></data>
   <data name="Score Loss Note" xml:space="preserve">
     <value>注意：丸めのせいから、スコアの低下が１－４ポイントの差があるかも</value>
   </data>
@@ -456,13 +411,10 @@
   </data>
   <data name="Score State" xml:space="preserve">
     <value>スコア状態</value>
-    <comment>状態の種類= Passed, Unpassed, Unscored</comment>
-  </data>
+    
+  <comment>状態の種類= Passed, Unpassed, Unscored</comment></data>
   <data name="Scores Parsed" xml:space="preserve">
     <value>スコア分析数</value>
-  </data>
-  <data name="Search Youtube" xml:space="preserve">
-    <value>youtubeを捜索</value>
   </data>
   <data name="Show Only ToDo Charts" xml:space="preserve">
     <value>やることリストの譜面どけ示す</value>
@@ -484,18 +436,8 @@
   </data>
   <data name="Song Type" xml:space="preserve">
     <value>曲種類</value>
-    <comment>Song Types = Arcade, Full Song, etc.</comment>
-  </data>
-  <data name="Stage Break" xml:space="preserve">
-    <value>Stage Break</value>
-  </data>
-  <data name="Standard Deviation" xml:space="preserve">
-    <value>標準偏差</value>
-    <comment>譜面投票によって</comment>
-  </data>
-  <data name="Star Rating" xml:space="preserve">
-    <value>{0} - {1}星</value>
-  </data>
+    
+  <comment>Song Types = Arcade, Full Song, etc.</comment></data>
   <data name="Starting Page" xml:space="preserve">
     <value>再開のページ</value>
   </data>
@@ -511,28 +453,19 @@
   <data name="To Do" xml:space="preserve">
     <value>やりこと</value>
   </data>
-  <data name="Toggle ToDo" xml:space="preserve">
-    <value>やりことトグル</value>
-  </data>
   <data name="Tools" xml:space="preserve">
     <value>ツルー</value>
   </data>
   <data name="Total Count" xml:space="preserve">
     <value>総計</value>
   </data>
-  <data name="Tournament Builder" xml:space="preserve">
-    <value>大会編成</value>
-  </data>
   <data name="Tournaments" xml:space="preserve">
     <value>大会</value>
   </data>
   <data name="Unpassed ToDos" xml:space="preserve">
-      <value>やりことリストの中のレベレ{1}で譜面まだ{0}曲が残してる（クリアしてない）</value>
-    <comment>例：レベレ２４の中でまだ９譜面が残してる</comment>
-  </data>
-  <data name="Update Grade" xml:space="preserve">
-    <value>ランク更新</value>
-  </data>
+    <value>やりことリストの中のレベレ{1}で譜面まだ{0}曲が残してる（クリアしてない）</value>
+    
+  <comment>例：レベレ２４の中でまだ９譜面が残してる</comment></data>
   <data name="Upload Scores" xml:space="preserve">
     <value>スコア更新</value>
   </data>
@@ -546,7 +479,7 @@
     <value>注意：ユーザーとパスワードを記録しないから、毎回使う場合はも一回入力必要あります。</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-      <value>https://piugame.comのAPI呼び出すのを減らすなめに、新しいとか改良スコアどけインポートする。各ユーザーは完全インポート（ユーザーとパスワード）一回だけのサービスを上げます。古いスコアが
+    <value>https://piugame.comのAPI呼び出すのを減らすなめに、新しいとか改良スコアどけインポートする。各ユーザーは完全インポート（ユーザーとパスワード）一回だけのサービスを上げます。古いスコアが
           も一回インポート場合、dev-toolsのスクリプト使ってください。</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
@@ -570,44 +503,41 @@
   <data name="Vote Count" xml:space="preserve">
     <value>{0}票</value>
   </data>
-  <data name="Your Difficulty Rating" xml:space="preserve">
-    <value>君の難度評定</value>
-  </data>
   <data name="Photos" xml:space="preserve">
     <value>写真</value>
-    <comment>写真</comment>
-  </data>
+    
+  <comment>写真</comment></data>
   <data name="Qualifiers Leaderboard" xml:space="preserve">
     <value>{0}資格ランキング</value>
-    <comment>資格ランキング</comment>
-  </data>
+    
+  <comment>資格ランキング</comment></data>
   <data name="Place" xml:space="preserve">
     <value>場所</value>
   </data>
   <data name="Rating" xml:space="preserve">
     <value>評定</value>
-    <comment>レーティング</comment>
-  </data>
+    
+  <comment>レーティング</comment></data>
   <data name="Pending" xml:space="preserve">
     <value>未決定</value>
-    <comment>未決定</comment>
-  </data>
+    
+  <comment>未決定</comment></data>
   <data name="Event Links" xml:space="preserve">
     <value>イベントリンク</value>
-    <comment>イベントリンク</comment>
-  </data>
+    
+  <comment>イベントリンク</comment></data>
   <data name="Rules" xml:space="preserve">
     <value>規則</value>
-    <comment>ルール</comment>
-  </data>
+    
+  <comment>ルール</comment></data>
   <data name="Event" xml:space="preserve">
     <value>イベント</value>
-    <comment>イベント</comment>
-  </data>
+    
+  <comment>イベント</comment></data>
   <data name="Website" xml:space="preserve">
     <value>サイト</value>
-    <comment>ウエブサイト</comment>
-  </data>
+    
+  <comment>ウエブサイト</comment></data>
   <data name="Chart Count" xml:space="preserve">
     <value>譜面数</value>
   </data>
@@ -620,14 +550,11 @@
   <data name="Max Rating" xml:space="preserve">
     <value>最高評定</value>
   </data>
-  <data name="Next Place Count" xml:space="preserve">
-    <value>次の位の差{0}</value>
-  </data>
   <data name="Qualifier Submit Phrase 1" xml:space="preserve">
     <value>このツルーはログイン必要ありません。登録前、ユーザ名を入力お願いします。</value>
   </data>
   <data name="Qualifier Submit Phrase 2" xml:space="preserve">
-      <value>初めての登録！ユーザ名はdiscordとかstart.ggで同じく確認してください</value>
+    <value>初めての登録！ユーザ名はdiscordとかstart.ggで同じく確認してください</value>
   </data>
   <data name="Qualifiers Submission" xml:space="preserve">
     <value>{0}資格の登録</value>
@@ -662,207 +589,1418 @@
   <data name="World Rankings" xml:space="preserve">
     <value>世界ランキング</value>
   </data>
-  <data name="You are X place!" xml:space="preserve">
-    <value>君は{0}位!</value>
-  </data>
   <data name="Play Num" xml:space="preserve">
     <value>せめて{0}曲遊んで</value>
   </data>
-  <data name="Group By Scoring Difficulty" xml:space="preserve">
-    <value>難度評定で分類</value>
-    <comment>スコアの難度評定でグルーポ分けする</comment>
-  </data>
-  <data name="Personalized" xml:space="preserve">
-    <value>個別化</value>
-    <comment>個別化</comment>
-  </data>
   <data name="Text View" xml:space="preserve">
     <value>テキストで表示</value>
-    <comment>文字示す</comment>
-  </data>
-  <data name="101 person tournament." xml:space="preserve">
-    <value>101名大会</value>
-  </data>
-  <data name="8-10 estimated charts played per player." xml:space="preserve">
-    <value>各プレーヤーは８から１０の見積もり譜面。</value>
-  </data>
-  <data name="9+ PIU Cabinets Running Phoenix." xml:space="preserve">
-      <value>9+ PHONEXの筐体</value>
-  </data>
-  <data name="99 matches tailored to each player's level." xml:space="preserve">
-    <value>99の試合</value>
-  </data>
-  <data name="CoOp and No Bar Old School Tournaments." xml:space="preserve">
-    <value>CoOpとノーバー大会</value>
-  </data>
-  <data name="The most Pump it Up that has ever been at one event." xml:space="preserve">
-    <value>世界一番PUMP IT UP</value>
-  </data>
-  <data name="Why don't you just get up and dance, man?" xml:space="preserve">
-    <value>Why don't you just get up and dance, man?</value>
-  </data>
+    
+  <comment>文字示す</comment></data>
   <data name="Open" xml:space="preserve">
 	  <value>Open</value>
-	  <comment>開く</comment>
-  </data>
+	  
+  <comment>開く</comment></data>
   <data name="Country" xml:space="preserve">
 	  <value>Country</value>
-	  <comment>国</comment>
-  </data>
+	  
+  <comment>国</comment></data>
   <data name="Avatar" xml:space="preserve">
 	  <value>アバター</value>
-	  <comment>自分のアイコン</comment>
-  </data>
+	  
+  <comment>自分のアイコン</comment></data>
   <data name="Name" xml:space="preserve">
 	  <value>名前</value>
-	  <comment>名</comment>
-  </data>
+	  
+  <comment>名</comment></data>
   <data name="Level" xml:space="preserve">
 	  <value>レベル</value>
-	  <comment>レベル</comment>
-  </data>
+	  
+  <comment>レベル</comment></data>
   <data name="Validation" xml:space="preserve">
 	  <value>確認</value>
-	  <comment>確認</comment>
-  </data>
+	  
+  <comment>確認</comment></data>
   <data name="Add UCS" xml:space="preserve">
 	  <value>UCS追加</value>
-      <comment>UCS追加</comment>
-  </data>
+	  
+  <comment>UCS追加</comment></data>
   <data name="Uploader" xml:space="preserve">
 	  <value>作者</value>
-	  <comment>アップロードの人</comment>
-  </data>
+	  
+  <comment>アップロードの人</comment></data>
   <data name="Step Artist" xml:space="preserve">
 	  <value>譜面作者</value>
-	  <comment>Step Artist</comment>
-  </data>
+	  
+  <comment>Step Artist</comment></data>
   <data name="Tag" xml:space="preserve">
 	  <value>タグ</value>
-	  <comment>Tag</comment>
-  </data>
+	  
+  <comment>Tag</comment></data>
   <data name="Add" xml:space="preserve">
 	  <value>追加</value>
-	  <comment>Add</comment>
-  </data>
+	  
+  <comment>Add</comment></data>
   <data name="Tags" xml:space="preserve">
 	  <value>タグ</value>
-	  <comment>Tags</comment>
-  </data>
+	  
+  <comment>Tags</comment></data>
   <data name="Link" xml:space="preserve">
 	  <value>リンク</value>
-	  <comment>Link</comment>
-  </data>
+	  
+  <comment>Link</comment></data>
   <data name="UCS Leaderboard" xml:space="preserve">
 	  <value>UCSランキング</value>
-	  <comment>UCS Leaderboard</comment>
-  </data>
+	  
+  <comment>UCS Leaderboard</comment></data>
   <data name="Stage Pass" xml:space="preserve">
 	  <value>Stageクリア</value>
-	  <comment>Stage Pass</comment>
-  </data>
+	  
+  <comment>Stage Pass</comment></data>
   <data name="BPM" xml:space="preserve">
 	  <value>BPM</value>
-	  <comment>BPM</comment>
-  </data>
+	  
+  <comment>BPM</comment></data>
   <data name="Note Count" xml:space="preserve">
 	  <value>ノーツ数</value>
-	  <comment>Note Count</comment>
-  </data>
+	  
+  <comment>Note Count</comment></data>
   <data name="Pass (Data Backed)" xml:space="preserve">
-      <value>クリア(データあり)</value>
-	  <comment>Pass (Data Backed)</comment>
-  </data>
+	  <value>クリア(データあり)</value>
+	  
+  <comment>Pass (Data Backed)</comment></data>
   <data name="Score (Data Backed)" xml:space="preserve">
 	  <value>スコア(データあり)</value>
-	  <comment>Score (Data Backed)</comment>
-  </data>
-  <data name="Popularity (PIIU Game Leaderboard)" xml:space="preserve">
-	  <value>人気さ(PIIU Game 公開ランキング)</value>
-	  <comment>Popularity (PIIU Game Leaderboard)</comment>
+	  
+  <comment>Score (Data Backed)</comment></data>
+  <data name="Popularity (PIU Game Leaderboard)" xml:space="preserve">
+	  <value>人気（PIU Gameランキング）</value>
+	  
   </data>
   <data name="Player Count" xml:space="preserve">
 	  <value>プレーヤー数</value>
-	  <comment>Player Count</comment>
-  </data>
+	  
+  <comment>Player Count</comment></data>
   <data name="Difficulty Categorization" xml:space="preserve">
 	  <value>難度カテゴリー分類</value>
-	  <comment>Difficulty Categorization</comment>
-  </data>
+	  
+  <comment>Difficulty Categorization</comment></data>
   <data name="Scoring Level" xml:space="preserve">
 	  <value>スコアのレベル</value>
-	  <comment>Scoring Level</comment>
-  </data>
+	  
+  <comment>Scoring Level</comment></data>
   <data name="Skill" xml:space="preserve">
 	  <value>スキル</value>
-	  <comment>Skill</comment>
-  </data>
+	  
+  <comment>Skill</comment></data>
   <data name="Age" xml:space="preserve">
 	  <value>歳</value>
-	  <comment>Age</comment>
-  </data>
+	  
+  <comment>Age</comment></data>
   <data name="Score Ranking" xml:space="preserve">
 	  <value>スコアランキング</value>
-	  <comment>Score Ranking</comment>
-  </data>
+	  
+  <comment>Score Ranking</comment></data>
   <data name="Settings" xml:space="preserve">
 	  <value>設定</value>
-	  <comment>Settings</comment>
-  </data>
+	  
+  <comment>Settings</comment></data>
   <data name="Show Skills" xml:space="preserve">
 	  <value>スキル表示</value>
-	  <comment>Show Skills</comment>
-  </data>
+	  
+  <comment>Show Skills</comment></data>
   <data name="Show Difficulty" xml:space="preserve">
 	  <value>難度表示</value>
-	  <comment>Show Difficulty</comment>
-  </data>
+	  
+  <comment>Show Difficulty</comment></data>
   <data name="Show Song Name" xml:space="preserve">
 	  <value>曲名表示</value>
-	  <comment>Show Song Name</comment>
-  </data>
+	  
+  <comment>Show Song Name</comment></data>
   <data name="Show Step Artist" xml:space="preserve">
 	  <value>譜面作者表示</value>
-	  <comment>Show Step Artist</comment>
-  </data>
+	  
+  <comment>Show Step Artist</comment></data>
   <data name="Personalized Difficulty" xml:space="preserve">
 	  <value>個別化難度</value>
-	  <comment>Personalized Difficulty</comment>
-  </data>
+	  
+  <comment>Personalized Difficulty</comment></data>
   <data name="Show Age" xml:space="preserve">
 	  <value>歳表示</value>
-	  <comment>Show Age</comment>
-  </data>
-  <data name="Add Filters" xml:space="preserve">
-	  <value>フィルター追加</value>
-	  <comment>Add Filters</comment>
-  </data>
+	  
+  <comment>Show Age</comment></data>
   <data name="Filters" xml:space="preserve">
 	  <value>フィアルた</value>
-	  <comment>Filters</comment>
-  </data>
+	  
+  <comment>Filters</comment></data>
   <data name="Min BPM" xml:space="preserve">
 	  <value>最低BPM</value>
-	  <comment>Min BPM</comment>
-  </data>
+	  
+  <comment>Min BPM</comment></data>
   <data name="Max BPM" xml:space="preserve">
 	  <value>最高BPM</value>
-	  <comment>Max BPM</comment>
-  </data>
+	  
+  <comment>Max BPM</comment></data>
   <data name="Min Note Count" xml:space="preserve">
-      <value>最低ノーツ数</value>
-	  <comment>Min Note Count</comment>
-  </data>
+	  <value>最低ノーツ数</value>
+	  
+  <comment>Min Note Count</comment></data>
   <data name="Max Note Count" xml:space="preserve">
 	  <value>最高ノーツ数</value>
-	  <comment>Max Note Count</comment>
-  </data>
+	  
+  <comment>Max Note Count</comment></data>
   <data name="Min Letter Grade" xml:space="preserve">
 	  <value>最低ランク</value>
-	  <comment>Min Letter Grade</comment>
-  </data>
+	  
+  <comment>Min Letter Grade</comment></data>
   <data name="Max Letter Grade" xml:space="preserve">
 	  <value>最高ランク</value>
-	  <comment>Max Letter Grade</comment>
+	  
+  <comment>Max Letter Grade</comment></data>
+  <data name="Admin" xml:space="preserve">
+	  <value>管理</value>
+  </data>
+  <data name="Do It" xml:space="preserve">
+	  <value>実行</value>
+	  
+  </data>
+  <data name="Clear Cache" xml:space="preserve">
+	  <value>キャッシュ消去</value>
+  </data>
+  <data name="ReCalculate Ratings" xml:space="preserve">
+	  <value>評定再計算</value>
+  </data>
+  <data name="Update Chart" xml:space="preserve">
+	  <value>譜面更新</value>
+  </data>
+  <data name="Chart" xml:space="preserve">
+	  <value>譜面</value>
+  </data>
+  <data name="Video URL" xml:space="preserve">
+	  <value>ビデオURL</value>
+  </data>
+  <data name="Channel Name" xml:space="preserve">
+	  <value>チャンネル名</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+	  <value>保存</value>
+  </data>
+  <data name="Create Song" xml:space="preserve">
+	  <value>曲作成</value>
+  </data>
+  <data name="Korean Name" xml:space="preserve">
+	  <value>韓国語名</value>
+  </data>
+  <data name="Image Name" xml:space="preserve">
+	  <value>画像名</value>
+  </data>
+  <data name="Minutes" xml:space="preserve">
+	  <value>分</value>
+  </data>
+  <data name="Seconds" xml:space="preserve">
+	  <value>秒</value>
+  </data>
+  <data name="Level/Players" xml:space="preserve">
+	  <value>レベル/プレーヤー数</value>
+	  
+  </data>
+  <data name="Youtube Hash" xml:space="preserve">
+	  <value>Youtubeハッシュ</value>
+  </data>
+  <data name="Create" xml:space="preserve">
+	  <value>作成</value>
+  </data>
+  <data name="Done" xml:space="preserve">
+	  <value>完了</value>
+  </data>
+  <data name="Restored" xml:space="preserve">
+	  <value>復元済</value>
+  </data>
+  <data name="Video info is not formatted correctly" xml:space="preserve">
+	  <value>ビデオ情報の形式が正しくありません</value>
+  </data>
+  <data name="Chart saved" xml:space="preserve">
+	  <value>譜面保存しました</value>
+  </data>
+  <data name="Bulk Vote" xml:space="preserve">
+	  <value>一括投票</value>
+  </data>
+  <data name="Your Difficulty Rating" xml:space="preserve">
+	  <value>君の難度評定</value>
+  </data>
+  <data name="Saved!" xml:space="preserve">
+	  <value>保存しました！</value>
+  </data>
+  <data name="Chart Update" xml:space="preserve">
+	  <value>譜面更新</value>
+  </data>
+  <data name="Difficulty" xml:space="preserve">
+	  <value>難度</value>
+  </data>
+  <data name="Save Chart" xml:space="preserve">
+	  <value>譜面保存</value>
+  </data>
+  <data name="Updated X Y" xml:space="preserve">
+	  <value>{0} {1}を更新しました</value>
+	  
+  </data>
+  <data name="Community Invite" xml:space="preserve">
+	  <value>コミュニティ招待</value>
+  </data>
+  <data name="Chart Compare" xml:space="preserve">
+	  <value>譜面比較</value>
+  </data>
+  <data name="Huge thank you for KyleTT for compiling this information from FEFEMZ's  recordings." xml:space="preserve">
+	  <value>FEFEMZさんの録画からこの情報をまとめてくれたKyleTTさんに感謝します。</value>
+	  
+  </data>
+  <data name="Note that this information is not final until referenced against actual released mix." xml:space="preserve">
+	  <value>注意：実際のリリースミックスと照合するまで、この情報は確定ではありません。</value>
+  </data>
+  <data name="Added" xml:space="preserve">
+	  <value>追加済み</value>
+  </data>
+  <data name="Changed Level" xml:space="preserve">
+	  <value>レベル変更</value>
+  </data>
+  <data name="Removed" xml:space="preserve">
+	  <value>削除済</value>
+  </data>
+  <data name="Step Artists" xml:space="preserve">
+	  <value>譜面作者</value>
+  </data>
+  <data name="Disclaimer: This list is being refined, some charts are missing step artists and some may have incorrect artists." xml:space="preserve">
+	  <value>注意：このリストは調整中で、譜面作者が未登録または誤っている場合があります。</value>
+  </data>
+  <data name="PIU Life Calculator" xml:space="preserve">
+	  <value>PIU体力計算</value>
+  </data>
+  <data name="Disclaimer: This data was data-mined in NX2 and Prime, it is unconfirmed how accurate it is today." xml:space="preserve">
+	  <value>注意：このデータはNX2とPrimeから抽出したもので、現在の正確性は未確認です。</value>
+  </data>
+  <data name="Lifebar stats" xml:space="preserve">
+	  <value>ライフバー統計</value>
+  </data>
+  <data name="Life Bar by Level" xml:space="preserve">
+	  <value>レベル別ライフバー</value>
+  </data>
+  <data name="Starting Life" xml:space="preserve">
+	  <value>開始体力</value>
+  </data>
+  <data name="Visible Life" xml:space="preserve">
+	  <value>視覚体力</value>
+  </data>
+  <data name="Max Life" xml:space="preserve">
+	  <value>最大体力</value>
+  </data>
+  <data name="Life Threshold" xml:space="preserve">
+	  <value>体力閾値</value>
+  </data>
+  <data name="Note Count from Full Life to Death/Threshold based on Combo between Breaks" xml:space="preserve">
+	  <value>失敗間のコンボに応じた、満タンから死亡/閾値までのノーツ数</value>
+  </data>
+  <data name="Perfect Combo, Miss Break" xml:space="preserve">
+	  <value>Perfectコンボ、Miss失敗</value>
+  </data>
+  <data name="Great Combo, Miss Break" xml:space="preserve">
+	  <value>Greatコンボ、Miss失敗</value>
+  </data>
+  <data name="Perfect Combo, Bad Break" xml:space="preserve">
+	  <value>Perfectコンボ、Bad失敗</value>
+  </data>
+  <data name="Great Combo, Bad Break" xml:space="preserve">
+	  <value>Greatコンボ、Bad失敗</value>
+  </data>
+  <data name="Notes to Full Life From Start of Song (50%)" xml:space="preserve">
+	  <value>曲開始から満タンまでのノーツ数（50%）</value>
+  </data>
+  <data name="Perfects" xml:space="preserve">
+	  <value>Perfect数</value>
+  </data>
+  <data name="Greats" xml:space="preserve">
+	  <value>Great数</value>
+  </data>
+  <data name="Lifebar Description" xml:space="preserve">
+	  <value>ライフバー説明</value>
+  </data>
+  <data name="Starting life is 500, visible  Life (Rainbow life bar) is 1000." xml:space="preserve">
+	  <value>開始体力は500、視覚体力（虹色ライフバー）は1000です。</value>
+	  
+  </data>
+  <data name="Lifebar overflows exponentially by level, up to about a 2350 overflow at level 28." xml:space="preserve">
+	  <value>ライフバーはレベルに応じて指数的にオーバーフローし、レベル28で約2350のオーバーフローに達します。</value>
+  </data>
+  <data name="Life loss description" xml:space="preserve">
+	  <value>体力減少について</value>
+  </data>
+  <data name="By default, bads lose 50 health, misses lose 250 health (at ~100% health)." xml:space="preserve">
+	  <value>デフォルトでBadは体力-50、Missは-250（体力約100%時）。</value>
+  </data>
+  <data name="Misses lose LESS health the further beneath 1000 health you are at (at 0 life you would lose 20 health for a miss)" xml:space="preserve">
+	  <value>1000体力より低いほどMissで失う体力は少なくなります（体力0ではMissで20失うのみ）。</value>
+  </data>
+  <data name="Life gain description" xml:space="preserve">
+	  <value>体力回復について</value>
+  </data>
+  <data name="By default at high combo, perfects gain 9.6 life, greats gain 8 life, goods gain 0 life." xml:space="preserve">
+	  <value>デフォルトで高コンボ時、Perfectは体力+9.6、Greatは+8、Goodは+0。</value>
+  </data>
+  <data name="This is modified by a multiplier that is almost entirely reset on a miss, and decreased drastically on a bad." xml:space="preserve">
+	  <value>これは倍率により調整され、Missでほぼ完全にリセットされ、Badで大きく減少します。</value>
+  </data>
+  <data name="Each perfect or great you get increases the multiplier by a minor amount." xml:space="preserve">
+	  <value>PerfectまたはGreatごとに倍率が少しずつ増加します。</value>
+  </data>
+  <data name="Effectively, this means that your life gain is heavily affected by combo, reaching maximum gain at ~40-50 combo." xml:space="preserve">
+	  <value>つまり、体力回復はコンボ数に大きく影響され、約40〜50コンボで最大値に達します。</value>
+  </data>
+  <data name="Bads vs Misses Observations" xml:space="preserve">
+	  <value>Bad対Missの観察</value>
+  </data>
+  <data name="To recover from Bads you require 17-21 combo per Bad. Bads typically let you live for 3x as long as misses." xml:space="preserve">
+	  <value>Badから回復するにはBadごとに17〜21コンボが必要です。Badは通常、Missの約3倍長く生き残れます。</value>
+  </data>
+  <data name="To remain alive you need to maintain 17-21 combo per Miss." xml:space="preserve">
+	  <value>生き残るにはMissごとに17〜21コンボの維持が必要です。</value>
+  </data>
+  <data name="To remain at 50% visible life, you need 37-46 combo per Miss." xml:space="preserve">
+	  <value>視覚体力50%を保つには、Missごとに37〜46コンボが必要です。</value>
+  </data>
+  <data name="To remain at Rainbow Life, you 46-55 combo per Miss." xml:space="preserve">
+	  <value>虹色ライフを保つには、Missごとに46〜55コンボが必要です。</value>
+	  
+  </data>
+  <data name="Bads at low health let you live for roughly 3x as long as misses, this gap increases the higher the life threshold you want to keep, up to misses punishing 6x as much when maintaining 100% visual life." xml:space="preserve">
+	  <value>低体力時、Badはミスの約3倍長く生き残れます。維持したい体力の閾値が高くなるほど差は広がり、視覚体力100%を保つ場合はミスがBadの最大6倍のペナルティになります。</value>
+  </data>
+  <data name="TLDR: Misses matter less at low life, but are always significantly more punishing than Bads." xml:space="preserve">
+	  <value>要約：Missは低体力時には影響が小さくなりますが、常にBadより大幅にペナルティが大きいです。</value>
+  </data>
+  <data name="Recovery Observations" xml:space="preserve">
+	  <value>回復の観察</value>
+  </data>
+  <data name="Misses or back-to-back Bads early in a run put you in a terribly position for maintaining life, as they reset your life gain multiplier and require you to combo ~40-50 to regain it. Start runs strong for increased success rates." xml:space="preserve">
+	  <value>プレイ序盤のMissや連続Badは、体力回復倍率をリセットし、約40〜50コンボで取り戻す必要があるため、体力維持に致命的です。成功率を上げるには序盤を強く始めましょう。</value>
+  </data>
+  <data name="When at 12% or lower visual life, a miss gives less life loss than a bad, but inhibits your recovery severely. This only really matters for notes at the end of a song or before guaranteed 100+ combo sections." xml:space="preserve">
+	  <value>視覚体力12%以下になると、MissはBadより体力減少が少なくなりますが、回復を著しく阻害します。これが本当に効くのは曲終盤や確定100+コンボ区間の前のノートだけです。</value>
+  </data>
+  <data name="TLDR" xml:space="preserve">
+	  <value>要約</value>
+  </data>
+  <data name="Misses severely hurt your lifebar." xml:space="preserve">
+	  <value>Missはライフバーを大きく損ないます。</value>
+  </data>
+  <data name="Bads mostly hurt your recovery." xml:space="preserve">
+	  <value>Badは主に回復力を損ないます。</value>
+  </data>
+  <data name="Try to maintain 17-21 combo per bad." xml:space="preserve">
+	  <value>Badごとに17〜21コンボの維持を心がけましょう。</value>
+  </data>
+  <data name="Try to maintain 40-50 combo per miss." xml:space="preserve">
+	  <value>Missごとに40〜50コンボの維持を心がけましょう。</value>
+  </data>
+  <data name="Lifebars are weird." xml:space="preserve">
+	  <value>ライフバーは奇妙です。</value>
+	  
+  </data>
+  <data name="Source" xml:space="preserve">
+	  <value>出典</value>
+  </data>
+  <data name="Team Infinitesimal, data-mine from NX2 + Prime" xml:space="preserve">
+	  <value>Team Infinitesimal、NX2 + Primeからのデータマイニング</value>
+  </data>
+  <data name="Welcome" xml:space="preserve">
+	  <value>ようこそ</value>
+  </data>
+  <data name="Welcome to Score Tracker, X!" xml:space="preserve">
+	  <value>Score Trackerへようこそ、{0}さん！</value>
+	  
+  </data>
+  <data name="Some players already maintain scores via Spreadsheets." xml:space="preserve">
+	  <value>一部のプレーヤーは既にスプレッドシートでスコアを管理しています。</value>
+  </data>
+  <data name="In some of those cases, it may be faster to upload a Spreadsheet instead of manually inputting thousands of grades." xml:space="preserve">
+	  <value>そのような場合、何千ものランクを手入力するより、スプレッドシートをアップロードする方が早いです。</value>
+  </data>
+  <data name="After the upload, if there are some rows/charts/attempts that did not upload correctly, you will be given the option to download a list of the failed rows and the reason they failed." xml:space="preserve">
+	  <value>アップロード後、正しくアップロードされなかった行・譜面・試行があれば、失敗した行とその理由のリストをダウンロードできます。</value>
+  </data>
+  <data name="Spreadsheet is uploading and being processed..." xml:space="preserve">
+	  <value>CSVファイルの処理中</value>
+  </data>
+  <data name="Parsed Scores" xml:space="preserve">
+	  <value>解析済スコア</value>
+  </data>
+  <data name="Type" xml:space="preserve">
+	  <value>種類</value>
+  </data>
+  <data name="XXLetterGrade" xml:space="preserve">
+	  <value>XXLetterGrade</value>
+	  
+  </data>
+  <data name="IsBroken" xml:space="preserve">
+	  <value>IsBroken</value>
+	  
+  </data>
+  <data name="If you leave this page or cancel, the upload will stop but you will not lose any scores that have already been recorded from your upload." xml:space="preserve">
+	  <value>このページを離れたら、アップロードしたスコアは失わないです。</value>
+  </data>
+  <data name="X/Y Uploaded. Z Remaining. W Failed to record" xml:space="preserve">
+	  <value>{0}/{1} 成功. {2} 残り. {3}登録失敗</value>
+	  
+  </data>
+  <data name="You had a few charts that were not able to be downloaded. You can download a CSV of the failures to make adjustments and try again." xml:space="preserve">
+	  <value>一部のスコアダウンロードが失敗しまいました。失敗なCSVファイルはダウンロードして編集しても一回アップロード可能です。</value>
+  </data>
+  <data name="All charts you uploaded were successfully updated!" xml:space="preserve">
+	  <value>アップロードした譜面全部更新出来ました！</value>
+  </data>
+  <data name="You somehow ended up in a state between realities. Refresh the page to try again." xml:space="preserve">
+	  <value>なんらかの理由で現実の狭間の状態になりました。ページを再読み込みして再試行してください。</value>
+  </data>
+  <data name="Supported Formats" xml:space="preserve">
+	  <value>対応フォーマット</value>
+  </data>
+  <data name="Hide" xml:space="preserve">
+	  <value>隠す</value>
+  </data>
+  <data name="Show" xml:space="preserve">
+	  <value>表示</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+	  <value>不明</value>
+  </data>
+  <data name="Player" xml:space="preserve">
+	  <value>プレーヤー</value>
+  </data>
+  <data name="Scores" xml:space="preserve">
+	  <value>スコア</value>
+  </data>
+  <data name="Download Example" xml:space="preserve">
+	  <value>サンプルダウンロード</value>
+  </data>
+  <data name="TRUE/FALSE Template" xml:space="preserve">
+	  <value>TRUE/FALSEテンプレート</value>
+  </data>
+  <data name="Letter Grade Template" xml:space="preserve">
+	  <value>ランクテンプレート</value>
+  </data>
+  <data name="Song Names" xml:space="preserve">
+	  <value>曲名</value>
+  </data>
+  <data name="Some adjustments to account for typos or difference in naming conventions have been accounted for. Song Names are Case Insensitive. (Note that some of these look the same because they are whitespace adjustments)" xml:space="preserve">
+	  <value>タイプミスや命名規則の違いに対する調整が含まれています。曲名は大文字小文字を区別しません。（同じに見えるものもありますが、空白文字の調整です）</value>
+  </data>
+  <data name="Song Name Mappings" xml:space="preserve">
+	  <value>曲名マッピング</value>
+  </data>
+  <data name="From" xml:space="preserve">
+	  <value>から</value>
+  </data>
+  <data name="To" xml:space="preserve">
+	  <value>まで</value>
+  </data>
+  <data name="Could not find chart" xml:space="preserve">
+	  <value>譜面が見つかりません</value>
+  </data>
+  <data name="Could not find song" xml:space="preserve">
+	  <value>曲が見つかりません</value>
+  </data>
+  <data name="An unknown error occurred" xml:space="preserve">
+	  <value>不明なエラーが発生しました</value>
+  </data>
+  <data name="File cannot be larger than 10 MB" xml:space="preserve">
+	  <value>ファイルは10MB以下にしてください</value>
+  </data>
+  <data name="There was an unknown error while parsing the file" xml:space="preserve">
+	  <value>ファイル解析中に不明なエラーが発生しました</value>
+  </data>
+  <data name="No Recorded Scores" xml:space="preserve">
+	  <value>スコア記録なし</value>
+  </data>
+  <data name="None" xml:space="preserve">
+	  <value>なし</value>
+  </data>
+  <data name="X% of Y Comparable Players" xml:space="preserve">
+	  <value>比較対象プレーヤー{1}人中{0}%</value>
+	  
+  </data>
+  <data name="Wouldn't You Like To Know" xml:space="preserve">
+	  <value>知りたいかい</value>
+	  
+  </data>
+  <data name="About The Site" xml:space="preserve">
+	  <value>このサイトについて</value>
+  </data>
+  <data name="Source Code" xml:space="preserve">
+	  <value>ソースコード</value>
+  </data>
+  <data name="Privacy Policy" xml:space="preserve">
+	  <value>個人情報保護方針</value>
+  </data>
+  <data name="Site constructed and maintained by DrMurloc" xml:space="preserve">
+	  <value>サイト製作・運営：DrMurloc</value>
+  </data>
+  <data name="Original Concept (excel score tracking) Constructed by KyleTT" xml:space="preserve">
+	  <value>元案（Excelスコア管理）はKyleTTさんが構築</value>
+  </data>
+  <data name="Bounties" xml:space="preserve">
+	  <value>バウンティ</value>
+  </data>
+  <data name="Bounty Leaderboard" xml:space="preserve">
+	  <value>バウンティランキング</value>
+  </data>
+  <data name="Monthly Total" xml:space="preserve">
+	  <value>月間合計</value>
+  </data>
+  <data name="Total" xml:space="preserve">
+	  <value>総計</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+	  <value>開始</value>
+  </data>
+  <data name="Game Stats" xml:space="preserve">
+	  <value>ゲーム統計</value>
+  </data>
+  <data name="Total Popularity Singles vs Doubles" xml:space="preserve">
+	  <value>総人気 Singles対Doubles</value>
+  </data>
+  <data name="Total Singles vs Doubles" xml:space="preserve">
+	  <value>総合 Singles対Doubles</value>
+  </data>
+  <data name="Chart Count By Level" xml:space="preserve">
+	  <value>レベル別譜面数</value>
+  </data>
+  <data name="Note Counts" xml:space="preserve">
+	  <value>ノーツ数</value>
+  </data>
+  <data name="X Note counts" xml:space="preserve">
+	  <value>{0}ノーツ数</value>
+	  
+  </data>
+  <data name="X Progress" xml:space="preserve">
+	  <value>{0}進捗</value>
+	  
+  </data>
+  <data name="Minimums" xml:space="preserve">
+	  <value>最小値</value>
+  </data>
+  <data name="Standard Low" xml:space="preserve">
+	  <value>標準低</value>
+  </data>
+  <data name="Standard High" xml:space="preserve">
+	  <value>標準高</value>
+  </data>
+  <data name="Maximums" xml:space="preserve">
+	  <value>最大値</value>
+  </data>
+  <data name="Missing" xml:space="preserve">
+	  <value>欠損</value>
+  </data>
+  <data name="Existing" xml:space="preserve">
+	  <value>既存</value>
+  </data>
+  <data name="LetterDifficulties" xml:space="preserve">
+	  <value>LetterDifficulties</value>
+	  
+  </data>
+  <data name="Folder Weighted Distribution" xml:space="preserve">
+	  <value>フォルダ重み付け分布</value>
+  </data>
+  <data name="Letter Difficulty" xml:space="preserve">
+	  <value>ランク難度</value>
+  </data>
+  <data name="Median" xml:space="preserve">
+	  <value>中央値</value>
+  </data>
+  <data name="Selected Chart" xml:space="preserve">
+	  <value>選択した譜面</value>
+  </data>
+  <data name="Percentile Distribution" xml:space="preserve">
+	  <value>パーセンタイル分布</value>
+  </data>
+  <data name="Difficulty By Letter" xml:space="preserve">
+	  <value>ランク別難度</value>
+  </data>
+  <data name="User Matches" xml:space="preserve">
+	  <value>ユーザー試合</value>
+  </data>
+  <data name="Calculated Tier List" xml:space="preserve">
+	  <value>計算ティアリスト</value>
+  </data>
+  <data name="Similar Players" xml:space="preserve">
+	  <value>近いプレーヤー</value>
+  </data>
+  <data name="Private User - X" xml:space="preserve">
+	  <value>非公開ユーザー - {0}</value>
+	  
+  </data>
+  <data name="Final Result" xml:space="preserve">
+	  <value>最終結果</value>
+  </data>
+  <data name="ChartScoring" xml:space="preserve">
+	  <value>ChartScoring</value>
+	  
+  </data>
+  <data name="Target Player Level" xml:space="preserve">
+	  <value>対象プレーヤーレベル</value>
+  </data>
+  <data name="Player Weights" xml:space="preserve">
+	  <value>プレーヤー重み</value>
+  </data>
+  <data name="All players with scores within the target folder are assigned weights based on how close their competitive level is to X." xml:space="preserve">
+	  <value>対象フォルダ内のスコアを持つ全プレーヤーは、競技レベルが{0}にどれだけ近いかに基づいて重み付けされます。</value>
+	  
+  </data>
+  <data name="Highlighted players have a recorded score on the chart in question." xml:space="preserve">
+	  <value>ハイライトされたプレーヤーは該当譜面のスコア記録があります。</value>
+  </data>
+  <data name="Anonymous" xml:space="preserve">
+	  <value>匿名</value>
+	  
+  </data>
+  <data name="Competitively" xml:space="preserve">
+	  <value>競技的に</value>
+	  
+  </data>
+  <data name="Folder Averages" xml:space="preserve">
+	  <value>フォルダ平均</value>
+  </data>
+  <data name="The target folder and the three surrounding are provided weighted average scores utilizing the player weights above." xml:space="preserve">
+	  <value>対象フォルダと前後3つのフォルダには、上記のプレーヤー重みを用いた重み付け平均スコアが提供されます。</value>
+  </data>
+  <data name="These averages are shifted away from the level in question by .5 of a standard deviation within their respective folder to make sure level changes are better represented by the bulk of a surrounding folder." xml:space="preserve">
+	  <value>これらの平均は、対象レベルから各フォルダ内の標準偏差0.5分ずらされており、レベル変動が周辺フォルダの大半でよりよく表現されるようになっています。</value>
+  </data>
+  <data name="Weighted Average Scores By Folder" xml:space="preserve">
+	  <value>フォルダ別重み付け平均スコア</value>
+  </data>
+  <data name="Chart Average" xml:space="preserve">
+	  <value>譜面平均</value>
+  </data>
+  <data name="The chart in question has its weighted average score projected onto the score distributions" xml:space="preserve">
+	  <value>該当譜面の重み付け平均スコアがスコア分布に投影されます</value>
+  </data>
+  <data name="There was not enough data for the targeted player level to evaluate a final difficulty." xml:space="preserve">
+	  <value>対象プレーヤーレベルの最終難度を評価するのにデータが不足しています。</value>
+  </data>
+  <data name="The weighted average for this chart is better than the average for a X." xml:space="preserve">
+	  <value>この譜面の重み付け平均は、{0}の平均より良いです。</value>
+	  
+  </data>
+  <data name="In this case, the chart is determined to be below by X utilizing standard deviations in the Y folder." xml:space="preserve">
+	  <value>この場合、{1}フォルダ内の標準偏差を用いて、譜面は{0}だけ下と判定されます。</value>
+	  
+  </data>
+  <data name="The weighted average for this chart is worst than the average for a X." xml:space="preserve">
+	  <value>この譜面の重み付け平均は、{0}の平均より悪いです。</value>
+	  
+  </data>
+  <data name="In this case, the chart is determined to be above by X utilizing standard deviations in the Y folder." xml:space="preserve">
+	  <value>この場合、{1}フォルダ内の標準偏差を用いて、譜面は{0}だけ上と判定されます。</value>
+	  
+  </data>
+  <data name="Determined to be X between Y and Z" xml:space="preserve">
+	  <value>{1}と{2}の間で{0}と判定</value>
+	  
+  </data>
+  <data name="Final Result: X" xml:space="preserve">
+	  <value>最終結果：{0}</value>
+	  
+  </data>
+  <data name="At this point, it's identified that this chart has no players with a weight of .5 or higher (within 1 level). The chart is marked as not having a scoring level as any estimation would be based on missing data." xml:space="preserve">
+	  <value>この時点で、この譜面には重み0.5以上（1レベル以内）のプレーヤーがいないと判定されます。データ不足のため、譜面はスコアレベルなしとマークされます。</value>
+  </data>
+  <data name="Difficulty By Player Level" xml:space="preserve">
+	  <value>プレーヤーレベル別難度</value>
+  </data>
+  <data name="The listed scoring difficulty is calculated for players competitively playing in the officially listed folder for a chart." xml:space="preserve">
+	  <value>表示されているスコア難度は、譜面の公式フォルダで競技的にプレイするプレーヤーを基準に計算されています。</value>
+  </data>
+  <data name="The outcome of this algorithm has drastically different results for players at different levels though" xml:space="preserve">
+	  <value>ただし、このアルゴリズムの結果はプレーヤーのレベルによって大きく異なります</value>
+  </data>
+  <data name="This is intended. There are charts that are relatively easier to score to others in the folder for players just pushing into the folder, but are harder for higher level players to perfect." xml:space="preserve">
+	  <value>これは意図的です。フォルダに入りたてのプレーヤーには相対的にスコアを取りやすい譜面でも、上級プレーヤーには完璧にするのが難しい譜面があります。</value>
+  </data>
+  <data name="Scoring Level by Player Competitive Level" xml:space="preserve">
+	  <value>プレーヤー競技レベル別スコアレベル</value>
+  </data>
+  <data name="Player Levels" xml:space="preserve">
+	  <value>プレーヤーレベル</value>
+  </data>
+  <data name="For CoOps, scoring level is simply the lowest level player who's been able to pass the chart." xml:space="preserve">
+	  <value>CoOpの場合、スコアレベルは譜面をクリアできた最も低いレベルのプレーヤーで決まります。</value>
+  </data>
+  <data name="This isn't perfect, but until I have more data other algorithms haven't been successful at projecting CoOps onto difficulty levels" xml:space="preserve">
+	  <value>完璧ではありませんが、データが揃うまで他のアルゴリズムはCoOpを難度レベルに投影することに成功していません</value>
+  </data>
+  <data name="No one has passed this CoOp yet so no level is assigned." xml:space="preserve">
+	  <value>このCoOpは誰もクリアしていないので、レベル未割当です。</value>
+  </data>
+  <data name="This gives this chart a scoring level of: X" xml:space="preserve">
+	  <value>これによりこの譜面のスコアレベルは：{0}</value>
+	  
+  </data>
+  <data name="Best Attempts" xml:space="preserve">
+	  <value>最高試行</value>
+  </data>
+  <data name="XX Progress" xml:space="preserve">
+	  <value>XX進捗</value>
+  </data>
+  <data name="Share Your Progress Page" xml:space="preserve">
+	  <value>進捗ページを共有</value>
+  </data>
+  <data name="Overview" xml:space="preserve">
+	  <value>概要</value>
+  </data>
+  <data name="As" xml:space="preserve">
+	  <value>A数</value>
+	  
+  </data>
+  <data name="Ss" xml:space="preserve">
+	  <value>S数</value>
+	  
+  </data>
+  <data name="SSs" xml:space="preserve">
+	  <value>SS数</value>
+	  
+  </data>
+  <data name="SSSs" xml:space="preserve">
+	  <value>SSS数</value>
+	  
+  </data>
+  <data name="Passed" xml:space="preserve">
+	  <value>クリア数</value>
+  </data>
+  <data name="Unpassed" xml:space="preserve">
+	  <value>未クリア</value>
+  </data>
+  <data name="Overall Letters" xml:space="preserve">
+	  <value>総合ランク</value>
+  </data>
+  <data name="Overall Passes" xml:space="preserve">
+	  <value>総合クリア</value>
+  </data>
+  <data name="Difficulty Letters" xml:space="preserve">
+	  <value>難度ランク</value>
+  </data>
+  <data name="Difficulty Passes" xml:space="preserve">
+	  <value>難度別クリア</value>
+  </data>
+  <data name="Share Url" xml:space="preserve">
+	  <value>共有URL</value>
+  </data>
+  <data name="Copied to clipboard!" xml:space="preserve">
+	  <value>クリップボードにコピーしました！</value>
+  </data>
+  <data name="Ungraded" xml:space="preserve">
+	  <value>未ランク</value>
+  </data>
+  <data name="Pass" xml:space="preserve">
+	  <value>クリア</value>
+  </data>
+  <data name="Difficulty Progress" xml:space="preserve">
+	  <value>難度進捗</value>
+  </data>
+  <data name="Passes" xml:space="preserve">
+	  <value>クリア</value>
+  </data>
+  <data name="Min Score" xml:space="preserve">
+	  <value>最低スコア</value>
+  </data>
+  <data name="Avg Score" xml:space="preserve">
+	  <value>平均スコア</value>
+  </data>
+  <data name="Max Score" xml:space="preserve">
+	  <value>最高スコア</value>
+  </data>
+  <data name="Avg Plate" xml:space="preserve">
+	  <value>平均プレート</value>
+  </data>
+  <data name="Passes By Level" xml:space="preserve">
+	  <value>レベル別クリア</value>
+  </data>
+  <data name="Remaining" xml:space="preserve">
+	  <value>残り</value>
+  </data>
+  <data name="Score Distribution Lines" xml:space="preserve">
+	  <value>スコア分布ライン</value>
+  </data>
+  <data name="Score Distribution" xml:space="preserve">
+	  <value>スコア分布</value>
+  </data>
+  <data name="Min" xml:space="preserve">
+	  <value>最小</value>
+  </data>
+  <data name="Max" xml:space="preserve">
+	  <value>最大</value>
+  </data>
+  <data name="Singles vs Doubles" xml:space="preserve">
+	  <value>Singles対Doubles</value>
+  </data>
+  <data name="Score Rankings" xml:space="preserve">
+	  <value>スコアランキング</value>
+  </data>
+  <data name="Scoring Rankings" xml:space="preserve">
+	  <value>スコアランキング</value>
+  </data>
+  <data name="Score Rankings (the colored scores) are based on comparisons to similarly skilled players." xml:space="preserve">
+	  <value>スコアランキング（色付きスコア）は、同程度の実力のプレーヤーとの比較に基づいています。</value>
+  </data>
+  <data name="The higher percent of players in your range that you perform better than, the better the color:" xml:space="preserve">
+	  <value>自分の範囲内のプレーヤーのうち、より高い割合に勝るほど、色も良くなります：</value>
+  </data>
+  <data name="100% (or everyone with a PG)" xml:space="preserve">
+	  <value>100%（またはPG獲得者全員）</value>
+	  
+  </data>
+  <data name="Similarly skilled players to you for Singles:" xml:space="preserve">
+	  <value>Singlesで自分と近い実力のプレーヤー：</value>
+  </data>
+  <data name="Similarly skilled players to you for Doubles (CoOp charts use doubles competitive level):" xml:space="preserve">
+	  <value>Doublesで自分と近い実力のプレーヤー（CoOp譜面はDoubles競技レベル使用）：</value>
+  </data>
+  <data name="Active Tournaments" xml:space="preserve">
+	  <value>開催中の大会</value>
+  </data>
+  <data name="Upcoming Tournaments" xml:space="preserve">
+	  <value>予定の大会</value>
+  </data>
+  <data name="Previous Tournaments" xml:space="preserve">
+	  <value>過去の大会</value>
+  </data>
+  <data name="Tournament" xml:space="preserve">
+	  <value>大会</value>
+  </data>
+  <data name="Start Date" xml:space="preserve">
+	  <value>開始日</value>
+  </data>
+  <data name="End Date" xml:space="preserve">
+	  <value>終了日</value>
+  </data>
+  <data name="Location" xml:space="preserve">
+	  <value>場所</value>
+  </data>
+  <data name="Always" xml:space="preserve">
+	  <value>常時</value>
+	  
+  </data>
+  <data name="Never" xml:space="preserve">
+	  <value>なし</value>
+	  
+  </data>
+  <data name="Start Date: X" xml:space="preserve">
+	  <value>開始日：{0}</value>
+	  
+  </data>
+  <data name="End Date: X" xml:space="preserve">
+	  <value>終了日：{0}</value>
+	  
+  </data>
+  <data name="Players have X to play charts. You are allowed to finish the song you are on when your time runs out. Your total score is total combined score of all charts you play." xml:space="preserve">
+	  <value>プレーヤーは{0}間譜面をプレイできます。時間切れの際、現在の曲は最後までプレイ可能です。総合スコアは全プレイ譜面の合計スコアです。</value>
+	  
+  </data>
+  <data name="Base Level Scores" xml:space="preserve">
+	  <value>基本レベルスコア</value>
+  </data>
+  <data name="Broken scores get a multiplier of X" xml:space="preserve">
+	  <value>失敗スコアに倍率{0}が適用されます</value>
+	  
+  </data>
+  <data name="Songs will have score adjusted based on song length (treating 2 minutes as baseline)" xml:space="preserve">
+	  <value>曲はその長さに応じてスコアが調整されます（2分を基準として扱います）</value>
+  </data>
+  <data name="are" xml:space="preserve">
+	  <value>する</value>
+	  
+  </data>
+  <data name="are not" xml:space="preserve">
+	  <value>しない</value>
+	  
+  </data>
+  <data name="Repeated charts X allowed." xml:space="preserve">
+	  <value>繰り返し譜面は{0}。</value>
+	  
+  </data>
+  <data name="X Brackets" xml:space="preserve">
+	  <value>{0} ブラケット</value>
+	  
+  </data>
+  <data name="Sync Qualifier Leaderboard" xml:space="preserve">
+	  <value>資格ランキング同期</value>
+  </data>
+  <data name="New Player Name" xml:space="preserve">
+	  <value>新プレーヤー名</value>
+  </data>
+  <data name="Add Player" xml:space="preserve">
+	  <value>プレーヤー追加</value>
+  </data>
+  <data name="Player Name" xml:space="preserve">
+	  <value>プレーヤー名</value>
+  </data>
+  <data name="Seed" xml:space="preserve">
+	  <value>シード</value>
+  </data>
+  <data name="Discord Id" xml:space="preserve">
+	  <value>Discord ID</value>
+  </data>
+  <data name="Notes" xml:space="preserve">
+	  <value>ノーツ</value>
+  </data>
+  <data name="Potential Conflict" xml:space="preserve">
+	  <value>競合の可能性</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+	  <value>削除</value>
+  </data>
+  <data name="Permissions" xml:space="preserve">
+	  <value>権限</value>
+  </data>
+  <data name="Players (Paste UserId from Account Page if not Public)" xml:space="preserve">
+	  <value>プレーヤー（非公開の場合はアカウントページのユーザーIDを貼付）</value>
+  </data>
+  <data name="Tournament Role" xml:space="preserve">
+	  <value>大会役割</value>
+  </data>
+  <data name="Machines" xml:space="preserve">
+	  <value>機種</value>
+  </data>
+  <data name="Machine Name" xml:space="preserve">
+	  <value>機種名</value>
+  </data>
+  <data name="Is Warmup" xml:space="preserve">
+	  <value>ウォームアップ</value>
+  </data>
+  <data name="Priority" xml:space="preserve">
+	  <value>優先度</value>
+  </data>
+  <data name="Player added" xml:space="preserve">
+	  <value>プレーヤー追加しました</value>
+  </data>
+  <data name="This user does not exist. Double check the User Id" xml:space="preserve">
+	  <value>このユーザーは存在しません。ユーザーIDを再確認してください</value>
+  </data>
+  <data name="Players synced" xml:space="preserve">
+	  <value>プレーヤー同期しました</value>
+  </data>
+  <data name="Record Session" xml:space="preserve">
+	  <value>セッション記録</value>
+  </data>
+  <data name="Test Scores" xml:space="preserve">
+	  <value>テストスコア</value>
+  </data>
+  <data name="Show Extra Info" xml:space="preserve">
+	  <value>追加情報を表示</value>
+  </data>
+  <data name="Difficulty Range" xml:space="preserve">
+	  <value>難度範囲</value>
+  </data>
+  <data name="Average Difficulty" xml:space="preserve">
+	  <value>平均難度</value>
+  </data>
+  <data name="Total Chart Bonus" xml:space="preserve">
+	  <value>総譜面ボーナス</value>
+  </data>
+  <data name="Pass Rate" xml:space="preserve">
+	  <value>クリア率</value>
+  </data>
+  <data name="Average PPS" xml:space="preserve">
+	  <value>平均PPS</value>
+  </data>
+  <data name="Rest Time" xml:space="preserve">
+	  <value>休憩時間</value>
+  </data>
+  <data name="Verification" xml:space="preserve">
+	  <value>確認</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+	  <value>編集</value>
+  </data>
+  <data name="X Charts" xml:space="preserve">
+	  <value>{0}譜面</value>
+	  
+  </data>
+  <data name="In Person" xml:space="preserve">
+	  <value>現地</value>
+  </data>
+  <data name="Estimated Point Gain Timeline" xml:space="preserve">
+	  <value>推定ポイント獲得タイムライン</value>
+  </data>
+  <data name="Points Per Second" xml:space="preserve">
+	  <value>秒間ポイント</value>
+  </data>
+  <data name="Chart Statistics" xml:space="preserve">
+	  <value>譜面統計</value>
+  </data>
+  <data name="Play Count" xml:space="preserve">
+	  <value>プレイ数</value>
+  </data>
+  <data name="Best Score" xml:space="preserve">
+	  <value>最高スコア</value>
+  </data>
+  <data name="X Plays" xml:space="preserve">
+	  <value>{0}プレイ数</value>
+	  
+  </data>
+  <data name="Stamina Session Builder" xml:space="preserve">
+	  <value>スタミナセッション構築</value>
+  </data>
+  <data name="Tournament Settings" xml:space="preserve">
+	  <value>大会設定</value>
+  </data>
+  <data name="PreBuilt Tournament Configuration" xml:space="preserve">
+	  <value>大会設定プリセット</value>
+  </data>
+  <data name="Default" xml:space="preserve">
+	  <value>デフォルト</value>
+  </data>
+  <data name="Levels" xml:space="preserve">
+	  <value>レベル</value>
+  </data>
+  <data name="Adjust Scores to Song Duration (uses 2 minutes as average chart duration)" xml:space="preserve">
+	  <value>スコアを曲時間に応じて調整（平均譜面時間を2分として計算）</value>
+  </data>
+  <data name="Continous Modifier Scale (modifier increments between letter grades)" xml:space="preserve">
+	  <value>連続倍率スケール（ランク間で倍率が増加）</value>
+	  
+  </data>
+  <data name="Perfect Score Modifier (Acts as a letter grade beyond SSS+)" xml:space="preserve">
+	  <value>パーフェクトスコア倍率（SSS+を超えるランクとして機能）</value>
+  </data>
+  <data name="Minimum Score" xml:space="preserve">
+	  <value>最低スコア</value>
+  </data>
+  <data name="Input Json" xml:space="preserve">
+	  <value>JSON入力</value>
+  </data>
+  <data name="Set Charts" xml:space="preserve">
+	  <value>セット譜面</value>
+  </data>
+  <data name="Extra Settings" xml:space="preserve">
+	  <value>追加設定</value>
+  </data>
+  <data name="Allow Repeats" xml:space="preserve">
+	  <value>繰り返し許可</value>
+  </data>
+  <data name="Stage Break Modifier" xml:space="preserve">
+	  <value>Stage失敗倍率</value>
+  </data>
+  <data name="Session Duration (Minutes)" xml:space="preserve">
+	  <value>セッション時間（分）</value>
+  </data>
+  <data name="Custom Scoring Formula" xml:space="preserve">
+	  <value>カスタムスコア式</value>
+  </data>
+  <data name="Admin Settings" xml:space="preserve">
+	  <value>管理設定</value>
+  </data>
+  <data name="Tournament Dates (EST)" xml:space="preserve">
+	  <value>大会日程（EST）</value>
+  </data>
+  <data name="Tournament Name" xml:space="preserve">
+	  <value>大会名</value>
+  </data>
+  <data name="Test With Player Data" xml:space="preserve">
+	  <value>プレーヤーデータでテスト</value>
+  </data>
+  <data name="Import Your Phoenix Scores" xml:space="preserve">
+	  <value>Phoenixスコアをインポート</value>
+  </data>
+  <data name="Hide Record-less Charts" xml:space="preserve">
+	  <value>記録なし譜面を隠す</value>
+  </data>
+  <data name="Hide Zero Scoring Charts" xml:space="preserve">
+	  <value>スコアレベル0の譜面を隠す</value>
+  </data>
+  <data name="Player To Test (Must Be Set To Public)" xml:space="preserve">
+	  <value>テスト対象プレーヤー（公開設定必須）</value>
+  </data>
+  <data name="Effective Level" xml:space="preserve">
+	  <value>実効レベル</value>
+  </data>
+  <data name="Your Score" xml:space="preserve">
+	  <value>自己スコア</value>
+  </data>
+  <data name="Points Pre-Score" xml:space="preserve">
+	  <value>ポイント（スコア前）</value>
+  </data>
+  <data name="Points Per Second Pre-Score" xml:space="preserve">
+	  <value>秒間ポイント（スコア前）</value>
+  </data>
+  <data name="Your Points" xml:space="preserve">
+	  <value>自己ポイント</value>
+  </data>
+  <data name="Your Points per Second" xml:space="preserve">
+	  <value>自己秒間ポイント</value>
+  </data>
+  <data name="Example Set Builder" xml:space="preserve">
+	  <value>サンプルセット構築</value>
+  </data>
+  <data name="Seconds of Rest Per Chart" xml:space="preserve">
+	  <value>譜面ごとの休憩秒数</value>
+  </data>
+  <data name="Build Session" xml:space="preserve">
+	  <value>セッション構築</value>
+  </data>
+  <data name="Score: X" xml:space="preserve">
+	  <value>スコア：{0}</value>
+	  
+  </data>
+  <data name="Total Charts: X" xml:space="preserve">
+	  <value>総譜面数：{0}</value>
+	  
+  </data>
+  <data name="Rest Time Per Chart: X" xml:space="preserve">
+	  <value>譜面ごとの休憩時間：{0}</value>
+	  
+  </data>
+  <data name="Duration" xml:space="preserve">
+	  <value>時間</value>
+  </data>
+  <data name="Chart Score" xml:space="preserve">
+	  <value>譜面スコア</value>
+  </data>
+  <data name="Session Score" xml:space="preserve">
+	  <value>セッションスコア</value>
+  </data>
+  <data name="Couldn't parse JSON" xml:space="preserve">
+	  <value>JSON解析失敗</value>
+  </data>
+  <data name="PIU Tier List" xml:space="preserve">
+	  <value>PIUティアリスト</value>
+  </data>
+  <data name="Category" xml:space="preserve">
+	  <value>カテゴリー</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+	  <value>タイトル</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+	  <value>説明</value>
+  </data>
+  <data name="Community Completion" xml:space="preserve">
+	  <value>コミュニティ達成</value>
+  </data>
+  <data name="Completion" xml:space="preserve">
+	  <value>達成</value>
+  </data>
+  <data name="Competitive Level" xml:space="preserve">
+	  <value>競技レベル</value>
+  </data>
+  <data name="All" xml:space="preserve">
+	  <value>全て</value>
+  </data>
+  <data name="Competitive Level: X" xml:space="preserve">
+	  <value>競技レベル：{0}</value>
+	  
+  </data>
+  <data name="Min Level" xml:space="preserve">
+	  <value>最小レベル</value>
+  </data>
+  <data name="Max Level" xml:space="preserve">
+	  <value>最大レベル</value>
+  </data>
+  <data name="Show Scoreless" xml:space="preserve">
+	  <value>スコアなし表示</value>
+  </data>
+  <data name="Show Top Only" xml:space="preserve">
+	  <value>上位のみ表示</value>
+  </data>
+  <data name="My Relative Difficulty" xml:space="preserve">
+	  <value>自分の相対難度</value>
+  </data>
+  <data name="Scoring Difficulty" xml:space="preserve">
+	  <value>スコア難度</value>
+  </data>
+  <data name="PIUGame Leaderboard Difficulty" xml:space="preserve">
+	  <value>PIUGameランキング難度</value>
+  </data>
+  <data name="Weekly Charts" xml:space="preserve">
+	  <value>週間譜面</value>
+  </data>
+  <data name="Current" xml:space="preserve">
+	  <value>現在</value>
+  </data>
+  <data name="Show Only Suggested Charts" xml:space="preserve">
+	  <value>おすすめ譜面のみ表示</value>
+  </data>
+  <data name="Monthly Leaderboard" xml:space="preserve">
+	  <value>月間ランキング</value>
+  </data>
+  <data name="Road to BITE (Monthly Leaderboard July 8th - August 4th)" xml:space="preserve">
+	  <value>Road to BITE（月間ランキング 7月8日〜8月4日）</value>
+	  
+  </data>
+  <data name="Week X - Top Y Charts" xml:space="preserve">
+	  <value>第{0}週 - トップ{1}譜面</value>
+	  
+  </data>
+  <data name="Leaderboard Type" xml:space="preserve">
+	  <value>ランキング種類</value>
+  </data>
+  <data name="Combined" xml:space="preserve">
+	  <value>合算</value>
+  </data>
+  <data name="Co-Op" xml:space="preserve">
+	  <value>Co-Op</value>
+	  
+  </data>
+  <data name="What Should I Play" xml:space="preserve">
+	  <value>何をプレイしようか</value>
+	  
+  </data>
+  <data name="What Should I Play?" xml:space="preserve">
+	  <value>何をプレイしようか？</value>
+	  
+  </data>
+  <data name="See Leaderboards" xml:space="preserve">
+	  <value>ランキングを見る</value>
+  </data>
+  <data name="Top 50 X" xml:space="preserve">
+	  <value>{0}トップ50</value>
+	  
+  </data>
+  <data name="Stats" xml:space="preserve">
+	  <value>統計</value>
+  </data>
+  <data name="Singles Level" xml:space="preserve">
+	  <value>Singlesレベル</value>
+  </data>
+  <data name="Doubles Level" xml:space="preserve">
+	  <value>Doublesレベル</value>
+  </data>
+  <data name="Good Suggestion" xml:space="preserve">
+	  <value>良いおすすめ</value>
+  </data>
+  <data name="Bad Suggestion" xml:space="preserve">
+	  <value>悪いおすすめ</value>
+  </data>
+  <data name="Reason" xml:space="preserve">
+	  <value>理由</value>
+  </data>
+  <data name="Doesn't Match My Personal Skills" xml:space="preserve">
+	  <value>自分のスキルに合わない</value>
+  </data>
+  <data name="I Don't Like The Chart" xml:space="preserve">
+	  <value>譜面が好きではない</value>
+  </data>
+  <data name="Not Relevant to Category" xml:space="preserve">
+	  <value>このカテゴリーに無関係</value>
+  </data>
+  <data name="I Just Want to Hide The Chart" xml:space="preserve">
+	  <value>譜面を隠したいだけ</value>
+  </data>
+  <data name="The Category Isn't Interesting to Me'" xml:space="preserve">
+	  <value>このカテゴリーに興味がない'</value>
+	  
+  </data>
+  <data name="Other" xml:space="preserve">
+	  <value>その他</value>
+  </data>
+  <data name="Additional Comments" xml:space="preserve">
+	  <value>追加コメント</value>
+  </data>
+  <data name="Hide Chart for this Category" xml:space="preserve">
+	  <value>このカテゴリーで譜面を隠す</value>
+  </data>
+  <data name="Added to ToDo List!" xml:space="preserve">
+	  <value>やりことリストに追加しました！</value>
+  </data>
+  <data name="Removed from ToDo List!" xml:space="preserve">
+	  <value>やりことリストから削除しました！</value>
+  </data>
+  <data name="Chart Details" xml:space="preserve">
+	  <value>譜面詳細</value>
+  </data>
+  <data name="Step Artist: X" xml:space="preserve">
+	  <value>譜面作者：{0}</value>
+	  
+  </data>
+  <data name="Note Count: X" xml:space="preserve">
+	  <value>ノーツ数：{0}</value>
+	  
+  </data>
+  <data name="Chart Difficulty by Letter Grade" xml:space="preserve">
+	  <value>ランク別譜面難度</value>
+  </data>
+  <data name="Plate Distribution" xml:space="preserve">
+	  <value>プレート分布</value>
+  </data>
+  <data name="Plate Breakdown" xml:space="preserve">
+	  <value>プレート内訳</value>
+  </data>
+  <data name="Plates" xml:space="preserve">
+	  <value>プレート</value>
+  </data>
+  <data name="Score Distribution By Player Level" xml:space="preserve">
+	  <value>プレーヤーレベル別スコア分布</value>
+  </data>
+  <data name="Scores by Competitive Level" xml:space="preserve">
+	  <value>競技レベル別スコア</value>
+  </data>
+  <data name="Passes by Competitive Level" xml:space="preserve">
+	  <value>競技レベル別クリア</value>
+  </data>
+  <data name="Chart Leaderboard" xml:space="preserve">
+	  <value>譜面ランキング</value>
+  </data>
+  <data name="Content Lock" xml:space="preserve">
+	  <value>コンテンツロック</value>
+  </data>
+  <data name="Search User (Name or UserId)" xml:space="preserve">
+	  <value>ユーザー検索（名前またはユーザーID）</value>
+  </data>
+  <data name="Current Username" xml:space="preserve">
+	  <value>現在のユーザ名</value>
+  </data>
+  <data name="Lock Status" xml:space="preserve">
+	  <value>ロック状態</value>
+  </data>
+  <data name="Locked" xml:space="preserve">
+	  <value>ロック済</value>
+  </data>
+  <data name="Unlocked" xml:space="preserve">
+	  <value>ロック解除済</value>
+  </data>
+  <data name="Lock User" xml:space="preserve">
+	  <value>ユーザロック</value>
+  </data>
+  <data name="Unlock User" xml:space="preserve">
+	  <value>ユーザロック解除</value>
+  </data>
+  <data name="User locked" xml:space="preserve">
+	  <value>ユーザーをロックしました</value>
+  </data>
+  <data name="User unlocked" xml:space="preserve">
+	  <value>ユーザーのロックを解除しました</value>
+  </data>
+  <data name="Locking will set this user's username to their GameTag." xml:space="preserve">
+	  <value>ロックすると、このユーザーのユーザー名がGameTagに設定されます。</value>
+  </data>
+  <data name="This user has no GameTag. Choose a username to assign before locking." xml:space="preserve">
+	  <value>このユーザーにはGameTagがありません。ロック前にユーザー名を割り当ててください。</value>
+  </data>
+  <data name="New Username" xml:space="preserve">
+	  <value>新ユーザ名</value>
+  </data>
+  <data name="Your account is content-locked. Message an admin if you have questions." xml:space="preserve">
+	  <value>アカウントはコンテンツロック中です。質問があれば管理者へご連絡ください。</value>
+  </data>
+  <data name="Delete All Scores" xml:space="preserve">
+	  <value>全スコア削除</value>
+  </data>
+  <data name="This will delete all of your scores and reset your player stats and title progress" xml:space="preserve">
+	  <value>全スコアが削除され、プレーヤー統計とタイトル進捗がリセットされます</value>
+  </data>
+  <data name="(Optional) Also delete historical data" xml:space="preserve">
+	  <value>（任意）履歴データも削除する</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+	  <value>確認</value>
+  </data>
+  <data name="Your scores have been deleted" xml:space="preserve">
+	  <value>スコアを削除しました</value>
   </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1953,4 +1953,28 @@
   <data name="Your scores have been deleted" xml:space="preserve">
     <value>Suas pontuações foram excluídas</value>
   </data>
+  <data name="Competition" xml:space="preserve">
+    <value>Competição</value>
+  </data>
+  <data name="Completion Leaderboards" xml:space="preserve">
+    <value>Classificações de conclusão</value>
+  </data>
+  <data name="Discord" xml:space="preserve">
+    <value>Discord</value>
+  </data>
+  <data name="Lifebar Calculator" xml:space="preserve">
+    <value>Calculadora de barra de vida</value>
+  </data>
+  <data name="Official Leaderboards" xml:space="preserve">
+    <value>Classificações oficiais</value>
+  </data>
+  <data name="PIU Scores" xml:space="preserve">
+    <value>PIU Scores</value>
+  </data>
+  <data name="PUMBILITY" xml:space="preserve">
+    <value>PUMBILITY</value>
+  </data>
+  <data name="UCS Leaderboards" xml:space="preserve">
+    <value>Classificações UCS</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Shared/MainLayout.razor
+++ b/ScoreTracker/ScoreTracker/Shared/MainLayout.razor
@@ -15,7 +15,7 @@
 @implements INotificationHandler<ImportStatusUpdated>
 @implements INotificationHandler<PlayerStatsUpdatedEvent>
 @implements INotificationHandler<ImportStatusError>
-<PageTitle>PIU Scores</PageTitle>
+<PageTitle>@L["PIU Scores"]</PageTitle>
 
 <MudThemeProvider Theme="Theme" />
 <MudPopoverProvider />
@@ -25,7 +25,7 @@
 <MudLayout>
     <MudAppBar Color="Color.Primary" Fixed="false">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="() => _isOpen = !_isOpen"/>
-        <MudText Typo="Typo.h6">@(_userId == null ? "PIU Scores" : $"{UserName}")</MudText>
+        <MudText Typo="Typo.h6">@(_userId == null ? L["PIU Scores"].Value : $"{UserName}")</MudText>
         <MudSpacer></MudSpacer>
         @if (CurrentUser.IsLoggedIn)
         {
@@ -68,7 +68,7 @@
                     <MudDivider DividerType="DividerType.Middle"></MudDivider>
                     @if (_currentMix == MixEnum.Phoenix)
                     {
-                        <MudNavLink Href="/Pumbility" Icon="@Icons.Material.Filled.Star">PUMBILITY</MudNavLink>
+                        <MudNavLink Href="/Pumbility" Icon="@Icons.Material.Filled.Star">@L["PUMBILITY"]</MudNavLink>
                     }
                 }
             </MudNavGroup>
@@ -143,7 +143,7 @@
         
         <MudSpacer></MudSpacer>
         <MudNavMenu>
-            <MudNavLink Href="https://discord.gg/MEYvr3bFte" Target="_blank" Icon="@Icons.Custom.Brands.Discord">Discord</MudNavLink>
+            <MudNavLink Href="https://discord.gg/MEYvr3bFte" Target="_blank" Icon="@Icons.Custom.Brands.Discord">@L["Discord"]</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
     <MudMainContent>


### PR DESCRIPTION
## Summary

Adds Japanese as a supported UI language. Builds on top of [#44](https://github.com/DrMurloc/PumpItUpScoreTracker/pull/44) (nabulator) — their commits are preserved at the base of this branch with co-authorship intact.

- Registers \`ja-JP\` in \`Program.cs\` request-localization.
- Adds 日本語 to the language picker in [Account.razor](ScoreTracker/ScoreTracker/Pages/Account.razor:54).
- Brings \`App.ja-JP.resx\` to the current en-US baseline: 588 keys, en-US document order.
  - Preserves nabulator's 192 valid translations verbatim (and the 61 of their comment annotations that are still attached to live keys).
  - Drops 34 keys that no longer exist in en-US (pruned by f297592 and earlier en-US trims).
  - Adds 396 machine-translated entries for keys that have appeared in en-US since the original PR opened, using nabulator's translations as a domain glossary (chart → 譜面, score → スコア, pass → クリア, letter grade → ランク, leaderboard → ランキング, tier list → ティアリスト, etc.).

## Translation-quality caveats

These are deliberate trade-offs, not blockers — flagging for a native-speaker follow-up:

- Dense paragraph strings (life-bar mechanics, scoring-algorithm explainers) are first-pass machine translations.
- nabulator's existing typos (フィアルた, ツルー, やりこと) are preserved as-is for internal consistency rather than fixed in this PR. A native review pass can clean these up; doing it inline here would mix structural and quality changes.
- A few of nabulator's word choices look questionable to me (\`Mix → ベーション\`, \`Broken → Break Off\`, \`CoOp Aggregation → CoOp集合\`) — same story, deliberately not touched.

## Test plan

- [x] \`dotnet build ScoreTracker/ScoreTracker.sln -c Release\` — 0 errors, 124 warnings (all pre-existing).
- [x] \`dotnet test ScoreTracker/ScoreTracker.Tests/...\` — 599/599 pass.
- [x] \`System.Resources.ResXResourceReader\` round-trips 588 entries; format strings resolve placeholders correctly (verified \`Welcome to Score Tracker, X!\` → \`Score Trackerへようこそ、{0}さん！\`).
- [ ] Manual smoke test: switch language to 日本語 in Account, click through Charts / Tier Lists / Communities / Account, confirm Japanese renders without layout regressions.

Closes [#44](https://github.com/DrMurloc/PumpItUpScoreTracker/pull/44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)