### PR TITLE
Flush over-due Phoenix score batches every 5 minutes via Hangfire

### DIFF
--- a/ScoreTracker/ScoreTracker.Application/Handlers/UpdatePhoenixRecordHandler.cs
+++ b/ScoreTracker/ScoreTracker.Application/Handlers/UpdatePhoenixRecordHandler.cs
@@ -14,7 +14,8 @@ public sealed class UpdatePhoenixRecordHandler(IPhoenixRecordRepository records,
         IMessageScheduler scheduler,
         IPlayerScoreBatchAccumulator batches)
     : IRequestHandler<UpdatePhoenixBestAttemptCommand>,
-        IConsumer<UpdatePhoenixRecordHandler.TryFireScoreMessage>
+        IConsumer<UpdatePhoenixRecordHandler.TryFireScoreMessage>,
+        IConsumer<FlushOverdueScoreBatchesEvent>
 {
     public async Task Handle(UpdatePhoenixBestAttemptCommand request, CancellationToken cancellationToken)
     {
@@ -72,5 +73,21 @@ public sealed class UpdatePhoenixRecordHandler(IPhoenixRecordRepository records,
         await bus.Publish(
             new PlayerScoreUpdatedEvent(context.Message.UserId, batch.NewChartIds, batch.UpscoredChartIds),
             context.CancellationToken);
+    }
+
+    // Safety net for batches whose scheduled TryFireScoreMessage was lost
+    // (in-memory MassTransit transport drops in-flight messages on restart).
+    public async Task Consume(ConsumeContext<FlushOverdueScoreBatchesEvent> context)
+    {
+        var now = dateTimeOffset.Now.UtcDateTime;
+        foreach (var entry in batches.Dump())
+        {
+            if (entry.FireAt > now) continue;
+            var batch = batches.TakeBatch(entry.UserId);
+            if (batch.NewChartIds.Length == 0 && batch.UpscoredChartIds.Count == 0) continue;
+            await bus.Publish(
+                new PlayerScoreUpdatedEvent(entry.UserId, batch.NewChartIds, batch.UpscoredChartIds),
+                context.CancellationToken);
+        }
     }
 }

--- a/ScoreTracker/ScoreTracker.Domain/Events/FlushOverdueScoreBatchesEvent.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Events/FlushOverdueScoreBatchesEvent.cs
@@ -1,0 +1,7 @@
+namespace ScoreTracker.Domain.Events
+{
+    [ExcludeFromCodeCoverage]
+    public sealed record FlushOverdueScoreBatchesEvent
+    {
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdatePhoenixRecordHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdatePhoenixRecordHandlerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MassTransit;
@@ -249,6 +250,83 @@ public sealed class UpdatePhoenixRecordHandlerTests
         ctx.Scheduler.Verify(s => s.SchedulePublish(
             It.IsAny<DateTime>(),
             It.IsAny<UpdatePhoenixRecordHandler.TryFireScoreMessage>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task FlushDrainsOverdueBatchesAndPublishesPlayerScoreUpdated()
+    {
+        var ctx = new HandlerContext();
+        var overdueUserA = Guid.NewGuid();
+        var overdueUserB = Guid.NewGuid();
+        var futureUser = Guid.NewGuid();
+        var newChartA = Guid.NewGuid();
+        var upscoreChartB = Guid.NewGuid();
+        ctx.Batches.Setup(b => b.Dump()).Returns(new[]
+        {
+            new BatchAccumulatorSnapshotEntry(overdueUserA, Now.UtcDateTime - TimeSpan.FromSeconds(1),
+                new[] { newChartA }, new Dictionary<Guid, int>()),
+            new BatchAccumulatorSnapshotEntry(overdueUserB, Now.UtcDateTime - TimeSpan.FromMinutes(10),
+                Array.Empty<Guid>(), new Dictionary<Guid, int> { { upscoreChartB, 850000 } }),
+            new BatchAccumulatorSnapshotEntry(futureUser, Now.UtcDateTime + TimeSpan.FromMinutes(1),
+                new[] { Guid.NewGuid() }, new Dictionary<Guid, int>())
+        });
+        ctx.Batches.Setup(b => b.TakeBatch(overdueUserA))
+            .Returns(new PendingScoreBatch(new[] { newChartA }, new Dictionary<Guid, int>()));
+        ctx.Batches.Setup(b => b.TakeBatch(overdueUserB))
+            .Returns(new PendingScoreBatch(Array.Empty<Guid>(),
+                new Dictionary<Guid, int> { { upscoreChartB, 850000 } }));
+
+        await ctx.Handler.Consume(BuildContext(new FlushOverdueScoreBatchesEvent()));
+
+        ctx.Batches.Verify(b => b.TakeBatch(overdueUserA), Times.Once);
+        ctx.Batches.Verify(b => b.TakeBatch(overdueUserB), Times.Once);
+        ctx.Batches.Verify(b => b.TakeBatch(futureUser), Times.Never);
+        ctx.Bus.Verify(b => b.Publish(
+            It.Is<PlayerScoreUpdatedEvent>(e => e.UserId == overdueUserA
+                                                && e.NewChartIds.Length == 1
+                                                && e.NewChartIds[0] == newChartA),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Bus.Verify(b => b.Publish(
+            It.Is<PlayerScoreUpdatedEvent>(e => e.UserId == overdueUserB
+                                                && e.UpscoredChartIds.ContainsKey(upscoreChartB)),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Bus.Verify(b => b.Publish(
+            It.Is<PlayerScoreUpdatedEvent>(e => e.UserId == futureUser),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task FlushSkipsEmptyBatchesFromDrainRace()
+    {
+        // If the original TryFireScoreMessage drains the user between Dump() and TakeBatch(),
+        // we should NOT publish a noisy empty PlayerScoreUpdatedEvent.
+        var ctx = new HandlerContext();
+        var racedUser = Guid.NewGuid();
+        ctx.Batches.Setup(b => b.Dump()).Returns(new[]
+        {
+            new BatchAccumulatorSnapshotEntry(racedUser, Now.UtcDateTime - TimeSpan.FromSeconds(1),
+                new[] { Guid.NewGuid() }, new Dictionary<Guid, int>())
+        });
+        ctx.Batches.Setup(b => b.TakeBatch(racedUser))
+            .Returns(new PendingScoreBatch(Array.Empty<Guid>(), new Dictionary<Guid, int>()));
+
+        await ctx.Handler.Consume(BuildContext(new FlushOverdueScoreBatchesEvent()));
+
+        ctx.Bus.Verify(b => b.Publish(It.IsAny<PlayerScoreUpdatedEvent>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task FlushDoesNothingWhenNoBatchesActive()
+    {
+        var ctx = new HandlerContext();
+        ctx.Batches.Setup(b => b.Dump()).Returns(Array.Empty<BatchAccumulatorSnapshotEntry>());
+
+        await ctx.Handler.Consume(BuildContext(new FlushOverdueScoreBatchesEvent()));
+
+        ctx.Batches.Verify(b => b.TakeBatch(It.IsAny<Guid>()), Times.Never);
+        ctx.Bus.Verify(b => b.Publish(It.IsAny<PlayerScoreUpdatedEvent>(),
             It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/ScoreTracker/ScoreTracker/HostedServices/RecurringJobRunner.cs
+++ b/ScoreTracker/ScoreTracker/HostedServices/RecurringJobRunner.cs
@@ -33,4 +33,7 @@ public sealed class RecurringJobRunner
 
     public Task PublishTryScheduleMoM() =>
         _bus.Publish(new MarchOfMurlocsHandler.TryScheduleMoM());
+
+    public Task PublishFlushOverdueScoreBatches() =>
+        _bus.Publish(new FlushOverdueScoreBatchesEvent());
 }

--- a/ScoreTracker/ScoreTracker/Program.cs
+++ b/ScoreTracker/ScoreTracker/Program.cs
@@ -229,7 +229,8 @@ var recurringJobs = new (string Id, System.Linq.Expressions.Expression<Func<Recu
     ("process-pass-tier-list",           r => r.PublishProcessPassTierList(),             "30 9 * * *"), // 04:30 ET
     ("calculate-chart-letter-difficulties", r => r.PublishCalculateChartLetterDifficulties(), "0 10 * * *"), // 05:00 ET
     ("start-leaderboard-import",         r => r.PublishStartLeaderboardImport(),          "30 10 * * 0"), // Sundays 05:30 ET
-    ("try-schedule-mom",                 r => r.PublishTryScheduleMoM(),                  "0 11 * * *")  // 06:00 ET
+    ("try-schedule-mom",                 r => r.PublishTryScheduleMoM(),                  "0 11 * * *"), // 06:00 ET
+    ("flush-overdue-score-batches",      r => r.PublishFlushOverdueScoreBatches(),        "*/5 * * * *") // every 5 min — safety net for stuck batches
 };
 if (builder.Configuration["PreventRecurringJobs"] == "true")
 {


### PR DESCRIPTION
## Summary

- New `FlushOverdueScoreBatchesEvent` consumed by `UpdatePhoenixRecordHandler`; walks `IPlayerScoreBatchAccumulator.Dump()` and drains any user whose `FireAt` is already past, publishing the same `PlayerScoreUpdatedEvent` the existing per-user path produces.
- New Hangfire recurring job `flush-overdue-score-batches` (cron `*/5 * * * *`) on `RecurringJobRunner` to fire it.
- Three new handler tests cover: drains over-due users / leaves future ones alone, skips empty batches from drain races, no-op when nothing is queued.

## Why

Score batches debounce per-user via a `TryFireScoreMessage` that MassTransit's in-memory delayed scheduler is supposed to fire ~2 minutes later. If that scheduled message is lost (transport hiccup, process restart, scheduler exception), the batch sits in `PlayerScoreBatchAccumulator` with no fire trigger and the user's scores get stuck. The 5-minute Hangfire flush is a safety net — Hangfire's schedule is durable in SQL, so even if the bus loses messages the periodic sweep still happens.

## Reviewer notes

- The flush drains directly via `Dump`/`TakeBatch` rather than re-publishing `TryFireScoreMessage`. Re-publishing would re-enter the in-memory scheduler — the very thing we're routing around.
- Empty-batch guard handles the race where the original `TryFireScoreMessage` won the drain between our `Dump` and `TakeBatch`. Without it we'd publish a noisy empty `PlayerScoreUpdatedEvent`.
- Existing `Consume(TryFireScoreMessage)` deliberately not modified — its `GetFireAt` will still throw `KeyNotFoundException` if the flush job races it on the same user. The window is narrow (both messages firing for the same user at almost the same moment) and the existing handler is left as-is per minimal-scope.

## Test plan

- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` — 0 errors
- [x] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` — 604/604 pass (including 3 new flush tests)
- [ ] After merge, watch Hangfire dashboard at `/hangfire` for the `flush-overdue-score-batches` recurring job to appear and fire on schedule
- [ ] Confirm via the existing admin dump endpoint (`/api/admin/pending-score-batches`) that stuck batches drain within 5 min of becoming over-due

🤖 Generated with [Claude Code](https://claude.com/claude-code)