### PR TITLE
Add credential-gated live-site smoke tests for the PIU import scraper

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/LiveSiteFactAttribute.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/LiveSiteFactAttribute.cs
@@ -2,15 +2,17 @@ namespace ScoreTracker.Tests.Integration.LiveSite;
 
 /// <summary>
 ///     Marks a test that talks to the real phoenix.piugame.com. These only run when a PIU
-///     account is configured via the PIU_TEST_USERNAME / PIU_TEST_PASSWORD environment
-///     variables — unconfigured environments (CI included) skip them, so the suite stays
-///     green for everyone while the owner can run the live canary on demand.
+///     account is configured — either PiuTest:Username / PiuTest:Password in the shared
+///     user-secrets store (the Aspire AppHost's) or the PIU_TEST_USERNAME / PIU_TEST_PASSWORD
+///     environment variables. Unconfigured environments (CI included) skip them, so the suite
+///     stays green for everyone while the owner can run the live canary on demand.
 /// </summary>
 public sealed class LiveSiteFactAttribute : FactAttribute
 {
     public LiveSiteFactAttribute()
     {
         if (!PiuGameSessionFixture.CredentialsConfigured)
-            Skip = "Live-site test: set PIU_TEST_USERNAME and PIU_TEST_PASSWORD to run against the real PIU site.";
+            Skip = "Live-site test: configure PiuTest:Username/PiuTest:Password user-secrets " +
+                   "(AppHost store) or PIU_TEST_USERNAME/PIU_TEST_PASSWORD env vars to run against the real PIU site.";
     }
 }

--- a/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/LiveSiteFactAttribute.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/LiveSiteFactAttribute.cs
@@ -1,0 +1,16 @@
+namespace ScoreTracker.Tests.Integration.LiveSite;
+
+/// <summary>
+///     Marks a test that talks to the real phoenix.piugame.com. These only run when a PIU
+///     account is configured via the PIU_TEST_USERNAME / PIU_TEST_PASSWORD environment
+///     variables — unconfigured environments (CI included) skip them, so the suite stays
+///     green for everyone while the owner can run the live canary on demand.
+/// </summary>
+public sealed class LiveSiteFactAttribute : FactAttribute
+{
+    public LiveSiteFactAttribute()
+    {
+        if (!PiuGameSessionFixture.CredentialsConfigured)
+            Skip = "Live-site test: set PIU_TEST_USERNAME and PIU_TEST_PASSWORD to run against the real PIU site.";
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/PiuGameLiveSiteTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/PiuGameLiveSiteTests.cs
@@ -1,0 +1,153 @@
+using ScoreTracker.SharedKernel.Enums;
+
+namespace ScoreTracker.Tests.Integration.LiveSite;
+
+/// <summary>
+///     Live canary for the PIU site scraper: every method the score-import flow depends on,
+///     exercised against the REAL phoenix.piugame.com with a real account. This is the suite
+///     that goes red the day PIU changes their HTML, image hosts, or login flow (like the
+///     2026-07-03 piugame.com → phoenix.piugame.com image-host move that broke every import).
+///     <para>
+///         Gated on PIU_TEST_USERNAME / PIU_TEST_PASSWORD environment variables — skipped
+///         everywhere they aren't set, including CI. Run on demand with:
+///         <c>dotnet test ScoreTracker/ScoreTracker.Tests.Integration/... --filter "FullyQualifiedName~PiuGameLiveSiteTests"</c>
+///     </para>
+///     <para>
+///         Assertions are shape-and-sanity based (parsers produce validated value types, so
+///         "it parsed at all" carries most of the weight) — live data changes, golden values
+///         belong in the offline approval fixtures. GetUcs is deliberately not covered: it
+///         needs a known-stable UCS id and is not part of the account-import path.
+///     </para>
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class PiuGameLiveSiteTests : IClassFixture<PiuGameSessionFixture>
+{
+    private readonly PiuGameSessionFixture _fixture;
+
+    public PiuGameLiveSiteTests(PiuGameSessionFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [LiveSiteFact]
+    public async Task Login_produces_a_session_and_account_data_parses()
+    {
+        var client = await _fixture.GetAuthenticatedClient(CancellationToken.None);
+
+        var account = await _fixture.Api.GetAccountData(client, CancellationToken.None);
+
+        Assert.False(string.IsNullOrWhiteSpace(account.AccountName.ToString()), "Account name did not parse.");
+        Assert.NotEqual("INVALID", account.AccountName.ToString());
+        Assert.True(account.ImageUrl.IsAbsoluteUri, "Profile image url did not parse.");
+    }
+
+    [LiveSiteFact]
+    public async Task Game_cards_list_the_accounts_cards_with_exactly_one_active()
+    {
+        var client = await _fixture.GetAuthenticatedClient(CancellationToken.None);
+
+        var cards = (await _fixture.Api.GetCards(client, CancellationToken.None)).ToList();
+
+        Assert.NotEmpty(cards);
+        Assert.Equal(1, cards.Count(c => c.IsActive));
+        Assert.All(cards, c => Assert.False(string.IsNullOrWhiteSpace(c.Id)));
+    }
+
+    [LiveSiteFact]
+    public async Task Best_scores_parse_after_reselecting_the_active_card()
+    {
+        // The real import iterates cards via SetCard then scrapes best scores per card.
+        // Re-selecting the already-active card exercises that endpoint without changing
+        // any account state.
+        var client = await _fixture.GetAuthenticatedClient(CancellationToken.None);
+        var cards = (await _fixture.Api.GetCards(client, CancellationToken.None)).ToList();
+        var activeCard = Assert.Single(cards, c => c.IsActive);
+
+        await _fixture.Api.SetCard(client, activeCard.Id, CancellationToken.None);
+        var result = await _fixture.Api.GetBestScores(client, 1, CancellationToken.None);
+
+        // The per-card try/catch swallows parse failures, so an empty page here means the
+        // parser is silently dropping every card — exactly the 2026-07-03 incident shape.
+        Assert.True(result.MaxPage >= 1, "Pagination did not parse.");
+        Assert.NotEmpty(result.Scores);
+        Assert.All(result.Scores, s =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(s.SongName.ToString()), "Song name did not parse.");
+            Assert.InRange((int)s.Score, 0, 1_000_000);
+        });
+    }
+
+    [LiveSiteFact]
+    public async Task Recent_scores_parse_for_the_account()
+    {
+        var client = await _fixture.GetAuthenticatedClient(CancellationToken.None);
+
+        var recents = (await _fixture.Api.GetRecentScores(client, CancellationToken.None)).ToList();
+
+        // Requires the account to have at least one recent play — the parser drops
+        // unparseable cards silently, so empty-when-you-played-yesterday means breakage.
+        Assert.NotEmpty(recents);
+        Assert.All(recents, r =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(r.SongName.ToString()), "Song name did not parse.");
+            Assert.True(r.NoteCount > 0, "Note counts did not parse.");
+        });
+    }
+
+    [LiveSiteFact]
+    public async Task Over_20_songs_and_their_song_leaderboards_parse()
+    {
+        var songs = await _fixture.Api.Get20AboveSongs(1, CancellationToken.None);
+
+        Assert.NotEmpty(songs.Results);
+        Assert.All(songs.Results, s =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(s.Name), "Song name did not parse.");
+            Assert.False(string.IsNullOrWhiteSpace(s.Id), "Song leaderboard id did not parse.");
+        });
+
+        var leaderboard = await _fixture.Api.GetSongLeaderboard(songs.Results.First().Id, CancellationToken.None);
+
+        Assert.NotEmpty(leaderboard.Results);
+        Assert.All(leaderboard.Results, e =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(e.ProfileName), "Profile name did not parse.");
+            Assert.InRange(e.Score, 0, 1_000_000);
+        });
+    }
+
+    [LiveSiteFact]
+    public async Task Rating_leaderboard_list_and_a_leaderboard_parse()
+    {
+        var leaderboards = await _fixture.Api.GetLeaderboards(CancellationToken.None);
+
+        Assert.NotEmpty(leaderboards.Entries);
+        Assert.All(leaderboards.Entries, e => Assert.False(string.IsNullOrWhiteSpace(e.Name)));
+
+        var withId = leaderboards.Entries.First(e => !string.IsNullOrWhiteSpace(e.Id));
+        var leaderboard = await _fixture.Api.GetLeaderboard(withId.Id, CancellationToken.None);
+
+        Assert.NotEmpty(leaderboard.Entries);
+        Assert.All(leaderboard.Entries, e =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(e.ProfileName), "Profile name did not parse.");
+            Assert.True(e.Rating > 0, "Rating did not parse.");
+        });
+    }
+
+    [LiveSiteFact]
+    public async Task Chart_popularity_leaderboard_parses()
+    {
+        var result = await _fixture.Api.GetChartPopularityLeaderboard(1, CancellationToken.None);
+
+        Assert.NotEmpty(result.Entries);
+        Assert.All(result.Entries, e =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(e.SongName.ToString()), "Song name did not parse.");
+            Assert.True(e.Place > 0, "Placement did not parse.");
+            Assert.True(e.ChartType is ChartType.Single or ChartType.Double or ChartType.CoOp
+                    or ChartType.SinglePerformance or ChartType.DoublePerformance,
+                "Chart type did not parse.");
+        });
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/PiuGameSessionFixture.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/PiuGameSessionFixture.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using ScoreTracker.Domain.SecondaryPorts;
@@ -29,8 +30,20 @@ public sealed class PiuGameSessionFixture : IDisposable
 
     public string? SessionId { get; private set; }
 
-    public static string? Username => Environment.GetEnvironmentVariable("PIU_TEST_USERNAME");
-    public static string? Password => Environment.GetEnvironmentVariable("PIU_TEST_PASSWORD");
+    // This project shares the Aspire AppHost's UserSecretsId (see the csproj), so credentials
+    // configured once for local dev also drive these tests:
+    //   dotnet user-secrets set "PiuTest:Username" "..." --project ScoreTracker/ScoreTracker.AppHost
+    // Environment variables (PIU_TEST_USERNAME / PIU_TEST_PASSWORD) still win when both are set.
+    private static readonly Lazy<IConfigurationRoot> Configuration = new(() =>
+        new ConfigurationBuilder()
+            .AddUserSecrets<PiuGameSessionFixture>(optional: true)
+            .Build());
+
+    public static string? Username =>
+        Environment.GetEnvironmentVariable("PIU_TEST_USERNAME") ?? Configuration.Value["PiuTest:Username"];
+
+    public static string? Password =>
+        Environment.GetEnvironmentVariable("PIU_TEST_PASSWORD") ?? Configuration.Value["PiuTest:Password"];
 
     public static bool CredentialsConfigured =>
         !string.IsNullOrWhiteSpace(Username) && !string.IsNullOrWhiteSpace(Password);

--- a/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/PiuGameSessionFixture.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/PiuGameSessionFixture.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.OfficialMirror.Infrastructure.Apis;
+
+namespace ScoreTracker.Tests.Integration.LiveSite;
+
+/// <summary>
+///     Shares one real PiuGameApi (and at most one login) across the live-site tests.
+///     Login is lazy: skipped tests never touch the network, and the whole class produces
+///     exactly one login POST per run no matter how many authenticated tests execute —
+///     polite to the real site and to the account.
+/// </summary>
+public sealed class PiuGameSessionFixture : IDisposable
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly HttpClient _publicClient;
+    private HttpClient? _authenticatedClient;
+
+    public PiuGameSessionFixture()
+    {
+        // Mirrors the typed-client registration in OfficialMirrorRegistrationExtensions.
+        _publicClient = new HttpClient();
+        _publicClient.DefaultRequestHeaders.Add("Origin", "https://phoenix.piugame.com");
+        Api = new PiuGameApi(_publicClient, NullLogger<PiuGameApi>.Instance, Mock.Of<ICurrentUserAccessor>());
+    }
+
+    internal PiuGameApi Api { get; }
+
+    public string? SessionId { get; private set; }
+
+    public static string? Username => Environment.GetEnvironmentVariable("PIU_TEST_USERNAME");
+    public static string? Password => Environment.GetEnvironmentVariable("PIU_TEST_PASSWORD");
+
+    public static bool CredentialsConfigured =>
+        !string.IsNullOrWhiteSpace(Username) && !string.IsNullOrWhiteSpace(Password);
+
+    public void Dispose()
+    {
+        _publicClient.Dispose();
+        _authenticatedClient?.Dispose();
+        _gate.Dispose();
+    }
+
+    internal async Task<HttpClient> GetAuthenticatedClient(CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (_authenticatedClient is not null) return _authenticatedClient;
+
+            var (client, sid) = await Api.GetSessionId(Username!, Password!, cancellationToken);
+            Assert.False(string.IsNullOrWhiteSpace(sid),
+                "Login against the live site produced no session id — the PIU login flow has changed shape.");
+            SessionId = sid;
+            _authenticatedClient = client;
+            return client;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests.Integration/ScoreTracker.Tests.Integration.csproj
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/ScoreTracker.Tests.Integration.csproj
@@ -5,6 +5,10 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <!-- Deliberately the AppHost's id: local secrets live in ONE store (the Aspire AppHost's),
+         so a `dotnet user-secrets set` against ScoreTracker.AppHost also configures the
+         live-site tests. Only PiuTest:* keys are read here. -->
+    <UserSecretsId>2957ac5b-8cbb-49cf-be12-3b607ea9b818</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.2" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.7.0" />
     <PackageReference Include="Respawn" Version="6.2.1" />


### PR DESCRIPTION
Follow-up to #113: a live canary so the next PIU site change shows up as a red test instead of prod telemetry.

## What it is
Seven tests in `ScoreTracker.Tests.Integration/LiveSite/` exercising every `PiuGameApi` method the score-import flow depends on **against the real phoenix.piugame.com** with a real account:

| Test | Covers |
|---|---|
| Login produces a session + account data parses | `GetSessionId`, `GetAccountData` |
| Game cards list with exactly one active | `GetCards` |
| Best scores parse after reselecting the active card | `SetCard` + `GetBestScores` — the exact card-iteration path the import walks (re-selecting the already-active card, so no account state changes) |
| Recent scores parse | `GetRecentScores` |
| Over-20 songs + song leaderboards parse | `Get20AboveSongs`, `GetSongLeaderboard` |
| Rating leaderboard list + a leaderboard parse | `GetLeaderboards`, `GetLeaderboard` |
| Chart popularity leaderboard parses | `GetChartPopularityLeaderboard` |

Assertions are shape/sanity-based (the parsers construct validated value types, so "it parsed at all" carries most of the weight) — golden values stay in the offline approval fixtures. One login per run via a lazy shared fixture. `GetUcs` is deliberately uncovered: needs a known-stable UCS id and isn't on the import path.

## How to run
```
$env:PIU_TEST_USERNAME = "..."
$env:PIU_TEST_PASSWORD = "..."
dotnet test ScoreTracker/ScoreTracker.Tests.Integration/ScoreTracker.Tests.Integration.csproj --filter "FullyQualifiedName~PiuGameLiveSiteTests"
```

Without the env vars every test **skips** (verified: 7 skipped in 32ms), so CI and other contributors are unaffected. The account needs at least one recent play for the recent-scores assertion.

Culture-per-account testing is deferred per owner — English only for now.

(Note: the previous commit of this work accidentally landed on the already-merged #113 branch — `claude/import-parser-phoenix-host` has a stray post-merge commit and can just be deleted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
