### PR TITLE
Rearchitecture: subdomain verticals with clean boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,6 +6,8 @@
 
 Pump It Up Score Tracker is a Blazor Server web app (with MVC API controllers) for tracking Pump It Up scores, leaderboards, tournaments, and player progression. It follows an onion architecture: a pure `Domain` core, a `MediatR`-based `Application` layer, an EF Core `Infrastructure` layer, and a Blazor/MVC `Presentation` layer wired through a `CompositionRoot`. Asynchronous work is dispatched over MassTransit on an in-memory transport.
 
+This file describes the code **as it is**. The working domain-boundary map feeding the planned rearchitecture is [CONTEXTS.md](CONTEXTS.md); product direction and audiences are in [PRODUCT.md](PRODUCT.md).
+
 ## Solution layout
 
 ```

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -227,13 +227,16 @@ Currently skipped — no critical user-visible flow is regressed often enough to
 
 Likely tooling: bUnit for Blazor Server components, Playwright for full browser flows.
 
-### Contract tests — *M* (only if a consumer appears)
+### Contract / API-shape tests — *M*
 
 ENTERPRISE: *Contract Test*
 
-Currently skipped — the codebase consumes external APIs but exposes only a thin MVC surface; there are no known external consumers of this app's API. Revisit if:
-- A second service starts consuming this app's API, or
-- A breaking change in `PiuGameApi` causes a production incident that contract verification would have caught.
+**Status updated 2026-06-11: external consumers exist.** Community tool makers consume the public API (`api/phoenixScores`, `api/tierlist`, `api/weeklyCharts`, `api/tournaments`, `api/charts/random`) and webhook feeds from the import ecosystem rather than building their own importers (see [PRODUCT.md](PRODUCT.md#platform-stance)). The old "revisit if a consumer appears" condition is met — response shapes are a de facto public contract.
+
+- [ ] Approval-style response-shape tests pinning each public API endpoint (golden JSON per endpoint, readable diffs; live in `ScoreTracker.Tests`, classify as `component`).
+- [ ] Same for webhook payloads once they're formalized (see [CONTEXTS.md](CONTEXTS.md) Q7).
+- [ ] Full consumer-driven contract tests (Pact-style) only if a partner tool wants to maintain one — approval tests are the right cost point today.
+- Also still relevant: a breaking change in `PiuGameApi` causing a production incident would justify contract verification on the *consuming* side.
 
 ---
 
@@ -243,6 +246,8 @@ Currently skipped — the codebase consumes external APIs but exposes only a thi
 
 Decisions locked from a 2026-05-17 workshop. ADR (Step 1.7) is the first rearch-session deliverable.
 
+> **Revised 2026-06-11** after the bounded-context analysis in [CONTEXTS.md](CONTEXTS.md). A1 and A5 are updated in place (marked *revised*) and supersede the 2026-05-17 versions where they differ; the remaining deltas are tracked as CONTEXTS.md *Open questions* and get finalized in the Step 1.7 ADR. CONTEXTS.md's friction inventory seeds Step 1.6's diagnostic catalog.
+
 ### Why not concurrent with Phoenix 2
 
 Phoenix 2 is **compiler-driven and mechanical**: required `MixEnum mix` parameters, composite-FK schema migration, mix-isolation tests before column flips. See [PHOENIX2-ROADMAP.md](PHOENIX2-ROADMAP.md) and [phoenix-records-schema.md](docs/phoenix2/features/phoenix-records-schema.md).
@@ -251,13 +256,16 @@ Rearch is **judgment-driven and structural**: what's domain vs orchestration, sh
 
 ### Locked decisions
 
-- **A1. Vertical taxonomy** — six subdomain verticals, each its own assembly with internal Domain/Application/Infra layers:
-  - **PlayerProgress** (current `ScoreTracker.PersonalProgress`; expanded to include Pumbility, PlayerHistory, ScoreQuality, Title, Skills)
-  - **Competition** (Qualifiers, WeeklyTournament, M.o.M., OfficialLeaderboard — Match/bracket dropped per the [Phoenix 2 carve-out](PHOENIX2-ROADMAP.md))
+- **A1. Vertical taxonomy** *(revised 2026-06-11 per [CONTEXTS.md](CONTEXTS.md))* — nine subdomain verticals, each its own assembly with internal Domain/Application/Infra layers:
+  - **ScoreLedger** *(new — was implicit)* — the score system of record + acquisition pipeline: Phoenix/XX records, official-account import, OCR/CSV upload, score-batch accumulation. Core per [PRODUCT.md](PRODUCT.md).
+  - **PlayerProgress** (current `ScoreTracker.PersonalProgress`; expanded to include Pumbility, PlayerHistory, ScoreQuality, Title, Skills — Skills placement is CONTEXTS Q5)
+  - **EventCompetition** (Qualifiers, M.o.M. — Match/bracket and the rest of the generic tournament domain dropped per the [Phoenix 2 carve-out](PHOENIX2-ROADMAP.md))
+  - **WeeklyChallenge** *(split from Competition — weekly serves the casual-competitive core audience, organized events the competitive secondary audience; PRODUCT.md §Audiences)*
+  - **OfficialMirror** *(pulled out of Competition — official leaderboard import, world rankings, avatars, PiuTracker sync, and the PiuGame ACL; revises A5)*
   - **Community**
-  - **CatalogDifficulty** (ScoringDifficulty, TierList, Randomizer)
+  - **ChartIntelligence** *(renames CatalogDifficulty — ScoringDifficulty, TierList, difficulty/preference/co-op votes, popularity; Randomizer placement is CONTEXTS Q4)*
   - **UCS**
-  - **Recommendations** (RecommendedCharts, PumbilityProjection)
+  - **Recommendations** (RecommendedCharts, PumbilityProjection) — *CONTEXTS Q1: keep as its own vertical or fold into PlayerProgress; the ADR decides.*
 - **A2. Shared kernel scope (tight)** — `Song`, `Chart`, `ChartType`, `DifficultyLevel`, `Mix` + `[LiveMix]`, `PhoenixScore`, `PhoenixLetterGrade`, `PhoenixPlate`, `Title`, `User` (identity only), `Name`, `Bpm`. Shared ports: `IUserRepository`, `IChartRepository`, `ISongRepository`, `ICurrentUserAccessor` (incl. `GetLiveMix()` / `GetUserSelectedMix()`), `IDateTimeOffsetAccessor`, `IBus`, `IPiuGameApi`. MediatR-in-Domain carve-out stays.
 - **A3. One DbContext** — entities namespaced by vertical (`Data.Persistence.Entities.<Vertical>`) so a future N-context split is cheap.
 - **A4. Cross-vertical communication** — three modes only:
@@ -265,7 +273,7 @@ Rearch is **judgment-driven and structural**: what's domain vs orchestration, sh
   - **In-process listener** = MediatR `INotification`.
   - **Durable/async** = MassTransit.
   - **Avoid:** concrete-type or repository imports across verticals. Today's `Application → PersonalProgress` leak (3 sagas importing `PersonalProgress.Queries`) is the canonical anti-example.
-- **A5. PiuGame ACL** — parsers + `IPiuGameApi` adapter live in Infrastructure with translation at the boundary into shared-kernel types. Not its own vertical.
+- **A5. PiuGame ACL** *(revised 2026-06-11)* — parsers + `IPiuGameApi` adapter live in **OfficialMirror's** Infrastructure with translation at the boundary into shared-kernel types. Other verticals receive official-site facts from OfficialMirror (events/interfaces), not by scraping directly. Whether `IPiuGameApi` stays on A2's shared-port list once OfficialMirror owns the ACL is CONTEXTS Q6 (ADR).
 
 ### Plan
 
@@ -299,7 +307,7 @@ Rearch is **judgment-driven and structural**: what's domain vs orchestration, sh
 
 ### Phoenix 2 interactions
 
-- `IPhoenixRecordRepository` / `IPlayerStatsRepository` are vertical-local post-rearch — they belong to PlayerProgress (or a Scoring sub-area). Phase 1 mix-isolation integration tests follow the port when it moves. Standard rename cost, not a redesign.
+- `IPhoenixRecordRepository` / `IPlayerStatsRepository` are vertical-local post-rearch — `IPhoenixRecordRepository` belongs to ScoreLedger, `IPlayerStatsRepository` to PlayerProgress. Phase 1 mix-isolation integration tests follow the port when it moves. Standard rename cost, not a redesign.
 - Mix joins the shared kernel by the end of Phoenix 2 Phase 2; rearch keeps it there.
 - Per-mix derived tables (Weekly Charts × Mix, Tier Lists × Mix, Community Leaderboards × Mix) ship in current structure during Phoenix 2; when their owning vertical extracts, the tables come along.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,10 @@ Deliberate, documented divergences. Read these before flagging a violation.
 
 `ARCHITECTURE.md` is the source of truth for solution layout, full dependency graph, eventing detail, data-access detail, glossary (Mix, Chart, Phoenix score, Pumbility, Tier list, Bounty, UCS, Saga), known divergences, and open questions. Update it in the same PR that changes a structural pattern.
 
+## Product & domain authority
+
+[PRODUCT.md](PRODUCT.md) is the source of truth for mission, audience segments, and the core/supporting classification — consult it when judging feature fit or priority. [CONTEXTS.md](CONTEXTS.md) is the **working** bounded-context map feeding the planned rearchitecture (see BACKLOG.md); treat it as direction, not current structure — `ARCHITECTURE.md` still describes the code as it is.
+
 ## Backlog
 
 [BACKLOG.md](BACKLOG.md) tracks the gaps between this codebase and `ENTERPRISE.md` that require real refactor work — real-dependency database tests, external-adapter coverage, dependency-realism labels, the `Data → Application` cleanup, etc. Items in `BACKLOG.md` are not current rules; consult it when picking up follow-on work, not when judging existing code.

--- a/CONTEXTS.md
+++ b/CONTEXTS.md
@@ -1,0 +1,150 @@
+# Domain Contexts
+
+> Status: **working map** · Last updated 2026-06-11
+>
+> This is the conceptual bounded-context map from the 2026-06 domain analysis. It feeds the [rearchitecture](BACKLOG.md#onion--ddd--hexagonal-rearchitecture) — the friction inventory below seeds Step 1.6's diagnostic catalog, and the open questions go to the Step 1.7 ADR. **It is direction, not locked design**: boundaries here will be refined as rearch sessions touch real code. [ARCHITECTURE.md](ARCHITECTURE.md) describes the code as it *is*; this file describes the domain as we currently *understand* it. For the audience and strategy behind the core/supporting calls, see [PRODUCT.md](PRODUCT.md).
+
+## How to read this
+
+A context here is a conceptual ownership boundary — one language, one set of rules, one owner for its data. It does **not** have to be one assembly; BACKLOG's A1 vertical taxonomy is the physical realization, and the mapping is given per context. Several contexts may share an assembly, and the shared kernel isn't a context at all.
+
+## Shared kernel — PIU Game Model
+
+Facts about the game itself: `PhoenixScore`, `XXScore`, `DifficultyLevel`, `ChartType`, `PhoenixLetterGrade`, `PhoenixPlate`, `Mix`, `Judgment`, grade/plate math, lifebar simulation, and chart/song identity. Stable and safe to share precisely because it's externally defined — it changes when Andamiro ships a mix, not when we refactor. The calculators under `Pages/Tools/` are UI over this kernel and need no context.
+
+BACKLOG A2 defines a deliberately *tighter* kernel (no scoring engine). Whether `ScoringConfiguration` joins the kernel is an open ADR question (Q3) — today it's used by tournament scoring, Pumbility, and world rankings alike.
+
+## Context overview
+
+| # | Context | Class | Primary audience | A1 vertical (physical) |
+|---|---|---|---|---|
+| 1 | Score Ledger | **Core** | All | `ScoreLedger` |
+| 2 | Player Progression | **Core** | Casual-competitive | `PlayerProgress` (+ `Recommendations`, Q1) |
+| 3 | Chart Intelligence | **Core** | Casual-competitive | `ChartIntelligence` |
+| 4 | Game Content Catalog | Supporting | All | shared kernel + shared ports today (Q2) |
+| 5 | Weekly Challenge | Supporting | Casual-competitive | `WeeklyChallenge` |
+| 6 | Event Competition | Supporting | Competitive | `EventCompetition` |
+| 7 | Community & Notification | Supporting | Casual | `Community` |
+| 8 | Official Game Mirror | Supporting (ACL) | cross-cutting | `OfficialMirror` |
+| 9 | Identity & Access | Generic | All | kernel `User` (identity) + Web auth |
+
+UCS keeps its own small `UCS` vertical per A1 (chart metadata + leaderboard + tags); conceptually it spans Catalog and competition, but it's small and cohesive enough that splitting it isn't worth the ceremony today.
+
+### 1. Score Ledger — core
+
+- **Purpose.** System of record for personal play results, plus the acquisition pipeline that fills it. The strategic data asset everything downstream derives from.
+- **Owns.** Phoenix best-attempts, legacy XX attempts, recorded dates; manual entry, official-account import, OCR and CSV upload (with song-name correction); the score-batch accumulation policy; score wipe/restore.
+- **Today in code.** `UpdatePhoenixRecordHandler`, `EFPhoenixRecordsRepository`, `EFXXChartAttemptRepository`, `PhoenixScoreFileExtractor`, the upload pages, `api/phoenixScores`.
+- **Contract surface.** `PlayerScoreUpdatedEvent` and `RecentScoreImportedEvent` are the de facto integration events of the whole system, and (via webhooks) of partner tools — treat them as published language. Plus `api/phoenixScores`.
+
+### 2. Player Progression — core
+
+- **Purpose.** Everything derived about a *player*: ratings, history, achievements, and the improvement loop.
+- **Owns.** PlayerStats (Pumbility, singles/doubles/skill ratings, competitive level), rating history, title/paragon evaluation, score-quality percentiles, Pumbility gain projections, chart recommendations.
+- **Today in code.** `PlayerRatingSaga` (PersonalProgress), `TitleSaga`, `PlayerHistorySaga`, `ScoreQualitySaga`, `PumbilityProjectionSaga`, `RecommendedChartsSaga`; the Progress / CompetitiveLevel / Titles / WhatShouldIPlay pages.
+- **Contract surface.** `PlayerRatingsImprovedEvent`, `NewTitlesAcquiredEvent`, `PlayerStatsUpdatedEvent`. No public API today — deliberate open question (PRODUCT.md §Platform stance).
+
+### 3. Chart Intelligence — core
+
+- **Purpose.** Everything derived about a *chart* from crowd data — the community's difficulty knowledge.
+- **Owns.** Tier lists of all categories, scoring-difficulty recalculation, letter-grade difficulty percentiles, difficulty/co-op/preference votes, popularity aggregates, chart tags.
+- **Today in code.** `TierListSaga`, `ScoringDifficultySaga`, `RateChartDifficultyHandler`, `RateCoOpDifficultyHandler`, `PreferenceRatingHandler`, BulkVote admin page, TierLists pages, `api/tierlist`.
+- **Contract surface.** `api/tierlist`. Note: this context consumes *two* feeds — community scores (Ledger) and official scores (Mirror). The official feed already populates an "Official Scores" tier list, which doubles as the cold-start story for a new mix before community data accumulates.
+
+### 4. Game Content Catalog — supporting
+
+- **Purpose.** The reference data everyone speaks: songs, charts, mixes, official levels, note counts, step artists, videos, name localization; the weighted random-selection engine over the catalog.
+- **Today in code.** `Chart`/`Song` models, `EFChartRepository`, `SkillsSaga` (Q5), `RandomizerSaga` (Q4), `ChartUpdate` admin page, `api/charts/random`.
+- **Contract surface.** ChartId/SongId are the published language of the entire system.
+- **Physical note (Q2).** A1/A2 realize the catalog as shared-kernel types plus shared ports rather than a vertical; this map records it as a conceptual context either way.
+
+### 5. Weekly Challenge — supporting, core-audience
+
+- **Purpose.** The automated recurring competition: weekly chart rotation, the live board, placement history. No organizer, no registration — entries arrive from score imports; it runs on a clock, not a human. Split from Event Competition because it serves a different audience (casual-competitive vs competitive).
+- **Today in code.** `WeeklyTournamentSaga`, WeeklyCharts page, `api/weeklyCharts`.
+- **Contract surface.** `UserWeeklyChartsProgressedEvent`, `api/weeklyCharts`.
+
+### 6. Event Competition — supporting
+
+- **Purpose.** Human-organized competition. Post-Phoenix 2 this slims to **M.o.M. + Qualifiers** — the Match/bracket subsystem and the rest of the generic tournament domain are dropped per the [Phoenix 2 carve-out](PHOENIX2-ROADMAP.md).
+- **Owns (target).** M.o.M. cycling and stamina sessions (`TournamentSession` — the codebase's best aggregate: approval workflow, photo verification), qualifier configs and submissions, the qualifier auto-enrollment policy (a clean process manager subscribing to Ledger events), per-event scoring presets.
+- **Today in code.** `TournamentHandler`, `QualifiersSaga`, `MarchOfMurlocsHandler`, `AutoBuildSessionHandler`; `MatchSaga` and the bracket pages exist today but are slated for removal.
+
+### 7. Community & Notification — supporting
+
+- **Purpose.** User groups (membership, invites, channels, privacy, regional/world auto-membership), community leaderboard views, and the achievement-broadcast policy to Discord. Almost purely a *downstream subscriber* — it owns routing policy, not the facts it routes. That's its correct nature; lean into it.
+- **Today in code.** `CommunitySaga` (consumes six event types), `EFCommunitiesRepository`, Communities pages, the bot's notification side.
+
+### 8. Official Game Mirror — supporting + anticorruption layer
+
+- **Purpose.** Everything scraped from piugame.com and derived from scraped data: official leaderboard snapshots, world rankings (computed over *all* players, including non-users — which is why this isn't Player Progression), avatars, account-data import handed to the Ledger, popularity feeds handed to Chart Intelligence, PiuTracker sync. HTML structure, session cookies, and song-name mapping quirks stay inside; everyone else receives clean facts. Game credentials never cross this boundary outward.
+- **Today in code.** `OfficialLeaderboardSaga`, `WorldRankingService`, `OfficialSiteClient`/`PiuGameApi`/`PiuTrackerClient`, OfficialLeaderboards pages.
+- **Usage note.** Its UI draws <1% of traffic — invest in contracts and scraper resilience, not pages.
+
+### 9. Identity & Access — generic
+
+- **Purpose.** Accounts, OAuth logins, API tokens, admin status, content locks, UI settings, profile privacy.
+- **Today in code.** `CreateUserHandler`, `UpdateUserHandler`, `ApiTokenHandler`, `EFUserRepository`, Account/Login pages, `UserAccessService`.
+- **Note.** Today's `User` record mixes auth identity with player-facing profile (game tag, country, visibility) — see F6.
+
+## Context map
+
+```
+ piugame.com ══ ACL ══> ┌──────────────┐  charts   ┌─────────────────┐
+ piutracker.app ══════> │ OFFICIAL     │ ────────> │ GAME CONTENT    │
+                        │ MIRROR       │ popularity│ CATALOG         │──ChartId/SongId──> (everyone)
+                        └───┬──────────┘     │     └─────────────────┘
+        "scores observed"   │                ▼
+                            ▼          ┌──────────────────┐
+   ┌────────────────┐  score facts     │ CHART            │
+   │  SCORE LEDGER  │ ───────────────> │ INTELLIGENCE     │
+   │  (CORE)        │                  └──────────────────┘
+   └──┬─────┬───┬───┘                        ▲ skill weights
+      │     │   └── events ──> ┌──────────────────┐
+      │     │                  │ PLAYER           │── ratings/titles ──┐
+      │     │                  │ PROGRESSION      │                    ▼
+      │     │                  └──────────────────┘   ┌───────────────────────────┐
+      │     └─ RecentScoreImported ─> EVENT           │ COMMUNITY & NOTIFICATION  │
+      │                               COMPETITION     │ (downstream subscriber →  │
+      ▼                                               │  Discord fan-out)         │
+   WEEKLY CHALLENGE ── placement events ────────────> └───────────────────────────┘
+
+   PIU GAME MODEL (shared kernel) — under everything
+   IDENTITY & ACCESS (generic) — account facts to all
+```
+
+| Relationship | Style |
+|---|---|
+| Catalog → everyone | Published language (ChartId, chart facts) |
+| Mirror → Ledger, Chart Intelligence, Weekly | Facts via events; Mirror is the ACL for piugame.com |
+| Ledger → Progression, Chart Intelligence, Weekly, Competition, Community | Customer–supplier via published events; also the partner-webhook source |
+| Progression → Community, Chart Intelligence | Rating/title events; skill-weight feed |
+| Community ← everything | Downstream subscriber (owns routing, not facts) |
+| Game Model | Shared kernel — stable because externally defined |
+
+## Friction inventory — where today's code crosses these boundaries
+
+Feeds rearch Step 1.6. Factual observations about current code, not blame.
+
+- **F1 — The score table is a shared database.** `IPhoenixRecordRepository` is read directly by `TierListSaga`, `ScoringDifficultySaga`, `CommunitySaga`, `ScoreQualitySaga`, `PumbilityProjectionSaga`, `RecommendedChartsSaga`, `TitleSaga`, `RandomizerSaga`, `AutoBuildSessionHandler`, and `OfficialLeaderboardSaga` — six of nine contexts querying one context's tables. The central rearch decision is how each consumer gets score facts instead (fat events, a read API, or context-local projections — different consumers warrant different answers).
+- **F2 — Events are thin, so consumers reach back.** `PlayerScoreUpdatedEvent` carries only IDs; `CommunitySaga` re-queries scores, charts, and users to compose a Discord message. Carrying events also matter externally: their payloads are the webhook bodies partner tools receive. Fatten them while the transport is still in-memory and the contracts private.
+- **F3 — The gateway knows about the weekly tournament.** [OfficialSiteClient.cs:230](ScoreTracker/ScoreTracker.Data/Clients/OfficialSiteClient.cs) sends `RegisterWeeklyChartScore` directly into the weekly feature. The Mirror should publish "official score observed" facts; Weekly subscribes. (Also the worst instance of the `Data → Application` divergence.)
+- **F4 — Chart Intelligence writes into the Catalog's aggregate.** `ScoringDifficultySaga` stores computed scoring levels on [Chart](ScoreTracker/ScoreTracker.Domain/Models/Chart.cs) (`ScoringLevel`). Split: Catalog owns the official level; Intelligence owns effective scoring level as its own projection.
+- **F5 — PlayerStats is everyone's input.** Community leaderboards, weekly bucketing, tier-list weighting, score-quality cohorts, and recommendations all read Progression's `PlayerStats` directly (`EFCommunitiesRepository` joins Community × PlayerStats × User). Progression needs a deliberate published read model — its biggest consumer is ~10% of site traffic (community leaderboards).
+- **F6 — `User` is two concepts.** Auth/token/lock data (Identity) and player-facing profile (game tag, country, visibility) in one record; `User.IsAdmin` is a hardcoded GUID. Split Account from PlayerProfile.
+- **F7 — `EFTierListRepository` spans three contexts' data** (tier entries + `UserHighestTitle` + `PhoenixBestAttempt`).
+- **F8 — `CommunitySaga` doubles as membership manager and notification router.** Separable once contexts exist: Community owns the channel registry; routing is a policy over published events.
+
+**Already aligned** (keep, and copy the pattern): the Ledger → Progression → Community event backbone; M.o.M. *snapshotting* scoring levels instead of referencing them live (correct inter-context copying); the qualifier auto-enroll process manager; `TournamentSession` and `UserQualifiers` as genuine aggregates.
+
+## Open questions for the rearch ADR (Step 1.7)
+
+- **Q1.** Recommendations: own vertical (A1, and active WSIP feature work) or inside Player Progression (this map)?
+- **Q2.** Catalog: conceptual context realized as shared kernel + shared ports (A2), or its own vertical?
+- **Q3.** Scoring engine (`ScoringConfiguration`): into the shared kernel (used by tournaments, Pumbility, world rankings) or vertical-local presets over a smaller kernel?
+- **Q4.** Randomizer home: catalog query service vs Chart Intelligence (A1's `CatalogDifficulty` placement) vs competition utility (match card draws used it; matches are being dropped).
+- **Q5.** Chart skill tagging (`SkillsSaga`): PlayerProgress (A1 — skills feed skill titles) vs Catalog (it's chart curation)?
+- **Q6.** Does `IPiuGameApi` remain a shared port (A2) once OfficialMirror owns the ACL, or do other verticals receive official-site facts only via Mirror events/interfaces?
+- **Q7.** Webhooks: per-context event contracts + a generic outbound-delivery service (subscriptions, signing, retries)? Today's partner wiring is bespoke; formalizing it removes per-partner labor and makes the contracts explicit.
+
+Strategy-level (not ADR): whether to expose a Progression API — see [PRODUCT.md](PRODUCT.md#platform-stance).

--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -2,7 +2,7 @@
 
 [Pump It Up](https://en.wikipedia.org/wiki/Pump_It_Up_\(video_game_series\)) (PIU) is a five-panel dance arcade game by [Andamiro](https://www.piugame.com/). Players step on arrows in time with music. This document defines the PIU and project terms the code uses, in a form approachable to people who haven't played the game.
 
-For solution layout and patterns, see [ARCHITECTURE.md](ARCHITECTURE.md). For project conventions, see [CLAUDE.md](CLAUDE.md).
+For solution layout and patterns, see [ARCHITECTURE.md](ARCHITECTURE.md). For project conventions, see [CLAUDE.md](CLAUDE.md). For the product's mission, audiences, and direction, see [PRODUCT.md](PRODUCT.md).
 
 ## Game basics
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,78 @@
+# Product Direction
+
+> Status: living document · Last updated 2026-06-11
+>
+> This is the "why and for whom" layer. For game terms see [DOMAIN.md](DOMAIN.md); for the code as it is, [ARCHITECTURE.md](ARCHITECTURE.md); for the working domain map, [CONTEXTS.md](CONTEXTS.md); for the work plan, [BACKLOG.md](BACKLOG.md) and [PHOENIX2-ROADMAP.md](PHOENIX2-ROADMAP.md).
+
+## Mission
+
+The arcade shows you your score once, then moves on. PIU Scores keeps what the game doesn't: a durable ledger of every score you've recorded, the insight derived from it (player ratings, progress routes, community chart knowledge), and the competition and community built on top. It serves roughly 5,000 unique players a month across ~60 countries.
+
+The ordering matters: **ledger first, insight second, community third.** Without the scores, nothing else here means anything — the ledger was the first thing built, and keeping it good (especially keeping import working across mix transitions) is existential. Each layer feeds the next.
+
+## Audiences
+
+Feature and priority decisions are planned against these segments. Level ranges are rough — "score pusher" vs "pass pusher" vs "stamina player" vs "completionist" make ranges mean different things along different axes of player.
+
+| Segment | Rough levels | Target? | What they want |
+|---|---|---|---|
+| Ultra casual | < ~10 | No | Light community involvement; not at a level where score analysis helps, and not looking for feedback |
+| Casual | ~10–16 | Secondary | To be part of something bigger — comparing progress, belonging, not necessarily pushing themselves |
+| **Casual-competitive** | ~17–23 | **Core** | Routes to improve: tier lists, title grinding, completion. This group is why chart tier lists are such a commodity in the community |
+| Competitive | ~23–26 | Secondary | Routes to prove themselves against the larger community — competition as a dopamine source, not necessarily "be the best" |
+| Ultra competitive | the top handful | No | Nothing from a tracker. They just play, and they know the charts better than any dataset ever will |
+| **Tool makers** | n/a (developers) | Yes | Score data without building an importer |
+
+Notes:
+
+- **Casual-competitive is the center of gravity.** When two designs conflict, the one that serves this segment wins by default.
+- **Tool makers are a real audience, invisible in page analytics.** Nobody else wants to build the importer — collecting passwords is painful and scraping is worse — so other community tools consume this site's APIs or take webhooks from its import ecosystem. That makes the import pipeline de facto infrastructure for the whole PIU tooling scene, and the API surface a public contract (see *Platform stance*).
+- The two non-targets are deliberate. No onboarding features chasing the ultra-casual; no "be the very best" ladders for the top tier.
+
+## Focus: what's core
+
+**Core** — where the differentiating, evolving logic lives; protect and invest:
+
+- **Score ledger & acquisition** — the system of record plus the pipeline that fills it: official-account import, OCR, CSV upload, score batching. The moat is that this pipeline exists and works.
+- **Player insight & progression** — Pumbility, competitive level, titles/paragons, history, recommendations ("What Should I Play"). The core audience's improvement loop.
+- **Chart intelligence** — tier lists, scoring difficulty, letter-grade difficulty, crowd votes. Community-generated knowledge about charts; the site's most-visited surface and its most-shared artifact.
+
+**Supporting** — necessary and real, but not the differentiator: weekly charts (automated competition for the core audience), organized competition (M.o.M., qualifiers — the competitive segment), communities and Discord notifications (the casual segment's home), the chart/song catalog, the official-site mirror, UCS.
+
+**Generic** — buy/borrow, keep thin and out of the way: identity and auth, email, blob storage, localization plumbing.
+
+## Platform stance
+
+The public API (score submission and import, tier lists, weekly charts, tournaments, random chart draws) is token-authenticated and consumed by third-party community tools. Score-import webhooks feed partner tools directly. Two consequences:
+
+- **Response shapes are a public contract.** Version and deprecate; don't break. Breaking changes break other people's products.
+- **The importer is community infrastructure.** Partner tools depend on it; they're also an early-warning channel when the official site changes underneath it.
+
+Open strategic question: whether to expose a player-rating (Pumbility/stats) API. Attribution in partner tools could entrench the rating further — or give the next official copy away for free. Unresolved on purpose.
+
+## Track record
+
+PUMBILITY started life as this site's player-rating formula; the official game later adopted it — name included — as its rating system, and official world rankings followed the site's. We take those wins, and we plan for the pattern to repeat: the derived-insight layer is where this project leads, so the freedom to evolve ratings beyond whatever becomes official (e.g. PUMBILITY+) is worth preserving.
+
+## Direction (as of mid-2026)
+
+1. **Phoenix 2 is the near-term forcing function** ([PHOENIX2-ROADMAP.md](PHOENIX2-ROADMAP.md)). Scores reset at PIU's end; ours don't. Keeping the ledger continuous across the mix transition and getting import working day-one is the highest-stakes work on the books.
+2. **After Phoenix 2: the rearchitecture** ([BACKLOG.md](BACKLOG.md#onion--ddd--hexagonal-rearchitecture), [CONTEXTS.md](CONTEXTS.md)) — restructure along subdomain boundaries so the core can evolve without dragging everything with it.
+3. **Legacy mixes are preserved, not invested in.** XX-era pages get effectively no traffic; manual entry stays (and may extend to even older mixes over time, for the completionists), but import and analytics investment targets the live mix.
+
+## Usage snapshot (May–June 2026)
+
+Rounded, from 30 days of page analytics (~10k sessions). Two caveats: API traffic doesn't appear at all (the tool-maker audience is invisible here), and the long tail of per-chart and per-user pages is undercounted.
+
+| Surface | Share of sessions |
+|---|---|
+| Tier lists | ~30% — two-thirds of typed views are **Pass** tier lists; views concentrate on levels 17–23 |
+| Home ("What Should I Play") | ~15% |
+| Phoenix score upload/import | ~10% — the single biggest page after home |
+| Communities | ~10% — country leaderboards dominate (Brazil, France, Italy, …) |
+| Account + login | ~15% |
+| Chart browse/record | ~7% |
+| Weekly charts / progression pages / tournaments / calculators | ~3–4% each — tournament traffic is spiky; nearly all of it was one event's qualifiers |
+| Official leaderboard pages | <1% |
+
+Reading it: the three core surfaces carry over half of all traffic; the tier-list difficulty distribution mirrors the audience pyramid above almost exactly; the official mirror is a data supplier, not a destination; and the audience the page data can't see (tool makers) is served by the same import pipeline the #2 page depends on.

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ A community-run web app for tracking [Pump It Up](https://en.wikipedia.org/wiki/
 - Weekly charts and UCS (User-Created Step) tracking
 - Discord bot for community notifications
 
-New to Pump It Up? See [DOMAIN.md](DOMAIN.md) for the terms used here.
+New to Pump It Up? See [DOMAIN.md](DOMAIN.md) for the terms used here. For who the tracker is built for and where it's headed, see [PRODUCT.md](PRODUCT.md).
 
 ## Use it
 
 Open https://piuscores.arroweclip.se/ — the live deployment is the recommended way to use the tracker.
 
 Self-hosting is possible but currently requires SQL Server plus OAuth (Discord / Google / Facebook), SendGrid, and Azure Blob credentials. A friction-free local-dev mode is on the [roadmap](BACKLOG.md).
+
+**Building a PIU tool?** You don't have to build your own importer. The tracker exposes token-authenticated APIs (score submission and import, tier lists, weekly charts, tournaments, random chart draws), and score-import webhooks can be wired into your tool. See [PRODUCT.md](PRODUCT.md#platform-stance) and ask on [Discord](https://discord.gg/AvS5PxnvSN).
 
 ## Contribute
 


### PR DESCRIPTION
Working branch for the Onion + DDD + Hexagonal rearchitecture (BACKLOG.md §rearch, revised per CONTEXTS.md). Commits land here one at a time as they resolve; each commit builds green.

## Roadmap (abridged)

- **P0 safety net** — ADR (Step 1.7) · API response-shape approval tests · arch-test harness · characterization tests
- **P1 dead weight** — Match subsystem deletion (Phoenix 2 carve-out) · past-tense events + envelopes · command-shaped messages out of Domain/Events
- **P2 SharedKernel** — PIU Game Model extraction
- **P3 contracts-before-moves** — IScoreReader / fat events / IPlayerStatsReader / ICatalogReader / OfficialScoreObserved; F1–F5 strangled consumer-by-consumer
- **P4 journal** — ScoreEventJournal capture (score-history feature groundwork, Phoenix 2 window)
- **P5 assembly moves** — one vertical at a time: UCS → ScoreLedger → Mirror → Catalog → ChartIntelligence → Weekly → EventCompetition → Community → PlayerProgress
- **P6 identity + teardown** — User split · Domain/Data assemblies deleted
- **P7 tail** — MT outbox · webhook delivery · per-vertical SQL schemas (optional)

Also contains the foundation docs (PRODUCT.md, CONTEXTS.md) from the original PR scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)