### PR TITLE
Bake a 1-hour command timeout into migration bundles

### DIFF
--- a/ScoreTracker/ScoreTracker.CompositionRoot/DesignTimeChartContextFactory.cs
+++ b/ScoreTracker/ScoreTracker.CompositionRoot/DesignTimeChartContextFactory.cs
@@ -15,7 +15,13 @@ internal sealed class DesignTimeChartContextFactory : IDesignTimeDbContextFactor
     {
         return new ChartAttemptDbContext(new DbContextOptionsBuilder<ChartAttemptDbContext>()
                 .UseSqlServer(
-                    "Server=localhost;Database=DesignTimeOnly;Integrated Security=true;TrustServerCertificate=true")
+                    "Server=localhost;Database=DesignTimeOnly;Integrated Security=true;TrustServerCertificate=true",
+                    // Migration bundles are built from this factory and keep these options
+                    // (only the connection string is swapped in at deploy time). Data-moving
+                    // migrations (e.g. the ScoreEventJournal backfill) can run for minutes
+                    // against prod-sized tables — SqlClient's default 30s killed the
+                    // 2026-07-02 deploy.
+                    o => o.CommandTimeout(3600))
                 .Options,
             VerticalModelContributions.All());
     }


### PR DESCRIPTION
Follow-up to the 2026-07-02 deploy failure: the `AddScoreEventJournal` backfill (`INSERT...SELECT` over all of `scores.PhoenixRecord`) exceeded SqlClient's default 30-second command timeout (`Error Number:-2, Execution Timeout Expired`) and the deploy stopped at the migration step.

Migration bundles are built from `DesignTimeChartContextFactory` and retain its `DbContextOptions` — only the connection string is swapped in at deploy time via `--connection`. Baking `CommandTimeout(3600)` into the factory means every future bundle tolerates data-moving migrations without needing `;Command Timeout=...` appended to the pipeline's connection-string variable.

(The immediate unblock for the failed run is the connection-string append + stage rerun — this PR is the durable version so that manual step isn't load-bearing forever.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
