### PR TITLE
Survive PIU's anonymous SSO handshake; retarget bare piugame.com references

### DIFF
--- a/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/Apis/Dtos/PiuGameGetSongLeaderboardResult.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/Apis/Dtos/PiuGameGetSongLeaderboardResult.cs
@@ -7,7 +7,7 @@ namespace ScoreTracker.OfficialMirror.Infrastructure.Apis.Dtos
         public sealed class EntryResultDto
         {
             public Uri AvatarUrl { get; set; } =
-                new("https://piugame.com/data/avatar_img/4f617606e7751b2dc2559d80f09c40bf.png", UriKind.Absolute);
+                new("https://phoenix.piugame.com/data/avatar_img/4f617606e7751b2dc2559d80f09c40bf.png", UriKind.Absolute);
 
             public string ProfileName { get; set; } = string.Empty;
             public int Score { get; set; }

--- a/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/Apis/PiuGameApi.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/Apis/PiuGameApi.cs
@@ -213,7 +213,9 @@ internal sealed class PiuGameApi : IPiuGameApi
             new Dictionary<string, string>
             {
                 { "page", page.ToString() },
-                { "date", $"{today.Year}{today.Month}" },
+                // Zero-padded month is mandatory: the endpoint answers "20267" with a redirect
+                // script pointing at "202607" and no data.
+                { "date", $"{today.Year}{today.Month:00}" },
                 { "mode", "full" }
             }, cancellationToken);
         var results = new List<PiuGameGetChartPopularityLeaderboardResult.Entry>();
@@ -403,6 +405,7 @@ internal sealed class PiuGameApi : IPiuGameApi
             try
             {
                 var response = await _client.PostAsync(url, new FormUrlEncodedContent(form), cancellationToken);
+                ThrowIfSsoBounced(response);
                 response.EnsureSuccessStatusCode();
                 return await response.Content.ReadAsStringAsync(cancellationToken);
                 break;
@@ -426,6 +429,7 @@ internal sealed class PiuGameApi : IPiuGameApi
                 var response =
                     await (client ?? _client).PostAsync(url, new FormUrlEncodedContent(form), cancellationToken);
 
+                ThrowIfSsoBounced(response);
                 //response.EnsureSuccessStatusCode();
                 return response;
                 break;
@@ -448,6 +452,7 @@ internal sealed class PiuGameApi : IPiuGameApi
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
                 var response = await (client ?? _client).SendAsync(request, cancellationToken);
+                ThrowIfSsoBounced(response);
                 return await response.Content.ReadAsStringAsync(cancellationToken);
                 break;
             }
@@ -458,6 +463,22 @@ internal sealed class PiuGameApi : IPiuGameApi
                 retry++;
                 await Task.Delay(1000, cancellationToken);
             }
+    }
+
+    /// <summary>
+    ///     Since the Phoenix 2 site rollout, phoenix.piugame.com fronts anonymous traffic with an
+    ///     am-pass SSO handshake: a fresh session's first request redirects through am-pass.net
+    ///     and dead-ends on a broken /ssoc URL (their bug — a browser recovers, HttpClient
+    ///     doesn't). The hop still deposits the anonymous session cookies in this client's
+    ///     cookie container, so an immediate retry of the original URL succeeds. Landing on
+    ///     /ssoc is therefore a transient failure for the retry loops above, not a result.
+    /// </summary>
+    private static void ThrowIfSsoBounced(HttpResponseMessage response)
+    {
+        if (response.RequestMessage?.RequestUri?.AbsolutePath.Contains("ssoc", StringComparison.OrdinalIgnoreCase) ==
+            true)
+            throw new HttpRequestException(
+                $"Bounced to the am-pass SSO handshake ({response.RequestMessage.RequestUri}); retrying now that session cookies are set.");
     }
 
     private ChartType? GetChartTypeFromUrl(string chartTypeUrl)

--- a/ScoreTracker/ScoreTracker/Pages/UploadPhoenixScores.razor
+++ b/ScoreTracker/ScoreTracker/Pages/UploadPhoenixScores.razor
@@ -373,7 +373,7 @@
         catch (InvalidCredentialException)
         {
             _passwordImportStatus = "Invalid Username/Password";
-            Snackbar.Add("Your password appears to be incorrect, could not log into https://piugame.com", Severity.Error);
+            Snackbar.Add("Your password appears to be incorrect, could not log into https://phoenix.piugame.com", Severity.Error);
         }
         catch (Exception e)
         {
@@ -417,7 +417,7 @@
         catch (InvalidCredentialException)
         {
             _passwordImportStatus = "Invalid Username/Password";
-            Snackbar.Add("Your password appears to be incorrect, could not log into https://piugame.com", Severity.Error);
+            Snackbar.Add("Your password appears to be incorrect, could not log into https://phoenix.piugame.com", Severity.Error);
         }
         catch (Exception e)
         {
@@ -587,17 +587,20 @@ var csvString=""data:text/csv;charset=utf-8,"";
     var pageIndex={_startPage};
     while(true) {{
 
-        var nextPageString = await $.get(""https://piugame.com/my_page/my_best_score.php?&&page=""+pageIndex)
+        var nextPageString = await $.get(""https://phoenix.piugame.com/my_page/my_best_score.php?&&page=""+pageIndex)
         var page=$(nextPageString);
         var foundScores=$(""ul.my_best_scoreList>li>div.in"",page);
         foundScores.each(function(){{
             var songName = $('.song_name',this)[0].children[0].innerText.replaceAll('""','""""').replaceAll('#','Num');
-            var chartType = $($('.stepBall_img_wrap .imG img',this)[0]).attr(""src"").substring(40,41);
-            var difficultyLevel = $('.stepBall_img_wrap .imG img',this).map((index,i)=> $(i).attr(""src"").substring(46,47)).get().join("""").replaceAll(""."","""");
+            var typeMatch = $($('.stepBall_img_wrap .imG img',this)[0]).attr(""src"").match(/\/full\/([a-z]+)_num_/i);
+            var chartType = typeMatch ? typeMatch[1] : ""?"";
+            var difficultyLevel = $('.stepBall_img_wrap .imG img',this).map((index,i)=>{{var m=$(i).attr(""src"").match(/_num_([0-9])\.png/);return m?m[1]:"""";}}).get().join("""");
             var scoreList = $("".etc_con>ul"",this)[0];
-            var letter = $(scoreList.children[1].children[0].children[0].children[0]).attr('src').substring(32).replace("".png"","""").replace(""_p"",""+"");
+            var letterMatch = $(scoreList.children[1].children[0].children[0].children[0]).attr('src').match(/\/grade\/([a-z_]+)\.png/i);
+            var letter = (letterMatch?letterMatch[1]:""?"").replace(""_p"",""+"");
             var score = $(scoreList.children[0].children[0].children[0].children[0])[0].innerText.replaceAll("","","""");
-            var plate = $(scoreList.children[2].children[0].children[0].children[0]).attr(""src"").substring(32,34);
+            var plateMatch = $(scoreList.children[2].children[0].children[0].children[0]).attr(""src"").match(/\/plate\/([a-z]+)\.png/i);
+            var plate = plateMatch?plateMatch[1]:""?"";
             csvString+='""'+songName+'"",'+chartType+difficultyLevel+"",""+score+"",""+letter+"",""+plate+""\r\n"";
         }});
         pageIndex++;

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -313,7 +313,7 @@
     <value>Use the Copy Script button below</value>
   </data>
   <data name="Phoenix Import Info 2" xml:space="preserve">
-    <value>Use that script in the dev tools while logged in on https://piugame.com to download a CSV of your scores. (Make sure you aren't on phoenix.piugame.com)</value>
+    <value>Use that script in the dev tools while logged in on https://phoenix.piugame.com to download a CSV of your scores. (Make sure you aren't on phoenix.piugame.com)</value>
   </data>
   <data name="Phoenix Import Info 3" xml:space="preserve">
     <value>You can then upload that CSV here for yoru scores to show up.</value>
@@ -479,7 +479,7 @@
     <value>I do not store a record of your username or password, you will have to type them in every time you use this.</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>To minimize calls to https://piugame.com I will only import new or improved scores. Every user only gets one full import using Username/Password. Use the dev-tools importer if you wish to re-import older scores.</value>
+    <value>To minimize calls to https://phoenix.piugame.com I will only import new or improved scores. Every user only gets one full import using Username/Password. Use the dev-tools importer if you wish to re-import older scores.</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
     <value>Once started, don't leave this page or else your scores will not finish saving.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -521,7 +521,7 @@
     <value>Mrg mrg grrrgl rgrlmrlgmrrgl mrg rglurg glub murlgrgl murglargrgl argrlg grrrmrrgl, murlg mrgl magrgl rgl rgrgl glurgl murg glrglrgl murgll murlg urgmrg mrglrgl.</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>Rgl rulggurgmrrr grglgrglgrrrrgl rgl https://piugame.com Mrg mrgl mglrgl murgmrg mrglgrgl argrlg mrrglubrgl grglrglrgl. Glrglrgl murglar mglrgl gurgrgl mrg blubmrrr murgmrg urgmrgl Murglargrgl/Grrrmrrgl. Urgmrg mrgl mrgblub-grglurgrgl mrlgargl arglgl murlg argl rgl grarrgrlgrrr-murgmrg prglplgl grglrglrgl.</value>
+    <value>Rgl rulggurgmrrr grglgrglgrrrrgl rgl https://phoenix.piugame.com Mrg mrgl mglrgl murgmrg mrglgrgl argrlg mrrglubrgl grglrglrgl. Glrglrgl murglar mglrgl gurgrgl mrg blubmrrr murgmrg urgmrgl Murglargrgl/Grrrmrrgl. Urgmrg mrgl mrgblub-grglurgrgl mrlgargl arglgl murlg argl rgl grarrgrlgrrr-murgmrg prglplgl grglrglrgl.</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
     <value>Blubargrl glrgl, prglprglblgrl blgrlargl mrglrgl murgbagl argrlg argrgl murlgrgl grglrglrgl mrgl grrrgl mrrglubgl arglmrgl.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -1033,7 +1033,7 @@
     <value>Use el botón Copiar script de abajo</value>
   </data>
   <data name="Phoenix Import Info 2" xml:space="preserve">
-    <value>Use ese script en las dev tools mientras esté con sesión iniciada en https://piugame.com para descargar un CSV de sus puntajes. (Asegúrese de no estar en phoenix.piugame.com)</value>
+    <value>Use ese script en las dev tools mientras esté con sesión iniciada en https://phoenix.piugame.com para descargar un CSV de sus puntajes. (Asegúrese de no estar en phoenix.piugame.com)</value>
   </data>
   <data name="Phoenix Import Info 3" xml:space="preserve">
     <value>Después puede subir ese CSV aquí para que sus puntajes aparezcan.</value>
@@ -1759,7 +1759,7 @@
     <value>No almacenamos un registro de tu usuario o contraseña, tendrá que introducirlos siempre que uses esa opción.</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>Para minimizar las llamadas para https://piugame.com/, solo importaremos scores nuevos o mejorados. Cada usuario recibirá importación completa usando usuario/contraseña solo una vez. Use el importador dev-tools si quiere reimportar puntajes más antiguas.</value>
+    <value>Para minimizar las llamadas para https://phoenix.piugame.com/, solo importaremos scores nuevos o mejorados. Cada usuario recibirá importación completa usando usuario/contraseña solo una vez. Use el importador dev-tools si quiere reimportar puntajes más antiguas.</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
     <value>Una vez iniciado, no salga de esta página, de lo contrario sus puntajes no serán guardadas.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -313,7 +313,7 @@
     <value>Utilisez le bouton Copier le script ci-dessous</value>
   </data>
   <data name="Phoenix Import Info 2" xml:space="preserve">
-    <value>Utilisez ce script dans la Console de Développement en étant connecté sur https://piugame.com pour télécharger un CSV de vos scores. (Vérifiez bien que vous n'êtes pas sur phoenix.piugame.com)</value>
+    <value>Utilisez ce script dans la Console de Développement en étant connecté sur https://phoenix.piugame.com pour télécharger un CSV de vos scores. (Vérifiez bien que vous n'êtes pas sur phoenix.piugame.com)</value>
   </data>
   <data name="Phoenix Import Info 3" xml:space="preserve">
     <value>Vous pourrez par la suite uploader ce CSV sur le site pour que vos scores y apparaissent.</value>
@@ -479,7 +479,7 @@
     <value>Je ne garde aucune trace de votre nom d'utilisateur ou mot de passe, vous devrez les entrer a chaque fois que vous utilisez ceci.</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>Pour limiter les requètes vers https://piugame.com, je n'importe que les scores nouveaux ou améliorés. Chaque utilisateur a un import entier avec son nom d'utilisateur et mot de passe. Utilisez l'importateur outils developpeur si vous souhaitez réimporter des scores plus anciens.</value>
+    <value>Pour limiter les requètes vers https://phoenix.piugame.com, je n'importe que les scores nouveaux ou améliorés. Chaque utilisateur a un import entier avec son nom d'utilisateur et mot de passe. Utilisez l'importateur outils developpeur si vous souhaitez réimporter des scores plus anciens.</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
     <value>Une fois démarré, ne pas quitter cette page pour ne pas interrompre la sauvegarde des scores.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -313,7 +313,7 @@
     <value>Usa il pulsante Copia lo script qui sotto</value>
   </data>
   <data name="Phoenix Import Info 2" xml:space="preserve">
-    <value>Usa quello script nei dev-tools mentre sei loggato su https://piugame.com per scaricare un CSV dei tuoi punteggi. (Assicurati di non essere su phoenix.piugame.com)</value>
+    <value>Usa quello script nei dev-tools mentre sei loggato su https://phoenix.piugame.com per scaricare un CSV dei tuoi punteggi. (Assicurati di non essere su phoenix.piugame.com)</value>
   </data>
   <data name="Phoenix Import Info 3" xml:space="preserve">
     <value>Puoi poi caricare quel CSV qui per far apparire i tuoi punteggi.</value>
@@ -479,7 +479,7 @@
     <value>Non memorizzo alcuna registrazione del tuo nome utente o della tua password, dovrai digitarli ogni volta che usi questa funzione.</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>Per ridurre al minimo le chiamate a https://piugame.com importerò solo punteggi nuovi o migliorati. Ogni utente riceve solo un'importazione completa tramite Username/Password. Usa l'importatore dev-tools se vuoi reimportare punteggi precedenti.</value>
+    <value>Per ridurre al minimo le chiamate a https://phoenix.piugame.com importerò solo punteggi nuovi o migliorati. Ogni utente riceve solo un'importazione completa tramite Username/Password. Usa l'importatore dev-tools se vuoi reimportare punteggi precedenti.</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
     <value>Una volta avviato, non lasciare questa pagina o i tuoi punteggi non finiranno di essere salvati.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -313,7 +313,7 @@
     <value>下のコピーバトン使ってください</value>
   </data>
   <data name="Phoenix Import Info 2" xml:space="preserve">
-    <value>CHROMEのDEV TOOLSでhttps://piugame.comがログインしてる状態にスクリプトを走ってください。phoenix.piugame.comが使ってない状態が気をつけてください</value>
+    <value>CHROMEのDEV TOOLSでhttps://phoenix.piugame.comがログインしてる状態にスクリプトを走ってください。phoenix.piugame.comが使ってない状態が気をつけてください</value>
   </data>
   <data name="Phoenix Import Info 3" xml:space="preserve">
     <value>スクリプトが作ったCSVファイルここでアップロード出来ます。</value>
@@ -479,7 +479,7 @@
     <value>注意：ユーザーとパスワードを記録しないから、毎回使う場合はも一回入力必要あります。</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>https://piugame.comのAPI呼び出すのを減らすなめに、新しいとか改良スコアどけインポートする。各ユーザーは完全インポート（ユーザーとパスワード）一回だけのサービスを上げます。古いスコアが
+    <value>https://phoenix.piugame.comのAPI呼び出すのを減らすなめに、新しいとか改良スコアどけインポートする。各ユーザーは完全インポート（ユーザーとパスワード）一回だけのサービスを上げます。古いスコアが
           も一回インポート場合、dev-toolsのスクリプト使ってください。</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -298,7 +298,7 @@
     <value>아래의 '스크립트 복사' 버튼을 사용하세요</value>
   </data>
   <data name="Phoenix Import Info 2" xml:space="preserve">
-    <value>https://piugame.com에 로그인한 상태에서 해당 스크립트를 사용하여 점수의 CSV를 다운로드하세요 (https://phoenix.piugame.com에서 작업하지 않도록 주의하세요)</value>
+    <value>https://phoenix.piugame.com에 로그인한 상태에서 해당 스크립트를 사용하여 점수의 CSV를 다운로드하세요 (https://phoenix.piugame.com에서 작업하지 않도록 주의하세요)</value>
   </data>
   <data name="Phoenix Import Info 3" xml:space="preserve">
     <value>CSV 파일을 이곳에 업로드하시면 점수가 표시됩니다.</value>
@@ -572,7 +572,7 @@
     <value>PIUScores가 본인의 계정에 로그인하여 점수를 가져옵니다.</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>https://piugame.com에 대한 호출을 최소화하기 위해 새 점수나 향상된 점수만 가져옵니다. 모든 유저는 아이디/비밀번호를 사용한 전체 가져오기를 한 번씩만 사용할 수 있습니다. 이전 점수를 다시 가져오시려면 개발자 도구 가져오기를 사용해주세요.</value>
+    <value>https://phoenix.piugame.com에 대한 호출을 최소화하기 위해 새 점수나 향상된 점수만 가져옵니다. 모든 유저는 아이디/비밀번호를 사용한 전체 가져오기를 한 번씩만 사용할 수 있습니다. 이전 점수를 다시 가져오시려면 개발자 도구 가져오기를 사용해주세요.</value>
   </data>
   <data name="Open" xml:space="preserve">
     <value>열기</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -301,7 +301,7 @@
     <value>Use o botão Copiar script abaixo</value>
   </data>
   <data name="Phoenix Import Info 2" xml:space="preserve">
-    <value>Use esse script nas ferramentas de desenvolvimento enquanto estiver conectado em https://piugame.com para baixar um CSV de suas pontuações. (Certifique-se de que não esteja em phoenix.piugame.com)</value>
+    <value>Use esse script nas ferramentas de desenvolvimento enquanto estiver conectado em https://phoenix.piugame.com para baixar um CSV de suas pontuações. (Certifique-se de que não esteja em phoenix.piugame.com)</value>
   </data>
   <data name="Phoenix Import Info 3" xml:space="preserve">
     <value>Em seguida, você pode carregar esse CSV aqui para que suas pontuações sejam exibidas.</value>
@@ -457,7 +457,7 @@
     <value>Não armazenamos um registro do seu nome de usuário ou senha, você terá que digitá-los sempre que usar essa opção.</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>Para minimizar as chamadas para https://piugame.com/, somente importaremos scores novos ou melhorados. Cada usuário receberá importação completa usando nome de usuário/senha apenas uma vez. Use o importador dev-tools se quiser re-importar pontuações mais antigas.</value>
+    <value>Para minimizar as chamadas para https://phoenix.piugame.com/, somente importaremos scores novos ou melhorados. Cada usuário receberá importação completa usando nome de usuário/senha apenas uma vez. Use o importador dev-tools se quiser re-importar pontuações mais antigas.</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
     <value>Uma vez iniciado, não saia desta página, caso contrário suas pontuações não serão salvas.</value>


### PR DESCRIPTION
The live-site canary (#114) caught two more Phoenix-2-rollout breakages in its first run, and the diagnosis you corrected mid-flight ("it works in incognito") led to the real mechanism.

## The SSO handshake (root cause of both failures)
phoenix.piugame.com now fronts **anonymous** traffic with an am-pass SSO handshake: a fresh session's first request 302s through `api.am-pass.net/sso` and dead-ends on a malformed `/ssoc&referer=...` 404 (`&` where `?` belongs — their bug; browsers recover, HttpClient doesn't). Critically, **the hop still deposits the anonymous session cookies**, so an immediate retry of the original URL succeeds. All three HTTP helpers now treat landing on `/ssoc` as a transient failure and let the existing retry loops re-issue the request.

This un-breaks the Sunday leaderboard import (`over_ranking.php` + `top_steps.php`) with **no credentials** — and it self-heals when the HttpClientFactory handler rotation discards cookies mid-sweep.

## Also in this sweep (per "make sure ALL references point at phoenix.piugame")
- **`top_steps.php` month padding**: the endpoint now rejects `date=20267` (returns a redirect stub pointing at `202607`). Fixed to `{Month:00}`.
- **Console score-exporter script** (`UploadPhoenixScores`): the user-pasted JS had the same two bugs its server-side twin had in #113 — bare `piugame.com` URL and positional `substring(46,47)`/`substring(32,34)` parsing. Now phoenix host + filename-regex extraction.
- **Bare-domain references**: login-failure snackbars, the default avatar URL, and the `Use Password 3` / `Phoenix Import Info 2` strings across all eight locale resx files now say `phoenix.piugame.com`. (Approval-test fixtures keep old-host captures deliberately — the parsers accept both hosts.)

## Verification
- 16/16 offline `PiuGameApiTests` approval tests.
- **7/7 live-site smoke tests (#114) against the real site** with this branch merged in — including the two that were red: over-20 songs + song leaderboards, and chart popularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
