### PR TITLE
Document Phoenix 2 rollout plan: roadmap, features, phase scripts

### DIFF
--- a/PHOENIX2-ROADMAP.md
+++ b/PHOENIX2-ROADMAP.md
@@ -1,0 +1,88 @@
+# Phoenix 2 Roadmap
+
+> Status: **planning** · Last updated: 2026-05-16
+
+This is the high-level gameplan for how PIU Scores will evolve as Phoenix 2 releases. It's written for site users — Discord folks reading along, not just devs. Technical details for each feature stack live in [`docs/phoenix2/features/`](docs/phoenix2/features/); the actionable work plan lives in [`docs/phoenix2/phases/`](docs/phoenix2/phases/).
+
+## The short version
+
+- **Phoenix 1 scores stay.** Everything you've recorded continues to work and remains visible.
+- **Phoenix 2 starts fresh.** Per how PIU has handled every prior mix, scores reset. We'll keep both mix's scores independently.
+- **Every Phoenix 1 feature continues to work in Phoenix 2.** Weekly Charts, Tier Lists, Communities, M.o.M., Qualifiers, World Rankings, Titles — they all get per-mix support. You'll see different results when you switch your active mix at the top of the page.
+- **You'll opt in to Phoenix 2.** When Phoenix 2 launches and the site is ready, an admin toggle flips on and the mix becomes selectable. Existing players stay on Phoenix 1 by default until they choose to switch.
+- **March of Murlocs supports any mix.** When you register a session, you pick the mix. No mixed-mix sessions. PUMBILITY+ continues to be the M.o.M. scoring system.
+
+## What's likely to change at PIU's end (informed speculation)
+
+Based on previous mix releases:
+
+- Player scores will reset on PIU's official site (we're keeping yours)
+- Phoenix 1 webpages will either retire or redirect to Phoenix 2 data
+- The title list will change, often in scoring logic too
+- Many Phoenix 1 charts won't carry over; many new charts will arrive
+- Rarely, a chart from before Phoenix 1 comes back (often polished)
+- Some charts will get note-count or video updates (we handle these ad hoc)
+
+What's almost certainly **not** going to change: difficulty levels, chart types, song metadata, the relationship of charts to songs, score logic, letter grades, plate logic.
+
+What's a real wildcard: whether PIU's username/password import path keeps working. The site's import flow is built on scraping PIU's "my page." If that goes away, manual entry continues to work, but auto-import would need a redesign.
+
+## How features will behave per mix
+
+| Feature | Phoenix 1 | Phoenix 2 |
+|---|---|---|
+| Score recording | Continues, untouched | Fresh, independent rows |
+| Weekly Charts | Continues its current rotation | Starts a new rotation with Phoenix 2's chart pool |
+| Tier Lists | Stays based on Phoenix 1 score history | Rebuilds from scratch as Phoenix 2 data accumulates |
+| Communities / Leaderboards | Continues | Independent per-mix views |
+| March of Murlocs | Sessions are mix-tagged at creation | Sessions are mix-tagged at creation |
+| Qualifiers | Mix is set per Qualifier config | Mix is set per Qualifier config |
+| World Rankings | Continues for Phoenix 1 scores | Independent rankings once data accumulates |
+| Titles | Existing Phoenix 1 title list | New Phoenix 2 title list (separate) |
+| Discord notifications | Quiets once Phoenix 2 is the live mix | Fires for Phoenix 2 score events |
+| Import | Existing Phoenix import page | New Phoenix 2 import page (shape depends on what PIU ships) |
+| Older mixes (XX and pre-XX) | Manual entry continues; goal is to extend to even older mixes over time | Same — manual entry, mix-tagged |
+
+## The "live mix" concept
+
+The site has a notion of which mix is currently "live" — that's the one new players default to, the one Discord notifications fire for, and the one that controls a few other defaults. Mix changes happen once every couple of years, so this is a small flag on the mix enum itself rather than a runtime setting. When Phoenix 2 is ready to be the default, we move the flag and deploy.
+
+While Phoenix 2 is in flight (added to the code but not yet the live mix), it'll be invisible in the mix selector. Once it's live, both mixes are selectable side by side.
+
+## Score reset and partitioning
+
+Phoenix 1 scores live in the same database table as Phoenix 2 scores will, but each row gets a mix tag. This is invisible to you — you'll never see Phoenix 1 and Phoenix 2 scores mixed together — but it means we don't have to delete or archive anything to "reset" for Phoenix 2. If PIU surprises us by carrying scores between mixes (unprecedented but possible), we'll handle that ad hoc.
+
+## Tier list and Weekly Charts during the warmup
+
+Tier lists, weekly chart placements, and world rankings will be sparse to nonexistent for Phoenix 2 in the first weeks. We'll keep the mix unselectable until enough scores accumulate that those features mean something, then announce in Discord when it's available.
+
+## What we don't know yet
+
+The big unknown is what PIU's website will look like at Phoenix 2 launch. Most of our import flow depends on scraping specific URLs and parsing specific HTML structure. If those URLs change shape or PIU rebuilds their player pages, the import flow has to be reworked. The plan accommodates this — most of the schema and feature work doesn't depend on the import side, so we can land most changes before Phoenix 2 ships, and tackle the import shape in the week after we see what the site looks like.
+
+## Roadmap (action plan)
+
+| Phase | When | What |
+|---|---|---|
+| [Phase 1: Safety nets](docs/phoenix2/phases/phase-1-safety-nets.md) | Now | Pre-flight test coverage and smoke checks so the migration can't silently corrupt Phoenix 1 data |
+| [Phase 2: Pre-launch](docs/phoenix2/phases/phase-2-pre-launch.md) | Before Phoenix 2 ships | Schema, accessors, events, gating — everything that doesn't depend on what PIU's site looks like |
+| [Phase 3: Launch week](docs/phoenix2/phases/phase-3-launch-week.md) | Week of Phoenix 2 release | Import-flow shape, defensive guards, the `[LiveMix]` flip, Discord communication |
+| [Phase 4: Slow burn](docs/phoenix2/phases/phase-4-slow-burn.md) | Post-launch | Derived-data audits, older-mix support, DB-backed titles if scope opens |
+
+## Feature deep-dives
+
+- [Mix model](docs/phoenix2/features/mix-model.md) — `MixEnum`, the `[LiveMix]` attribute, selectability rules, user-selection vs live-mix accessors
+- [PhoenixRecords schema](docs/phoenix2/features/phoenix-records-schema.md) — adding `MixId`, composite FK, backfill, repository signature changes
+- [Events](docs/phoenix2/features/events.md) — adding `MixEnum Mix` to score-flow events, semantics
+- [Notifications gating](docs/phoenix2/features/notifications-gating.md) — Discord/community side-effects fire only on the live mix
+- [Qualifiers & M.o.M.](docs/phoenix2/features/qualifiers-mom.md) — session-level Mix, set-once invariant, Qualifiers config carrying Mix
+- [Import flow](docs/phoenix2/features/import-flow.md) — explicit Mix on import command, silent-corruption guard
+- [Derived data](docs/phoenix2/features/derived-data.md) — Weekly Charts, Tier Lists, Community Leaderboards per-mix
+- [Title lists](docs/phoenix2/features/title-lists.md) — `Phoenix2TitleList` parallel to `PhoenixTitleList`
+- [Known-fragile scraper spots](docs/phoenix2/features/known-fragile.md) — silent-failure inventory and smoke assertion plan
+
+## Carve-outs
+
+- **Tournament domain other than M.o.M. and Qualifiers is being dropped going into Phoenix 2.** The old Match-shaped tournament features won't be carried forward. Only March of Murlocs and Qualifiers remain mix-aware.
+- **Pre-Phoenix mixes (older than XX) are an "eventually" goal**, not in scope for Phoenix 2 release. The complication is that Difficulty Level and Chart Type don't exist as concepts in those mixes, which requires schema rework that's intentionally out of scope here.

--- a/docs/phoenix2/features/derived-data.md
+++ b/docs/phoenix2/features/derived-data.md
@@ -1,0 +1,99 @@
+# Feature: Derived data tables (Weekly Charts, Tier Lists, Community Leaderboards)
+
+> Status: **design locked** · Last updated: 2026-05-16
+
+Tables that aggregate or project PhoenixRecords data. They need the same `MixId` treatment so Phoenix 1 and Phoenix 2 derived data stay independent.
+
+## Load these first (agent context)
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`mix-model.md`](mix-model.md)
+- [`phoenix-records-schema.md`](phoenix-records-schema.md)
+
+## Scope
+
+- Weekly Chart entity (rotation per mix)
+- Tier List output entities (rankings per mix)
+- Community Leaderboard projections (per mix)
+- Any other derived-data table that joins `PhoenixRecords`
+- Audit pass after the primary schema lands
+
+## Out of scope
+
+- The primary `PhoenixRecords` schema change — see [phoenix-records-schema.md](phoenix-records-schema.md)
+- Tournament/Match-shaped derived data — feature being dropped, don't touch
+
+## Locked decisions
+
+- **J1** — Phoenix 1 and Phoenix 2 derived data are entirely separate. Weekly Chart rotations, Tier List rankings, and Community Leaderboard projections each carry `MixId` and read/write per-mix.
+- Same migration shape as PhoenixRecords: add `MixId`, expand PK, backfill existing rows to `Phoenix`.
+- Tables that are **fully rebuilt each cycle** (e.g., a Tier List that's recomputed weekly from scratch) can defer to Phase 4 since stale data clears on the next rebuild. Tables that **persist across recomputes** (e.g., Weekly Chart rotation history) need the column before Phoenix 2 has data.
+
+## Why this matters
+
+Without `MixId` on these tables:
+
+- Weekly Charts would mix Phoenix 1 and Phoenix 2 chart selections — the "what was last week's weekly chart" query returns nonsense across the mix boundary.
+- Tier Lists would compute rankings across Phoenix 1 and Phoenix 2 scores combined — meaningless.
+- Community Leaderboards would mix scores across both mixes — fixable post-hoc but ugly.
+
+## Tables in scope (audit list)
+
+To verify during implementation — grep for entities and DbSets:
+
+- **Weekly Charts**
+  - `WeeklyTournamentChart` / `WeeklyChart*` entities in `ScoreTracker.Data/Persistence/Entities/`
+  - The rotation history table (whatever stores "chart X was the weekly chart for week N")
+  - User progress against weekly charts (`UserWeeklyChartsProgressedEvent` writes here)
+- **Tier Lists**
+  - Tier list output entities (the persisted tier assignments per chart)
+  - Difficulty-tier projections used by the Tier List UI
+- **Community Leaderboards**
+  - Community leaderboard projection tables
+  - Community-specific rating snapshots
+- **World Rankings**
+  - World ranking snapshots / projections
+  - Per-user world rank history
+- **Pumbility / PUMBILITY+ projections** (if persisted; some may be query-time computed)
+
+The audit during Phase 2 catalogs which actually exist, which need `MixId`, and which can defer.
+
+## Migration shape (per table)
+
+Same as PhoenixRecords:
+
+```sql
+ALTER TABLE scores.<Table>
+    ADD MixId UNIQUEIDENTIFIER NOT NULL CONSTRAINT DF_<Table>_MixId
+        DEFAULT '1ABB8F5A-BDA3-40F0-9CE7-1C4F9F8F1D3B'; -- Phoenix mix ID
+
+ALTER TABLE scores.<Table> DROP CONSTRAINT DF_<Table>_MixId;
+
+-- Drop old PK, add new one including MixId
+ALTER TABLE scores.<Table> DROP CONSTRAINT PK_<Table>;
+ALTER TABLE scores.<Table>
+    ADD CONSTRAINT PK_<Table> PRIMARY KEY (<existing cols>, MixId);
+```
+
+## Files this touches
+
+- Entities under `ScoreTracker.Data/Persistence/Entities/` — list firmed up during audit
+- Their associated `EF*Repository` implementations
+- The corresponding Domain ports — add required `MixEnum` parameter, same pattern as `IPhoenixRecordRepository`
+- Queries/handlers that consume these — thread `Mix` through, default to LiveMix at the controller/page edge
+- New EF migrations per table
+
+## Risks
+
+- **Forgotten table.** A derived-data table missed in the audit silently mixes data after Phoenix 2 has rows. Mitigate with an audit checklist in Phase 2 — list every entity that joins `PhoenixRecord` or `ChartId`, sweep each for whether it needs `MixId`.
+- **Sequence with PhoenixRecords migration.** These migrations should land **after** PhoenixRecords gets its `MixId`, so the join behavior is consistent. Don't interleave.
+- **Rebuilt-each-cycle tables.** Tempting to defer all of them, but the ones that *don't* fully rebuild (Weekly Chart rotation history) need `MixId` before Phoenix 2 has data. Audit carefully.
+
+## Open questions
+
+- Full entity list — resolved during Phase 2 audit.
+- Are any of these tables already mix-tagged (e.g., via a join to `ChartMix`)? Verify; some may not need the column if they already resolve mix through their chart join.
+
+## Changelog
+
+- 2026-05-16: Doc created from workshop.

--- a/docs/phoenix2/features/events.md
+++ b/docs/phoenix2/features/events.md
@@ -1,0 +1,93 @@
+# Feature: Event schema changes
+
+> Status: **design locked** · Last updated: 2026-05-16
+
+The score-flow events grow a `MixEnum Mix` property so downstream consumers never have to ask "which mix?"
+
+## Load these first (agent context)
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`mix-model.md`](mix-model.md)
+- [`phoenix-records-schema.md`](phoenix-records-schema.md)
+- [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) — section "Eventing"
+
+## Scope
+
+- Adding `MixEnum Mix` to score-flow events
+- Locking down the semantics of that property
+- Updating publishers to populate it correctly
+- Updating consumers to use it instead of querying user selection
+
+## Out of scope
+
+- Adding mix to events that aren't score-shaped (no mix concept attached)
+- Notification gating logic — see [notifications-gating.md](notifications-gating.md)
+
+## Locked decisions
+
+- **D1** — Events that gain a `MixEnum Mix` property:
+  - `PlayerScoreUpdatedEvent`
+  - `RecentScoreImportedEvent`
+  - `PlayerRatingsImprovedEvent`
+  - `PlayerStatsUpdatedEvent`
+  - `ChartDifficultyUpdatedEvent`
+  - `NewTitlesAcquiredEvent`
+  - `TitlesDetectedEvent`
+  - `UserWeeklyChartsProgressedEvent`
+  
+  Audit `ScoreTracker.Domain/Events/` during implementation for any others that are score-derived. Cheap to add now, expensive to retrofit.
+  
+- **D2** — `Mix` on an event = **the mix the score/record belongs to**, not the user's currently-selected mix at the moment of the event. Once a score exists, it has a mix; user selection is a UI affordance, not a property of the score. This makes events replay-safe and lets historical Phoenix 1 imports work cleanly after LiveMix flips to Phoenix 2.
+
+## Why this matters
+
+Today, sagas that need a mix have two unappealing options:
+
+1. **Re-query the user's currently selected mix.** Concurrency hazard — user could have changed selection between event publish and consume.
+2. **Default to Phoenix.** Works today because everything is Phoenix; silently corrupts the moment Phoenix 2 has data.
+
+With `Mix` on the event, neither is needed. The event carries the mix it pertains to, and consumers act on that.
+
+## Semantics checklist
+
+When publishing one of these events, the publisher must know which mix the change pertains to:
+
+- **`PlayerScoreUpdatedEvent`** — the mix the new score belongs to. For imports, this comes from the import command (see [import-flow.md](import-flow.md)). For manual entry, from the UI page (e.g. `UploadXXScores.razor` → XX; future per-mix manual entry pages → that mix).
+- **`RecentScoreImportedEvent`** — the mix of the import session (carried on the import command).
+- **`PlayerRatingsImprovedEvent`** — the mix the rating recalc was for (Pumbility/PUMBILITY+ is per-mix).
+- **`PlayerStatsUpdatedEvent`** — the mix of the stats row that just changed.
+- **`ChartDifficultyUpdatedEvent`** — the mix the difficulty adjustment applies to (seasonal adjustments only apply to the current/live mix per the roadmap; older mixes use official difficulty).
+- **`NewTitlesAcquiredEvent`**, **`TitlesDetectedEvent`** — the mix the titles were observed in (Phoenix 2 has its own title list — see [title-lists.md](title-lists.md)).
+- **`UserWeeklyChartsProgressedEvent`** — the mix whose Weekly Charts rotation this progress was against.
+
+## Comment to attach to each event
+
+```csharp
+/// <summary>
+/// The mix this event pertains to — i.e. the mix the score/record/title belongs to,
+/// NOT the user's currently-selected mix at publish time. This makes the event
+/// replay-safe and lets consumers act without re-querying user state.
+/// </summary>
+public required MixEnum Mix { get; init; }
+```
+
+Locking the semantics in a per-event comment removes the chance someone misreads `Mix` as "user's selection" later.
+
+## Files this touches
+
+- Every event record in `ScoreTracker.Domain/Events/` listed above
+- Every publisher: search for `_bus.Publish(new <Event>` and `IBus.Publish<<Event>>` across the solution
+- Every consumer (`IConsumer<<Event>>` implementations in `ScoreTracker.Application/Handlers/`) — most will use the new property instead of re-querying user selection
+
+## Risks
+
+- **Forgotten publish site.** A `_bus.Publish(new PlayerScoreUpdatedEvent { ... })` site that doesn't populate `Mix` becomes a compile error if `Mix` is `required`. Use `required` on the property to make the compiler enforce.
+- **Consumer drift.** A consumer that still re-queries user selection instead of using the event's `Mix` defeats the purpose. Add a code-review checklist item; consider lightweight architectural tests asserting consumers of these events don't inject `ICurrentUserAccessor` (heuristic, not perfect).
+
+## Open questions
+
+None known.
+
+## Changelog
+
+- 2026-05-16: Doc created from workshop.

--- a/docs/phoenix2/features/import-flow.md
+++ b/docs/phoenix2/features/import-flow.md
@@ -1,0 +1,114 @@
+# Feature: Import flow
+
+> Status: **design partial — shape depends on PIU's Phoenix 2 site** · Last updated: 2026-05-16
+
+The most-unknown feature stack. We can land the *command* shape and the *guards* before Phoenix 2; the actual *scraper* work waits until we can see PIU's Phoenix 2 site.
+
+## Load these first (agent context)
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`mix-model.md`](mix-model.md)
+- [`events.md`](events.md)
+- [`known-fragile.md`](known-fragile.md)
+- [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) — section "Layers / Infrastructure", clients
+
+## Scope
+
+- The import command shape: explicit `Mix` parameter
+- Separate UI pages per mix (`UploadPhoenixScores.razor`, future `UploadPhoenix2Scores.razor`)
+- The defensive corruption guard
+- The unknowns and how we'll handle them when we know more
+
+## Out of scope
+
+- Implementing the Phoenix 2 scraper — deferred until PIU's site is observable (see [phase-3-launch-week.md](../phases/phase-3-launch-week.md))
+- Scraper internals — see [known-fragile.md](known-fragile.md) for the silent-failure inventory
+
+## Locked decisions
+
+- **G1** — `Mix` is **explicit on the import command**, not inferred from the scraper response. The import UI page knows which mix it's for (Phoenix 1 page → Phoenix; Phoenix 2 page → Phoenix2); the command carries that explicitly.
+- **G2** — A **defensive corruption guard** runs against scraped responses to verify the data shape matches the declared mix. Even a heuristic check is worth shipping: the failure mode (Phoenix 1 page silently returning Phoenix 2 data) is invisible otherwise.
+
+## Open (depends on what PIU ships)
+
+- Whether Phoenix 1 and Phoenix 2 will be supported simultaneously on PIU's site, or Phoenix 1 will be turned off at launch
+- Whether the scraping URLs/HTML structure change
+- Whether username/password import survives at all (the existential question — if PIU pulls that, manual entry continues but auto-import dies)
+
+## Import command shape
+
+```csharp
+// ScoreTracker.Application/Commands/ImportPhoenixScoresCommand.cs
+public sealed record ImportPhoenixScoresCommand(
+    Guid UserId,
+    string Username,
+    string Password,
+    MixEnum Mix,                 // NEW — explicit, no default
+    bool SyncPiuTracker = false) : IRequest;
+```
+
+`Mix` is required. The UI page passes it in based on which import page the user clicked.
+
+## UI surface
+
+- Existing: [`Pages/UploadPhoenixScores.razor`](../../../ScoreTracker/ScoreTracker/Pages/UploadPhoenixScores.razor) — keep, modify to pass `Mix = MixEnum.Phoenix` explicitly.
+- Existing: [`Pages/UploadXXScores.razor`](../../../ScoreTracker/ScoreTracker/Pages/UploadXXScores.razor) — already mix-specific (XX), no change to its mix selection; XX has its own command path.
+- New (Phase 3): `Pages/UploadPhoenix2Scores.razor` — sibling page, passes `Mix = MixEnum.Phoenix2`. Shape depends on what PIU's Phoenix 2 site looks like.
+
+Each page is gated on the mix being selectable per the [mix-model selectability rule](mix-model.md) — Phoenix 2's page is reachable only after `[LiveMix]` moves to `Phoenix2`.
+
+## Defensive corruption guard
+
+The risk: PIU keeps serving Phoenix 1's URLs but those URLs start returning Phoenix 2 data (chart IDs that don't exist in Phoenix 1, scores against new charts, etc.). The Phoenix 1 import command writes those to Phoenix 1's rows → silent corruption of the most-important data we have.
+
+Guard placement: in `OfficialLeaderboardSaga.Consume(ImportPhoenixScoresEvent)` (or equivalent), after the scraper returns its parsed list and before writes occur. Verify:
+
+1. Every scraped chart ID exists in `ChartMix` for the declared mix. If a substantial fraction don't, fail loud — refuse to write, log an alert.
+2. (Heuristic, optional) Look for at least one chart known to exist in the declared mix but not in the other. Presence = response is the right shape.
+
+This isn't a complete defense — a perfect overlap between Phoenix 1 and Phoenix 2 chart pools would fool it — but the failure mode it catches is high-likelihood and otherwise invisible.
+
+```csharp
+private void GuardOrThrow(IReadOnlyCollection<ScrapedScore> scores, MixEnum declaredMix)
+{
+    var validChartIds = _chartRepo.GetChartIdsInMix(declaredMix);  // cache this
+    var unknownIds = scores.Select(s => s.ChartId).Except(validChartIds).ToList();
+    if (unknownIds.Count > scores.Count * 0.10)  // >10% unknown is suspicious
+        throw new ImportMixMismatchException(declaredMix, unknownIds.Take(5).ToList());
+}
+```
+
+Tune the threshold during implementation.
+
+## Files this touches
+
+- Modified: `ScoreTracker.Application/Commands/ImportPhoenixScoresCommand.cs` (add `MixEnum Mix`)
+- Modified: `ScoreTracker.Application/Handlers/OfficialLeaderboardSaga.cs` (use the new property; add guard)
+- Modified: `ScoreTracker/Pages/UploadPhoenixScores.razor` (pass mix explicitly)
+- Modified: `ScoreTracker/Controllers/Api/PhoenixScoresController.cs` (if any API surface exposes import, accept mix)
+- Phase 3: New `ScoreTracker/Pages/UploadPhoenix2Scores.razor`
+- Phase 3: Possibly `ScoreTracker.Data/Apis/PiuGameApi.cs` and `ScoreTracker.Data/Clients/OfficialSiteClient.cs` rework — shape unknown until PIU ships
+
+## Risks
+
+- **Scraper assumes Phoenix 1 forever.** Hardcoded URLs in [`PiuGameApi.cs`](../../../ScoreTracker/ScoreTracker.Data/Apis/PiuGameApi.cs) point at `piugame.com/my_page/...` and `piugame.com/leaderboard/...`. If those URLs change, the scraper fails — possibly silently (returns empty). The smoke assertion ([known-fragile.md](known-fragile.md), I2) catches "returned empty."
+- **The guard is heuristic.** It can be defeated by a fully-overlapping chart pool. The honest framing: it defends against the obvious failure mode, not every possible mix-confusion bug.
+- **PiuTracker shares auth.** [`PiuTrackerClient`](../../../ScoreTracker/ScoreTracker.Data/Clients/PiuTrackerClient.cs) reuses the PIU session token. If PIU auth changes, this breaks too, but silently (it's behind an optional flag).
+
+## What we'll know in Phase 3
+
+- Whether the existing scraper URLs work for Phoenix 2 unchanged
+- Whether PIU's HTML structure for the "my best score" pages changed
+- Whether the avatar URL CDN paths changed
+- Whether login still works
+- Whether there's a separate Phoenix 1 vs Phoenix 2 site, or a single site with mix-aware data
+
+Plan for each scenario in Phase 3, not now.
+
+## Open questions
+
+- (Resolved in Phase 3 when PIU's site is observable.)
+
+## Changelog
+
+- 2026-05-16: Doc created from workshop.

--- a/docs/phoenix2/features/known-fragile.md
+++ b/docs/phoenix2/features/known-fragile.md
@@ -1,0 +1,114 @@
+# Feature: Known-fragile scraper spots
+
+> Status: **inventory** · Last updated: 2026-05-16
+
+The places in the import/scraping stack that will silently break or mis-behave if PIU's site changes shape. Not a remediation plan — that lives in [import-flow.md](import-flow.md) and Phase 3. This doc is the *inventory* so we don't forget what to check when Phoenix 2 ships.
+
+## Load these first (agent context)
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`import-flow.md`](import-flow.md)
+- [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) — section "Data access", section "Eventing"
+
+## Scope
+
+- Hardcoded URL constants in scraping code
+- Regex patterns parsing HTML structure
+- Hardcoded mapping dictionaries that paper over PIU's inconsistencies
+- Silent-failure modes in the recurring import job
+- The single-smoke-assertion that catches the broadest category of breakage
+
+## Out of scope
+
+- Fixing the scraper for Phoenix 2 — that work waits until PIU's site is observable, see [phase-3-launch-week.md](../phases/phase-3-launch-week.md)
+- Refactoring the scraper architecture — out of scope for the Phoenix 2 release
+
+## Locked decisions
+
+- **I1** — Document the silent failure modes here. Action (rework, alerting, restructure) deferred until we see what changes. Awareness now, action later.
+- **I2** — Add a smoke assertion to the weekly leaderboard import Hangfire job: "imported >0 scores at known levels." Mix-agnostic, cheap, catches the broadest scraper-broke-and-returned-empty failure.
+
+## Inventory
+
+### Hardcoded URLs in [`PiuGameApi.cs`](../../../ScoreTracker/ScoreTracker.Data/Apis/PiuGameApi.cs)
+
+Verified during the explore pass:
+
+| URL | Purpose | Risk |
+|---|---|---|
+| `https://piugame.com/leaderboard/over_ranking.php` | Top-level "20 above" leaderboard | 404 on path change → no leaderboard data |
+| `https://piugame.com/leaderboard/over_ranking_view.php` | Per-song leaderboard | 404 on path change → no per-song data |
+| `https://piugame.com/leaderboard/rating_ranking.php` | Rating leaderboards | 404 on path change |
+| `https://piugame.com/ajax/top_steps.php` (POST) | Chart popularity | Schema change → silent bad parse |
+| `https://piugame.com/my_page/recently_played.php` | User recent scores | 404 → no recent-import flow |
+| `https://piugame.com/my_page/my_best_score.php` | User best scores (paginated) | 404 → **import dies** |
+| `https://piugame.com/my_page/title.php` | User profile + titles | 404 → no title detection, no avatar |
+| `https://piugame.com/bbs/login_check.php` (POST) | Authentication | Change → **auth dies entirely** |
+| `https://piugame.com/my_page/game_id_information.php` | Game card switching | 404 → no card switching |
+| `https://ucs.piugame.com/bbs/board.php` | UCS chart metadata | 404 → no UCS detail |
+| `https://piutracker.app:3002/api/sync/` ([`PiuTrackerClient.cs`](../../../ScoreTracker/ScoreTracker.Data/Clients/PiuTrackerClient.cs)) | Third-party sync | Auth-dependent on the same session token |
+
+### Regex patterns and CDN-path parsing
+
+- **Difficulty parsing via image URLs**: regex matches `stepball/full/<level>.png` style paths to infer chart level. If PIU restructures their image CDN, every imported chart silently parses as the default level. ([`PiuGameApi.cs`](../../../ScoreTracker/ScoreTracker.Data/Apis/PiuGameApi.cs) lines ~18–28)
+- **Avatar URL regex**: matches `piugame.com/data/avatar_img/` patterns to extract avatar IDs and store them in Azure Blob. Path change → avatars silently break.
+- **Plate parsing via image filename**: `PhoenixPlateHelperMethods.ParseShorthand()` works off plate image filenames. Filename change → plate parsing fails.
+
+### Hardcoded mappings in [`OfficialSiteClient.cs`](../../../ScoreTracker/ScoreTracker.Data/Clients/OfficialSiteClient.cs)
+
+- **Korean → English song name dictionary** (around lines 334–344). Papers over inconsistent naming on PIU's side. If PIU normalizes their naming, the dictionary becomes dead code or causes mis-mappings.
+
+### Silent failure modes
+
+- **Hangfire weekly leaderboard import job** ([`Program.cs`](../../../ScoreTracker/ScoreTracker/Program.cs) `start-leaderboard-import`, Sundays 05:30 ET, cron `30 10 * * 0`): no alerting on failure. Can fail every Sunday for a month and nothing notifies. Smoke assertion (I2) is the mitigation.
+- **No retry/alerting on `OfficialLeaderboardSaga`**: if the saga throws, the message is in-memory-bus-only and not redelivered after a restart.
+- **`PiuTrackerClient` failures**: behind a `SyncPiuTracker` flag on the import command. Failures here are deliberately optional and currently swallowed.
+
+## The smoke assertion (I2)
+
+In the Hangfire-driven recurring leaderboard import:
+
+```csharp
+// HostedServices/RecurringJobRunner.cs (illustrative)
+public async Task RunWeeklyLeaderboardImport()
+{
+    var result = await _bus.Request<StartLeaderboardImportEvent, LeaderboardImportCompleted>(/*...*/);
+    
+    // Smoke assertion: at least N scores at canonical levels imported
+    if (result.ImportedScoreCount < 100 || !result.LevelsObserved.Any(l => l >= 20))
+    {
+        _logger.LogError("Leaderboard import returned suspicious data: {Count} scores, levels {Levels}",
+            result.ImportedScoreCount, string.Join(",", result.LevelsObserved));
+        // Optionally: publish AlertEvent → Discord webhook
+    }
+}
+```
+
+Threshold values tuned during Phase 1. Goal: catch "scraper returned empty" and "scraper returned data with no high-level charts" — both indicate a parser break.
+
+## What to check on Phoenix 2 launch day
+
+Phase 3's first task: walk this list against PIU's actual Phoenix 2 site.
+
+1. **Does login still work?** (`login_check.php`)
+2. **Do the URL paths still exist?** (404 hunt across the URL table above)
+3. **Has the HTML structure changed?** (compare a recent vs. live `my_best_score.php` page; if class names changed, parsing breaks)
+4. **Did the image CDN paths change?** (`stepball/full/`, avatars, plates)
+5. **Are there new song names that need mapping entries?**
+6. **Did the rating/leaderboard query format change?**
+
+## Files this touches
+
+This doc is reference-only. Action items live in the relevant phase docs:
+
+- Smoke assertion: [phase-1-safety-nets.md](../phases/phase-1-safety-nets.md)
+- Scraper rework: [phase-3-launch-week.md](../phases/phase-3-launch-week.md)
+- Long-term restructure (out of current scope): [phase-4-slow-burn.md](../phases/phase-4-slow-burn.md)
+
+## Open questions
+
+- (Resolved as PIU's Phoenix 2 site becomes observable.)
+
+## Changelog
+
+- 2026-05-16: Doc created from workshop.

--- a/docs/phoenix2/features/mix-model.md
+++ b/docs/phoenix2/features/mix-model.md
@@ -1,0 +1,130 @@
+# Feature: Mix model and LiveMix
+
+> Status: **design locked** · Last updated: 2026-05-16
+
+The foundational mix model. Everything else in the Phoenix 2 rollout depends on this.
+
+## Load these first (agent context)
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`CLAUDE.md`](../../../CLAUDE.md)
+- [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) — section "Layers / Domain", section "Cross-cutting concerns"
+
+## Scope
+
+- The `MixEnum` shape and the `[LiveMix]` attribute
+- How "the current live mix" is resolved at runtime
+- How "this user's selected mix" is resolved at runtime
+- UI selectability rule (which mixes appear in the dropdown)
+- User-create writes `CurrentMix = LiveMix`
+- Backfill for existing users with no persisted `Universal__CurrentMix`
+- Anonymous user default behavior
+
+## Out of scope
+
+- Changes to PhoenixRecords schema — see [phoenix-records-schema.md](phoenix-records-schema.md)
+- Threading Mix through queries/commands — see the per-feature docs and [phase-2-pre-launch.md](../phases/phase-2-pre-launch.md)
+
+## Locked decisions
+
+- **C1** — On user create, write `CurrentMix = LiveMix` to `UserUiSettings`. Existing users get backfilled. No read-time fallback for persisted users.
+- **C2** — LiveMix is encoded as a `[LiveMix]` attribute on exactly one `MixEnum` value. Changing the live mix means moving the attribute and deploying. Mix changes are once-every-few-years, so a deploy is fine.
+- **C3** — Existing users stay on their currently-selected mix (Phoenix 1) when Phoenix 2 goes live. They opt in by clicking. Auto-roll is rejected.
+- **C4** — UI selectability rule: a mix is selectable iff it carries `[LiveMix]` OR is declared *before* the `[LiveMix]` value in `MixEnum` declaration order. Mixes declared after the live one are invisible until promoted.
+- **H1** — Same `[LiveMix]` attribute serves as the toggle (no separate "enabled" flag). Phoenix 2 starts in the enum without the attribute → invisible. Move attribute → Phoenix 2 becomes live and selectable in one step.
+- **A5** — Backfill `UserUiSettings.Universal__CurrentMix = Phoenix` for every existing user without a row, in the same migration that flips the create-handler to write `LiveMix`.
+
+## The `MixEnum` shape
+
+```csharp
+// ScoreTracker.Domain/Enums/MixEnum.cs
+public enum MixEnum
+{
+    XX,
+    [LiveMix] Phoenix,
+    Phoenix2     // declared but invisible until [LiveMix] moves
+}
+
+// ScoreTracker.Domain/Enums/LiveMixAttribute.cs (new)
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+public sealed class LiveMixAttribute : Attribute { }
+```
+
+When Phoenix 2 launches, the attribute moves:
+
+```csharp
+public enum MixEnum
+{
+    XX,
+    Phoenix,
+    [LiveMix] Phoenix2
+}
+```
+
+## Accessor shape
+
+Two named methods, no silent fall-through:
+
+```csharp
+// ScoreTracker.Domain.SecondaryPorts (port)
+public interface ICurrentUserAccessor
+{
+    // ...existing...
+    MixEnum GetUserSelectedMix();    // throws if user is anonymous + no value persisted
+    MixEnum GetLiveMix();             // resolves the [LiveMix]-attributed enum value
+}
+```
+
+Implementation notes:
+
+- `GetLiveMix()` reads the `MixEnum` once via reflection at startup and caches the value. Deploy = pickup.
+- `GetUserSelectedMix()` for **persisted users** reads `UserUiSettings.Universal__CurrentMix` directly with no fallback. The backfill (A5) guarantees the value is present.
+- For **anonymous users**, `GetUserSelectedMix()` reads from `ProtectedBrowserStorage` and falls back to `GetLiveMix()` if nothing is persisted. (This is the *only* fallback in the accessor surface; persisted users have no fallback.)
+- Default in [`UiSettingsAccessor.cs:33`](../../../ScoreTracker/ScoreTracker/Services/UiSettingsAccessor.cs) is removed for the persisted path.
+
+## UI selectability rule
+
+In [`Shared/MainLayout.razor`](../../../ScoreTracker/ScoreTracker/Shared/MainLayout.razor), the mix dropdown enumerates `Enum.GetValues<MixEnum>()`. After this change, filter:
+
+```csharp
+private static readonly int LiveMixOrdinal = (int)typeof(MixEnum)
+    .GetFields(BindingFlags.Public | BindingFlags.Static)
+    .Single(f => f.GetCustomAttribute<LiveMixAttribute>() != null)
+    .GetValue(null)!;
+
+bool IsSelectable(MixEnum mix) => (int)mix <= LiveMixOrdinal;
+```
+
+`XX` (ordinal 0) is selectable. `Phoenix` (ordinal 1, [LiveMix]) is selectable. `Phoenix2` (ordinal 2) is hidden until the attribute moves.
+
+## Backfill migration
+
+Same PR that introduces the no-fallback accessor:
+
+1. EF migration adds a backfill SQL statement: for every user without a `Universal__CurrentMix` row in `UserUiSettings`, insert one with value `Phoenix`.
+2. Verify on a prod-sized restore before shipping.
+3. Once shipped, the read path can safely assume the row exists for persisted users.
+
+## Files this touches
+
+- New: `ScoreTracker.Domain/Enums/LiveMixAttribute.cs`
+- Modified: `ScoreTracker.Domain/Enums/MixEnum.cs` (add `Phoenix2`, add `[LiveMix]` on `Phoenix`)
+- Modified: `ScoreTracker.Domain/SecondaryPorts/ICurrentUserAccessor.cs` (add `GetLiveMix()`, rename current method to `GetUserSelectedMix()` if the existing surface needs disambiguation)
+- Modified: `ScoreTracker.Web/Accessors/HttpContextUserAccessor.cs`
+- Modified: `ScoreTracker.Web/Services/UiSettingsAccessor.cs` (remove read-time default for persisted users; keep for anonymous)
+- Modified: `ScoreTracker.Web/Shared/MainLayout.razor` (selectability filter)
+- New EF migration in `ScoreTracker.Data/Migrations/` (backfill `Universal__CurrentMix`)
+
+## Risks
+
+- **Reflection cost on every accessor call** — mitigate by caching the resolved live mix at startup.
+- **Backfill missing rows** — if any user has *some* UserUiSettings entries but not the mix one, the migration must `INSERT` for them, not assume one already exists. Verify with a per-user-count check.
+- **Anonymous fallback feels asymmetric** — it is, by design. The asymmetry is documented; alternative (forcing anonymous users to pick a mix before any read) is worse UX.
+
+## Open questions
+
+None known. Ready to implement once Phase 2 begins.
+
+## Changelog
+
+- 2026-05-16: Doc created from workshop.

--- a/docs/phoenix2/features/notifications-gating.md
+++ b/docs/phoenix2/features/notifications-gating.md
@@ -1,0 +1,89 @@
+# Feature: Notifications gating (CommunitySaga, Discord)
+
+> Status: **design locked** · Last updated: 2026-05-16
+
+Community side-effects — Discord notifications, community leaderboards — fire only when the score's mix matches the live mix.
+
+## Load these first (agent context)
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`mix-model.md`](mix-model.md)
+- [`events.md`](events.md)
+- [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) — section "Eventing"
+
+## Scope
+
+- The rule for when Community/Discord side-effects fire
+- Where the rule is enforced
+- How it behaves during the LiveMix transition
+
+## Out of scope
+
+- Adding `Mix` to events themselves — see [events.md](events.md)
+- The community leaderboard data model — see [derived-data.md](derived-data.md)
+- Future support for old-mix submissions being notification-worthy — explicitly deferred per workshop
+
+## Locked decisions
+
+- **The rule** — Discord and community-side notification consumers fire **only when `event.Mix == liveMixAccessor.GetLiveMix()`**. Any score event for a non-live mix (Phoenix 1 scores after Phoenix 2 goes live, future XX manual entries, future older-mix support) is silently dropped at the consumer level.
+- Future "support old-mix notifications" work is tackled as a feature add later if/when scope opens. Not in Phoenix 2 release scope.
+
+## Why this matters
+
+Two failure modes the gating prevents:
+
+1. **Discord notification storm during transition.** A user importing Phoenix 1 scores after Phoenix 2 is live shouldn't blast Phoenix 1 PB announcements into Discord channels that are now Phoenix-2-focused.
+2. **Community leaderboard pollution.** Phoenix 2 community leaderboards shouldn't include Phoenix 1 scores from late-importing users.
+
+The rule is mix-aware **without** requiring complex per-channel routing — the community side just stops listening to non-live-mix events.
+
+## Implementation shape
+
+Each affected consumer adds a guard at the top of `Consume`:
+
+```csharp
+public async Task Consume(ConsumeContext<PlayerScoreUpdatedEvent> context)
+{
+    if (context.Message.Mix != _currentUserAccessor.GetLiveMix())
+        return;
+
+    // ...existing community/Discord logic...
+}
+```
+
+Or, cleaner, a small extension method:
+
+```csharp
+public static bool IsLiveMixEvent(this ConsumeContext<TEvent> ctx, ILiveMixAccessor liveMix)
+    where TEvent : IMixedEvent
+    => ctx.Message.Mix == liveMix.GetLiveMix();
+```
+
+(Worth considering an `IMixedEvent` marker interface during the events.md work — it'd make this guard generic across all mixed events.)
+
+## Consumers that need the guard
+
+Audit during implementation. Starting list (from the explore pass):
+
+- `CommunitySaga` — consumes `RecentScoreImportedEvent`, `NewTitlesAcquiredEvent`, `TitlesDetectedEvent`. All three need gating.
+- `QualifiersSaga` — note: Qualifiers carry their own mix on the Qualifier config (see [qualifiers-mom.md](qualifiers-mom.md)). The gating here is "this score event's mix matches the Qualifier's configured mix," not the live mix. Different rule, same shape.
+- Any Discord-publishing handler in `ScoreTracker.Application/Handlers/`
+
+## Files this touches
+
+- `ScoreTracker.Application/Handlers/CommunitySaga.cs`
+- Any other consumer that publishes Discord notifications or updates community-visible state
+- Possibly: new `ScoreTracker.Domain/Events/IMixedEvent.cs` marker interface
+
+## Risks
+
+- **Forgetting a consumer.** Any consumer that should be gated but isn't will leak Phoenix 1 notifications after the LiveMix flip. The mitigation is mechanical: grep for `IConsumer<` in `ScoreTracker.Application/Handlers/` and `ScoreTracker.PersonalProgress/`, audit each for whether it produces user-visible community side-effects.
+- **Test coverage gap.** Worth a component test per affected saga asserting "given event.Mix != LiveMix, no Discord call is made." Mock the live mix accessor, mock `IBotClient`, verify no calls.
+
+## Open questions
+
+None known.
+
+## Changelog
+
+- 2026-05-16: Doc created from workshop.

--- a/docs/phoenix2/features/phoenix-records-schema.md
+++ b/docs/phoenix2/features/phoenix-records-schema.md
@@ -1,0 +1,146 @@
+# Feature: PhoenixRecords schema (and PlayerStats)
+
+> Status: **design locked** · Last updated: 2026-05-16
+
+The structural change that makes Phoenix 1 and Phoenix 2 scores coexist. Same pattern applies to `PlayerStats`.
+
+## Load these first (agent context)
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`mix-model.md`](mix-model.md)
+- [`CLAUDE.md`](../../../CLAUDE.md) — section "One DbContext", section "Test conventions"
+- [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) — section "Data access"
+
+## Scope
+
+- Adding `MixId` to `PhoenixRecords` (`PhoenixRecordEntity`) and `PlayerStats` (`PlayerStatsEntity`)
+- Composite FK to `ChartMix(ChartId, MixId)` on `PhoenixRecords`
+- Unique key expansion to `(UserId, ChartId, MixId)`
+- Backfill existing rows to the `Phoenix` mix ID
+- Repository signature changes (required `MixEnum` parameter, no defaults)
+- Pre-flip integration tests asserting mix isolation
+
+## Out of scope
+
+- Weekly Charts / Tier List output tables — see [derived-data.md](derived-data.md)
+- TournamentSession Mix column — see [qualifiers-mom.md](qualifiers-mom.md)
+- Event schema changes that *consume* the new column — see [events.md](events.md)
+
+## Locked decisions
+
+- **A1** — `PhoenixRecords.MixId` carries a composite FK to `ChartMix(ChartId, MixId)`. The score is formally a child of "chart-in-this-mix," matching where per-mix note count already lives.
+- **A2** — Add the `(ChartId, MixId)` secondary index alongside the new wider unique. SQL health is currently fine; preemptive is cheaper than retroactive.
+- **A3** — Every `EFPhoenixRecordsRepository` method takes `MixEnum mix` as a **required** parameter. No default values. The compiler is the audit tool.
+- **A4** — Before the column flips on in prod, the integration suite (`ScoreTracker.Tests.Integration`) has per-method coverage asserting "a Phoenix 1 caller sees zero Phoenix 2 rows" for every read-path repository method.
+- **A5** — Existing rows backfill to `Phoenix` mix ID in the same migration that adds the column.
+- **B1** — `PlayerStatsEntity` follows the same migration shape: add `MixId`, expand PK, backfill existing rows to `Phoenix`. Phoenix 1 forward — XX has its own table already (`BestAttempts`).
+
+## Schema change shape
+
+### PhoenixRecords
+
+Current (approximate):
+
+```sql
+CREATE TABLE scores.PhoenixRecords (
+    UserId UNIQUEIDENTIFIER NOT NULL,
+    ChartId UNIQUEIDENTIFIER NOT NULL,
+    Score INT NULL,
+    Plate INT NULL,
+    IsBroken BIT NOT NULL,
+    RecordedDate DATETIME2 NOT NULL,
+    -- ...
+    CONSTRAINT PK_PhoenixRecords PRIMARY KEY (UserId, ChartId)
+);
+```
+
+After:
+
+```sql
+ALTER TABLE scores.PhoenixRecords
+    ADD MixId UNIQUEIDENTIFIER NOT NULL CONSTRAINT DF_PhoenixRecords_MixId
+        DEFAULT '1ABB8F5A-BDA3-40F0-9CE7-1C4F9F8F1D3B'; -- Phoenix mix ID
+
+-- Backfill is implicit via the default; verify with a row count before dropping default.
+
+ALTER TABLE scores.PhoenixRecords DROP CONSTRAINT DF_PhoenixRecords_MixId;
+
+ALTER TABLE scores.PhoenixRecords DROP CONSTRAINT PK_PhoenixRecords;
+ALTER TABLE scores.PhoenixRecords
+    ADD CONSTRAINT PK_PhoenixRecords PRIMARY KEY (UserId, ChartId, MixId);
+
+ALTER TABLE scores.PhoenixRecords
+    ADD CONSTRAINT FK_PhoenixRecords_ChartMix
+        FOREIGN KEY (ChartId, MixId) REFERENCES scores.ChartMix(ChartId, MixId);
+
+CREATE INDEX IX_PhoenixRecords_ChartId_MixId
+    ON scores.PhoenixRecords (ChartId, MixId);
+```
+
+EF Core migration mirrors this — generated with `dotnet ef migrations add AddMixIdToPhoenixRecords`.
+
+### PlayerStats
+
+Same shape:
+
+```sql
+ALTER TABLE scores.PlayerStats
+    ADD MixId UNIQUEIDENTIFIER NOT NULL CONSTRAINT DF_PlayerStats_MixId
+        DEFAULT '1ABB8F5A-BDA3-40F0-9CE7-1C4F9F8F1D3B';
+
+ALTER TABLE scores.PlayerStats DROP CONSTRAINT DF_PlayerStats_MixId;
+ALTER TABLE scores.PlayerStats DROP CONSTRAINT PK_PlayerStats;
+ALTER TABLE scores.PlayerStats
+    ADD CONSTRAINT PK_PlayerStats PRIMARY KEY (UserId, MixId);
+```
+
+## Repository signature changes
+
+Every method on [`IPhoenixRecordRepository`](../../../ScoreTracker/ScoreTracker.Domain/SecondaryPorts/) gets a `MixEnum mix` parameter. Same for `IPlayerStatsRepository`.
+
+Example shape (illustrative, not exhaustive):
+
+```csharp
+// Before
+Task<IEnumerable<RecordedPhoenixScore>> GetRecordedScores(Guid userId, CancellationToken ct = default);
+
+// After
+Task<IEnumerable<RecordedPhoenixScore>> GetRecordedScores(Guid userId, MixEnum mix, CancellationToken ct = default);
+```
+
+**No default values for the `MixEnum` parameter.** The compiler error is the migration audit tool — every caller has to be touched, deliberately.
+
+## Files this touches
+
+### Domain
+- Modified: `ScoreTracker.Domain/SecondaryPorts/IPhoenixRecordRepository.cs`
+- Modified: `ScoreTracker.Domain/SecondaryPorts/IPlayerStatsRepository.cs` (and any other stat-shaped ports)
+
+### Data
+- Modified: `ScoreTracker.Data/Persistence/Entities/PhoenixRecordEntity.cs` (add `MixId`)
+- Modified: `ScoreTracker.Data/Persistence/Entities/PlayerStatsEntity.cs` (add `MixId`)
+- Modified: `ScoreTracker.Data/Persistence/ChartAttemptDbContext.cs` (composite FK config)
+- Modified: `ScoreTracker.Data/Repositories/EFPhoenixRecordsRepository.cs`
+- Modified: `ScoreTracker.Data/Repositories/EFPlayerStatsRepository.cs` (or equivalent)
+- New: `ScoreTracker.Data/Migrations/<timestamp>_AddMixIdToPhoenixRecords.cs`
+- New: `ScoreTracker.Data/Migrations/<timestamp>_AddMixIdToPlayerStats.cs`
+
+### Application
+- Every handler that calls a touched repository method needs the `MixEnum` plumbed in. The compiler error list is the work list.
+
+### Tests
+- New: `ScoreTracker.Tests.Integration/Repositories/EFPhoenixRecordsRepositoryMixIsolationTests.cs` — one test per read-path method asserting Phoenix 1 callers see zero Phoenix 2 rows. See [phase-1-safety-nets.md](../phases/phase-1-safety-nets.md) — these are pre-flight, before the column ships.
+
+## Risks
+
+- **Wider unique index rebuild on a large table.** `PhoenixRecords` is the largest user-data table. The migration rebuilds the clustered index on every row. Test on a prod-sized restore before shipping; consider running off-hours if needed.
+- **Silent mix-bleed if a query forgets the filter.** This is the failure mode the A4 integration tests defend against. Don't ship the column without those tests green.
+- **Composite FK adds a join cost on insert.** Every score write now verifies `(ChartId, MixId)` exists in `ChartMix`. Negligible compared to the integrity guarantee, but worth measuring during pre-flip load testing.
+
+## Open questions
+
+None known. Ready to implement once Phase 1 (the safety net tests) is in place.
+
+## Changelog
+
+- 2026-05-16: Doc created from workshop.

--- a/docs/phoenix2/features/qualifiers-mom.md
+++ b/docs/phoenix2/features/qualifiers-mom.md
@@ -1,0 +1,119 @@
+# Feature: Qualifiers and March of Murlocs
+
+> Status: **design locked** · Last updated: 2026-05-16
+
+The two tournament-shaped features that survive into Phoenix 2. Both are mix-aware; everything else in the tournament domain is being dropped.
+
+## Load these first (agent context)
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`mix-model.md`](mix-model.md)
+- [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) — section "Layers / Application", subsection on Saga conventions
+
+## Scope
+
+- `TournamentSession.Mix` — set-once at session creation
+- Qualifiers configuration carrying `Mix` for the duration of the Qualifier
+- "No mixed-mix sessions" invariant
+- The dropped tournament features (so future-you doesn't go looking)
+
+## Out of scope
+
+- Match-shaped tournament features (bracket play, etc.) — being **dropped** going into Phoenix 2. No mix work needed because the feature is going away.
+- Pumbility/PUMBILITY+ algorithm changes — handled per existing service, just mix-parameterized.
+
+## Locked decisions
+
+- **F1** — `MixId` lives on `TournamentSession` (the user's registration in a tournament), **not** on `TournamentEntity` (the tournament itself). A tournament can host sessions of any mix; each session picks one.
+- **F2** — Qualifiers carry their `Mix` on the Qualifier configuration. All Qualifier actions (score submissions, leaderboard reads, eligibility checks) thread that Mix through.
+- **F3** — `TournamentSession.Mix` is **set-once-at-creation and immutable**. Once a session exists with a mix, that mix is locked. Matches the existing `TournamentSession` invariant style (`Approve`, `AddPhoto`, etc. are monotonic).
+
+## Why `Mix` is on the session, not the tournament
+
+The roadmap requirement: "March of Murlocs should support any mix, but you must select Mix when registering a session (I.E. no mixed-mix sessions)."
+
+That's a session-level rule, not a tournament-level rule. If `Mix` were on the tournament, the tournament would have to be Phoenix-1-only or Phoenix-2-only — and you'd need separate M.o.M. tournaments per mix. Putting `Mix` on the session lets one M.o.M. event accept both mixes of player, with each session sandboxed to its declared mix.
+
+## TournamentSession shape
+
+```csharp
+// ScoreTracker.Domain/Models/TournamentSession.cs
+public sealed record TournamentSession
+{
+    // ...existing properties...
+
+    public MixEnum Mix { get; }  // set in the constructor, no setter, no With() that changes it
+
+    public TournamentSession(
+        // ...existing args...
+        MixEnum mix)
+    {
+        // ...
+        Mix = mix;
+    }
+
+    // No method on TournamentSession may mutate Mix. If a future feature wants
+    // "change session mix," that's a new TournamentSession.
+}
+```
+
+Approval, photo-add, etc. remain unchanged. They all operate within the session's declared mix.
+
+## Qualifiers shape
+
+The Qualifier configuration (the entity that defines a Qualifier event) gains a `MixEnum Mix` property. Every Qualifier-shaped query/command takes a Qualifier ID, and from that resolves the mix — no separate mix parameter needed at the call site for most actions.
+
+Submission flow (illustrative):
+
+```csharp
+// Application/Commands/SubmitQualifierScoreCommand.cs
+public sealed record SubmitQualifierScoreCommand(
+    Guid QualifierId,
+    Guid ChartId,
+    PhoenixScore Score)
+    : IRequest;
+
+// Handler
+public async Task Handle(SubmitQualifierScoreCommand cmd, CancellationToken ct)
+{
+    var config = await _qualifierConfigRepo.Get(cmd.QualifierId, ct);
+    // config.Mix is the authoritative mix for everything in this submission
+    var score = new RecordedPhoenixScore(/* ... */, mix: config.Mix);
+    await _scoreRepo.UpsertBestAttempt(score, config.Mix, ct);
+    await _bus.Publish(new PlayerScoreUpdatedEvent { /* ... */, Mix = config.Mix });
+}
+```
+
+The Qualifier config is the source of truth; everything downstream reads from it.
+
+## Tournament features being dropped
+
+These do **not** carry forward into Phoenix 2 and don't need mix support:
+
+- Match-shaped tournament features (bracket play, head-to-head matches, `MatchSaga` operations)
+- `MatchUpdatedEvent` and related
+- Tournament leaderboards beyond M.o.M.'s own
+
+The classes can remain in the codebase post-Phoenix 2 for historical Phoenix 1 data viewing, but new development against them stops. They are explicitly **not** in scope for the mix-threading pass — leaving them mix-blind is fine because Phoenix 2 won't use them.
+
+## Files this touches
+
+- Modified: `ScoreTracker.Domain/Models/TournamentSession.cs` — add `Mix` property, constructor argument, immutability
+- Modified: `ScoreTracker.Data/Persistence/Entities/TournamentSessionEntity.cs` (or equivalent) — add `MixId` column
+- Modified: Qualifier config entity and repository — add `MixId`, thread through queries/commands
+- New EF migrations: add `MixId` to `TournamentSessions`, add `MixId` to Qualifier config table
+- Backfill: existing rows → `Phoenix` mix ID
+
+## Risks
+
+- **Existing TournamentSession rows have no mix.** Backfill to `Phoenix`. Same migration pattern as PhoenixRecords.
+- **Match-shaped features still exist in the codebase and quietly accept Phoenix-only data.** Document this explicitly so future-you doesn't try to retrofit mix support there in confusion — it's intentional that they remain mix-blind.
+- **Qualifier mix mismatch across submission and chart.** If a Qualifier is configured for Phoenix 2 but accidentally references a chart that only exists in Phoenix 1, the composite FK on PhoenixRecords (`(ChartId, MixId)` → `ChartMix`) catches it. Good — no silent corruption.
+
+## Open questions
+
+- Is there a `TournamentSessionEntity` or similar EF entity, or is `TournamentSession` persisted via a different shape? Verify file naming during implementation. The principle holds either way.
+
+## Changelog
+
+- 2026-05-16: Doc created from workshop.

--- a/docs/phoenix2/features/title-lists.md
+++ b/docs/phoenix2/features/title-lists.md
@@ -1,0 +1,95 @@
+# Feature: Title lists
+
+> Status: **design locked** · Last updated: 2026-05-16
+
+Phoenix 2 gets its own title list, parallel to `PhoenixTitleList`. Hardcoded static class, same pattern as Phoenix 1.
+
+## Load these first (agent context)
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`mix-model.md`](mix-model.md)
+- [`events.md`](events.md)
+
+## Scope
+
+- New `Phoenix2TitleList` static class, structured like `PhoenixTitleList`
+- `TitleSaga` branching by mix
+- `GetTitleProgressQuery` already takes `MixEnum` — verify Phoenix 2 routing
+- TODO comment noting future DB-backed migration
+
+## Out of scope
+
+- Migrating titles to a DB-backed table — explicitly deferred. Worth it eventually, but not in Phoenix 2 release scope.
+- XX titles — already handled separately if present
+
+## Locked decisions
+
+- **E2** — Phoenix 2 title list is a **hardcoded `Phoenix2TitleList` static class**, parallel to the existing `PhoenixTitleList`. DB-backed titles would be cleaner but are out of scope for this rollout.
+- A `// TODO: DB-backed titles when scope allows` comment sits next to both static classes so the deferred decision is visible in code.
+
+## Why not DB-backed now
+
+Worth restating the trade-off:
+
+- **DB-backed pros**: edit titles without deploy; one source of truth; easier when PIU surprises us with a title rebalance mid-release (which they do).
+- **DB-backed cons**: schema work, migration, admin UI to manage the data, seed data for both Phoenix 1 and Phoenix 2.
+
+The release scope says "do the minimum that ships Phoenix 2 support correctly." Title migration adds work without unblocking anything else. Phase 4 (slow burn) is a reasonable home for it.
+
+## Phoenix2TitleList shape
+
+Mirrors [`PhoenixTitleList.cs`](../../../ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixTitleList.cs):
+
+```csharp
+// ScoreTracker.Domain/Models/Titles/Phoenix2/Phoenix2TitleList.cs
+// TODO: Migrate titles to DB-backed storage when scope allows.
+// Mirror is intentional during Phoenix 2 rollout — see docs/phoenix2/features/title-lists.md
+public static class Phoenix2TitleList
+{
+    public static readonly IReadOnlyList<Title> All = new[]
+    {
+        // populated as Phoenix 2 titles become known
+    };
+}
+```
+
+Initial content can be empty or near-empty at code commit — populated as titles are documented post-Phoenix 2 launch. The list **must** exist as a stub before Phoenix 2's `[LiveMix]` flip, even if empty, so `TitleSaga` doesn't NullReference.
+
+## TitleSaga branching
+
+```csharp
+// ScoreTracker.Application/Handlers/TitleSaga.cs
+public async Task Consume(ConsumeContext<TitlesDetectedEvent> ctx)
+{
+    var titleList = ctx.Message.Mix switch
+    {
+        MixEnum.Phoenix => PhoenixTitleList.All,
+        MixEnum.Phoenix2 => Phoenix2TitleList.All,
+        _ => throw new NotSupportedException($"No title list for mix {ctx.Message.Mix}")
+    };
+    // ...rest of processing uses titleList...
+}
+```
+
+`TitlesDetectedEvent` already carries `Mix` per [events.md](events.md), so no re-querying is needed.
+
+## Files this touches
+
+- New: `ScoreTracker.Domain/Models/Titles/Phoenix2/Phoenix2TitleList.cs` (and any related per-tier classes if `PhoenixTitleList` is split)
+- Modified: `ScoreTracker.Application/Handlers/TitleSaga.cs` (mix-aware branching)
+- Comment: add `// TODO: DB-backed titles when scope allows` to `PhoenixTitleList.cs` and `Phoenix2TitleList.cs`
+- Verify: [`GetTitleProgressQuery`](../../../ScoreTracker/ScoreTracker.Application/Queries/GetTitleProgressQuery.cs) — already mix-aware per the explore pass, just confirm Phoenix 2 routes correctly
+
+## Risks
+
+- **Title list incompleteness at launch.** Phoenix 2 titles aren't fully documented until PIU ships and the community catalogs them. Ship a stub list and update it post-launch. Communicate this in Discord.
+- **Title detection works even when the list is empty** — title-detected events fire, but matching against an empty list means no `NewTitlesAcquiredEvent`. Acceptable; users see updates as the list fills in.
+- **Code duplication.** `Phoenix2TitleList` shares structure with `PhoenixTitleList`. That's the cost of deferring DB-backed titles. Live with it; the deferred work cleans it up.
+
+## Open questions
+
+- Are there sub-files per title tier (`Bronze`, `Silver`, `Gold`, `Platinum`) under `Phoenix/`, or is it one flat list? Verify during implementation and mirror the structure exactly under `Phoenix2/`.
+
+## Changelog
+
+- 2026-05-16: Doc created from workshop.

--- a/docs/phoenix2/phases/phase-1-safety-nets.md
+++ b/docs/phoenix2/phases/phase-1-safety-nets.md
@@ -1,0 +1,77 @@
+# Phase 1: Safety nets
+
+> Status: **[ ] Not started** · Last updated: 2026-05-16
+
+Pre-flight work. Goal: make sure the Phoenix 2 migration can't silently corrupt Phoenix 1 data or fail silently. Nothing in this phase changes production behavior.
+
+## Load these first (required)
+
+Refuse to proceed if any of these are missing:
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`docs/phoenix2/features/phoenix-records-schema.md`](../features/phoenix-records-schema.md)
+- [`docs/phoenix2/features/known-fragile.md`](../features/known-fragile.md)
+- [`CLAUDE.md`](../../../CLAUDE.md) — section "Test conventions"
+- [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) — section "Testing strategy"
+
+## In scope
+
+- Per-method integration tests asserting **"Phoenix 1 caller sees zero Phoenix 2 rows"** for every read-path repository method on `EFPhoenixRecordsRepository` (and `EFPlayerStatsRepository` once it's in scope). These tests are written *before* the `MixId` column lands, but they should pass against the current schema (since there's no Phoenix 2 data yet, the assertion is vacuously true — until the schema change, where it has to hold non-vacuously). Locked decision: **A4**.
+- Smoke assertion on the weekly leaderboard import Hangfire job: "imported >0 scores at known levels." Locked decision: **I2**.
+- Backfill migration dry-runs against a prod-sized SQL Server restore — verify wider unique index rebuild time and row counts.
+
+## Out of scope (defer)
+
+- Adding `MixId` columns — Phase 2
+- Threading `MixEnum` through Application — Phase 2
+- Any UI changes — Phase 2
+- The actual Phoenix 2 scraper — Phase 3
+- Derived-data audit pass — Phase 2 (audit) and Phase 4 (deferred tables)
+
+## Locked decisions affecting this phase
+
+- **A3** — Repository methods take `MixEnum mix` as required (no default). Tests in this phase are written *anticipating* that signature.
+- **A4** — Mix isolation integration tests exist and pass *before* the column flips on in prod.
+- **I2** — Smoke assertion is mix-agnostic ("scores at known levels imported >0").
+
+## Tasks
+
+1. [ ] **Mix isolation integration tests.**
+   - For every public method on `IPhoenixRecordRepository`, add a test in `ScoreTracker.Tests.Integration/Repositories/`:
+     - Seed: 5 Phoenix scores for a user. (No Phoenix 2 yet, so seeding Phoenix 2 needs the test to manually insert with the future `MixId` GUID — Phoenix 2's GUID, distinct from Phoenix's. Pre-create the Phoenix 2 mix row if needed for the test's setup.)
+     - Call: the method with `MixEnum.Phoenix`.
+     - Assert: zero Phoenix 2 rows present in the result.
+   - Tests will run *vacuously green* until `MixId` exists; once the column lands they have to hold non-vacuously.
+   - Reference the integration test pattern in [`CLAUDE.md`](../../../CLAUDE.md) — Testcontainers.MsSql + Respawn.
+
+2. [ ] **Smoke assertion in `RecurringJobRunner`.**
+   - File: [`ScoreTracker/HostedServices/RecurringJobRunner.cs`](../../../ScoreTracker/ScoreTracker/HostedServices/RecurringJobRunner.cs)
+   - Method: the one that publishes `StartLeaderboardImportEvent`.
+   - After the import completes (note: today this is fire-and-forget via `IBus.Publish`; the smoke check may need to live inside `OfficialLeaderboardSaga.Consume` instead, depending on shape).
+   - Logic: count imported scores; assert >100 (tune); assert at least one chart at level ≥20 was observed.
+   - On failure: `_logger.LogError` (and optional Discord webhook to admin channel — out of scope unless trivial).
+
+3. [ ] **Backfill migration dry-run.**
+   - Take a prod-sized restore (latest backup, restored to a dev DB).
+   - Write the candidate migration SQL from [`phoenix-records-schema.md`](../features/phoenix-records-schema.md) (don't ship yet — this is verification only).
+   - Apply and measure: index rebuild time, lock duration, disk usage delta.
+   - Record findings here (Changelog below) for the Phase 2 cutover decision.
+
+4. [ ] **Audit recurring-job error logging.**
+   - Verify Hangfire job failures actually surface somewhere. If they currently fail to a void, decide whether to add Application Insights alerts or accept the silence as a deferred problem.
+
+## Success criteria
+
+- [ ] Integration test suite has per-method mix-isolation coverage for `IPhoenixRecordRepository`.
+- [ ] Suite runs green (vacuously, pre-column) via `dotnet test ScoreTracker/ScoreTracker.Tests.Integration/ScoreTracker.Tests.Integration.csproj`.
+- [ ] Smoke assertion is in place on the weekly leaderboard import; failure path tested manually (force-return-empty in a dev env, verify log appears).
+- [ ] Backfill migration timing documented in this file's Changelog.
+
+## Open questions
+
+- Does the smoke assertion belong in `RecurringJobRunner` or inside `OfficialLeaderboardSaga.Consume`? The job runner publishes fire-and-forget; the saga is where the data actually arrives. Implementation note: probably the saga.
+- What's the right threshold for "suspicious data"? Worth checking historical import counts to tune.
+
+## Changelog
+
+- 2026-05-16: Phase doc created from workshop.

--- a/docs/phoenix2/phases/phase-2-pre-launch.md
+++ b/docs/phoenix2/phases/phase-2-pre-launch.md
@@ -1,0 +1,122 @@
+# Phase 2: Pre-launch
+
+> Status: **[ ] Not started** · Last updated: 2026-05-16
+
+Everything that can land before Phoenix 2 ships, none of which depends on what PIU's site looks like. After this phase, the codebase is ready for Phoenix 2; only the `[LiveMix]` attribute and the import-flow shape remain.
+
+## Load these first (required)
+
+Refuse to proceed if any of these are missing:
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`docs/phoenix2/features/mix-model.md`](../features/mix-model.md)
+- [`docs/phoenix2/features/phoenix-records-schema.md`](../features/phoenix-records-schema.md)
+- [`docs/phoenix2/features/events.md`](../features/events.md)
+- [`docs/phoenix2/features/notifications-gating.md`](../features/notifications-gating.md)
+- [`docs/phoenix2/features/qualifiers-mom.md`](../features/qualifiers-mom.md)
+- [`docs/phoenix2/features/derived-data.md`](../features/derived-data.md)
+- [`docs/phoenix2/features/title-lists.md`](../features/title-lists.md)
+- [`docs/phoenix2/phases/phase-1-safety-nets.md`](phase-1-safety-nets.md) — verify it's done
+- [`CLAUDE.md`](../../../CLAUDE.md)
+- [`ARCHITECTURE.md`](../../../ARCHITECTURE.md)
+
+## Prerequisites
+
+- Phase 1 complete: integration tests in place, smoke assertion live, backfill dry-run validated.
+
+## In scope
+
+- `MixEnum.Phoenix2` added to the enum (without `[LiveMix]`)
+- `[LiveMix]` attribute created and applied to `Phoenix`
+- `ICurrentUserAccessor` split into `GetUserSelectedMix()` and `GetLiveMix()`
+- `UiSettingsAccessor` read-time default removed for persisted users; anonymous fallback retained
+- Backfill migration: `Universal__CurrentMix = Phoenix` for every existing user without it
+- New-user-create handler writes `CurrentMix = LiveMix`
+- UI mix selector filters by selectability rule (only `[LiveMix]` mix and earlier are shown)
+- `PhoenixRecords` schema migration: add `MixId`, composite FK to `ChartMix`, wider unique, secondary index
+- `PlayerStats` schema migration: add `MixId`, expand PK
+- `TournamentSession` schema migration: add `MixId` (set-once)
+- Qualifier configuration: add `MixId`, thread through Qualifier queries/commands
+- Derived-data table audit (Weekly Charts, Tier List outputs, Community Leaderboards): catalog and migrate the ones that persist across recomputes
+- Event schema: add `MixEnum Mix` to listed events (see [events.md](../features/events.md))
+- Repository signatures: required `MixEnum` parameter on `IPhoenixRecordRepository`, `IPlayerStatsRepository`, derived-data repositories
+- Application: thread `MixEnum` through queries/commands; default to LiveMix only at controller/page edge
+- `Phoenix2TitleList` stub (empty or near-empty is fine)
+- `TitleSaga` branches by mix
+- `CommunitySaga` and Discord-publishing consumers gated on `event.Mix == GetLiveMix()`
+
+## Out of scope (defer to Phase 3)
+
+- Moving `[LiveMix]` from `Phoenix` to `Phoenix2` — that's the launch-day flip
+- `UploadPhoenix2Scores.razor` page — shape depends on PIU's site
+- Phoenix 2 scraper rework — shape depends on PIU's site
+- The defensive corruption guard's tuning — needs real Phoenix 2 traffic to threshold
+- Populating `Phoenix2TitleList` — depends on what Phoenix 2 ships
+
+## Locked decisions affecting this phase
+
+All of A1–A5, B1, C1–C4, D1, D2, E1, E2, F1, F2, F3, H1, J1.
+
+The phase docs are not the place to re-debate these. See the feature docs for the canonical decision text. Reference by ID in this doc and in PRs.
+
+## Tasks
+
+### Foundation (do first)
+
+1. [ ] **Add `LiveMixAttribute`.** New file `ScoreTracker.Domain/Enums/LiveMixAttribute.cs`. Simple `AttributeUsage(Field)` marker. See [mix-model.md](../features/mix-model.md).
+
+2. [ ] **Add `Phoenix2` to `MixEnum`, mark `Phoenix` with `[LiveMix]`.** File: `ScoreTracker.Domain/Enums/MixEnum.cs`.
+
+3. [ ] **Add new Mix row to the database** for Phoenix 2 with a stable GUID. Record the GUID in `EFChartRepository.MixGuids` dictionary.
+
+4. [ ] **Split accessor surface.** `ICurrentUserAccessor` gains `GetUserSelectedMix()` and `GetLiveMix()`. Implementations updated.
+
+5. [ ] **Backfill migration for `UserUiSettings`.** A5. Verify on prod-sized restore.
+
+6. [ ] **Remove read-time mix default for persisted users.** [`UiSettingsAccessor.cs`](../../../ScoreTracker/ScoreTracker/Services/UiSettingsAccessor.cs). Anonymous fallback to `GetLiveMix()` retained.
+
+7. [ ] **`CreateUserHandler` writes `CurrentMix = LiveMix`** for new accounts.
+
+8. [ ] **UI selectability filter** in `Shared/MainLayout.razor`. Phoenix 2 invisible until `[LiveMix]` moves.
+
+### Schema (do after foundation)
+
+9. [ ] **`PhoenixRecords` migration.** A1, A2, A3, A5. See [phoenix-records-schema.md](../features/phoenix-records-schema.md).
+
+10. [ ] **`PlayerStats` migration.** B1.
+
+11. [ ] **`TournamentSession` migration.** F1, F3 (set-once). Backfill existing rows to `Phoenix`.
+
+12. [ ] **Qualifier configuration migration.** F2. Backfill existing rows to `Phoenix`.
+
+13. [ ] **Derived-data audit and migration.** J1. Sweep `ScoreTracker.Data/Persistence/Entities/` for tables that join `PhoenixRecord` or `ChartId`. Catalog each as "needs `MixId` now" or "fully rebuilds, defer to Phase 4."
+
+### Application (do after schema)
+
+14. [ ] **Event schemas.** D1. Add `MixEnum Mix` (required) to events listed in [events.md](../features/events.md). Update every publisher to pass it; update every consumer to use it.
+
+15. [ ] **Repository signatures.** A3. Mix as required parameter on every read/write method of affected repositories.
+
+16. [ ] **Thread Mix through Application.** E1. Every query/command that touched Phoenix-hardcoded code (see [explore findings: TierListsController, WeeklyChartsController, PumbilityProjectionSaga, Community queries, WorldRankingService](../features/mix-model.md)) gains `MixEnum` in its contract. Default to `GetLiveMix()` *only* at the Razor page / API controller edge.
+
+17. [ ] **Notification gating.** [`notifications-gating.md`](../features/notifications-gating.md). `CommunitySaga` and Discord-publishing consumers add the `event.Mix != GetLiveMix() → return` guard.
+
+18. [ ] **`Phoenix2TitleList` stub + `TitleSaga` branching.** E2. Empty `Phoenix2TitleList` is acceptable.
+
+## Success criteria
+
+- [ ] `dotnet build ScoreTracker/ScoreTracker.sln -c Release` succeeds.
+- [ ] `dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` runs green.
+- [ ] `dotnet test ScoreTracker/ScoreTracker.Tests.Integration/ScoreTracker.Tests.Integration.csproj` runs green — including the Phase 1 mix-isolation tests, now non-vacuously.
+- [ ] Application boots locally with both Phoenix and Phoenix2 in the enum; mix selector shows only Phoenix and XX (Phoenix 2 hidden per selectability rule).
+- [ ] A test user can: select Phoenix → import scores → see them recorded with `MixId = Phoenix`. Switching to Phoenix 2 in the UI is not yet possible (correct — gate works).
+- [ ] Manually insert a Phoenix 2 score row in dev DB → verify it doesn't appear in Phoenix mode views.
+
+## Open questions
+
+- The derived-data audit may surface tables we didn't anticipate. Log findings in Changelog.
+- Some Application-layer changes are touchpoint-heavy (every controller/page). Worth splitting into smaller PRs by feature area? Default: yes, separate PRs per feature stack.
+
+## Changelog
+
+- 2026-05-16: Phase doc created from workshop.

--- a/docs/phoenix2/phases/phase-3-launch-week.md
+++ b/docs/phoenix2/phases/phase-3-launch-week.md
@@ -1,0 +1,130 @@
+# Phase 3: Launch week
+
+> Status: **[ ] Not started** · Last updated: 2026-05-16
+
+The week of Phoenix 2's actual release. This phase is reactive — most tasks depend on what PIU's Phoenix 2 site actually looks like once it's live.
+
+## Load these first (required)
+
+Refuse to proceed if any of these are missing:
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`docs/phoenix2/features/import-flow.md`](../features/import-flow.md)
+- [`docs/phoenix2/features/known-fragile.md`](../features/known-fragile.md)
+- [`docs/phoenix2/features/mix-model.md`](../features/mix-model.md)
+- [`docs/phoenix2/features/notifications-gating.md`](../features/notifications-gating.md)
+- [`docs/phoenix2/phases/phase-2-pre-launch.md`](phase-2-pre-launch.md) — verify it's done
+
+## Prerequisites
+
+- Phase 2 complete: schema, events, gating, accessors all in place. Phoenix 2 exists in the enum without `[LiveMix]`.
+- PIU has shipped Phoenix 2 (or is shipping imminently) — we can see the live site.
+
+## In scope
+
+- Walk the [`known-fragile.md`](../features/known-fragile.md) checklist against PIU's actual Phoenix 2 site
+- Build `UploadPhoenix2Scores.razor` — shape determined by PIU's site
+- Rework the scraper (`PiuGameApi`, `OfficialSiteClient`) if PIU's URLs, HTML, or auth changed
+- Tune the defensive corruption guard threshold against real Phoenix 2 traffic
+- Move `[LiveMix]` from `Phoenix` to `Phoenix2` (one-line code change, deploy)
+- Verify notification gating actually quieted Phoenix 1 → Discord
+- Communicate to Discord users when Phoenix 2 mode is available
+
+## Out of scope (defer to Phase 4)
+
+- Derived-data tables that were marked "fully rebuilds, defer"
+- DB-backed titles
+- Older-mix support (pre-XX)
+- Scraper architectural rework
+
+## Locked decisions affecting this phase
+
+- **G1** — Import is explicit on the command (`UploadPhoenix2Scores.razor` passes `Mix = MixEnum.Phoenix2`).
+- **G2** — Defensive guard runs against scraped responses. Threshold tuned during this phase.
+- **C2/C4/H1** — Moving `[LiveMix]` from `Phoenix` to `Phoenix2` is the one-line toggle. Same change makes Phoenix 2 selectable in the UI and becomes the default for new users.
+
+## Tasks
+
+### Reconnaissance (do first)
+
+1. [ ] **Walk the fragile-spots checklist.** See [known-fragile.md "What to check on Phoenix 2 launch day"](../features/known-fragile.md).
+   - Does `login_check.php` still authenticate?
+   - Do the 11+ hardcoded URLs still resolve?
+   - Has the HTML for `my_best_score.php` changed?
+   - Have image CDN paths (`stepball/full/`, avatars, plates) changed?
+   - Are there new song names that need mapping entries?
+   - Document findings in this file's Changelog.
+
+2. [ ] **Manual import dry-run against Phoenix 2 data, in a dev env with `MixId = Phoenix2`.** Don't ship yet — observe what the scraper actually parses.
+
+### Scraper rework (only what reconnaissance flagged)
+
+3. [ ] **Update hardcoded URLs** in [`PiuGameApi.cs`](../../../ScoreTracker/ScoreTracker.Data/Apis/PiuGameApi.cs) if any changed.
+
+4. [ ] **Update HTML parsers** if class names or structure changed.
+
+5. [ ] **Update image-path regexes** (difficulty parsing, avatars, plates) if CDN paths changed.
+
+6. [ ] **Add new song-name mappings** to `OfficialSiteClient`'s Korean→English dict if needed.
+
+7. [ ] **Handle simultaneous Phoenix 1 + Phoenix 2 support**, if PIU ships both at once:
+   - Decision needed: does the scraper accept a `MixEnum` and route to different URLs per mix, or does the scraper auto-detect mix from response shape? The roadmap defaults to **explicit mix on command** (G1) — the scraper accepts mix as a parameter and uses different URLs as needed.
+   - If PIU shut Phoenix 1 down at Phoenix 2 launch: ignore this task; only Phoenix 2 URLs matter.
+
+### UI
+
+8. [ ] **Build `UploadPhoenix2Scores.razor`.** Sibling of `UploadPhoenixScores.razor`. Same flow; passes `Mix = MixEnum.Phoenix2` to the command. Gated on Phoenix 2 being selectable (which happens after step 11 below).
+
+### Guard tuning
+
+9. [ ] **Tune the corruption guard threshold** against observed Phoenix 2 traffic. Run several test imports; measure how often the heuristic fires false-positive. Adjust thresholds in [`OfficialLeaderboardSaga`](../../../ScoreTracker/ScoreTracker.Application/Handlers/OfficialLeaderboardSaga.cs).
+
+### The flip
+
+10. [ ] **Final verification before flip:**
+    - All scraper tests green
+    - Test users can import to Phoenix 2 in dev with no corruption
+    - Notification gating verified (Phoenix 1 import in dev does not fire Discord notifications when LiveMix moves)
+    - Backup taken of prod DB
+
+11. [ ] **Move `[LiveMix]` from `Phoenix` to `Phoenix2` in `MixEnum.cs`.** Deploy. This:
+    - Makes Phoenix 2 the default for new users (C1 — create handler writes LiveMix)
+    - Makes Phoenix 2 selectable in the UI (C4 selectability rule)
+    - Quiets Phoenix 1 → Discord notifications (notification gating)
+    - Keeps Phoenix 1 selectable for existing users (per C3, they stay opted in)
+
+12. [ ] **Post-deploy verification:**
+    - Existing users still see Phoenix 1 mode by default (their `CurrentMix` is unchanged).
+    - New users land on Phoenix 2.
+    - The Phoenix 2 import page is reachable.
+    - Importing a Phoenix 2 score writes a row with `MixId = Phoenix2`.
+    - Phoenix 1 import flow still works; the guard doesn't false-positive on legit Phoenix 1 data.
+
+### Communication
+
+13. [ ] **Discord announcement.** Cover:
+    - Phoenix 2 mode is live; how to switch.
+    - Tier Lists and Weekly Charts will be sparse early; that's expected.
+    - Phoenix 1 scores remain accessible by toggling mix.
+    - Known issues / what's not yet supported (Title list is sparse; etc.)
+
+## Success criteria
+
+- [ ] Phoenix 2 mode is selectable and functional in prod.
+- [ ] At least one real Phoenix 2 import has succeeded end-to-end with correct `MixId` writes.
+- [ ] Phoenix 1 scores remain untouched and queryable.
+- [ ] No silent corruption: every Phoenix 1 import in prod still parses as Phoenix 1; every Phoenix 2 import as Phoenix 2.
+- [ ] Discord notification gating verified live.
+- [ ] Smoke assertion (from Phase 1) is reporting non-zero counts again post-Phoenix-2 scraper rework.
+
+## Open questions (resolved during this phase)
+
+- Whether Phoenix 1 site stays up alongside Phoenix 2 (informs scraper URL routing)
+- Whether auth changed
+- Whether HTML structure changed
+- Whether new song-name mappings are needed
+- Final corruption-guard threshold
+
+## Changelog
+
+- 2026-05-16: Phase doc created from workshop.

--- a/docs/phoenix2/phases/phase-4-slow-burn.md
+++ b/docs/phoenix2/phases/phase-4-slow-burn.md
@@ -1,0 +1,109 @@
+# Phase 4: Slow burn
+
+> Status: **[ ] Not started** · Last updated: 2026-05-16
+
+Post-launch work that doesn't block Phoenix 2 from shipping. Tackled at leisure as scope opens.
+
+## Load these first (required)
+
+- [`PHOENIX2-ROADMAP.md`](../../../PHOENIX2-ROADMAP.md)
+- [`docs/phoenix2/features/derived-data.md`](../features/derived-data.md)
+- [`docs/phoenix2/features/title-lists.md`](../features/title-lists.md)
+- [`docs/phoenix2/features/known-fragile.md`](../features/known-fragile.md)
+- [`docs/phoenix2/phases/phase-3-launch-week.md`](phase-3-launch-week.md) — verify it's done
+
+## Prerequisites
+
+- Phase 3 complete: Phoenix 2 is live, the `[LiveMix]` flip happened, the scraper works against PIU's Phoenix 2 site.
+
+## In scope
+
+- Derived-data tables that were deferred during Phase 2 (the "fully rebuilds each cycle" ones)
+- DB-backed titles migration (if scope opens)
+- Older-mix support (pre-XX), including the schema rework around DifficultyLevel/ChartType not existing in older mixes
+- Scoring philosophy work for pre-Phoenix mixes (different score logic, plates may not exist, etc.)
+- Scraper architectural rework — if the launch-week patches accumulated too much fragility, consider a fuller restructure
+- Populating `Phoenix2TitleList` as the title list firms up
+- Possibly: alerting on Hangfire job failures (if Phase 1's smoke assertion is judged insufficient)
+
+## Out of scope
+
+- Anything not listed above is either Phase 3 hotfix territory or genuinely not in this rollout.
+
+## Locked decisions
+
+None new — this phase is execution against decisions captured in feature docs. Specific items reference their feature docs by ID.
+
+## Tasks (pick up as scope allows; no fixed order)
+
+### Derived-data deferred items
+
+1. [ ] **Sweep the derived-data audit catalog** (from Phase 2). For each table marked "fully rebuilds, defer":
+   - Verify it's actually rebuilding cleanly post-Phoenix-2.
+   - If a stale row from before the cutover is causing user-visible weirdness, migrate it now.
+   - Otherwise leave alone until next natural touch.
+
+### DB-backed titles
+
+2. [ ] **Design** a `TitleDefinitions` table. Reference [title-lists.md](../features/title-lists.md) — the existing static classes (`PhoenixTitleList`, `Phoenix2TitleList`) are the seed data.
+
+3. [ ] **Migration** to seed the table from the static classes.
+
+4. [ ] **Admin UI** for editing titles (minimal — even a /hangfire-style admin page is fine).
+
+5. [ ] **Replace static-class lookups** in `TitleSaga` with repo lookups.
+
+6. [ ] **Remove `// TODO: DB-backed titles` comments** when done.
+
+### Older-mix support
+
+7. [ ] **Schema audit** for pre-Phoenix-1 mix support. Specifically:
+   - `Chart` model has non-nullable `DifficultyLevel` and `ChartType`. Older mixes don't have these. Options: nullable, per-mix Chart projection, or older-mix-only entity.
+   - Score logic differs per mix. Older score storage may need a separate table or a polymorphic Score concept.
+
+8. [ ] **Decide on storage shape** based on the audit. Document in a new `docs/phoenix2/features/older-mixes.md`.
+
+9. [ ] **Implement manual-entry pages** per supported older mix (sibling of `UploadXXScores.razor`).
+
+10. [ ] **Mix-tag everything** so older-mix scores don't leak into Phoenix/Phoenix2 leaderboards.
+
+### Scraper rework (only if Phase 3 patches are creaking)
+
+11. [ ] **Evaluate scraper fragility post-Phase-3.** If hardcoded URLs grew, regex patches accumulated, and the scraper feels brittle, consider:
+    - Centralizing all URLs in a config class
+    - Replacing regex parsing with a proper HTML parser query language (HtmlAgilityPack already in use)
+    - Adding contract tests against snapshot HTML samples
+
+12. [ ] **Decide whether to act**, or accept the cost of the existing shape until a future mix forces the issue.
+
+### Phoenix 2 title list population
+
+13. [ ] **Populate `Phoenix2TitleList`** as the title set is documented post-launch. Iterative — each batch is a small PR.
+
+### Cross-mix Tier List views
+
+14. [ ] **Tier List cross-mix awareness.** Make the Tier List feature aware of scores from other mixes the user has played. Two variants worth considering (potentially both):
+    - **Highlight previously-passed charts**: in Phoenix 2's Tier List, visually distinguish charts the user has passed in Phoenix 1 (even with no Phoenix 2 score yet). Especially useful in the early Phoenix 2 weeks when score history is sparse — players can see "I've already cleared this, just need to redo it."
+    - **Best score across all mixes**: per chart, surface the user's best score across any mix it's been recorded in. Reduces "what's my actual peak on this chart" to a single number regardless of which mix it was set in.
+
+    Cross-mix score comparison is only meaningful where scoring philosophy is consistent (Phoenix 1 ↔ Phoenix 2 — same Phoenix score model). XX and older mixes use different scoring; don't extend without re-thinking the comparison.
+
+### Optional: alerting
+
+15. [ ] **Hangfire job failure alerting.** If the Phase 1 smoke assertion proves insufficient (e.g., it fires too late, or only on the recurring job, missing ad-hoc imports), add a richer alerting pipeline:
+    - Application Insights alerts on logged errors
+    - Discord webhook on admin channel for any Hangfire job failure
+
+## Success criteria
+
+This phase doesn't have a binary "done" — it's a backlog. Items are individually shippable. Track progress here in the task list.
+
+## Open questions
+
+- **Older-mix score logic**: which historical mixes have well-defined score formulas, and which require approximation? The "complications" the user has acknowledged.
+- **Scraper rework scope**: is the cost-of-change in the existing shape painful enough to justify rework, or is it cheaper to keep patching?
+
+## Changelog
+
+- 2026-05-16: Phase doc created from workshop.
+- 2026-05-16: Added "Cross-mix Tier List views" — highlight previously-passed charts and/or best score across all mixes.


### PR DESCRIPTION
## Summary
- High-level user-facing gameplan (`PHOENIX2-ROADMAP.md`) for the upcoming Phoenix 2 mix release: how Phoenix 1 data is preserved, the "live mix" concept, per-mix feature behavior, and the score-reset framing
- 9 per-feature design docs in `docs/phoenix2/features/` capturing locked decisions by ID (mix model, PhoenixRecords schema, events, notifications gating, qualifiers & M.o.M., import flow, derived data, title lists, known-fragile scraper spots)
- 4 phase-script docs in `docs/phoenix2/phases/` (safety nets, pre-launch, launch week, slow burn) with enforced "Load these first" prerequisite blocks so future sessions can resume mid-rollout cleanly

## Notes for review
- **Docs only — no code changes.** This is workshop output, captured before implementation begins.
- The doc structure separates *concept reference* (feature docs, durable, locked decisions) from *task scripts* (phase docs, living, checkboxes + changelog). Phase docs reference feature docs by decision ID rather than duplicating decisions, so there's a single source of truth per decision.
- Some questions in `import-flow.md` and `known-fragile.md` are explicitly deferred to Phase 3 — they depend on what PIU's Phoenix 2 site actually ships.
- The `[LiveMix]` attribute mechanism in `mix-model.md` is the load-bearing primitive — once Phoenix 2 is ready, the launch-day change is moving that one attribute and deploying.

## Test plan
- [ ] Skim `PHOENIX2-ROADMAP.md` and check the user-facing framing reads well for Discord readers
- [ ] Skim each feature doc and verify locked decisions match what we workshopped (A1–A5, B1, C1–C4, D1–D2, E1–E2, F1–F3, G1–G2, H1, I1–I2, J1)
- [ ] Skim each phase doc and confirm task ordering / prerequisite blocks make sense
- [ ] Verify relative links between docs resolve (worth a quick visual pass on GitHub's rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)