### PR TITLE
CI: migration bundle + approval-gated production deploy (multi-stage YAML)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,13 +14,12 @@
 #   yourself as approver. Every run then pauses before the Deploy stage until you sign off.
 #
 # One-time setup (owner):
-#   1. Fill in azureServiceConnection + webAppName below.
-#   2. Pipeline → Edit → Variables → add secret variable ProdSqlConnectionString.
-#   3. Add the approval check to the 'production' environment (it is auto-created on first run,
+#   1. Pipeline → Edit → Variables → add secret variable ProdSqlConnectionString.
+#   2. Add the approval check to the 'production' environment (it is auto-created on first run,
 #      or pre-create it under Pipelines → Environments).
-#   4. First deploy run will prompt to permit this pipeline to use the service connection and
+#   3. First deploy run will prompt to permit this pipeline to use the service connection and
 #      environment — approve both.
-#   5. Disable/delete the classic release pipeline so it doesn't double-deploy off the drop.
+#   4. Disable/delete the classic release pipeline so it doesn't double-deploy off the drop.
 
 trigger:
 - main
@@ -31,9 +30,7 @@ pr:
 variables:
   solution: 'ScoreTracker/ScoreTracker.sln'
   buildConfiguration: 'Release'
-  # TODO(owner): fill in the service connection name before the first YAML deploy
-  # (Project settings → Service connections — the Azure RM connection to Pay-As-You-Go).
-  azureServiceConnection: ''
+  azureServiceConnection: 'Pay-As-You-Go (71fd4e21-2111-4006-988f-28fa73d3d655)'  # ARM connection (Workload Identity federation)
   webAppName: 'piuscores'  # Windows App Service in resource group Sharkingbird
 
 stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,26 @@
-# ASP.NET + integration tests
+# ASP.NET build + tests + gated production deploy (multi-stage YAML — no classic release pipeline)
 #
-# Two parallel jobs:
-#   1) Windows: build the whole solution (incl. the deployable Web package), run unit/component/
-#      approval tests via VSTest. Targets ScoreTracker.Tests.dll explicitly so the integration
-#      project (which needs Docker + Linux containers) isn't picked up here.
-#   2) Linux:   run the Testcontainers-backed integration suite against an ephemeral SQL Server
-#      2025 instance. ubuntu-latest agents ship with Docker + Linux container support, which is
-#      what Testcontainers.MsSql needs.
+# Stages:
+#   Build  — two parallel jobs:
+#     1) Windows: build the whole solution, run unit/component/approval tests, publish the
+#        deployable Web zip + EF migration bundle into the 'drop' artifact.
+#     2) Linux:   run the Testcontainers-backed integration suite against an ephemeral
+#        SQL Server 2025 instance (ubuntu-latest ships Docker + Linux containers).
+#   Deploy — main-branch runs only. A deployment job against the 'production' environment:
+#        applies pending EF migrations (efbundle), then zip-deploys the Web app.
+#
+# The manual gate lives on the ENVIRONMENT, not in this file:
+#   Pipelines → Environments → production → Approvals and checks → add an Approval with
+#   yourself as approver. Every run then pauses before the Deploy stage until you sign off.
+#
+# One-time setup (owner):
+#   1. Fill in azureServiceConnection + webAppName below.
+#   2. Pipeline → Edit → Variables → add secret variable ProdSqlConnectionString.
+#   3. Add the approval check to the 'production' environment (it is auto-created on first run,
+#      or pre-create it under Pipelines → Environments).
+#   4. First deploy run will prompt to permit this pipeline to use the service connection and
+#      environment — approve both.
+#   5. Disable/delete the classic release pipeline so it doesn't double-deploy off the drop.
 
 trigger:
 - main
@@ -17,96 +31,128 @@ pr:
 variables:
   solution: 'ScoreTracker/ScoreTracker.sln'
   buildConfiguration: 'Release'
+  # TODO(owner): fill these two in before the first YAML deploy.
+  azureServiceConnection: ''  # Project settings → Service connections — the Azure RM connection name
+  webAppName: ''              # The App Service name hosting the site
 
-jobs:
-- job: BuildAndUnitTests
-  displayName: 'Build + Unit/Component/Approval Tests (Windows)'
-  pool:
-    vmImage: 'windows-latest'
-  steps:
-  # nuget.exe + VSBuild can't handle this solution anymore: NuGet-resolved MSBuild SDKs
-  # (Aspire.AppHost.Sdk) never get assets files from nuget.exe restore, and VS 2022's
-  # MSBuild doesn't support net10 targets. The dotnet CLI is the supported path.
-  - task: UseDotNet@2
-    displayName: 'Install .NET 10 SDK'
-    inputs:
-      packageType: 'sdk'
-      version: '10.0.x'
+stages:
+- stage: Build
+  displayName: 'Build & Test'
+  jobs:
+  - job: BuildAndUnitTests
+    displayName: 'Build + Unit/Component/Approval Tests (Windows)'
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    # nuget.exe + VSBuild can't handle this solution anymore: NuGet-resolved MSBuild SDKs
+    # (Aspire.AppHost.Sdk) never get assets files from nuget.exe restore, and VS 2022's
+    # MSBuild doesn't support net10 targets. The dotnet CLI is the supported path.
+    - task: UseDotNet@2
+      displayName: 'Install .NET 10 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '10.0.x'
 
-  - script: dotnet restore $(solution)
-    displayName: 'Restore'
+    - script: dotnet restore $(solution)
+      displayName: 'Restore'
 
-  - script: dotnet build $(solution) -c $(buildConfiguration) --no-restore
-    displayName: 'Build'
+    - script: dotnet build $(solution) -c $(buildConfiguration) --no-restore
+      displayName: 'Build'
 
-  # The integration project builds alongside but runs in the Linux job below — it needs
-  # Docker with Linux containers, which windows-latest doesn't have configured.
-  - script: dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj -c $(buildConfiguration) --no-build --logger "trx;LogFileName=unit.trx" --results-directory $(Agent.TempDirectory)
-    displayName: 'Unit/Component tests'
+    # The integration project builds alongside but runs in the Linux job below — it needs
+    # Docker with Linux containers, which windows-latest doesn't have configured.
+    - script: dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj -c $(buildConfiguration) --no-build --logger "trx;LogFileName=unit.trx" --results-directory $(Agent.TempDirectory)
+      displayName: 'Unit/Component tests'
 
-  - script: dotnet test ScoreTracker/ScoreTracker.Tests.Api/ScoreTracker.Tests.Api.csproj -c $(buildConfiguration) --no-build --logger "trx;LogFileName=api.trx" --results-directory $(Agent.TempDirectory)
-    displayName: 'API wire-shape approval tests'
+    - script: dotnet test ScoreTracker/ScoreTracker.Tests.Api/ScoreTracker.Tests.Api.csproj -c $(buildConfiguration) --no-build --logger "trx;LogFileName=api.trx" --results-directory $(Agent.TempDirectory)
+      displayName: 'API wire-shape approval tests'
 
-  - task: PublishTestResults@2
-    displayName: 'Publish test results'
-    condition: always()
-    inputs:
-      testResultsFormat: 'VSTest'
-      testResultsFiles: '$(Agent.TempDirectory)/**/*.trx'
-      failTaskOnFailedTests: true
+    - task: PublishTestResults@2
+      displayName: 'Publish test results'
+      condition: always()
+      inputs:
+        testResultsFormat: 'VSTest'
+        testResultsFiles: '$(Agent.TempDirectory)/**/*.trx'
+        failTaskOnFailedTests: true
 
-  - script: dotnet publish ScoreTracker/ScoreTracker/ScoreTracker.Web.csproj -c $(buildConfiguration) --no-restore -o $(Agent.TempDirectory)/publish
-    displayName: 'Publish Web app'
+    - script: dotnet publish ScoreTracker/ScoreTracker/ScoreTracker.Web.csproj -c $(buildConfiguration) --no-restore -o $(Agent.TempDirectory)/publish
+      displayName: 'Publish Web app'
 
-  # Plain zip (zip-deploy shape), replacing the old WebDeploy package. If the release
-  # stage was set to "Web Deploy package" mode, switch it to zip deploy.
-  - task: ArchiveFiles@2
-    displayName: 'Zip Web app'
-    inputs:
-      rootFolderOrFile: '$(Agent.TempDirectory)/publish'
-      includeRootFolder: false
-      archiveType: 'zip'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/ScoreTracker.Web.zip'
+    - task: ArchiveFiles@2
+      displayName: 'Zip Web app'
+      inputs:
+        rootFolderOrFile: '$(Agent.TempDirectory)/publish'
+        includeRootFolder: false
+        archiveType: 'zip'
+        archiveFile: '$(Build.ArtifactStagingDirectory)/ScoreTracker.Web.zip'
 
-  # Deploy-time migrations: a self-contained bundle ships in the drop so the release
-  # pipeline applies pending migrations as its own step right before the app deploy —
-  # automated per-deploy, never at app startup. In the release stage, run:
-  #   efbundle.exe --connection "<connection string>"
-  # It exits 0 with nothing to do when the database is already current.
-  - script: dotnet tool restore
-    displayName: 'Restore dotnet tools (dotnet-ef)'
+    # Deploy-time migrations: a self-contained bundle ships in the drop and the Deploy stage
+    # below runs it right before the app deploy — automated per-deploy, never at app startup.
+    # It exits 0 with nothing to do when the database is already current.
+    - script: dotnet tool restore
+      displayName: 'Restore dotnet tools (dotnet-ef)'
 
-  - script: dotnet ef migrations bundle --project ScoreTracker/ScoreTracker.Data --startup-project ScoreTracker/ScoreTracker.CompositionRoot --configuration $(buildConfiguration) --self-contained -r win-x64 --force -o $(Build.ArtifactStagingDirectory)/efbundle.exe
-    displayName: 'Create EF migration bundle'
+    - script: dotnet ef migrations bundle --project ScoreTracker/ScoreTracker.Data --startup-project ScoreTracker/ScoreTracker.CompositionRoot --configuration $(buildConfiguration) --self-contained -r win-x64 --force -o $(Build.ArtifactStagingDirectory)/efbundle.exe
+      displayName: 'Create EF migration bundle'
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      ArtifactName: 'drop'
-      publishLocation: 'Container'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: 'drop'
+        publishLocation: 'Container'
 
-- job: IntegrationTests
-  displayName: 'Integration Tests (Linux, Testcontainers + SQL Server 2025)'
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-  - task: UseDotNet@2
-    displayName: 'Install .NET 10 SDK'
-    inputs:
-      packageType: 'sdk'
-      version: '10.0.x'
+  - job: IntegrationTests
+    displayName: 'Integration Tests (Linux, Testcontainers + SQL Server 2025)'
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - task: UseDotNet@2
+      displayName: 'Install .NET 10 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '10.0.x'
 
-  # First run on a fresh agent pulls the SQL Server 2025 image (~2 min). Subsequent tests against
-  # the same agent are fast — but Microsoft-hosted agents are fresh per run, so expect that cost
-  # every time. ~3 min total job runtime on a clean agent.
-  - script: dotnet test ScoreTracker/ScoreTracker.Tests.Integration/ScoreTracker.Tests.Integration.csproj -c $(buildConfiguration) --logger "trx;LogFileName=integration.trx" --results-directory $(Agent.TempDirectory)
-    displayName: 'Run integration tests (real SQL Server 2025 via Testcontainers)'
+    # First run on a fresh agent pulls the SQL Server 2025 image (~2 min). Subsequent tests against
+    # the same agent are fast — but Microsoft-hosted agents are fresh per run, so expect that cost
+    # every time. ~3 min total job runtime on a clean agent.
+    - script: dotnet test ScoreTracker/ScoreTracker.Tests.Integration/ScoreTracker.Tests.Integration.csproj -c $(buildConfiguration) --logger "trx;LogFileName=integration.trx" --results-directory $(Agent.TempDirectory)
+      displayName: 'Run integration tests (real SQL Server 2025 via Testcontainers)'
 
-  - task: PublishTestResults@2
-    displayName: 'Publish integration test results'
-    condition: always()
-    inputs:
-      testResultsFormat: 'VSTest'
-      testResultsFiles: '$(Agent.TempDirectory)/**/integration.trx'
-      testRunTitle: 'Integration Tests (SQL Server 2025)'
-      failTaskOnFailedTests: true
+    - task: PublishTestResults@2
+      displayName: 'Publish integration test results'
+      condition: always()
+      inputs:
+        testResultsFormat: 'VSTest'
+        testResultsFiles: '$(Agent.TempDirectory)/**/integration.trx'
+        testRunTitle: 'Integration Tests (SQL Server 2025)'
+        failTaskOnFailedTests: true
+
+# Runs only for pushes to main (PR builds stop after Build). The environment's approval
+# check is what makes this wait for a human — see the header comment.
+- stage: DeployProduction
+  displayName: 'Deploy to Production'
+  dependsOn: Build
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  jobs:
+  - deployment: Deploy
+    displayName: 'Migrate database + deploy Web app'
+    pool:
+      vmImage: 'windows-latest'  # efbundle.exe is built self-contained for win-x64
+    environment: 'production'
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          # Deployment jobs download the run's artifacts automatically → $(Pipeline.Workspace)/drop.
+          # Migrations run first: if they fail, the release stops here and the old app keeps
+          # serving against the old schema. All pending migrations are additive-first by policy.
+          - script: '"$(Pipeline.Workspace)\drop\efbundle.exe" --connection "$(ProdSqlConnectionString)"'
+            displayName: 'Apply EF migrations'
+
+          - task: AzureWebApp@1
+            displayName: 'Deploy Web app (zip deploy)'
+            inputs:
+              azureSubscription: '$(azureServiceConnection)'
+              appType: 'webApp'
+              appName: '$(webAppName)'
+              package: '$(Pipeline.Workspace)/drop/ScoreTracker.Web.zip'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
       testResultsFiles: '$(Agent.TempDirectory)/**/*.trx'
       failTaskOnFailedTests: true
 
-  - script: dotnet publish ScoreTracker/ScoreTracker/ScoreTracker.Web.csproj -c $(buildConfiguration) --no-restore -o $(Build.ArtifactStagingDirectory)/publish
+  - script: dotnet publish ScoreTracker/ScoreTracker/ScoreTracker.Web.csproj -c $(buildConfiguration) --no-restore -o $(Agent.TempDirectory)/publish
     displayName: 'Publish Web app'
 
   # Plain zip (zip-deploy shape), replacing the old WebDeploy package. If the release
@@ -63,14 +63,25 @@ jobs:
   - task: ArchiveFiles@2
     displayName: 'Zip Web app'
     inputs:
-      rootFolderOrFile: '$(Build.ArtifactStagingDirectory)/publish'
+      rootFolderOrFile: '$(Agent.TempDirectory)/publish'
       includeRootFolder: false
       archiveType: 'zip'
       archiveFile: '$(Build.ArtifactStagingDirectory)/ScoreTracker.Web.zip'
 
+  # Deploy-time migrations: a self-contained bundle ships in the drop so the release
+  # pipeline applies pending migrations as its own step right before the app deploy —
+  # automated per-deploy, never at app startup. In the release stage, run:
+  #   efbundle.exe --connection "<connection string>"
+  # It exits 0 with nothing to do when the database is already current.
+  - script: dotnet tool restore
+    displayName: 'Restore dotnet tools (dotnet-ef)'
+
+  - script: dotnet ef migrations bundle --project ScoreTracker/ScoreTracker.Data --startup-project ScoreTracker/ScoreTracker.CompositionRoot --configuration $(buildConfiguration) --self-contained -r win-x64 --force -o $(Build.ArtifactStagingDirectory)/efbundle.exe
+    displayName: 'Create EF migration bundle'
+
   - task: PublishBuildArtifacts@1
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)/ScoreTracker.Web.zip'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
       ArtifactName: 'drop'
       publishLocation: 'Container'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,9 +31,10 @@ pr:
 variables:
   solution: 'ScoreTracker/ScoreTracker.sln'
   buildConfiguration: 'Release'
-  # TODO(owner): fill these two in before the first YAML deploy.
-  azureServiceConnection: ''  # Project settings → Service connections — the Azure RM connection name
-  webAppName: ''              # The App Service name hosting the site
+  # TODO(owner): fill in the service connection name before the first YAML deploy
+  # (Project settings → Service connections — the Azure RM connection to Pay-As-You-Go).
+  azureServiceConnection: ''
+  webAppName: 'piuscores'  # Windows App Service in resource group Sharkingbird
 
 stages:
 - stage: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,11 @@
 #   Pipelines → Environments → production → Approvals and checks → add an Approval with
 #   yourself as approver. Every run then pauses before the Deploy stage until you sign off.
 #
-# One-time setup (owner):
-#   1. Pipeline → Edit → Variables → add secret variable ProdSqlConnectionString.
-#   2. Add the approval check to the 'production' environment (it is auto-created on first run,
-#      or pre-create it under Pipelines → Environments).
+# One-time setup (owner) — do 1 and 2 BEFORE merging this to main:
+#   1. Pre-create the 'production' environment (Pipelines → Environments → New environment)
+#      and add an Approval check with yourself as approver. Runs triggered by the GitHub app
+#      can't auto-create environments, and without the check the deploy sails straight through.
+#   2. Pipeline → Edit → Variables → add secret variable ProdSqlConnectionString.
 #   3. First deploy run will prompt to permit this pipeline to use the service connection and
 #      environment — approve both.
 #   4. Disable/delete the classic release pipeline so it doesn't double-deploy off the drop.
@@ -125,32 +126,35 @@ stages:
         testRunTitle: 'Integration Tests (SQL Server 2025)'
         failTaskOnFailedTests: true
 
-# Runs only for pushes to main (PR builds stop after Build). The environment's approval
-# check is what makes this wait for a human — see the header comment.
-- stage: DeployProduction
-  displayName: 'Deploy to Production'
-  dependsOn: Build
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
-  jobs:
-  - deployment: Deploy
-    displayName: 'Migrate database + deploy Web app'
-    pool:
-      vmImage: 'windows-latest'  # efbundle.exe is built self-contained for win-x64
-    environment: 'production'
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-          # Deployment jobs download the run's artifacts automatically → $(Pipeline.Workspace)/drop.
-          # Migrations run first: if they fail, the release stops here and the old app keeps
-          # serving against the old schema. All pending migrations are additive-first by policy.
-          - script: '"$(Pipeline.Workspace)\drop\efbundle.exe" --connection "$(ProdSqlConnectionString)"'
-            displayName: 'Apply EF migrations'
+# Compile-time gate: the stage only exists in main-branch runs, so PR builds stop after
+# Build. A runtime `condition:` is NOT enough here — environment authorization is resolved
+# at run creation for every stage in the graph, so PR runs would fail on the 'production'
+# environment before any condition is evaluated. The environment's approval check is what
+# makes this wait for a human — see the header comment.
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - stage: DeployProduction
+    displayName: 'Deploy to Production'
+    dependsOn: Build
+    jobs:
+    - deployment: Deploy
+      displayName: 'Migrate database + deploy Web app'
+      pool:
+        vmImage: 'windows-latest'  # efbundle.exe is built self-contained for win-x64
+      environment: 'production'
+      strategy:
+        runOnce:
+          deploy:
+            steps:
+            # Deployment jobs download the run's artifacts automatically → $(Pipeline.Workspace)/drop.
+            # Migrations run first: if they fail, the release stops here and the old app keeps
+            # serving against the old schema. All pending migrations are additive-first by policy.
+            - script: '"$(Pipeline.Workspace)\drop\efbundle.exe" --connection "$(ProdSqlConnectionString)"'
+              displayName: 'Apply EF migrations'
 
-          - task: AzureWebApp@1
-            displayName: 'Deploy Web app (zip deploy)'
-            inputs:
-              azureSubscription: '$(azureServiceConnection)'
-              appType: 'webApp'
-              appName: '$(webAppName)'
-              package: '$(Pipeline.Workspace)/drop/ScoreTracker.Web.zip'
+            - task: AzureWebApp@1
+              displayName: 'Deploy Web app (zip deploy)'
+              inputs:
+                azureSubscription: '$(azureServiceConnection)'
+                appType: 'webApp'
+                appName: '$(webAppName)'
+                package: '$(Pipeline.Workspace)/drop/ScoreTracker.Web.zip'


### PR DESCRIPTION
Follow-up to #108 (which merged with only the dotnet-CLI fix — these commits landed on the branch after the merge). This PR carries the other two moves:

## 1. EF migration bundle in the drop (`5c8a019`)
`dotnet ef migrations bundle` (self-contained, win-x64, built from the CompositionRoot design-time factory so every vertical's model contribution is included) ships as `efbundle.exe` alongside `ScoreTracker.Web.zip`. Validated locally against the Aspire dev database: clean no-op when current.

## 2. Multi-stage YAML with an approval-gated production deploy (`cc2b7c8` + fill-ins)
Replaces the classic release pipeline entirely. Merges to main now run: **Build & Test** → *pause for your manual approval* → **Deploy to Production** (apply migrations via `efbundle.exe`, then zip-deploy the Web app — same run, same artifact). PR builds stop after the Build stage. If migrations fail, the release stops before the app deploy and the old code keeps serving.

Deploy targets are filled in and verified against the subscription: `webAppName: piuscores` (Windows App Service, rg Sharkingbird, netFrameworkVersion v10.0, WebSockets on) and `azureServiceConnection: Pay-As-You-Go (71fd4e21-2111-4006-988f-28fa73d3d655)` (the ARM/Workload Identity federation connection).

### One-time setup before the first gated deploy (also in the pipeline header comment)
1. **Add the secret variable** `ProdSqlConnectionString` (Pipeline → Edit → Variables → keep secret).
2. **Add the approval gate**: Pipelines → Environments → `production` (auto-created on first run, or pre-create it) → Approvals and checks → Approval → add yourself. This is what makes the Deploy stage wait for you.
3. First deploy run will prompt to **permit the pipeline** to use the service connection and the environment — approve both prompts.
4. **Disable/delete the classic release pipeline** so it doesn't double-deploy off the drop artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
