### PR TITLE
Expose NoteCount on chart API responses

### DIFF
--- a/ScoreTracker/ScoreTracker/Dtos/Api/ChartDto.cs
+++ b/ScoreTracker/ScoreTracker/Dtos/Api/ChartDto.cs
@@ -12,6 +12,7 @@ namespace ScoreTracker.Web.Dtos.Api
             Level = c.Level;
             Type = c.Type.GetDisplayName();
             Shorthand = c.DifficultyString;
+            NoteCount = c.NoteCount;
             Song = new SongDto
             {
                 Name = c.Song.Name,
@@ -24,6 +25,7 @@ namespace ScoreTracker.Web.Dtos.Api
         public string Type { get; set; } = string.Empty;
         public string Shorthand { get; set; } = string.Empty;
         public int Level { get; set; }
+        public int? NoteCount { get; set; }
         public SongDto Song { get; set; } = new();
     }
 }


### PR DESCRIPTION
## What changed

Added `NoteCount` to `ChartDto`, the record returned by the public chart API. It's mapped from `Chart.NoteCount` in the constructor and exposed as a nullable `int?`.

Both chart endpoints now return it:
- `GET /api/charts`
- `GET /api/charts/random`

## Why

The `Chart` domain model has carried `NoteCount` for some time — it's stored in `ChartMixEntity` and backfilled from the PIU site import (`OfficialSiteClient` → `EFChartRepository.UpdateNoteCount`). But `ChartDto` never surfaced it, so API clients had no way to read the note count even though the data was already in the domain and database.

## Reviewer notes

- Exposed as `int?` to mirror the domain value. A chart returns `null` here until a recent-score import backfills its note count.
- No behavioral change beyond the added response field; build passes (pre-existing MudBlazor analyzer warnings only).
- `ChartDto` lives in `ScoreTracker.Web`, which the test project does not reference, so this mapping is verified by the build rather than a unit test. Flagging in case API-surface coverage is wanted as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)