### PR TITLE
Security hardening: global regex match timeout + [ApiController] validation

### DIFF
--- a/ScoreTracker/ScoreTracker/Controllers/Api/AdminController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/AdminController.cs
@@ -3,6 +3,7 @@ using ScoreTracker.Domain.SecondaryPorts;
 
 namespace ScoreTracker.Web.Controllers.Api;
 
+[ApiController]
 [Route("api/admin")]
 public sealed class AdminController : Controller
 {

--- a/ScoreTracker/ScoreTracker/Controllers/Api/ChartsController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/ChartsController.cs
@@ -17,6 +17,7 @@ using ScoreTracker.Web.Security;
 namespace ScoreTracker.Web.Controllers.Api;
 
 [ApiToken]
+[ApiController]
 [Route("api/charts")]
 [EnableCors("API")]
 public sealed class ChartsController : Controller

--- a/ScoreTracker/ScoreTracker/Controllers/Api/DevExportController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/DevExportController.cs
@@ -17,6 +17,7 @@ namespace ScoreTracker.Web.Controllers.Api;
 ///     </para>
 /// </summary>
 [ApiToken]
+[ApiController]
 [Route("dev/export")]
 [EnableCors("API")]
 [ApiExplorerSettings(IgnoreApi = true)]

--- a/ScoreTracker/ScoreTracker/Controllers/Api/PhoenixScoresController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/PhoenixScoresController.cs
@@ -24,6 +24,7 @@ using ScoreTracker.Web.Security;
 namespace ScoreTracker.Web.Controllers.Api;
 
 [ApiToken]
+[ApiController]
 [Route("api/phoenixScores")]
 [EnableCors("API")]
 public sealed class PhoenixScoresController : Controller
@@ -96,7 +97,7 @@ public sealed class PhoenixScoresController : Controller
         { "RecordedDate", "Score", "LetterGrade", "Plate", "Level", "Pumbility", "PumbilityPlus" };
 
     [HttpGet]
-    public async Task<IActionResult> Get([FromQuery(Name = "Page")] [DefaultValue(1)] int page,
+    public async Task<IActionResult> Get([FromQuery(Name = "Page")] [DefaultValue(1)] int page = 1,
         [FromQuery(Name = "Count")] [DefaultValue(50)] int count = 50,
         [FromQuery(Name = "SortBy")] [DefaultValue("RecordedDate")] string sortBy = "RecordedDate",
         [FromQuery(Name = "SortDir")] [DefaultValue("Desc")] string sortDir = "Desc",

--- a/ScoreTracker/ScoreTracker/Controllers/Api/TierListsController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/TierListsController.cs
@@ -15,6 +15,7 @@ using ScoreTracker.Web.Security;
 namespace ScoreTracker.Web.Controllers.Api
 {
     [ApiToken]
+    [ApiController]
     [Route("api/tierlist")]
     [EnableCors("API")]
     public class TierListsController : Controller

--- a/ScoreTracker/ScoreTracker/Controllers/Api/TournamentController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/TournamentController.cs
@@ -13,6 +13,7 @@ using ScoreTracker.Web.Security;
 namespace ScoreTracker.Web.Controllers.Api
 {
     [ApiToken]
+    [ApiController]
     [Route("api/tournaments")]
     [EnableCors("API")]
     public class TournamentController : Controller

--- a/ScoreTracker/ScoreTracker/Controllers/Api/WeeklyChartsController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/WeeklyChartsController.cs
@@ -15,6 +15,7 @@ using ScoreTracker.WeeklyChallenge.Contracts.Queries;
 namespace ScoreTracker.Web.Controllers.Api;
 
 [ApiToken]
+[ApiController]
 [Route("api/weeklyCharts")]
 [EnableCors("API")]
 public sealed class WeeklyChartsController : Controller

--- a/ScoreTracker/ScoreTracker/Controllers/LoginController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/LoginController.cs
@@ -291,6 +291,7 @@ public sealed class LoginController : Controller
     public async Task<IActionResult> DevLogin([FromForm] Guid userId)
     {
         if (!_devAuth.Value.Enabled) return NotFound();
+        if (!ModelState.IsValid) return BadRequest("Invalid user id");
 
         var user = await _mediator.Send(new GetUserByIdQuery(userId), HttpContext.RequestAborted);
         if (user == null) return BadRequest("User not found");

--- a/ScoreTracker/ScoreTracker/Controllers/SitemapController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/SitemapController.cs
@@ -6,6 +6,7 @@ using ScoreTracker.Domain.SecondaryPorts;
 
 namespace ScoreTracker.Web.Controllers
 {
+    [ApiController]
     [Route("")]
     public sealed class SitemapController : Controller
     {

--- a/ScoreTracker/ScoreTracker/Program.cs
+++ b/ScoreTracker/ScoreTracker/Program.cs
@@ -35,6 +35,11 @@ using Swashbuckle.AspNetCore.Filters;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+// Process-wide default regex match timeout (S6444 backstop): covers every Regex constructed
+// without an explicit timeout — chiefly OfficialMirror's parsing of scraped piugame HTML.
+// Must run before any Regex is constructed, so it stays the first statement.
+AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", TimeSpan.FromSeconds(5));
+
 var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 builder.Services.Configure<JsonSerializerOptions>(o =>


### PR DESCRIPTION
Fallout from the first SonarCloud security review (dashboard triage of the false positives/deliberate items was done directly in SonarCloud; this PR carries the two code-level fixes).

## Changes

- **Process-wide default regex match timeout (5s)** — set via `REGEX_DEFAULT_MATCH_TIMEOUT` as the first statement of `Program.cs`, before any `Regex` is constructed. This is the .NET-wide default applied to every regex that does not pass an explicit timeout, so it covers all 18 S6444 hotspot sites — chiefly OfficialMirror parsing scraped piugame HTML — plus anything added later. Patterns with explicit timeouts are unaffected.
- **`[ApiController]` on the attribute-routed `api/*` controllers + `SitemapController`** (S6967) — model-binding failures now short-circuit to a 400 instead of running actions on default-bound values. Success wire shapes are untouched (57/57 contract tests green); only responses to *malformed* requests change (ProblemDetails 400 instead of ad-hoc text or a 500).
- **`LoginController.DevLogin`** gets an explicit `ModelState` check instead — deliberately keeping `[ApiController]` semantics away from the browser-facing OAuth/redirect flows.
- **`PhoenixScoresController.Get`**: `Page` now genuinely defaults to 1. It previously had only the Swagger `[DefaultValue(1)]` annotation, so an omitted `Page` bound to 0 (and was echoed back as `"Page": 0`); under auto-validation it needed a real C# default.

## Verification

- `dotnet build` Release: 0 errors
- `ScoreTracker.Tests`: 746/746 passed
- `ScoreTracker.Tests.Api` (public API wire-shape contracts): 57/57 passed

## After merge

The 14 S6967 CRITICALs auto-resolve on the next main analysis. The 18 S6444 regex hotspots need a manual "reviewed: fixed" pass (the analyzer cannot see the process-wide default) — will run that once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
