### PR TITLE
Fix race conditions in player score batch accumulator

### DIFF
--- a/ScoreTracker/ScoreTracker.Application/Handlers/UpdatePhoenixRecordHandler.cs
+++ b/ScoreTracker/ScoreTracker.Application/Handlers/UpdatePhoenixRecordHandler.cs
@@ -4,6 +4,7 @@ using ScoreTracker.Application.Commands;
 using ScoreTracker.Domain.Events;
 using ScoreTracker.Domain.Models;
 using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.Domain.ValueTypes;
 
 namespace ScoreTracker.Application.Handlers;
 
@@ -39,19 +40,16 @@ public sealed class UpdatePhoenixRecordHandler(IPhoenixRecordRepository records,
         var isUpscore = existing?.Score != null && request.Score != null && existing.Score < request.Score;
         if (!isNewScore && !isUpscore) return;
 
-        //Batches up score posts to reduce noise
+        // Batch up score posts to reduce noise. AddToBatch atomically creates-or-extends
+        // the user's batch; only schedule a drain when this call created the batch.
         var fireAt = dateTimeOffset.Now.UtcDateTime + TimeSpan.FromMinutes(2);
-        if (batches.RegisterFireAt(user.User.Id, fireAt))
+        PhoenixScore? upscoredFrom = isUpscore ? existing!.Score!.Value : null;
+        if (batches.AddToBatch(user.User.Id, fireAt, request.ChartId, isNewScore, upscoredFrom))
         {
             await scheduler.SchedulePublish(fireAt + TimeSpan.FromSeconds(5),
                 new TryFireScoreMessage(user.User.Id),
                 cancellationToken);
         }
-
-        if (isNewScore) batches.RecordNewChart(user.User.Id, request.ChartId);
-
-        if (isUpscore)
-            batches.RecordUpscoreIfNotNew(user.User.Id, request.ChartId, existing!.Score!.Value);
     }
 
     public sealed record ScheduleScoreMessage(Guid UserId, Guid[] ChartIds);
@@ -61,15 +59,20 @@ public sealed class UpdatePhoenixRecordHandler(IPhoenixRecordRepository records,
     public async Task Consume(ConsumeContext<TryFireScoreMessage> context)
     {
         var fireAt = batches.GetFireAt(context.Message.UserId);
-        if (dateTimeOffset.Now.UtcDateTime < fireAt)
+        if (fireAt is null) return; // batch already drained by a concurrent TryFire/flush
+        if (dateTimeOffset.Now.UtcDateTime < fireAt.Value)
         {
-            await scheduler.SchedulePublish(fireAt + TimeSpan.FromMinutes(2),
+            // Reschedule to the moving target plus a tiny buffer — using a +2min retry
+            // would compound on every reschedule and starve active players.
+            await scheduler.SchedulePublish(fireAt.Value + TimeSpan.FromSeconds(5),
                 new TryFireScoreMessage(context.Message.UserId),
                 context.CancellationToken);
             return;
         }
 
         var batch = batches.TakeBatch(context.Message.UserId);
+        if (batch is null) return; // raced another drain
+        if (batch.NewChartIds.Length == 0 && batch.UpscoredChartIds.Count == 0) return;
         await bus.Publish(
             new PlayerScoreUpdatedEvent(context.Message.UserId, batch.NewChartIds, batch.UpscoredChartIds),
             context.CancellationToken);
@@ -84,6 +87,7 @@ public sealed class UpdatePhoenixRecordHandler(IPhoenixRecordRepository records,
         {
             if (entry.FireAt > now) continue;
             var batch = batches.TakeBatch(entry.UserId);
+            if (batch is null) continue;
             if (batch.NewChartIds.Length == 0 && batch.UpscoredChartIds.Count == 0) continue;
             await bus.Publish(
                 new PlayerScoreUpdatedEvent(entry.UserId, batch.NewChartIds, batch.UpscoredChartIds),

--- a/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPlayerScoreBatchAccumulator.cs
+++ b/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IPlayerScoreBatchAccumulator.cs
@@ -7,30 +7,31 @@ namespace ScoreTracker.Domain.SecondaryPorts;
 /// Per-user score-update debouncer. UpdatePhoenixRecordHandler accumulates
 /// new clears and upscores into a batch and schedules a single
 /// PlayerScoreUpdatedEvent once the user has stopped recording for a while.
-/// Implementation must be a singleton so state survives across handler instances.
+/// Implementation must be a singleton so state survives across handler instances
+/// and must be safe for concurrent use across all members.
 /// </summary>
 public interface IPlayerScoreBatchAccumulator
 {
     /// <summary>
-    /// Sets the fire-at time for this user. Returns true if no batch existed yet
-    /// (caller should schedule the fire message); false if a batch was already active
-    /// (its fire time has just been pushed forward).
+    /// Atomically adds a chart update to the user's batch (creating the batch if
+    /// needed) and pushes the fire-at time forward. If <paramref name="isNewClear"/>
+    /// is true and <paramref name="upscoredFrom"/> is non-null for the same chart,
+    /// new-clear takes precedence and the upscore is dropped.
+    ///
+    /// Returns true if this call created a new batch (caller should schedule a
+    /// TryFireScoreMessage); false if a batch was already active (its fire-at has
+    /// just been pushed forward).
     /// </summary>
-    bool RegisterFireAt(Guid userId, DateTime fireAt);
+    bool AddToBatch(Guid userId, DateTime fireAt, Guid chartId, bool isNewClear, PhoenixScore? upscoredFrom);
 
-    void RecordNewChart(Guid userId, Guid chartId);
+    /// <summary>Returns the scheduled fire-at, or null if no batch is active for the user.</summary>
+    DateTime? GetFireAt(Guid userId);
 
     /// <summary>
-    /// Records an upscore against the user's batch UNLESS the chart is already
-    /// being tracked as a new clear (a new clear with a higher score takes precedence).
+    /// Atomically removes and returns the user's pending batch, or null if no batch
+    /// is active (e.g. another in-flight drain already took it).
     /// </summary>
-    void RecordUpscoreIfNotNew(Guid userId, Guid chartId, PhoenixScore previousScore);
-
-    /// <summary>Returns the scheduled fire-at time. Throws if no batch is active for the user.</summary>
-    DateTime GetFireAt(Guid userId);
-
-    /// <summary>Atomically removes and returns the user's pending batch.</summary>
-    PendingScoreBatch TakeBatch(Guid userId);
+    PendingScoreBatch? TakeBatch(Guid userId);
 
     /// <summary>
     /// Diagnostic snapshot of every active batch. Best-effort — entries may be

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdatePhoenixRecordHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdatePhoenixRecordHandlerTests.cs
@@ -25,10 +25,11 @@ public sealed class UpdatePhoenixRecordHandlerTests
     private static readonly Guid ChartId = Guid.NewGuid();
 
     [Fact]
-    public async Task NewClearSavesRecordSchedulesFireAndRecordsNewChart()
+    public async Task NewClearSavesRecordSchedulesFireAndAddsBatch()
     {
         var ctx = new HandlerContext();
-        ctx.Batches.Setup(b => b.RegisterFireAt(UserId, It.IsAny<DateTime>())).Returns(true);
+        ctx.Batches.Setup(b => b.AddToBatch(UserId, It.IsAny<DateTime>(), ChartId, true,
+            It.IsAny<PhoenixScore?>())).Returns(true);
 
         await ctx.Handler.Handle(
             new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 950000,
@@ -45,9 +46,8 @@ public sealed class UpdatePhoenixRecordHandlerTests
             It.IsAny<DateTime>(),
             It.Is<UpdatePhoenixRecordHandler.TryFireScoreMessage>(m => m.UserId == UserId),
             It.IsAny<CancellationToken>()), Times.Once);
-        ctx.Batches.Verify(b => b.RecordNewChart(UserId, ChartId), Times.Once);
-        ctx.Batches.Verify(b => b.RecordUpscoreIfNotNew(It.IsAny<Guid>(), It.IsAny<Guid>(),
-            It.IsAny<PhoenixScore>()), Times.Never);
+        ctx.Batches.Verify(b => b.AddToBatch(UserId, It.IsAny<DateTime>(), ChartId, true,
+            It.Is<PhoenixScore?>(s => !s.HasValue)), Times.Once);
     }
 
     [Fact]
@@ -116,58 +116,59 @@ public sealed class UpdatePhoenixRecordHandlerTests
     }
 
     [Fact]
-    public async Task NewClearWhenExistingWasBrokenRecordsNewChart()
+    public async Task NewClearWhenExistingWasBrokenAddsAsNewClearOnly()
     {
         var ctx = new HandlerContext();
         // Existing was broken at the same score → transition to a clear is a new clear,
         // and 950000 < 950000 is false so it is NOT also an upscore.
         ctx.GivenExistingScore(score: 950000, plate: PhoenixPlate.SuperbGame, isBroken: true);
-        ctx.Batches.Setup(b => b.RegisterFireAt(UserId, It.IsAny<DateTime>())).Returns(true);
+        ctx.Batches.Setup(b => b.AddToBatch(UserId, It.IsAny<DateTime>(), ChartId, true,
+            It.IsAny<PhoenixScore?>())).Returns(true);
 
         await ctx.Handler.Handle(
             new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 950000,
                 Plate: PhoenixPlate.SuperbGame),
             CancellationToken.None);
 
-        ctx.Batches.Verify(b => b.RecordNewChart(UserId, ChartId), Times.Once);
-        ctx.Batches.Verify(b => b.RecordUpscoreIfNotNew(It.IsAny<Guid>(), It.IsAny<Guid>(),
-            It.IsAny<PhoenixScore>()), Times.Never);
+        ctx.Batches.Verify(b => b.AddToBatch(UserId, It.IsAny<DateTime>(), ChartId, true,
+            It.Is<PhoenixScore?>(s => !s.HasValue)), Times.Once);
     }
 
     [Fact]
-    public async Task ClearedWithHigherScoreFromBrokenIsBothNewChartAndUpscore()
+    public async Task ClearedWithHigherScoreFromBrokenAddsBothFlags()
     {
-        // When transitioning from broken→clear with a higher score, both branches fire;
-        // the accumulator (per its contract) takes new-clear precedence.
+        // Broken→clear with a higher score: AddToBatch is called with isNewClear=true AND
+        // upscoredFrom=previousScore in a single atomic call. New-clear precedence is
+        // resolved inside the accumulator.
         var ctx = new HandlerContext();
         ctx.GivenExistingScore(score: 700000, plate: PhoenixPlate.RoughGame, isBroken: true);
-        ctx.Batches.Setup(b => b.RegisterFireAt(UserId, It.IsAny<DateTime>())).Returns(true);
+        ctx.Batches.Setup(b => b.AddToBatch(UserId, It.IsAny<DateTime>(), ChartId, true,
+            It.IsAny<PhoenixScore?>())).Returns(true);
 
         await ctx.Handler.Handle(
             new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 950000,
                 Plate: PhoenixPlate.SuperbGame),
             CancellationToken.None);
 
-        ctx.Batches.Verify(b => b.RecordNewChart(UserId, ChartId), Times.Once);
-        ctx.Batches.Verify(b => b.RecordUpscoreIfNotNew(UserId, ChartId,
-            It.Is<PhoenixScore>(s => s == (PhoenixScore)700000)), Times.Once);
+        ctx.Batches.Verify(b => b.AddToBatch(UserId, It.IsAny<DateTime>(), ChartId, true,
+            It.Is<PhoenixScore?>(s => s.HasValue && s.Value == (PhoenixScore)700000)), Times.Once);
     }
 
     [Fact]
-    public async Task UpscoreRecordsUpscoreWithPreviousScore()
+    public async Task UpscoreAddsAsUpscoreOnly()
     {
         var ctx = new HandlerContext();
         ctx.GivenExistingScore(score: 900000, plate: PhoenixPlate.SuperbGame, isBroken: false);
-        ctx.Batches.Setup(b => b.RegisterFireAt(UserId, It.IsAny<DateTime>())).Returns(true);
+        ctx.Batches.Setup(b => b.AddToBatch(UserId, It.IsAny<DateTime>(), ChartId, false,
+            It.IsAny<PhoenixScore?>())).Returns(true);
 
         await ctx.Handler.Handle(
             new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 970000,
                 Plate: PhoenixPlate.SuperbGame),
             CancellationToken.None);
 
-        ctx.Batches.Verify(b => b.RecordUpscoreIfNotNew(UserId, ChartId,
-            It.Is<PhoenixScore>(s => s == (PhoenixScore)900000)), Times.Once);
-        ctx.Batches.Verify(b => b.RecordNewChart(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
+        ctx.Batches.Verify(b => b.AddToBatch(UserId, It.IsAny<DateTime>(), ChartId, false,
+            It.Is<PhoenixScore?>(s => s.HasValue && s.Value == (PhoenixScore)900000)), Times.Once);
     }
 
     [Fact]
@@ -182,23 +183,22 @@ public sealed class UpdatePhoenixRecordHandlerTests
                 Plate: PhoenixPlate.SuperbGame),
             CancellationToken.None);
 
-        ctx.Batches.Verify(b => b.RegisterFireAt(It.IsAny<Guid>(), It.IsAny<DateTime>()), Times.Never);
+        ctx.Batches.Verify(b => b.AddToBatch(It.IsAny<Guid>(), It.IsAny<DateTime>(),
+            It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<PhoenixScore?>()), Times.Never);
         ctx.Scheduler.Verify(s => s.SchedulePublish(
             It.IsAny<DateTime>(),
             It.IsAny<UpdatePhoenixRecordHandler.TryFireScoreMessage>(),
             It.IsAny<CancellationToken>()), Times.Never);
-        ctx.Batches.Verify(b => b.RecordNewChart(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
-        ctx.Batches.Verify(b => b.RecordUpscoreIfNotNew(It.IsAny<Guid>(), It.IsAny<Guid>(),
-            It.IsAny<PhoenixScore>()), Times.Never);
     }
 
     [Fact]
-    public async Task SkipsSchedulingWhenBatchAlreadyActiveButStillRecords()
+    public async Task SkipsSchedulingWhenBatchAlreadyActiveButStillAdds()
     {
         var ctx = new HandlerContext();
-        // Batch already active: RegisterFireAt returns false, so the handler must NOT
-        // schedule a new fire message — but it must still record the new clear.
-        ctx.Batches.Setup(b => b.RegisterFireAt(UserId, It.IsAny<DateTime>())).Returns(false);
+        // Batch already active: AddToBatch returns false, so the handler must NOT
+        // schedule a new fire message — but the call itself must still happen.
+        ctx.Batches.Setup(b => b.AddToBatch(UserId, It.IsAny<DateTime>(), ChartId, true,
+            It.IsAny<PhoenixScore?>())).Returns(false);
 
         await ctx.Handler.Handle(
             new UpdatePhoenixBestAttemptCommand(ChartId, IsBroken: false, Score: 950000,
@@ -209,7 +209,8 @@ public sealed class UpdatePhoenixRecordHandlerTests
             It.IsAny<DateTime>(),
             It.IsAny<UpdatePhoenixRecordHandler.TryFireScoreMessage>(),
             It.IsAny<CancellationToken>()), Times.Never);
-        ctx.Batches.Verify(b => b.RecordNewChart(UserId, ChartId), Times.Once);
+        ctx.Batches.Verify(b => b.AddToBatch(UserId, It.IsAny<DateTime>(), ChartId, true,
+            It.IsAny<PhoenixScore?>()), Times.Once);
     }
 
     [Fact]
@@ -221,8 +222,10 @@ public sealed class UpdatePhoenixRecordHandlerTests
 
         await ctx.Handler.Consume(BuildContext(new UpdatePhoenixRecordHandler.TryFireScoreMessage(UserId)));
 
+        // Reschedule must use a small (+5s) buffer, NOT +2min — the latter compounds on
+        // every retry and starves active players.
         ctx.Scheduler.Verify(s => s.SchedulePublish(
-            fireAt + TimeSpan.FromMinutes(2),
+            fireAt + TimeSpan.FromSeconds(5),
             It.Is<UpdatePhoenixRecordHandler.TryFireScoreMessage>(m => m.UserId == UserId),
             It.IsAny<CancellationToken>()), Times.Once);
         ctx.Bus.Verify(b => b.Publish(It.IsAny<PlayerScoreUpdatedEvent>(),
@@ -236,7 +239,7 @@ public sealed class UpdatePhoenixRecordHandlerTests
         var ctx = new HandlerContext();
         var fireAt = Now.UtcDateTime - TimeSpan.FromSeconds(1); // already past
         var newCharts = new[] { Guid.NewGuid() };
-        var upscored = new System.Collections.Generic.Dictionary<Guid, int> { { Guid.NewGuid(), 900000 } };
+        var upscored = new Dictionary<Guid, int> { { Guid.NewGuid(), 900000 } };
         ctx.Batches.Setup(b => b.GetFireAt(UserId)).Returns(fireAt);
         ctx.Batches.Setup(b => b.TakeBatch(UserId)).Returns(new PendingScoreBatch(newCharts, upscored));
 
@@ -250,6 +253,42 @@ public sealed class UpdatePhoenixRecordHandlerTests
         ctx.Scheduler.Verify(s => s.SchedulePublish(
             It.IsAny<DateTime>(),
             It.IsAny<UpdatePhoenixRecordHandler.TryFireScoreMessage>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFireNoOpsWhenBatchAlreadyDrained()
+    {
+        // GetFireAt returns null = the batch was already drained by a concurrent
+        // TryFire or the Hangfire flush. Consumer must not crash, must not publish,
+        // must not reschedule.
+        var ctx = new HandlerContext();
+        ctx.Batches.Setup(b => b.GetFireAt(UserId)).Returns((DateTime?)null);
+
+        await ctx.Handler.Consume(BuildContext(new UpdatePhoenixRecordHandler.TryFireScoreMessage(UserId)));
+
+        ctx.Bus.Verify(b => b.Publish(It.IsAny<PlayerScoreUpdatedEvent>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        ctx.Scheduler.Verify(s => s.SchedulePublish(
+            It.IsAny<DateTime>(),
+            It.IsAny<UpdatePhoenixRecordHandler.TryFireScoreMessage>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        ctx.Batches.Verify(b => b.TakeBatch(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFireNoOpsWhenAnotherDrainTookTheBatchBetweenGetAndTake()
+    {
+        // FireAt is past (so we proceed to TakeBatch), but TakeBatch returns null
+        // because another consumer drained between our GetFireAt and TakeBatch.
+        var ctx = new HandlerContext();
+        var fireAt = Now.UtcDateTime - TimeSpan.FromSeconds(1);
+        ctx.Batches.Setup(b => b.GetFireAt(UserId)).Returns(fireAt);
+        ctx.Batches.Setup(b => b.TakeBatch(UserId)).Returns((PendingScoreBatch?)null);
+
+        await ctx.Handler.Consume(BuildContext(new UpdatePhoenixRecordHandler.TryFireScoreMessage(UserId)));
+
+        ctx.Bus.Verify(b => b.Publish(It.IsAny<PlayerScoreUpdatedEvent>(),
             It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -297,10 +336,10 @@ public sealed class UpdatePhoenixRecordHandlerTests
     }
 
     [Fact]
-    public async Task FlushSkipsEmptyBatchesFromDrainRace()
+    public async Task FlushSkipsRacedBatchesWhenTakeBatchReturnsNull()
     {
-        // If the original TryFireScoreMessage drains the user between Dump() and TakeBatch(),
-        // we should NOT publish a noisy empty PlayerScoreUpdatedEvent.
+        // If the original TryFireScoreMessage drains the user between Dump() and
+        // TakeBatch(), TakeBatch returns null — we must NOT publish a noisy empty event.
         var ctx = new HandlerContext();
         var racedUser = Guid.NewGuid();
         ctx.Batches.Setup(b => b.Dump()).Returns(new[]
@@ -308,8 +347,7 @@ public sealed class UpdatePhoenixRecordHandlerTests
             new BatchAccumulatorSnapshotEntry(racedUser, Now.UtcDateTime - TimeSpan.FromSeconds(1),
                 new[] { Guid.NewGuid() }, new Dictionary<Guid, int>())
         });
-        ctx.Batches.Setup(b => b.TakeBatch(racedUser))
-            .Returns(new PendingScoreBatch(Array.Empty<Guid>(), new Dictionary<Guid, int>()));
+        ctx.Batches.Setup(b => b.TakeBatch(racedUser)).Returns((PendingScoreBatch?)null);
 
         await ctx.Handler.Consume(BuildContext(new FlushOverdueScoreBatchesEvent()));
 

--- a/ScoreTracker/ScoreTracker/Accessors/PlayerScoreBatchAccumulator.cs
+++ b/ScoreTracker/ScoreTracker/Accessors/PlayerScoreBatchAccumulator.cs
@@ -7,60 +7,69 @@ namespace ScoreTracker.Web.Accessors;
 
 public sealed class PlayerScoreBatchAccumulator : IPlayerScoreBatchAccumulator
 {
-    private readonly ConcurrentDictionary<Guid, DateTime> _fireAt = new();
-    private readonly ConcurrentDictionary<Guid, ISet<Guid>> _newCharts = new();
-    private readonly ConcurrentDictionary<Guid, IDictionary<Guid, PhoenixScore>> _upscoreCharts = new();
-
-    public bool RegisterFireAt(Guid userId, DateTime fireAt)
+    private sealed class BatchState
     {
-        var isNew = !_fireAt.ContainsKey(userId);
-        if (isNew)
+        public readonly object Gate = new();
+        public DateTime FireAt;
+        public readonly HashSet<Guid> NewCharts = new();
+        public readonly Dictionary<Guid, PhoenixScore> UpscoreCharts = new();
+    }
+
+    private readonly ConcurrentDictionary<Guid, BatchState> _batches = new();
+
+    public bool AddToBatch(Guid userId, DateTime fireAt, Guid chartId, bool isNewClear, PhoenixScore? upscoredFrom)
+    {
+        // Loop guards a race where TakeBatch removes our state between GetOrAdd and
+        // acquiring the lock — in that case we'd be writing to an orphaned state, so
+        // we drop and re-add a fresh one.
+        while (true)
         {
-            _newCharts[userId] = new HashSet<Guid>();
-            _upscoreCharts[userId] = new ConcurrentDictionary<Guid, PhoenixScore>();
+            var fresh = new BatchState();
+            var state = _batches.GetOrAdd(userId, fresh);
+            var isNew = ReferenceEquals(state, fresh);
+            lock (state.Gate)
+            {
+                if (!_batches.TryGetValue(userId, out var current) || !ReferenceEquals(current, state))
+                    continue;
+                state.FireAt = fireAt;
+                if (isNewClear) state.NewCharts.Add(chartId);
+                if (upscoredFrom.HasValue && !state.NewCharts.Contains(chartId))
+                    state.UpscoreCharts[chartId] = upscoredFrom.Value;
+                return isNew;
+            }
         }
-        _fireAt[userId] = fireAt;
-        return isNew;
     }
 
-    public void RecordNewChart(Guid userId, Guid chartId)
+    public DateTime? GetFireAt(Guid userId)
     {
-        _newCharts[userId].Add(chartId);
+        if (!_batches.TryGetValue(userId, out var state)) return null;
+        lock (state.Gate) return state.FireAt;
     }
 
-    public void RecordUpscoreIfNotNew(Guid userId, Guid chartId, PhoenixScore previousScore)
+    public PendingScoreBatch? TakeBatch(Guid userId)
     {
-        if (!_newCharts[userId].Contains(chartId))
-            _upscoreCharts[userId][chartId] = previousScore;
-    }
-
-    public DateTime GetFireAt(Guid userId) => _fireAt[userId];
-
-    public PendingScoreBatch TakeBatch(Guid userId)
-    {
-        var newChartIds = _newCharts.TryGetValue(userId, out var newChart)
-            ? newChart.ToArray()
-            : Array.Empty<Guid>();
-        var upscoredChartIds = _upscoreCharts.TryGetValue(userId, out var chart)
-            ? chart.ToDictionary(kv => kv.Key, kv => (int)kv.Value)
-            : new Dictionary<Guid, int>();
-        _fireAt.TryRemove(userId, out _);
-        _upscoreCharts.TryRemove(userId, out _);
-        _newCharts.TryRemove(userId, out _);
-        return new PendingScoreBatch(newChartIds, upscoredChartIds);
+        if (!_batches.TryGetValue(userId, out var state)) return null;
+        lock (state.Gate)
+        {
+            if (!_batches.TryGetValue(userId, out var current) || !ReferenceEquals(current, state))
+                return null;
+            var newCharts = state.NewCharts.ToArray();
+            var upscores = state.UpscoreCharts.ToDictionary(kv => kv.Key, kv => (int)kv.Value);
+            _batches.TryRemove(userId, out _);
+            return new PendingScoreBatch(newCharts, upscores);
+        }
     }
 
     public IReadOnlyCollection<BatchAccumulatorSnapshotEntry> Dump()
     {
-        return _fireAt.ToArray().Select(kv =>
+        return _batches.ToArray().Select(kv =>
         {
-            var newChartIds = _newCharts.TryGetValue(kv.Key, out var newSet)
-                ? newSet.ToArray()
-                : Array.Empty<Guid>();
-            var upscored = _upscoreCharts.TryGetValue(kv.Key, out var upscoreMap)
-                ? (IReadOnlyDictionary<Guid, int>)upscoreMap.ToDictionary(e => e.Key, e => (int)e.Value)
-                : new Dictionary<Guid, int>();
-            return new BatchAccumulatorSnapshotEntry(kv.Key, kv.Value, newChartIds, upscored);
+            lock (kv.Value.Gate)
+            {
+                var newCharts = kv.Value.NewCharts.ToArray();
+                var upscores = kv.Value.UpscoreCharts.ToDictionary(e => e.Key, e => (int)e.Value);
+                return new BatchAccumulatorSnapshotEntry(kv.Key, kv.Value.FireAt, newCharts, upscores);
+            }
         }).ToArray();
     }
 }


### PR DESCRIPTION
## Summary
- Two user-visible symptoms motivated this:
  - **Rare**: a player's score post never triggers downstream notifications.
  - **More common**: scores get "stuck" until the Hangfire safety-net flush 5 minutes later.
- Both trace to [PlayerScoreBatchAccumulator](ScoreTracker/ScoreTracker/Accessors/PlayerScoreBatchAccumulator.cs) splitting per-user state across three `ConcurrentDictionary`s with no atomicity between them.

## Bugs fixed

- `HashSet<Guid>` for new charts wasn't safe under concurrent `RecordNewChart` calls → silent loss / occasional `InvalidOperationException` → "score never appears."
- `RegisterFireAt` was a check-then-act race; two concurrent posts could each think they were "first" and overwrite the other's empty set → first writer's chart dropped from the batch payload.
- `TryFireScoreMessage` and the `FlushOverdueScoreBatchesEvent` flush could race; one would drain successfully and the other would call `GetFireAt` → `KeyNotFoundException`, faulting the consumer → batch sat in memory until the next flush 5 min later → "stuck."
- Reschedule used `fireAt + 2min`, which compounded on every retry and could starve active players.

## Approach

- Collapse the three dictionaries into one `ConcurrentDictionary<Guid, BatchState>` guarded by a per-user lock. Different users still proceed in parallel.
- `AddToBatch(...)` is now a single atomic call that creates-or-extends the batch and pushes fire-at forward; the handler dropped from three port calls to one.
- `GetFireAt` and `TakeBatch` return null when the batch is gone; consumer no-ops cleanly instead of crashing.
- Reschedule uses `fireAt + 5s` to track the moving target without compounding drift.

## What this does NOT cover

Restart loss (in-memory accumulator + in-memory MassTransit transport). Out of scope for this PR — that's the SQL-row migration tracked separately.

## Test plan
- [x] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` clean (0 warnings, 0 errors)
- [x] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` — 606/606 pass
- [x] Two new tests cover the null-safe consumer paths that fix the "stuck" symptom: `TryFireNoOpsWhenBatchAlreadyDrained`, `TryFireNoOpsWhenAnotherDrainTookTheBatchBetweenGetAndTake`
- [ ] Watch production for a few days: pending-batch admin endpoint should show fewer/no batches stranded past their `FireAt` between Hangfire flushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)