### PR TITLE
Fix Discord score-import notifications by making per-user score cache thread-safe

### DIFF
--- a/ScoreTracker/ScoreTracker.Data/Repositories/EFPhoenixRecordsRepository.cs
+++ b/ScoreTracker/ScoreTracker.Data/Repositories/EFPhoenixRecordsRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -100,19 +101,20 @@ public sealed class EFPhoenixRecordsRepository : IPhoenixRecordRepository,
         await database.SaveChangesAsync(cancellationToken);
     }
 
-    private async Task<IDictionary<Guid, RecordedPhoenixScore>> GetCachedScores(Guid userId,
+    private async Task<ConcurrentDictionary<Guid, RecordedPhoenixScore>> GetCachedScores(Guid userId,
         CancellationToken cancellationToken)
     {
         return await _cache.GetOrCreateAsync(ScoreCache(userId), async o =>
         {
             o.AbsoluteExpiration = DateTimeOffset.Now + TimeSpan.FromMinutes(60);
             await using var database = await _factory.CreateDbContextAsync(cancellationToken);
-            var result = (await database.PhoenixBestAttempt.Where(pba => pba.UserId == userId)
+            var rows = await database.PhoenixBestAttempt.Where(pba => pba.UserId == userId)
                 .Select(pba => new RecordedPhoenixScore(pba.ChartId, pba.Score,
                     PhoenixPlateHelperMethods.TryParse(pba.Plate), pba.IsBroken, pba.RecordedDate))
-                .ToArrayAsync(cancellationToken)).ToDictionary(r => r.ChartId);
+                .ToArrayAsync(cancellationToken);
 
-            return result;
+            return new ConcurrentDictionary<Guid, RecordedPhoenixScore>(
+                rows.Select(r => new KeyValuePair<Guid, RecordedPhoenixScore>(r.ChartId, r)));
         });
     }
 


### PR DESCRIPTION
## Summary

- Switch `EFPhoenixRecordsRepository.GetCachedScores` from `Dictionary<Guid, RecordedPhoenixScore>` to `ConcurrentDictionary<Guid, RecordedPhoenixScore>` so the in-memory cache is safe to mutate via `cache[chartId] = score` under `UpdateBestAttempt` while `CommunitySaga` and `PlayerRatingSaga` concurrently iterate `.Values` and call `.TryGetValue(...)`.
- No call-site changes — same indexer / TryGetValue / Values surface area, just thread-safe now.

## Why

Users were seeing inconsistent Discord posts for score imports (new passes, upscores, rating changes) since the weekend deploy, while weekly-charts posts kept working. The race that triggered it:

1. `GetCachedScores` cached a plain `Dictionary<,>` shared by reference across all reads/writes for a given `userId`.
2. `UpdateBestAttempt` mutated that dict in place (`cache[chartId] = score`), and `CommunitySaga.Consume(PlayerScoreUpdatedEvent)` / `PlayerRatingSaga.Consume` iterated the same dict — `Dictionary<,>` explicitly does not support concurrent read+write.
3. The race had been mostly hidden because score writes were being serialized by the repository's long-lived `DbContext` field. The per-call DbContext + pooled-factory refactor ([1421c98](https://github.com/DrMurloc/PumpItUpScoreTracker/commit/1421c98), [6321a6c](https://github.com/DrMurloc/PumpItUpScoreTracker/commit/6321a6c)) removed that serialization, and the cache-TTL bump ([26eab30](https://github.com/DrMurloc/PumpItUpScoreTracker/commit/26eab30)) kept the corrupted dict in memory ~6× longer (10m → 60m absolute, plus `_cache.Set` dropping the TTL entirely on first write). Together they made the race land often and stick.
4. When the dict was in a bad state, `CommunitySaga.Consume`'s `scores.TryGetValue(c, out var score) && score.Score != null` filter quietly dropped chart IDs from the announcement, leaving `messages` empty and triggering the early `return` before `SendToCommunityDiscords`. Weekly-charts posts use the event payload directly without that lookup, which is why they were unaffected.

`ConcurrentDictionary` makes indexer writes, `TryGetValue`, and `Values` enumeration all thread-safe. Currently-stuck users self-heal at the next process restart or whenever their cache entry next rebuilds via `GetOrCreateAsync`.

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` — clean (0 errors)
- [x] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` — 601/601 passing
- [ ] Post-deploy: verify Discord posts land consistently for new-pass / upscore / rating-change events on a user who was previously affected