### PR TITLE
CI: live-site smoke tests as a deploy gate, credentials from Key Vault

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,10 @@
 #   3. First deploy run will prompt to permit this pipeline to use the service connection and
 #      environment — approve both.
 #   4. Disable/delete the classic release pipeline so it doesn't double-deploy off the drop.
+#   5. Live-site deploy gate: the integration job pulls a real PIU account from the
+#      arrow-eclipse Key Vault (secrets PiuTest-Username / PiuTest-Password) so the
+#      live-site smoke tests run on every build. Before merging this: create both secrets
+#      and grant the service connection's identity get/list on the vault's secrets.
 
 trigger:
 - main
@@ -101,7 +105,7 @@ stages:
         publishLocation: 'Container'
 
   - job: IntegrationTests
-    displayName: 'Integration Tests (Linux, Testcontainers + SQL Server 2025)'
+    displayName: 'Integration Tests (Linux, Testcontainers + SQL Server 2025 + live PIU site)'
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -111,11 +115,28 @@ stages:
         packageType: 'sdk'
         version: '10.0.x'
 
+    # The live-site smoke tests (Tests.Integration/LiveSite/) need a real PIU account; it
+    # lives in Key Vault, and this task surfaces the two secrets as secret pipeline
+    # variables for this job only. Scraper rot against the real site fails this job — and
+    # a failed Build stage means the deploy stage never runs.
+    - task: AzureKeyVault@2
+      displayName: 'Pull PIU test account from Key Vault'
+      inputs:
+        azureSubscription: '$(azureServiceConnection)'
+        KeyVaultName: 'arrow-eclipse'
+        SecretsFilter: 'PiuTest-Username,PiuTest-Password'
+        RunAsPreJob: false
+
     # First run on a fresh agent pulls the SQL Server 2025 image (~2 min). Subsequent tests against
     # the same agent are fast — but Microsoft-hosted agents are fresh per run, so expect that cost
     # every time. ~3 min total job runtime on a clean agent.
+    # Secret variables are never auto-exposed to scripts — the explicit env mapping below is
+    # what lets the LiveSite tests see the account (everywhere else they skip).
     - script: dotnet test ScoreTracker/ScoreTracker.Tests.Integration/ScoreTracker.Tests.Integration.csproj -c $(buildConfiguration) --logger "trx;LogFileName=integration.trx" --results-directory $(Agent.TempDirectory)
-      displayName: 'Run integration tests (real SQL Server 2025 via Testcontainers)'
+      displayName: 'Run integration tests (real SQL Server 2025 via Testcontainers + live PIU site)'
+      env:
+        PIU_TEST_USERNAME: $(PiuTest-Username)
+        PIU_TEST_PASSWORD: $(PiuTest-Password)
 
     - task: PublishTestResults@2
       displayName: 'Publish integration test results'

--- a/docs/HOW-TO-TEST.md
+++ b/docs/HOW-TO-TEST.md
@@ -43,9 +43,26 @@ dotnet test ScoreTracker/ScoreTracker.Tests.Integration/ScoreTracker.Tests.Integ
 
 **Docker Desktop must be running.** The suite provisions its own ephemeral SQL Server 2025 container via Testcontainers (first run pulls the image, ~2 min), applies every EF migration, runs the tests with Respawn wiping the `scores` schema between them, and tears the container down. No local SQL setup or connection string needed.
 
+### Live-site smoke tests — PIU account required
+
+`Tests.Integration/LiveSite/` exercises every scraper method the score-import flow depends on **against the real phoenix.piugame.com** — the code most likely to break in production, since PIU changes their site without notice. The tests need a real PIU account and **skip automatically when none is configured**, so they never affect contributors.
+
+To run them locally, configure credentials once in the shared user-secrets store (the same one the Aspire AppHost uses):
+
+```sh
+dotnet user-secrets set "PiuTest:Username" "..." --project ScoreTracker/ScoreTracker.AppHost
+dotnet user-secrets set "PiuTest:Password" "..." --project ScoreTracker/ScoreTracker.AppHost
+```
+
+(`PIU_TEST_USERNAME` / `PIU_TEST_PASSWORD` environment variables also work and take precedence.) Then:
+
+```sh
+dotnet test ScoreTracker/ScoreTracker.Tests.Integration/ScoreTracker.Tests.Integration.csproj --filter "FullyQualifiedName~PiuGameLiveSiteTests"
+```
+
 ### What CI runs
 
-Every PR and every merge to `main` runs all three suites on [Azure Pipelines](https://dev.azure.com/joneccker/ScoreTracker) — the fast suites on a Windows agent, the integration suite on a Linux agent with Docker. Merges to `main` additionally build the deployable artifact and wait at a manual approval gate before deploying.
+Every PR and every merge to `main` runs all three suites on [Azure Pipelines](https://dev.azure.com/joneccker/ScoreTracker) — the fast suites on a Windows agent, the integration suite on a Linux agent with Docker. **The live-site smoke tests run in CI too**: the integration job pulls a PIU test account from Azure Key Vault, so scraper breakage fails the build — and since the deploy stage only runs after a green Build stage, a broken importer can't reach production. Merges to `main` additionally build the deployable artifact and wait at a manual approval gate before deploying.
 
 ## Conventions
 


### PR DESCRIPTION
Makes the live-site smoke tests (#114) a **deploy gate**: the integration job now pulls a PIU test account from the `arrow-eclipse` Key Vault and runs the LiveSite suite on every build. If the scraper is broken against the real site, the Build stage goes red and the deploy stage never runs — importer breakage can't silently ship.

## How it works
- `AzureKeyVault@2` (via the existing `Pay-As-You-Go` ARM service connection) surfaces `PiuTest-Username` / `PiuTest-Password` as secret pipeline variables, scoped to the integration job.
- Secrets are never auto-exposed to scripts, so an explicit `env:` mapping on the test step is what lets the LiveSite tests see the account. Everywhere else (contributor machines, any job without the mapping) they skip.
- No pipeline variables to manage — credentials live in Key Vault only.

## ⚠️ Do BEFORE merging (Azure-side, ~1 minute)
```sh
az keyvault secret set --vault-name arrow-eclipse --name PiuTest-Username --value "<piu username>"
az keyvault secret set --vault-name arrow-eclipse --name PiuTest-Password --value "<piu password>"
az keyvault set-policy --name arrow-eclipse --secret-permissions get list --spn 6709822f-f5e3-4f09-b639-c30ca6611f5a
```
The `--spn` is the service connection's identity (`joneccker-ScoreTracker-71fd4e21...`); the vault uses access policies, not RBAC. If the secrets or the policy are missing, the KV task fails the build with a clear error — nothing worse.

Note: this also means every PR build logs into PIU once from a Microsoft-hosted agent (~10 requests). If that ever bothers PIU, the KV task + env mapping can be conditioned to main-branch runs only — the tests skip gracefully without creds.

Also updates docs/HOW-TO-TEST.md with the live-suite section (local user-secrets/env-var setup and the CI gating behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
