### PR TITLE
Add admin endpoint to dump pending score-update batches

### DIFF
--- a/ScoreTracker/ScoreTracker.Domain/Records/BatchAccumulatorSnapshotEntry.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Records/BatchAccumulatorSnapshotEntry.cs
@@ -1,0 +1,8 @@
+namespace ScoreTracker.Domain.Records;
+
+[ExcludeFromCodeCoverage]
+public sealed record BatchAccumulatorSnapshotEntry(
+    Guid UserId,
+    DateTime FireAt,
+    Guid[] NewChartIds,
+    IReadOnlyDictionary<Guid, int> UpscoredChartIds);

--- a/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPlayerScoreBatchAccumulator.cs
+++ b/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPlayerScoreBatchAccumulator.cs
@@ -31,4 +31,10 @@ public interface IPlayerScoreBatchAccumulator
 
     /// <summary>Atomically removes and returns the user's pending batch.</summary>
     PendingScoreBatch TakeBatch(Guid userId);
+
+    /// <summary>
+    /// Diagnostic snapshot of every active batch. Best-effort — entries may be
+    /// added or removed concurrently with the read.
+    /// </summary>
+    IReadOnlyCollection<BatchAccumulatorSnapshotEntry> Dump();
 }

--- a/ScoreTracker/ScoreTracker/Accessors/PlayerScoreBatchAccumulator.cs
+++ b/ScoreTracker/ScoreTracker/Accessors/PlayerScoreBatchAccumulator.cs
@@ -49,4 +49,18 @@ public sealed class PlayerScoreBatchAccumulator : IPlayerScoreBatchAccumulator
         _newCharts.TryRemove(userId, out _);
         return new PendingScoreBatch(newChartIds, upscoredChartIds);
     }
+
+    public IReadOnlyCollection<BatchAccumulatorSnapshotEntry> Dump()
+    {
+        return _fireAt.ToArray().Select(kv =>
+        {
+            var newChartIds = _newCharts.TryGetValue(kv.Key, out var newSet)
+                ? newSet.ToArray()
+                : Array.Empty<Guid>();
+            var upscored = _upscoreCharts.TryGetValue(kv.Key, out var upscoreMap)
+                ? (IReadOnlyDictionary<Guid, int>)upscoreMap.ToDictionary(e => e.Key, e => (int)e.Value)
+                : new Dictionary<Guid, int>();
+            return new BatchAccumulatorSnapshotEntry(kv.Key, kv.Value, newChartIds, upscored);
+        }).ToArray();
+    }
 }

--- a/ScoreTracker/ScoreTracker/Controllers/Api/AdminController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/AdminController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using ScoreTracker.Domain.SecondaryPorts;
+
+namespace ScoreTracker.Web.Controllers.Api;
+
+[Route("api/admin")]
+public sealed class AdminController : Controller
+{
+    private readonly ICurrentUserAccessor _currentUser;
+    private readonly IPlayerScoreBatchAccumulator _batches;
+
+    public AdminController(ICurrentUserAccessor currentUser, IPlayerScoreBatchAccumulator batches)
+    {
+        _currentUser = currentUser;
+        _batches = batches;
+    }
+
+    [HttpGet("scoreBatches")]
+    public IActionResult GetScoreBatches()
+    {
+        if (!_currentUser.IsLoggedInAsAdmin) return NotFound();
+
+        var entries = _batches.Dump();
+        return Json(new
+        {
+            Count = entries.Count,
+            Entries = entries
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- New `GET /api/admin/scoreBatches` endpoint returns the in-memory state of `PlayerScoreBatchAccumulator` (per-user `FireAt` + new clears + upscored chart IDs) as JSON, gated on `User.IsAdmin` (404s otherwise so the endpoint isn't discoverable).
- Adds a `Dump()` method to `IPlayerScoreBatchAccumulator` and a new `BatchAccumulatorSnapshotEntry` record (in `Domain/Records`, `[ExcludeFromCodeCoverage]` per convention).

## Why
Users are reporting that upscore + rating Discord notifications are largely not firing while weekly-chart notifications are fine. The notification publish is debounced 2:05 behind a MassTransit in-memory delayed message; if either the batch state or the `TryFireScoreMessage` is lost, the user's notification silently disappears. This endpoint lets us inspect what's currently sitting in the accumulator on the live App Service without a memory dump.

## Notes for the reviewer
- No `[ApiToken]` attribute — admin uses the cookie scheme (OAuth login), same posture as the Hangfire dashboard.
- `Dump()` is best-effort under concurrent writes; the implementation snapshots the `_fireAt` keys with `.ToArray()` first, then reads each entry's batch state. Comment on the interface notes this.
- All 601 existing tests still pass; existing `Mock<IPlayerScoreBatchAccumulator>` setups in handler tests are unaffected (Moq returns defaults for unset members).

## Test plan
- [ ] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` clean
- [ ] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` green
- [ ] Hit `/api/admin/scoreBatches` while logged in as DrMurloc → JSON payload
- [ ] Hit `/api/admin/scoreBatches` while logged out / as a non-admin → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)