### PR TITLE
api/phoenixScores: sorting, filters, and per-score Pumbility worth

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Api/PhoenixScoresApiShapeTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Api/PhoenixScoresApiShapeTests.cs
@@ -18,25 +18,34 @@ namespace ScoreTracker.Tests.Api;
 
 public sealed class PhoenixScoresApiShapeTests
 {
-    [Fact]
-    public async Task GetPreservesPagedResponseShapeIncludingBrokenScorelessRecords()
+    private static PhoenixScoresController BuildController(params RecordedPhoenixScore[] records)
     {
         var mediator = new Mock<IMediator>();
         var currentUser = new Mock<ICurrentUserAccessor>();
         currentUser.Setup(c => c.User).Returns(ApiTestData.PublicUser);
         mediator.Setup(m => m.Send(It.IsAny<GetPhoenixRecordsQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[]
-            {
-                new RecordedPhoenixScore(ApiTestData.ChartId1, PhoenixScore.From(985000),
-                    PhoenixPlate.ExtremeGame, false, ApiTestData.Date2),
-                new RecordedPhoenixScore(ApiTestData.ChartId2, null, null, true, ApiTestData.Date1)
-            });
+            .ReturnsAsync(records);
         mediator.Setup(m => m.Send(It.IsAny<GetChartsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { ApiTestData.Chart1, ApiTestData.Chart2 });
-        var controller = new PhoenixScoresController(currentUser.Object, mediator.Object)
+        return new PhoenixScoresController(currentUser.Object, mediator.Object)
         {
             ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
         };
+    }
+
+    private static RecordedPhoenixScore ScoredS20 { get; } = new(ApiTestData.ChartId1, PhoenixScore.From(985000),
+        PhoenixPlate.ExtremeGame, false, ApiTestData.Date2);
+
+    private static RecordedPhoenixScore BrokenScoreless { get; } =
+        new(ApiTestData.ChartId2, null, null, true, ApiTestData.Date1);
+
+    private static RecordedPhoenixScore ScoredD22 { get; } = new(ApiTestData.ChartId2, PhoenixScore.From(995000),
+        PhoenixPlate.SuperbGame, false, ApiTestData.Date1);
+
+    [Fact]
+    public async Task GetPreservesPagedResponseShapeIncludingBrokenScorelessRecords()
+    {
+        var controller = BuildController(ScoredS20, BrokenScoreless);
 
         var result = await controller.Get(page: 1, count: 50);
 
@@ -50,6 +59,8 @@ public sealed class PhoenixScoresApiShapeTests
                   "plate": "Extreme Game",
                   "letterGrade": "SS\u002B",
                   "score": 985000,
+                  "pumbility": 897,
+                  "pumbilityPlus": 897,
                   "isBroken": false,
                   "recordedDate": "2026-02-20T00:00:00+00:00",
                   "chart": {
@@ -69,6 +80,8 @@ public sealed class PhoenixScoresApiShapeTests
                   "plate": null,
                   "letterGrade": null,
                   "score": null,
+                  "pumbility": null,
+                  "pumbilityPlus": null,
                   "isBroken": true,
                   "recordedDate": "2026-01-15T00:00:00+00:00",
                   "chart": {
@@ -87,5 +100,148 @@ public sealed class PhoenixScoresApiShapeTests
               ]
             }
             """, result);
+    }
+
+    [Fact]
+    public async Task GetSortsByPumbilityDescendingWithScorelessRecordsLast()
+    {
+        var controller = BuildController(ScoredS20, BrokenScoreless, ScoredD22);
+
+        var result = await controller.Get(page: 1, count: 50, sortBy: "Pumbility");
+
+        JsonApproval.AssertWireShape("""
+            {
+              "page": 1,
+              "count": 3,
+              "totalResults": 3,
+              "results": [
+                {
+                  "plate": "Superb Game",
+                  "letterGrade": "SSS\u002B",
+                  "score": 995000,
+                  "pumbility": 1320,
+                  "pumbilityPlus": 1320,
+                  "isBroken": false,
+                  "recordedDate": "2026-01-15T00:00:00+00:00",
+                  "chart": {
+                    "id": "22222222-2222-2222-2222-222222222222",
+                    "type": "Double",
+                    "shorthand": "D22",
+                    "level": 22,
+                    "noteCount": 845,
+                    "song": {
+                      "name": "District 1",
+                      "type": "Arcade",
+                      "imagePath": "https://piuimages.example.com/district1.png"
+                    }
+                  }
+                },
+                {
+                  "plate": "Extreme Game",
+                  "letterGrade": "SS\u002B",
+                  "score": 985000,
+                  "pumbility": 897,
+                  "pumbilityPlus": 897,
+                  "isBroken": false,
+                  "recordedDate": "2026-02-20T00:00:00+00:00",
+                  "chart": {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "type": "Single",
+                    "shorthand": "S20",
+                    "level": 20,
+                    "noteCount": 731,
+                    "song": {
+                      "name": "Conflict",
+                      "type": "Arcade",
+                      "imagePath": "https://piuimages.example.com/conflict.png"
+                    }
+                  }
+                },
+                {
+                  "plate": null,
+                  "letterGrade": null,
+                  "score": null,
+                  "pumbility": null,
+                  "pumbilityPlus": null,
+                  "isBroken": true,
+                  "recordedDate": "2026-01-15T00:00:00+00:00",
+                  "chart": {
+                    "id": "22222222-2222-2222-2222-222222222222",
+                    "type": "Double",
+                    "shorthand": "D22",
+                    "level": 22,
+                    "noteCount": 845,
+                    "song": {
+                      "name": "District 1",
+                      "type": "Arcade",
+                      "imagePath": "https://piuimages.example.com/district1.png"
+                    }
+                  }
+                }
+              ]
+            }
+            """, result);
+    }
+
+    [Fact]
+    public async Task GetAppliesLevelAndPlateFiltersBeforePaging()
+    {
+        var controller = BuildController(ScoredS20, BrokenScoreless, ScoredD22);
+
+        var result = await controller.Get(page: 1, count: 50, minLevel: 21, minPlate: "Superb Game");
+
+        JsonApproval.AssertWireShape("""
+            {
+              "page": 1,
+              "count": 1,
+              "totalResults": 1,
+              "results": [
+                {
+                  "plate": "Superb Game",
+                  "letterGrade": "SSS\u002B",
+                  "score": 995000,
+                  "pumbility": 1320,
+                  "pumbilityPlus": 1320,
+                  "isBroken": false,
+                  "recordedDate": "2026-01-15T00:00:00+00:00",
+                  "chart": {
+                    "id": "22222222-2222-2222-2222-222222222222",
+                    "type": "Double",
+                    "shorthand": "D22",
+                    "level": 22,
+                    "noteCount": 845,
+                    "song": {
+                      "name": "District 1",
+                      "type": "Arcade",
+                      "imagePath": "https://piuimages.example.com/district1.png"
+                    }
+                  }
+                }
+              ]
+            }
+            """, result);
+    }
+
+    [Theory]
+    [InlineData("SortBy", "banana")]
+    [InlineData("SortDir", "sideways")]
+    [InlineData("ChartType", "Quad")]
+    [InlineData("MinLetterGrade", "Z")]
+    [InlineData("MinPlate", "Wooden Game")]
+    public async Task GetRejectsInvalidParametersWithBadRequest(string parameter, string value)
+    {
+        var controller = BuildController(ScoredS20);
+
+        var result = parameter switch
+        {
+            "SortBy" => await controller.Get(page: 1, count: 50, sortBy: value),
+            "SortDir" => await controller.Get(page: 1, count: 50, sortDir: value),
+            "ChartType" => await controller.Get(page: 1, count: 50, chartType: value),
+            "MinLetterGrade" => await controller.Get(page: 1, count: 50, minLetterGrade: value),
+            _ => await controller.Get(page: 1, count: 50, minPlate: value)
+        };
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains(parameter, (string)badRequest.Value!);
     }
 }

--- a/ScoreTracker/ScoreTracker/Controllers/Api/PhoenixScoresController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/PhoenixScoresController.cs
@@ -13,8 +13,11 @@ using Microsoft.AspNetCore.Mvc;
 using ScoreTracker.Application.Commands;
 using ScoreTracker.Application.Queries;
 using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.SharedKernel.Models;
 using ScoreTracker.Domain.SecondaryPorts;
 using ScoreTracker.SharedKernel.ValueTypes;
+using Chart = ScoreTracker.SharedKernel.Models.Chart;
 using ScoreTracker.Web.Dtos.Api;
 using ScoreTracker.Web.Security;
 
@@ -87,28 +90,130 @@ public sealed class PhoenixScoresController : Controller
         return Ok();
     }
 
+    private static readonly string[] SortKeys =
+        { "RecordedDate", "Score", "LetterGrade", "Plate", "Level", "Pumbility", "PumbilityPlus" };
+
     [HttpGet]
     public async Task<IActionResult> Get([FromQuery(Name = "Page")] [DefaultValue(1)] int page,
-        [FromQuery(Name = "Count")] [DefaultValue(50)] int count = 50)
+        [FromQuery(Name = "Count")] [DefaultValue(50)] int count = 50,
+        [FromQuery(Name = "SortBy")] [DefaultValue("RecordedDate")] string sortBy = "RecordedDate",
+        [FromQuery(Name = "SortDir")] [DefaultValue("Desc")] string sortDir = "Desc",
+        [FromQuery(Name = "MinLevel")] int? minLevel = null,
+        [FromQuery(Name = "MaxLevel")] int? maxLevel = null,
+        [FromQuery(Name = "ChartType")] string? chartType = null,
+        [FromQuery(Name = "MinLetterGrade")] string? minLetterGrade = null,
+        [FromQuery(Name = "MinPlate")] string? minPlate = null,
+        [FromQuery(Name = "IsBroken")] bool? isBroken = null)
     {
+        var sortKey = SortKeys.FirstOrDefault(k => k.Equals(sortBy, StringComparison.OrdinalIgnoreCase));
+        if (sortKey == null) return BadRequest($"SortBy is invalid, valid values: {string.Join(", ", SortKeys)}");
+
+        if (!sortDir.Equals("Asc", StringComparison.OrdinalIgnoreCase) &&
+            !sortDir.Equals("Desc", StringComparison.OrdinalIgnoreCase))
+            return BadRequest("SortDir is invalid, valid values: Asc, Desc");
+        var descending = sortDir.Equals("Desc", StringComparison.OrdinalIgnoreCase);
+
+        ChartType? typeFilter = null;
+        if (chartType != null)
+        {
+            if (!Enum.TryParse<ChartType>(chartType, true, out var parsedType))
+                return BadRequest(
+                    $"ChartType is invalid, valid values: {string.Join(", ", Enum.GetNames<ChartType>())}");
+            typeFilter = parsedType;
+        }
+
+        PhoenixLetterGrade? minGrade = null;
+        if (minLetterGrade != null)
+        {
+            minGrade = Enum.GetValues<PhoenixLetterGrade>().Cast<PhoenixLetterGrade?>()
+                .FirstOrDefault(g =>
+                    g!.Value.ToString().Equals(minLetterGrade, StringComparison.OrdinalIgnoreCase) ||
+                    g!.Value.GetName().Equals(minLetterGrade, StringComparison.OrdinalIgnoreCase));
+            if (minGrade == null)
+                return BadRequest(
+                    $"MinLetterGrade is invalid, valid values: {string.Join(", ", Enum.GetValues<PhoenixLetterGrade>().Select(g => g.GetName()))}");
+        }
+
+        PhoenixPlate? minPlateFilter = null;
+        if (minPlate != null)
+        {
+            if (!Enum.TryParse<PhoenixPlate>(minPlate.Replace(" ", ""), true, out var parsedPlate))
+                return BadRequest(
+                    $"MinPlate is invalid, valid values: {string.Join(", ", Enum.GetValues<PhoenixPlate>().Select(p => p.GetName()))}");
+            minPlateFilter = parsedPlate;
+        }
+
         var records = (await _mediator.Send(new GetPhoenixRecordsQuery(_currentUser.User.Id))).ToArray();
-        var next = records.OrderByDescending(r => r.RecordedDate).Skip((page - 1) * count).Take(count).ToArray();
-        var charts = (await _mediator.Send(new GetChartsQuery(MixEnum.Phoenix, ChartIds: next.Select(r => r.ChartId))))
-            .ToDictionary(c => c.Id);
+        var charts = (await _mediator.Send(new GetChartsQuery(MixEnum.Phoenix))).ToDictionary(c => c.Id);
+
+        // Mirrors PlayerRatingSaga's per-score stats exactly so the API number matches the site.
+        var pumbilityScoring = ScoringConfiguration.PumbilityScoring(true);
+        var pumbilityPlusScoring = ScoringConfiguration.PumbilityPlus;
+        var rows = records.Where(r => charts.ContainsKey(r.ChartId)).Select(r =>
+        {
+            var chart = charts[r.ChartId];
+            return (Record: r, Chart: chart,
+                Pumbility: r.Score == null
+                    ? (double?)null
+                    : Math.Round(
+                        pumbilityScoring.GetScore(chart, r.Score.Value, r.Plate ?? PhoenixPlate.RoughGame,
+                            r.IsBroken), 2),
+                PumbilityPlus: r.Score == null
+                    ? (double?)null
+                    : Math.Round(
+                        pumbilityPlusScoring.GetScore(chart, r.Score.Value, r.Plate ?? PhoenixPlate.RoughGame,
+                            r.IsBroken), 2));
+        });
+
+        if (minLevel != null) rows = rows.Where(x => (int)x.Chart.Level >= minLevel.Value);
+        if (maxLevel != null) rows = rows.Where(x => (int)x.Chart.Level <= maxLevel.Value);
+        if (typeFilter != null) rows = rows.Where(x => x.Chart.Type == typeFilter.Value);
+        if (minGrade != null)
+            rows = rows.Where(x => x.Record.Score != null && x.Record.Score.Value.LetterGrade >= minGrade.Value);
+        if (minPlateFilter != null)
+            rows = rows.Where(x => x.Record.Plate != null && x.Record.Plate.Value >= minPlateFilter.Value);
+        if (isBroken != null) rows = rows.Where(x => x.Record.IsBroken == isBroken.Value);
+
+        var filtered = rows.ToArray();
+
+        object? Key((RecordedPhoenixScore Record, Chart Chart, double? Pumbility, double? PumbilityPlus) x)
+        {
+            return sortKey switch
+            {
+                "Score" => x.Record.Score == null ? null : (int)x.Record.Score.Value,
+                "LetterGrade" => x.Record.Score == null ? null : (int)x.Record.Score.Value.LetterGrade,
+                "Plate" => x.Record.Plate == null ? null : (int)x.Record.Plate.Value,
+                "Level" => (int)x.Chart.Level,
+                "Pumbility" => x.Pumbility,
+                "PumbilityPlus" => x.PumbilityPlus,
+                _ => x.Record.RecordedDate
+            };
+        }
+
+        // Nulls (scoreless/plateless records) always sort last; ties break newest-first so
+        // pagination stays stable within a sort.
+        var withNullsLast = filtered.OrderBy(x => Key(x) == null ? 1 : 0);
+        var ordered = descending
+            ? withNullsLast.ThenByDescending(Key).ThenByDescending(x => x.Record.RecordedDate)
+            : withNullsLast.ThenBy(Key).ThenByDescending(x => x.Record.RecordedDate);
+
+        var next = ordered.Skip((page - 1) * count).Take(count).ToArray();
 
         return Json(new PageDto<PhoenixRecordDto>
         {
             Count = next.Length,
             Page = page,
-            TotalResults = records.Length,
-            Results = next.Select(r => new PhoenixRecordDto
+            TotalResults = filtered.Length,
+            Results = next.Select(x => new PhoenixRecordDto
             {
-                IsBroken = r.IsBroken,
-                LetterGrade = r.Score?.LetterGrade.GetName(),
-                Plate = r.Plate?.GetName(),
-                RecordedDate = r.RecordedDate,
-                Score = r.Score,
-                Chart = new ChartDto(charts[r.ChartId])
+                IsBroken = x.Record.IsBroken,
+                LetterGrade = x.Record.Score?.LetterGrade.GetName(),
+                Plate = x.Record.Plate?.GetName(),
+                RecordedDate = x.Record.RecordedDate,
+                Score = x.Record.Score,
+                Pumbility = x.Pumbility,
+                PumbilityPlus = x.PumbilityPlus,
+                Chart = new ChartDto(x.Chart)
             }).ToArray()
         });
     }

--- a/ScoreTracker/ScoreTracker/Dtos/Api/PhoenixRecordDto.cs
+++ b/ScoreTracker/ScoreTracker/Dtos/Api/PhoenixRecordDto.cs
@@ -5,6 +5,10 @@
         public string? Plate { get; set; }
         public string? LetterGrade { get; set; }
         public int? Score { get; set; }
+
+        public double? Pumbility { get; set; }
+
+        public double? PumbilityPlus { get; set; }
         public bool IsBroken { get; set; }
         public DateTimeOffset RecordedDate { get; set; }
         public ChartDto Chart { get; set; }

--- a/docs/API.md
+++ b/docs/API.md
@@ -19,7 +19,7 @@ These endpoints are the contract for community tool makers. Their exact JSON wir
 | Area | Route | What's there |
 |---|---|---|
 | Charts | `api/charts` | Paginated chart listing by mix/level/type; `api/charts/random` for weighted random draws |
-| Phoenix scores | `api/phoenixScores` | GET your recorded scores (paginated); POST a single best attempt; POST `import` to trigger an official-site import with your game account credentials |
+| Phoenix scores | `api/phoenixScores` | GET your recorded scores (paginated; sortable via `SortBy` = RecordedDate/Score/LetterGrade/Plate/Level/Pumbility/PumbilityPlus + `SortDir`; filterable via `MinLevel`/`MaxLevel`/`ChartType`/`MinLetterGrade`/`MinPlate`/`IsBroken`; each record carries its Pumbility and PUMBILITY+ worth); POST a single best attempt; POST `import` to trigger an official-site import with your game account credentials |
 | Tier lists | `api/tierlist` | Four rankings per level+chart type: `scores`, `officialscores`, `passcount`, `popularity` |
 | Weekly charts | `api/weeklyCharts` | The current weekly challenge board and player scores on it |
 | Tournaments | `api/tournaments` | Tournament list; `api/tournaments/{id}/matches` for bracket matches, filterable by phase/state |


### PR DESCRIPTION
Community tool-maker request: sorting parameters for `GET api/phoenixScores` (newest, by plate, by pumbility worth) — plus the filters that usually turn out to be the other half of the ask.

## New query parameters (all optional, defaults byte-identical to today)

- `SortBy`: `RecordedDate` (default) | `Score` | `LetterGrade` | `Plate` | `Level` | `Pumbility` | `PumbilityPlus`
- `SortDir`: `Asc` | `Desc` (default)
- Filters: `MinLevel`, `MaxLevel`, `ChartType`, `MinLetterGrade` (accepts `AA+` or `AAPlus`), `MinPlate` (accepts `Superb Game` or `SuperbGame`), `IsBroken`
- Invalid values → 400 with the valid options listed

Semantics: scoreless/plateless records always sort last regardless of direction; plates sort by tier order, not alphabetically; ties break newest-first so pagination stays stable; `totalResults` reflects the filtered set.

## Deliberate public-contract addition

`PhoenixRecordDto` gains `pumbility` and `pumbilityPlus`, computed inline with the exact SharedKernel calls `PlayerRatingSaga` uses for the per-score stats table (`PumbilityScoring(true)` / `PumbilityPlus`, plate defaulting to Rough Game, broken passed through) so the API number always matches the site — rounded to 2 decimals for sane wire values. Sorting by an invisible key is bad API design, hence the field exposure; owner-approved in workshop.

## Tests

- `Tests.Api`: 14 passed — existing golden updated **intentionally** for the two new fields; new goldens pin the Pumbility sort order (nulls last) and filter behavior; a theory covers the five invalid-parameter 400s.
- `ScoreTracker.Tests`: 695 passed, untouched.
- `docs/API.md` route row updated; Swagger picks the new params up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)