### PR TITLE
Discord card iteration 2: more scores, enriched captions, title routing

### DIFF
--- a/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
@@ -124,8 +124,9 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     // old ratings/weekly messages are retired (titles keep a legacy announcement only
     // for site-detected titles, which no card covers).
     private const int ArtRowCap = 5;
-    private const int InlineRowCap = 10;
-    private const int CoOpRowCap = 3;
+    private const int NotableRowCap = 10;
+    private const int MoreScoresCap = 10;
+    private const int CoOpScoresCap = 5;
     private const int WeeklyLineCap = 4;
     private const int TitleNameCap = 10;
     private const int ProgressDeltaCap = 3;
@@ -166,9 +167,10 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
             return c.Flags != HighlightFlags.None || ReferenceEquals(c, bigGain);
         }
 
-        // Notable rows lead and own the art; within each group the universal noteworthy
-        // ordering applies — difficulty desc, scoring level desc, score desc (the same
-        // composite the Sessions page uses).
+        // Non-co-op rows in the universal noteworthy order (difficulty desc, scoring level
+        // desc, score desc): flagged rows lead as art/text rows and own the captions, the
+        // rest fall to the compact "More scores" block, anything past that to the grouped
+        // overflow line.
         var standard = known
             .Where(c => charts[c.ChartId].Type != ChartType.CoOp)
             .OrderByDescending(Notable)
@@ -176,20 +178,22 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
             .ThenByDescending(c => scoringLevels.TryGetValue(c.ChartId, out var sl) ? sl : 0)
             .ThenByDescending(c => (int)(bests[c.ChartId].Score ?? 0))
             .ToArray();
-        var notable = standard.Where(Notable).Take(InlineRowCap).ToArray();
+        var notable = standard.Where(Notable).Take(NotableRowCap).ToArray();
+        var notableIds = notable.Select(c => c.ChartId).ToHashSet();
+        var moreScores = standard.Where(c => !notableIds.Contains(c.ChartId)).Take(MoreScoresCap).ToArray();
 
-        // Co-ops always show (owner call) — they can't earn the S/D flags, so they get
-        // their own rows: up to 3, community co-op difficulty rating descending.
+        // Co-ops get their own compact bucket (owner call): up to 5, community co-op pass
+        // difficulty descending. They no longer take art rows.
         var coOpChanges = known.Where(c => charts[c.ChartId].Type == ChartType.CoOp).ToArray();
-        var coOpRows = Array.Empty<ScoreHighlightsCapturedEvent.HighlightedChange>();
+        var coOpScores = Array.Empty<ScoreHighlightsCapturedEvent.HighlightedChange>();
         if (coOpChanges.Length > 0)
         {
             var coOpRatings = (await _mediator.Send(new GetCoOpRatingsQuery(), context.CancellationToken))
                 .ToDictionary(r => r.ChartId, r => r.Ratings.Count > 0 ? r.Ratings.Values.Max(l => (int)l) : 0);
-            coOpRows = coOpChanges
+            coOpScores = coOpChanges
                 .OrderByDescending(c => coOpRatings.GetValueOrDefault(c.ChartId, 0))
                 .ThenByDescending(c => (int)(bests[c.ChartId].Score ?? 0))
-                .Take(CoOpRowCap)
+                .Take(CoOpScoresCap)
                 .ToArray();
         }
 
@@ -209,7 +213,7 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
             // The board read is a flex, not a fact the card owes anyone.
         }
 
-        var inputs = new SnapshotInputs(e, user, known, notable, coOpRows, charts, bests, weekly);
+        var inputs = new SnapshotInputs(e, user, known, notable, moreScores, coOpScores, charts, bests, weekly);
         var message = await BuildSnapshotCard(inputs, context.CancellationToken);
         await SendRichToCommunityDiscords(user.Id, new[] { message }, context.CancellationToken);
     }
@@ -220,7 +224,8 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         User User,
         ScoreHighlightsCapturedEvent.HighlightedChange[] Known,
         ScoreHighlightsCapturedEvent.HighlightedChange[] Notable,
-        ScoreHighlightsCapturedEvent.HighlightedChange[] CoOpRows,
+        ScoreHighlightsCapturedEvent.HighlightedChange[] MoreScores,
+        ScoreHighlightsCapturedEvent.HighlightedChange[] CoOpScores,
         Dictionary<Guid, Chart> Charts,
         Dictionary<Guid, RecordedPhoenixScore> Bests,
         WeeklyPlacementRecord[] Weekly);
@@ -238,6 +243,8 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         // ③ Notable scores: art while the slots last, individual text rows after,
         // everything else one grouped count line.
         AddNotableRows(blocks, inputs);
+        AddCompactBucket(blocks, inputs.MoreScores, inputs, "More scores");
+        AddCompactBucket(blocks, inputs.CoOpScores, inputs, "Co-op");
         AddOverflowLine(blocks, inputs);
 
         var passCharts = inputs.Known
@@ -267,7 +274,7 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     private static void AddNotableRows(List<IRichBotBlock> blocks, SnapshotInputs inputs)
     {
         var artLeft = ArtRowCap;
-        foreach (var change in inputs.Notable.Concat(inputs.CoOpRows))
+        foreach (var change in inputs.Notable)
         {
             var chart = inputs.Charts[change.ChartId];
             var text = RowText(change, chart, inputs.Bests[change.ChartId], IsBigGain(change, inputs.Known));
@@ -275,9 +282,27 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         }
     }
 
+    // The low-ceremony buckets (owner call): one compact line per score in a single text
+    // block — difficulty, song, score, grade — no art, no caption. Non-co-op "More scores"
+    // and co-op each get their own labelled block.
+    private static void AddCompactBucket(List<IRichBotBlock> blocks,
+        ScoreHighlightsCapturedEvent.HighlightedChange[] rows, SnapshotInputs inputs, string label)
+    {
+        if (rows.Length == 0) return;
+        var lines = rows.Select(c => CompactRow(inputs.Charts[c.ChartId], inputs.Bests[c.ChartId]));
+        blocks.Add(new RichBotText($"-# {label}\n" + string.Join("\n", lines)));
+    }
+
+    private static string CompactRow(Chart chart, RecordedPhoenixScore best)
+    {
+        return $"#DIFFICULTY|{chart.DifficultyString}# {chart.Song.Name} — **{(int)best.Score!.Value:N0}** " +
+               $"#LETTERGRADE|{best.Score!.Value.LetterGrade}|{best.IsBroken}##PLATE|{best.Plate}#";
+    }
+
     private static void AddOverflowLine(List<IRichBotBlock> blocks, SnapshotInputs inputs)
     {
-        var shown = inputs.Notable.Concat(inputs.CoOpRows).Select(c => c.ChartId).ToHashSet();
+        var shown = inputs.Notable.Concat(inputs.MoreScores).Concat(inputs.CoOpScores)
+            .Select(c => c.ChartId).ToHashSet();
         var rest = inputs.Known.Where(c => !shown.Contains(c.ChartId)).ToArray();
         if (rest.Length == 0) return;
 
@@ -370,14 +395,14 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     {
         var lines = new List<string>();
         var titles = e.Milestones.Where(m => m.Kind == MilestoneKind.TitleCompleted).ToArray();
-        lines.AddRange(titles.Take(TitleNameCap).Select(t => $"🏅 **{t.Title}** completed"));
+        lines.AddRange(titles.Take(TitleNameCap).Select(t => $"🏅 **{Bracket(t.Title)}** completed"));
         if (titles.Length > TitleNameCap)
             lines.Add($"…and {titles.Length - TitleNameCap} more titles");
 
         // Paragon gains are never counted or aggregated — the new grade IS the content
         // (owner call), so every gain is its own grade-named line.
         var paragons = e.Milestones.Where(m => m.Kind == MilestoneKind.ParagonLevelGain).ToArray();
-        lines.AddRange(paragons.Select(p => $"🏅 **{p.Title}** paragon → {ParagonEmoji(p.Detail)}"));
+        lines.AddRange(paragons.Select(p => $"🏅 **{Bracket(p.Title)}** paragon → {ParagonEmoji(p.Detail)}"));
 
         foreach (var lamp in e.Milestones.Where(m => m.Kind is MilestoneKind.FolderPassLamp
                      or MilestoneKind.FolderGradeLamp or MilestoneKind.FolderPlateLamp))
@@ -387,11 +412,11 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
             $"🏆 **#{w.Place}** on {charts[w.ChartId].Song.Name} " +
             $"#DIFFICULTY|{charts[w.ChartId].DifficultyString}# weekly"));
 
-        // The nothing-completed fallback: real per-title progress deltas (owner call),
-        // nearest to complete first.
-        if (!titles.Any() && !paragons.Any())
-            lines.AddRange(e.TitleProgress.Take(ProgressDeltaCap).Select(d =>
-                $"🏅 {d.Title} {(int)(d.OldPercent * 100)}% → **{(int)(d.NewPercent * 100)}%**"));
+        // Generic title progress (difficulty/co-op) always rides the top section, nearest to
+        // complete first (owner call) — completed titles show only their completion line, and
+        // chart-specific skill progress rides the per-row caption instead.
+        lines.AddRange(e.TitleProgress.Take(ProgressDeltaCap).Select(d =>
+            $"🏅 {Bracket(d.Title)} {(int)(d.OldPercent * 100)}% → **{(int)(d.NewPercent * 100)}%**"));
 
         return lines;
     }
@@ -436,7 +461,7 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
                 cancellationToken);
             if (total > 0)
                 parts.Add(
-                    $"#DIFFICULTY|{group.Key.Type.GetShortHand()}{group.Key.Level}# {clears}/{total} ({100.0 * clears / total:0.0}%)");
+                    $"#DIFFICULTY|{group.Key.Type.GetShortHand()}{group.Key.Level}# {clears}/{total}");
         }
 
         return string.Join(" · ", parts);
@@ -462,7 +487,7 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     {
         return $"#DIFFICULTY|{chart.DifficultyString}# {SongLink(change, chart, bigGain)}\n" +
                $"**{(int)best.Score!.Value:N0}** #LETTERGRADE|{best.Score!.Value.LetterGrade}|{best.IsBroken}##PLATE|{best.Plate}#" +
-               FlagCaption(change.Flags, bigGain);
+               FlagCaption(change, chart, best, bigGain);
     }
 
     private static string UpscoreRow(ScoreHighlightsCapturedEvent.HighlightedChange change, Chart chart,
@@ -479,7 +504,7 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         }
 
         return row + $" #LETTERGRADE|{best.Score!.Value.LetterGrade}|{best.IsBroken}##PLATE|{best.Plate}#" +
-               FlagCaption(change.Flags, bigGain);
+               FlagCaption(change, chart, best, bigGain);
     }
 
     private static string SongLink(ScoreHighlightsCapturedEvent.HighlightedChange change, Chart chart,
@@ -489,20 +514,65 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         return change.Flags == HighlightFlags.None && !bigGain ? link : $"**{link}**";
     }
 
-    // The why-it's-noteworthy caption, rendered as Discord subtext under the score.
-    // Vocabulary mirrors the Sessions page badge tooltips.
-    private static string FlagCaption(HighlightFlags flags, bool bigGain)
+    // The why-it's-noteworthy caption, rendered as Discord subtext under the score. Each flag
+    // renders its captured detail — the pumbility rank, the peer standing (or PG ratio), the
+    // skill title's score/threshold, the folder-debut ordinal. Vocabulary mirrors the
+    // Sessions page badges.
+    private static string FlagCaption(ScoreHighlightsCapturedEvent.HighlightedChange change, Chart chart,
+        RecordedPhoenixScore best, bool bigGain)
     {
+        var flags = change.Flags;
         if (flags == HighlightFlags.None && !bigGain) return string.Empty;
+        var d = change.Detail;
         var parts = new List<string>();
-        if (flags.HasFlag(HighlightFlags.PumbilityTop50)) parts.Add("👑 PUMBILITY top 50");
-        if (flags.HasFlag(HighlightFlags.ScoreQuality90)) parts.Add("📊 Top scores among peers");
-        if (flags.HasFlag(HighlightFlags.TitleProgress)) parts.Add("🏅 Title progress");
-        if (flags.HasFlag(HighlightFlags.FolderDebut)) parts.Add("🆕 Folder debut");
+        if (flags.HasFlag(HighlightFlags.PumbilityTop50))
+            parts.Add(d?.PumbilityRank != null ? $"👑 #{d.PumbilityRank} in your PUMBILITY" : "👑 PUMBILITY top 50");
+        if (flags.HasFlag(HighlightFlags.ScoreQuality90)) parts.Add(PeerCaption(d, best));
+        if (flags.HasFlag(HighlightFlags.TitleProgress)) parts.Add(SkillCaption(d));
+        if (flags.HasFlag(HighlightFlags.FolderDebut))
+            parts.Add(d?.FolderDebutOrdinal != null
+                ? $"🆕 {Ordinal(d.FolderDebutOrdinal.Value)} {chart.Type.GetShortHand()}{(int)chart.Level}"
+                : "🆕 Folder debut");
         if (flags.HasFlag(HighlightFlags.FolderCompletion90)) parts.Add("📁 Nearly complete folder");
         if (flags.HasFlag(HighlightFlags.CompetitiveImprover)) parts.Add("⬆ Raised competitive level");
         if (bigGain) parts.Add("💥 Biggest gain of the session");
         return "\n-# " + string.Join(" · ", parts);
+    }
+
+    private static string PeerCaption(HighlightDetail? d, RecordedPhoenixScore best)
+    {
+        if (d?.PeerCount is null or 0) return "📊 Top scores among peers";
+        var isPg = best.Score != null && (int)best.Score.Value == 1_000_000;
+        if (isPg && d.PeerPgCount != null)
+            return $"📊 PG · {d.PeerPgCount} of {d.PeerCount} peers have it";
+        return $"📊 #{(d.PeerBetterCount ?? 0) + 1} of {d.PeerCount} peers";
+    }
+
+    private static string SkillCaption(HighlightDetail? d)
+    {
+        if (d?.SkillTitleName == null) return "🏅 Title progress";
+        return d.SkillTitleScore != null && d.SkillTitleThreshold != null
+            ? $"🏅 {Bracket(d.SkillTitleName)} ({Abbrev(d.SkillTitleScore.Value)}/{Abbrev(d.SkillTitleThreshold.Value)})"
+            : $"🏅 {Bracket(d.SkillTitleName)}";
+    }
+
+    // In-game titles show bracketed ([Expert Lv. 4]); skill/co-op/boss names already carry
+    // their own bracket, so wrap only when one isn't there.
+    private static string Bracket(string? title)
+    {
+        if (string.IsNullOrEmpty(title)) return string.Empty;
+        return title.StartsWith('[') ? title : $"[{title}]";
+    }
+
+    private static string Ordinal(int n)
+    {
+        return n switch { 1 => "First", 2 => "Second", 3 => "Third", _ => $"#{n}" };
+    }
+
+    // Floored to thousands so a near-threshold score never rounds up to a false complete.
+    private static string Abbrev(int score)
+    {
+        return $"{score / 1000}k";
     }
 
     private static string Charts(int count)

--- a/ScoreTracker/ScoreTracker.Data/Migrations/20260709001035_AddScoreHighlightCaptionDetail.Designer.cs
+++ b/ScoreTracker/ScoreTracker.Data/Migrations/20260709001035_AddScoreHighlightCaptionDetail.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScoreTracker.Data.Persistence;
 
@@ -11,9 +12,11 @@ using ScoreTracker.Data.Persistence;
 namespace ScoreTracker.Data.Migrations
 {
     [DbContext(typeof(ChartAttemptDbContext))]
-    partial class ChartAttemptDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709001035_AddScoreHighlightCaptionDetail")]
+    partial class AddScoreHighlightCaptionDetail
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ScoreTracker/ScoreTracker.Data/Migrations/20260709001035_AddScoreHighlightCaptionDetail.cs
+++ b/ScoreTracker/ScoreTracker.Data/Migrations/20260709001035_AddScoreHighlightCaptionDetail.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScoreTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScoreHighlightCaptionDetail : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FolderDebutOrdinal",
+                schema: "scores",
+                table: "ScoreHighlight",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PeerBetterCount",
+                schema: "scores",
+                table: "ScoreHighlight",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PeerCount",
+                schema: "scores",
+                table: "ScoreHighlight",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PeerPgCount",
+                schema: "scores",
+                table: "ScoreHighlight",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PumbilityRank",
+                schema: "scores",
+                table: "ScoreHighlight",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SkillTitleName",
+                schema: "scores",
+                table: "ScoreHighlight",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SkillTitleScore",
+                schema: "scores",
+                table: "ScoreHighlight",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SkillTitleThreshold",
+                schema: "scores",
+                table: "ScoreHighlight",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FolderDebutOrdinal",
+                schema: "scores",
+                table: "ScoreHighlight");
+
+            migrationBuilder.DropColumn(
+                name: "PeerBetterCount",
+                schema: "scores",
+                table: "ScoreHighlight");
+
+            migrationBuilder.DropColumn(
+                name: "PeerCount",
+                schema: "scores",
+                table: "ScoreHighlight");
+
+            migrationBuilder.DropColumn(
+                name: "PeerPgCount",
+                schema: "scores",
+                table: "ScoreHighlight");
+
+            migrationBuilder.DropColumn(
+                name: "PumbilityRank",
+                schema: "scores",
+                table: "ScoreHighlight");
+
+            migrationBuilder.DropColumn(
+                name: "SkillTitleName",
+                schema: "scores",
+                table: "ScoreHighlight");
+
+            migrationBuilder.DropColumn(
+                name: "SkillTitleScore",
+                schema: "scores",
+                table: "ScoreHighlight");
+
+            migrationBuilder.DropColumn(
+                name: "SkillTitleThreshold",
+                schema: "scores",
+                table: "ScoreHighlight");
+        }
+    }
+}

--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixSkillTitle.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix/PhoenixSkillTitle.cs
@@ -24,6 +24,10 @@ public sealed class PhoenixSkillTitle : PhoenixTitle, ISpecificChartTitle
 
     public override bool PopulatesFromDatabase => false;
 
+    // Owner call: skill progress measures the climb from a decent pass (900k) to the SSS,
+    // so a fresh pass doesn't read as nearly complete.
+    public override int CompletionFloor => 900_000;
+
 
     public override double CompletionProgress(Chart chart, RecordedPhoenixScore attempt)
     {

--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/Title.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/Title.cs
@@ -20,4 +20,11 @@ public abstract class Title
     public Name Category { get; }
     public string Description { get; }
     public int CompletionRequired { get; }
+
+    /// <summary>
+    ///     The progress baseline below which "how close" is meaningless — 0 for
+    ///     rating-accumulation titles, but skill titles floor at a decent pass so a
+    ///     barely-passed chart doesn't read as ~98% of the way to the SSS.
+    /// </summary>
+    public virtual int CompletionFloor => 0;
 }

--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/TitleProgress.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/TitleProgress.cs
@@ -20,5 +20,19 @@ public abstract class TitleProgress
         _forcedComplete = true;
     }
 
+    /// <summary>
+    ///     Progress toward completion as a 0–1 fraction, rebased on the title's
+    ///     <see cref="Titles.Title.CompletionFloor" /> so skill titles measure the climb
+    ///     from a decent pass to the target rather than from zero.
+    /// </summary>
+    public double PercentComplete
+    {
+        get
+        {
+            var span = Title.CompletionRequired - Title.CompletionFloor;
+            return span <= 0 ? 0 : Math.Clamp((CompletionCount - Title.CompletionFloor) / (double)span, 0, 1);
+        }
+    }
+
     public virtual string AdditionalNote => string.Empty;
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/HighlightCaptureSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/HighlightCaptureSaga.cs
@@ -88,13 +88,14 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
     {
         var e = context.Message;
         var flags = new Dictionary<Guid, HighlightFlags>();
+        var details = new Dictionary<Guid, HighlightDetail>();
         var writes = new List<ScoreHighlightWrite>();
         var lamps = new List<PlayerMilestoneWrite>();
 
         if (e.Mix is MixEnum.Phoenix or MixEnum.Phoenix2 && e.Changes.Any())
             try
             {
-                writes = await ComputeFlags(e, flags, lamps, context.CancellationToken);
+                writes = await ComputeFlags(e, flags, details, lamps, context.CancellationToken);
             }
             catch (Exception ex)
             {
@@ -105,6 +106,7 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
                 // `writes` was never reassigned on the throwing path — only the
                 // by-reference collections the compute mutated need clearing.
                 flags.Clear();
+                details.Clear();
                 lamps.Clear();
             }
 
@@ -154,7 +156,8 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
         await context.Publish(ScoreHighlightsCapturedEvent.Create(e.OccurredAt, e.UserId, e.Mix, e.SessionId,
             e.Changes.Select(c => new ScoreHighlightsCapturedEvent.HighlightedChange(c.ChartId, c.IsNewPass,
                 c.OldScore, c.NewScore, c.Plate, c.IsBroken,
-                flags.TryGetValue(c.ChartId, out var f) ? f : HighlightFlags.None)).ToArray(),
+                flags.TryGetValue(c.ChartId, out var f) ? f : HighlightFlags.None,
+                details.GetValueOrDefault(c.ChartId))).ToArray(),
             milestones, titleProgress));
     }
 
@@ -188,35 +191,36 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
     private sealed record CaptureData(
         Dictionary<Guid, Chart> Charts,
         Dictionary<Guid, RecordedPhoenixScore> Bests,
-        HashSet<Guid> Top50,
+        Dictionary<Guid, int> Top50Ranks,
         PhoenixTitleProgress[] IncompleteTitles,
         IDictionary<Guid, double> ScoringLevels,
         Dictionary<(ChartType Type, DifficultyLevel Level), int> FolderSizes,
         Dictionary<(ChartType Type, DifficultyLevel Level), int> FolderClears);
 
     private async Task<List<ScoreHighlightWrite>> ComputeFlags(PlayerScoresUpdatedEvent e,
-        Dictionary<Guid, HighlightFlags> flags, List<PlayerMilestoneWrite> lamps,
-        CancellationToken cancellationToken)
+        Dictionary<Guid, HighlightFlags> flags, Dictionary<Guid, HighlightDetail> details,
+        List<PlayerMilestoneWrite> lamps, CancellationToken cancellationToken)
     {
         var data = await LoadCaptureData(e, cancellationToken);
         var known = e.Changes
             .Where(c => data.Charts.ContainsKey(c.ChartId) && data.Bests.ContainsKey(c.ChartId))
             .ToArray();
 
-        FlagTop50AndTitleProgress(known, data, flags);
+        FlagTop50AndTitleProgress(known, data, flags, details);
         foreach (var folder in known.GroupBy(c => (data.Charts[c.ChartId].Type, data.Charts[c.ChartId].Level)))
         {
-            await FlagScoreQuality(e, folder.Key, folder.ToArray(), data, flags, cancellationToken);
+            await FlagScoreQuality(e, folder.Key, folder.ToArray(), data, flags, details, cancellationToken);
             var newPasses = folder.Where(c => c.IsNewPass && !data.Bests[c.ChartId].IsBroken).ToArray();
             CaptureFolderLamps(e, folder.ToArray(), folder.Key, data, newPasses.Length, lamps);
-            FlagFolderCompletionAndDebut(folder.Key, newPasses, data, flags);
+            FlagFolderCompletionAndDebut(folder.Key, newPasses, data, flags, details);
         }
 
         return known
             .Where(c => flags.GetValueOrDefault(c.ChartId) != HighlightFlags.None)
             .Select(c => new ScoreHighlightWrite(c.ChartId, e.SessionId, e.OccurredAt, flags[c.ChartId],
                 data.Charts[c.ChartId].Level,
-                data.ScoringLevels.TryGetValue(c.ChartId, out var sl) ? sl : null))
+                data.ScoringLevels.TryGetValue(c.ChartId, out var sl) ? sl : null,
+                details.GetValueOrDefault(c.ChartId)))
             .ToList();
     }
 
@@ -225,8 +229,10 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
     {
         var charts = (await _charts.GetCharts(e.Mix, cancellationToken: cancellationToken)).ToDictionary(c => c.Id);
         var bests = (await _scores.GetBestScores(e.Mix, e.UserId, cancellationToken)).ToDictionary(s => s.ChartId);
+        // Ordered pumbility-desc, so a chart's index is its rank in the player's Pumbility.
         var top50 = (await _mediator.Send(new GetTop50ForPlayerQuery(e.UserId, null, Mix: e.Mix), cancellationToken))
-            .Select(s => s.ChartId).ToHashSet();
+            .Select((s, i) => (s.ChartId, Rank: i + 1))
+            .ToDictionary(x => x.ChartId, x => x.Rank);
         var completed = (await _titles.GetCompletedTitles(e.Mix, e.UserId, cancellationToken))
             .Select(t => t.Title).ToHashSet();
         var incompleteTitles = (e.Mix == MixEnum.Phoenix
@@ -247,8 +253,17 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
         return new CaptureData(charts, bests, top50, incompleteTitles, scoringLevels, folderSizes, folderClears);
     }
 
+    private const int PerfectGameScore = 1_000_000;
+
+    // Accumulates per-chart caption detail across the flag passes. Records are immutable,
+    // so each pass reads the current value and `with`-updates the field it owns.
+    private static HighlightDetail Detail(Dictionary<Guid, HighlightDetail> details, Guid id)
+    {
+        return details.TryGetValue(id, out var d) ? d : new HighlightDetail();
+    }
+
     private static void FlagTop50AndTitleProgress(PlayerScoresUpdatedEvent.ScoreChange[] known,
-        CaptureData data, Dictionary<Guid, HighlightFlags> flags)
+        CaptureData data, Dictionary<Guid, HighlightFlags> flags, Dictionary<Guid, HighlightDetail> details)
     {
         foreach (var change in known)
         {
@@ -257,10 +272,31 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
             if (best.IsBroken || best.Score == null) continue;
 
             var f = HighlightFlags.None;
-            if (data.Top50.Contains(chart.Id)) f |= HighlightFlags.PumbilityTop50;
-            if (data.IncompleteTitles.Any(t => t.PhoenixTitle.CompletionProgress(chart, best) > 0))
+            if (data.Top50Ranks.TryGetValue(chart.Id, out var rank))
+            {
+                f |= HighlightFlags.PumbilityTop50;
+                details[chart.Id] = Detail(details, chart.Id) with { PumbilityRank = rank };
+            }
+
+            // Per-row title progress is chart-specific only (skill titles). Generic
+            // difficulty/co-op progress rides the card's top section as % deltas, not a row
+            // caption — so a level's worth of upscores no longer each claim a title flag.
+            var skill = data.IncompleteTitles
+                .Select(t => t.PhoenixTitle)
+                .OfType<PhoenixSkillTitle>()
+                .FirstOrDefault(t => t.AppliesToChart(chart) && t.CompletionProgress(chart, best) > 0);
+            if (skill != null)
+            {
                 f |= HighlightFlags.TitleProgress;
-            if (f != HighlightFlags.None) flags[chart.Id] = f;
+                details[chart.Id] = Detail(details, chart.Id) with
+                {
+                    SkillTitleName = skill.Name.ToString(),
+                    SkillTitleScore = (int)best.Score.Value,
+                    SkillTitleThreshold = skill.CompletionRequired
+                };
+            }
+
+            if (f != HighlightFlags.None) flags[chart.Id] = flags.GetValueOrDefault(chart.Id) | f;
         }
     }
 
@@ -268,7 +304,8 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
     // have no Co-Op side).
     private async Task FlagScoreQuality(PlayerScoresUpdatedEvent e,
         (ChartType Type, DifficultyLevel Level) folder, PlayerScoresUpdatedEvent.ScoreChange[] folderChanges,
-        CaptureData data, Dictionary<Guid, HighlightFlags> flags, CancellationToken cancellationToken)
+        CaptureData data, Dictionary<Guid, HighlightFlags> flags, Dictionary<Guid, HighlightDetail> details,
+        CancellationToken cancellationToken)
     {
         if (folder.Type is not (ChartType.Single or ChartType.Double)) return;
         var cohort = await GetCohortScores(e.Mix, e.UserId, folder.Type, folder.Level, cancellationToken);
@@ -277,14 +314,28 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
             var best = data.Bests[change.ChartId];
             if (best.IsBroken || best.Score == null) continue;
             var cohortScores = cohort.GetValueOrDefault(change.ChartId, Array.Empty<PhoenixScore>());
-            if (ScoreRankings.TieInclusivePercentile(cohortScores, best.Score.Value) >= 0.9)
-                flags[change.ChartId] = flags.GetValueOrDefault(change.ChartId) | HighlightFlags.ScoreQuality90;
+            // "Top scores among peers" needs peers.
+            if (cohortScores.Length == 0) continue;
+            if (ScoreRankings.TieInclusivePercentile(cohortScores, best.Score.Value) < 0.9) continue;
+
+            var score = (int)best.Score.Value;
+            var pgCount = cohortScores.Count(s => (int)s == PerfectGameScore);
+            // A PG most peers also hold isn't noteworthy (owner call) — suppress it.
+            if (score == PerfectGameScore && pgCount * 2 > cohortScores.Length) continue;
+
+            flags[change.ChartId] = flags.GetValueOrDefault(change.ChartId) | HighlightFlags.ScoreQuality90;
+            details[change.ChartId] = Detail(details, change.ChartId) with
+            {
+                PeerCount = cohortScores.Length,
+                PeerBetterCount = cohortScores.Count(s => (int)s > score),
+                PeerPgCount = pgCount
+            };
         }
     }
 
     private static void FlagFolderCompletionAndDebut((ChartType Type, DifficultyLevel Level) folder,
         PlayerScoresUpdatedEvent.ScoreChange[] newPasses, CaptureData data,
-        Dictionary<Guid, HighlightFlags> flags)
+        Dictionary<Guid, HighlightFlags> flags, Dictionary<Guid, HighlightDetail> details)
     {
         if (newPasses.Length == 0) return;
         var size = data.FolderSizes.GetValueOrDefault(folder);
@@ -295,16 +346,22 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
                 flags[chartId] = flags.GetValueOrDefault(chartId) | HighlightFlags.FolderCompletion90;
 
         // Folder debut: the first 3 passes ever in this folder (S and D counted
-        // separately). A batch landing several at once debuts its top ones by
-        // noteworthy ordering.
-        var debutSlots = 3 - (clears - newPasses.Length);
+        // separately). A batch landing several at once debuts its top ones by noteworthy
+        // ordering; the ordinal (First/Second/Third) is the prior clear count plus place.
+        var priorClears = clears - newPasses.Length;
+        var debutSlots = 3 - priorClears;
         if (debutSlots <= 0) return;
+        var ordinal = priorClears;
         foreach (var chartId in newPasses
                      .OrderByDescending(c => data.ScoringLevels.TryGetValue(c.ChartId, out var sl) ? sl : 0)
                      .ThenByDescending(c => (int?)data.Bests[c.ChartId].Score ?? 0)
                      .Take(debutSlots)
                      .Select(p => p.ChartId))
+        {
+            ordinal++;
             flags[chartId] = flags.GetValueOrDefault(chartId) | HighlightFlags.FolderDebut;
+            details[chartId] = Detail(details, chartId) with { FolderDebutOrdinal = ordinal };
+        }
     }
 
     // Folder lamps fire on the crossing, every letter and plate boundary, no floor

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/HighlightCaptureSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/HighlightCaptureSaga.cs
@@ -33,7 +33,9 @@ namespace ScoreTracker.PlayerProgress.Application;
 internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>,
     IConsumer<UserWeeklyChartsProgressedEvent>,
     IRequestHandler<GetScoreHighlightsQuery, IEnumerable<ScoreHighlightRecord>>,
-    IRequestHandler<GetPlayerMilestonesQuery, IEnumerable<PlayerMilestoneRecord>>
+    IRequestHandler<GetPlayerMilestonesQuery, IEnumerable<PlayerMilestoneRecord>>,
+    IRequestHandler<GetScoreHighlightsForSessionsQuery, IEnumerable<ScoreHighlightRecord>>,
+    IRequestHandler<GetPlayerMilestonesForSessionsQuery, IEnumerable<PlayerMilestoneRecord>>
 {
     private readonly IMemoryCache _cache;
     private readonly IChartRepository _charts;
@@ -168,6 +170,18 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
     {
         return await _milestones.GetMilestones(request.Mix, request.UserId, request.Since, request.Until,
             cancellationToken);
+    }
+
+    public async Task<IEnumerable<ScoreHighlightRecord>> Handle(GetScoreHighlightsForSessionsQuery request,
+        CancellationToken cancellationToken)
+    {
+        return await _highlights.GetHighlightsBySessions(request.UserId, request.SessionIds, cancellationToken);
+    }
+
+    public async Task<IEnumerable<PlayerMilestoneRecord>> Handle(GetPlayerMilestonesForSessionsQuery request,
+        CancellationToken cancellationToken)
+    {
+        return await _milestones.GetMilestonesBySessions(request.UserId, request.SessionIds, cancellationToken);
     }
 
     /// <summary>Everything the flag computation reads, loaded once per batch.</summary>

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/TitleSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/TitleSaga.cs
@@ -10,6 +10,7 @@ using ScoreTracker.Domain.Events;
 using ScoreTracker.Domain.Models;
 using ScoreTracker.SharedKernel.Models;
 using ScoreTracker.Domain.Models.Titles;
+using ScoreTracker.Domain.Models.Titles.Interface;
 using ScoreTracker.Domain.Models.Titles.Phoenix;
 using ScoreTracker.Domain.Models.Titles.Phoenix2;
 using ScoreTracker.Domain.Models.Titles.XX;
@@ -142,9 +143,13 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
 
     public async Task Consume(ConsumeContext<TitlesDetectedEvent> context)
     {
+        // The site path owns only the badges the score pipeline can't compute
+        // (CompletionRequired == 0): events, play/plate counts, staff. Difficulty, skill,
+        // boss-breaker and co-op completions ride the session card via the score path, so
+        // this path stops announcing them (it still saves everything — DB stays correct).
         await ProcessCharts(context.Message.Mix, context.Message.UserId,
             context.Message.TitlesFound.Select(Name.From),
-            context.CancellationToken);
+            context.CancellationToken, siteOnlyAnnounce: true);
     }
 
     private ParagonLevel GetLevel(TitleProgress tp)
@@ -154,7 +159,7 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
 
     private async Task<IReadOnlyList<PlayerMilestoneRecord>> ProcessCharts(MixEnum mix, Guid userId,
         IEnumerable<Name> newCharts, CancellationToken cancellationToken, Guid? sessionId = null,
-        bool announceLegacy = true)
+        bool announceLegacy = true, bool mint = true, bool siteOnlyAnnounce = false)
     {
         var existingTitles = (await _titles.GetCompletedTitles(mix, userId, cancellationToken))
             .ToDictionary(t => t.Title);
@@ -178,11 +183,22 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
         if (highest != null)
             await _titles.SetHighestDifficultyTitle(mix, userId, highest.Name, highest.Level, cancellationToken);
 
+        // The score path (CaptureSessionTitles) persists through here but mints its own
+        // milestones from the batch's before→after crossing, so it skips this tail.
+        if (!mint) return Array.Empty<PlayerMilestoneRecord>();
 
         var newCompleted = allCompleted.Where(c => !existingTitles.ContainsKey(c.Title))
             .Select(c => c.Title.ToString()).ToArray();
         var upgraded = allCompleted.Where(c =>
             existingTitles.ContainsKey(c.Title) && existingTitles[c.Title].ParagonLevel != c.ParagonLevel).ToArray();
+
+        // The site path announces only the badges the score pipeline can't compute.
+        if (siteOnlyAnnounce)
+        {
+            newCompleted = newCompleted.Where(n => GetTitleByName(mix, Name.From(n)).CompletionRequired == 0)
+                .ToArray();
+            upgraded = upgraded.Where(u => GetTitleByName(mix, u.Title).CompletionRequired == 0).ToArray();
+        }
 
         if (newCompleted.Length == 0 && upgraded.Length == 0) return Array.Empty<PlayerMilestoneRecord>();
 
@@ -226,9 +242,15 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
         if (request.Mix is not (MixEnum.Phoenix or MixEnum.Phoenix2))
             return new SessionTitlesResult(Array.Empty<PlayerMilestoneRecord>(), Array.Empty<TitleProgressDelta>());
 
+        // Persist the up-to-date title set (SaveTitles + highest) WITHOUT minting or
+        // announcing — the card's title milestones come from this batch's before→after
+        // crossing, which surfaces a completion even when the site-detection path already
+        // saved the same title (it fires first during imports).
+        await ProcessCharts(request.Mix, request.UserId, Array.Empty<Name>(), cancellationToken,
+            request.SessionId, announceLegacy: false, mint: false);
+
+        var milestones = await ComputeBatchCompletions(request, cancellationToken);
         var progress = await ComputeProgressDeltas(request, cancellationToken);
-        var milestones = await ProcessCharts(request.Mix, request.UserId, Array.Empty<Name>(), cancellationToken,
-            request.SessionId, announceLegacy: false);
         return new SessionTitlesResult(milestones, progress);
     }
 
@@ -239,7 +261,8 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
     ///     upscored chart reverts to its old score (old plate isn't on the event, so
     ///     plate-based progress is approximated by the current plate). Only titles
     ///     whose ROUNDED percent actually moved make the list, nearest-to-complete
-    ///     first, capped at 5 — the card shows at most 3.
+    ///     first, capped at 5 — the card shows at most 3. Chart-specific titles (skill,
+    ///     boss-breaker) are excluded: they ride the per-row caption, not the top deltas.
     /// </summary>
     private async Task<IReadOnlyList<TitleProgressDelta>> ComputeProgressDeltas(CaptureSessionTitles request,
         CancellationToken cancellationToken)
@@ -250,18 +273,12 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
             .Select(t => t.Title).ToHashSet();
         var current = (await _phoenixScores.GetBestScores(request.Mix, request.UserId, cancellationToken))
             .ToArray();
-        var changed = request.Changes.GroupBy(c => c.ChartId).ToDictionary(g => g.Key, g => g.First());
-        var before = current
-            .Where(s => !changed.TryGetValue(s.ChartId, out var c) || c.OldScore != null)
-            .Select(s => changed.TryGetValue(s.ChartId, out var c)
-                ? s with { Score = PhoenixScore.From(c.OldScore!.Value), IsBroken = c.IsNewPass }
-                : s)
-            .ToArray();
+        var before = BeforeScores(current, request.Changes);
 
         var beforeByTitle = BuildProgress(request.Mix, charts, before, completed)
             .ToDictionary(t => t.Title.Name);
         return BuildProgress(request.Mix, charts, current, completed)
-            .Where(t => !t.IsComplete && t.Title.CompletionRequired > 0)
+            .Where(t => !t.IsComplete && t.Title.CompletionRequired > 0 && t.Title is not ISpecificChartTitle)
             .Select(t => new TitleProgressDelta(t.Title.Name,
                 beforeByTitle.TryGetValue(t.Title.Name, out var b) ? Percent(b) : 0,
                 Percent(t)))
@@ -269,6 +286,63 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
             .OrderByDescending(d => d.NewPercent)
             .Take(5)
             .ToArray();
+    }
+
+    // The batch's before-state: current scores with the changed charts reverted to their
+    // old score (a chart with no prior score drops out; an upscored chart reverts, its plate
+    // approximated by the current one).
+    private static RecordedPhoenixScore[] BeforeScores(IReadOnlyList<RecordedPhoenixScore> current,
+        IReadOnlyList<PlayerScoresUpdatedEvent.ScoreChange> changes)
+    {
+        var changed = changes.GroupBy(c => c.ChartId).ToDictionary(g => g.Key, g => g.First());
+        return current
+            .Where(s => !changed.TryGetValue(s.ChartId, out var c) || c.OldScore != null)
+            .Select(s => changed.TryGetValue(s.ChartId, out var c)
+                ? s with { Score = PhoenixScore.From(c.OldScore!.Value), IsBroken = c.IsNewPass }
+                : s)
+            .ToArray();
+    }
+
+    /// <summary>
+    ///     Title completions and paragon gains this batch crossed, from the changes' old→new
+    ///     scores against a SCORE-ONLY completion state (empty completed set) — so a fresh
+    ///     crossing surfaces even when the site-detection path already persisted the title
+    ///     (it fires first during imports). Mints the milestones the snapshot card renders,
+    ///     chart-specific titles (skill, boss-breaker) included.
+    /// </summary>
+    private async Task<IReadOnlyList<PlayerMilestoneRecord>> ComputeBatchCompletions(CaptureSessionTitles request,
+        CancellationToken cancellationToken)
+    {
+        var charts = (await _charts.GetCharts(request.Mix, cancellationToken: cancellationToken))
+            .ToDictionary(c => c.Id);
+        var current = (await _phoenixScores.GetBestScores(request.Mix, request.UserId, cancellationToken))
+            .ToArray();
+        var before = BeforeScores(current, request.Changes);
+
+        var empty = (ISet<Name>)new HashSet<Name>();
+        var beforeByTitle = BuildProgress(request.Mix, charts, before, empty).ToDictionary(t => t.Title.Name);
+
+        var writes = new List<PlayerMilestoneWrite>();
+        foreach (var title in BuildProgress(request.Mix, charts, current, empty)
+                     .Where(t => t.Title.CompletionRequired > 0 && t.IsComplete))
+        {
+            var wasBefore = beforeByTitle.GetValueOrDefault(title.Title.Name);
+            var newlyComplete = wasBefore is not { IsComplete: true };
+            if (newlyComplete)
+                writes.Add(new PlayerMilestoneWrite(MilestoneKind.TitleCompleted, request.SessionId, _dateTime.Now,
+                    Title: title.Title.Name.ToString()));
+
+            var newParagon = GetLevel(title);
+            var oldParagon = wasBefore == null ? ParagonLevel.None : GetLevel(wasBefore);
+            if (newParagon != ParagonLevel.None && (newlyComplete || newParagon > oldParagon))
+                writes.Add(new PlayerMilestoneWrite(MilestoneKind.ParagonLevelGain, request.SessionId,
+                    _dateTime.Now, Title: title.Title.Name.ToString(), Detail: newParagon.ToString()));
+        }
+
+        if (writes.Count == 0) return Array.Empty<PlayerMilestoneRecord>();
+        await _milestones.Append(request.Mix, request.UserId, writes, cancellationToken);
+        return writes.Select(w => new PlayerMilestoneRecord(w.Kind, w.SessionId, w.OccurredAt, w.OldValue,
+            w.NewValue, w.Title, w.Detail)).ToList();
     }
 
     private static double Percent(TitleProgress progress)

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/Events/ScoreHighlightsCapturedEvent.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/Events/ScoreHighlightsCapturedEvent.cs
@@ -41,5 +41,6 @@ public sealed record ScoreHighlightsCapturedEvent(
         int? NewScore,
         string? Plate,
         bool IsBroken,
-        HighlightFlags Flags);
+        HighlightFlags Flags,
+        HighlightDetail? Detail = null);
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/HighlightDetail.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/HighlightDetail.cs
@@ -1,0 +1,19 @@
+namespace ScoreTracker.PlayerProgress.Contracts;
+
+/// <summary>
+///     The per-flag detail a highlighted score carries beyond its flag bits — computed at
+///     capture and persisted so it stays historically true. The chart's pumbility rank, its
+///     folder-debut ordinal, the peer-cohort standing (total · how many scored higher · how
+///     many hold the PG), and the chart-specific skill title it progressed (name · current
+///     score · threshold). Every field is null when its flag isn't present or needs no detail.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed record HighlightDetail(
+    int? PumbilityRank = null,
+    int? FolderDebutOrdinal = null,
+    int? PeerCount = null,
+    int? PeerBetterCount = null,
+    int? PeerPgCount = null,
+    string? SkillTitleName = null,
+    int? SkillTitleScore = null,
+    int? SkillTitleThreshold = null);

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/Queries/GetPlayerMilestonesForSessionsQuery.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/Queries/GetPlayerMilestonesForSessionsQuery.cs
@@ -1,0 +1,12 @@
+using MediatR;
+
+namespace ScoreTracker.PlayerProgress.Contracts.Queries;
+
+/// <summary>
+///     Reads a player's captured milestones (gold rows) for specific sessions. Session-keyed
+///     like <see cref="GetScoreHighlightsForSessionsQuery" />; session-less milestones (weekly
+///     placements, admin recalcs) still read through the windowed query.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed record GetPlayerMilestonesForSessionsQuery(Guid UserId, IReadOnlyCollection<Guid> SessionIds)
+    : IQuery<IEnumerable<PlayerMilestoneRecord>>;

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/Queries/GetScoreHighlightsForSessionsQuery.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/Queries/GetScoreHighlightsForSessionsQuery.cs
@@ -1,0 +1,13 @@
+using MediatR;
+
+namespace ScoreTracker.PlayerProgress.Contracts.Queries;
+
+/// <summary>
+///     Reads a player's captured noteworthy-score flags for specific sessions. FK straight
+///     to SessionId rather than a date window: highlights are stamped at batch-drain,
+///     minutes after their journal rows, so a row-time window drops the freshest session's
+///     flags (the "Of Note shows nothing" bug).
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed record GetScoreHighlightsForSessionsQuery(Guid UserId, IReadOnlyCollection<Guid> SessionIds)
+    : IQuery<IEnumerable<ScoreHighlightRecord>>;

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/ScoreHighlightRecord.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/ScoreHighlightRecord.cs
@@ -7,4 +7,5 @@ public sealed record ScoreHighlightRecord(
     DateTimeOffset OccurredAt,
     HighlightFlags Flags,
     int Level,
-    double? ScoringLevel);
+    double? ScoringLevel,
+    HighlightDetail? Detail = null);

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Domain/IPlayerMilestoneRepository.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Domain/IPlayerMilestoneRepository.cs
@@ -10,6 +10,10 @@ internal interface IPlayerMilestoneRepository
 
     Task<IEnumerable<PlayerMilestoneRecord>> GetMilestones(MixEnum mix, Guid userId, DateTimeOffset since,
         DateTimeOffset until, CancellationToken cancellationToken);
+
+    /// <summary>Reads session-attached milestones for specific sessions (FK by SessionId).</summary>
+    Task<IEnumerable<PlayerMilestoneRecord>> GetMilestonesBySessions(Guid userId, IEnumerable<Guid> sessionIds,
+        CancellationToken cancellationToken);
 }
 
 internal sealed record PlayerMilestoneWrite(

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Domain/IScoreHighlightRepository.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Domain/IScoreHighlightRepository.cs
@@ -15,6 +15,14 @@ internal interface IScoreHighlightRepository
 
     Task<IEnumerable<ScoreHighlightRecord>> GetHighlights(MixEnum mix, Guid userId, DateTimeOffset since,
         DateTimeOffset until, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Reads highlights for specific sessions (the Sessions page). FK by SessionId, not a
+    ///     date window — highlight OccurredAt is the batch-drain time, minutes past the
+    ///     journal rows, so a row-time window drops the freshest session's flags.
+    /// </summary>
+    Task<IEnumerable<ScoreHighlightRecord>> GetHighlightsBySessions(Guid userId, IEnumerable<Guid> sessionIds,
+        CancellationToken cancellationToken);
 }
 
 internal sealed record ScoreHighlightWrite(

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Domain/IScoreHighlightRepository.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Domain/IScoreHighlightRepository.cs
@@ -31,4 +31,5 @@ internal sealed record ScoreHighlightWrite(
     DateTimeOffset OccurredAt,
     HighlightFlags Flags,
     int Level,
-    double? ScoringLevel);
+    double? ScoringLevel,
+    HighlightDetail? Detail = null);

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/EFPlayerMilestoneRepository.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/EFPlayerMilestoneRepository.cs
@@ -55,4 +55,21 @@ internal sealed class EFPlayerMilestoneRepository : IPlayerMilestoneRepository
             .Where(r => r != null)
             .Cast<PlayerMilestoneRecord>();
     }
+
+    public async Task<IEnumerable<PlayerMilestoneRecord>> GetMilestonesBySessions(Guid userId,
+        IEnumerable<Guid> sessionIds, CancellationToken cancellationToken)
+    {
+        var ids = sessionIds.Distinct().Select(s => (Guid?)s).ToArray();
+        if (ids.Length == 0) return Array.Empty<PlayerMilestoneRecord>();
+        await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+        return (await database.Set<PlayerMilestoneEntity>()
+                .Where(e => e.UserId == userId && ids.Contains(e.SessionId))
+                .ToArrayAsync(cancellationToken))
+            .Select(e => Enum.TryParse<MilestoneKind>(e.Kind, out var kind)
+                ? new PlayerMilestoneRecord(kind, e.SessionId, e.OccurredAt, e.OldValue, e.NewValue, e.Title,
+                    e.Detail)
+                : null)
+            .Where(r => r != null)
+            .Cast<PlayerMilestoneRecord>();
+    }
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/EFScoreHighlightRepository.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/EFScoreHighlightRepository.cs
@@ -42,10 +42,11 @@ internal sealed class EFScoreHighlightRepository : IScoreHighlightRepository
             {
                 row.Flags |= (int)write.Flags;
                 if (row.ScoringLevel == null && write.ScoringLevel != null) row.ScoringLevel = write.ScoringLevel;
+                MergeDetail(row, write.Detail);
             }
             else
             {
-                await database.AddAsync(new ScoreHighlightEntity
+                var entity = new ScoreHighlightEntity
                 {
                     Id = Guid.NewGuid(),
                     UserId = userId,
@@ -56,11 +57,34 @@ internal sealed class EFScoreHighlightRepository : IScoreHighlightRepository
                     Flags = (int)write.Flags,
                     Level = write.Level,
                     ScoringLevel = write.ScoringLevel
-                }, cancellationToken);
+                };
+                MergeDetail(entity, write.Detail);
+                await database.AddAsync(entity, cancellationToken);
             }
         }
 
         await database.SaveChangesAsync(cancellationToken);
+    }
+
+    // Detail is set once by capture; the improver pass carries none, so fill only nulls.
+    private static void MergeDetail(ScoreHighlightEntity row, HighlightDetail? detail)
+    {
+        if (detail == null) return;
+        row.PumbilityRank ??= detail.PumbilityRank;
+        row.FolderDebutOrdinal ??= detail.FolderDebutOrdinal;
+        row.PeerCount ??= detail.PeerCount;
+        row.PeerBetterCount ??= detail.PeerBetterCount;
+        row.PeerPgCount ??= detail.PeerPgCount;
+        row.SkillTitleName ??= detail.SkillTitleName;
+        row.SkillTitleScore ??= detail.SkillTitleScore;
+        row.SkillTitleThreshold ??= detail.SkillTitleThreshold;
+    }
+
+    private static ScoreHighlightRecord ToRecord(ScoreHighlightEntity e)
+    {
+        return new ScoreHighlightRecord(e.ChartId, e.SessionId, e.OccurredAt, (HighlightFlags)e.Flags, e.Level,
+            e.ScoringLevel, new HighlightDetail(e.PumbilityRank, e.FolderDebutOrdinal, e.PeerCount, e.PeerBetterCount,
+                e.PeerPgCount, e.SkillTitleName, e.SkillTitleScore, e.SkillTitleThreshold));
     }
 
     public async Task<IEnumerable<ScoreHighlightRecord>> GetHighlights(MixEnum mix, Guid userId,
@@ -71,8 +95,7 @@ internal sealed class EFScoreHighlightRepository : IScoreHighlightRepository
         return (await database.Set<ScoreHighlightEntity>()
                 .Where(e => e.UserId == userId && e.MixId == mixId && e.OccurredAt >= since && e.OccurredAt <= until)
                 .ToArrayAsync(cancellationToken))
-            .Select(e => new ScoreHighlightRecord(e.ChartId, e.SessionId, e.OccurredAt, (HighlightFlags)e.Flags,
-                e.Level, e.ScoringLevel));
+            .Select(ToRecord);
     }
 
     public async Task<IEnumerable<ScoreHighlightRecord>> GetHighlightsBySessions(Guid userId,
@@ -84,7 +107,6 @@ internal sealed class EFScoreHighlightRepository : IScoreHighlightRepository
         return (await database.Set<ScoreHighlightEntity>()
                 .Where(e => e.UserId == userId && ids.Contains(e.SessionId))
                 .ToArrayAsync(cancellationToken))
-            .Select(e => new ScoreHighlightRecord(e.ChartId, e.SessionId, e.OccurredAt, (HighlightFlags)e.Flags,
-                e.Level, e.ScoringLevel));
+            .Select(ToRecord);
     }
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/EFScoreHighlightRepository.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/EFScoreHighlightRepository.cs
@@ -74,4 +74,17 @@ internal sealed class EFScoreHighlightRepository : IScoreHighlightRepository
             .Select(e => new ScoreHighlightRecord(e.ChartId, e.SessionId, e.OccurredAt, (HighlightFlags)e.Flags,
                 e.Level, e.ScoringLevel));
     }
+
+    public async Task<IEnumerable<ScoreHighlightRecord>> GetHighlightsBySessions(Guid userId,
+        IEnumerable<Guid> sessionIds, CancellationToken cancellationToken)
+    {
+        var ids = sessionIds.Distinct().Select(s => (Guid?)s).ToArray();
+        if (ids.Length == 0) return Array.Empty<ScoreHighlightRecord>();
+        await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+        return (await database.Set<ScoreHighlightEntity>()
+                .Where(e => e.UserId == userId && ids.Contains(e.SessionId))
+                .ToArrayAsync(cancellationToken))
+            .Select(e => new ScoreHighlightRecord(e.ChartId, e.SessionId, e.OccurredAt, (HighlightFlags)e.Flags,
+                e.Level, e.ScoringLevel));
+    }
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/Entities/ScoreHighlightEntity.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/Entities/ScoreHighlightEntity.cs
@@ -32,4 +32,22 @@ internal sealed class ScoreHighlightEntity
     public int Level { get; set; }
 
     public double? ScoringLevel { get; set; }
+
+    // Caption detail computed at capture (historically true) — see HighlightDetail in
+    // PlayerProgress contracts. Null when the row's flags need no detail.
+    public int? PumbilityRank { get; set; }
+
+    public int? FolderDebutOrdinal { get; set; }
+
+    public int? PeerCount { get; set; }
+
+    public int? PeerBetterCount { get; set; }
+
+    public int? PeerPgCount { get; set; }
+
+    public string? SkillTitleName { get; set; }
+
+    public int? SkillTitleScore { get; set; }
+
+    public int? SkillTitleThreshold { get; set; }
 }

--- a/ScoreTracker/ScoreTracker.Tests.E2E/PlayerSessionsTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/PlayerSessionsTests.cs
@@ -43,7 +43,7 @@ public sealed class PlayerSessionsTests : IAsyncLifetime
         await _fixture.Seed.SeedMilestoneAsync(_publicUser, sessionId, Now, "PumbilityGain",
             oldValue: 8000, newValue: 8100);
         await _fixture.Seed.SeedHighlightAsync(_publicUser, passChart, sessionId, Now.AddMinutes(-3),
-            flags: 1 /* PumbilityTop50 */, level: 21);
+            flags: 1 /* PumbilityTop50 */, level: 21, pumbilityRank: 4);
 
         _browser = await _fixture.NewBrowserContextAsync();
         _page = await _browser.NewPageAsync();
@@ -70,8 +70,9 @@ public sealed class PlayerSessionsTests : IAsyncLifetime
         await Expect(_page.Locator("[data-testid='milestone-strip']")).ToBeVisibleAsync(timeout);
         await Expect(_page.GetByText("8,000 → 8,100")).ToBeVisibleAsync();
 
-        // The card leads with the flagged row; the full breakdown opens as a dialog.
+        // The card leads with the flagged row, whose crown badge now carries the pumbility rank.
         await Expect(_page.GetByText("New Pass").First).ToBeVisibleAsync();
+        await Expect(cards.First.GetByText("#4")).ToBeVisibleAsync();
         await cards.First.Locator("[data-testid='view-all-scores']").ClickAsync();
         var dialog = _page.Locator("[data-testid='session-scores-dialog']");
         await Expect(dialog).ToBeVisibleAsync(timeout);

--- a/ScoreTracker/ScoreTracker.Tests.E2E/Support/E2ESeedData.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/Support/E2ESeedData.cs
@@ -122,11 +122,11 @@ public sealed class E2ESeedData
     }
 
     public async Task SeedHighlightAsync(Guid userId, Guid chartId, Guid? sessionId, DateTimeOffset occurredAt,
-        int flags, int level, CancellationToken cancellationToken = default)
+        int flags, int level, int? pumbilityRank = null, CancellationToken cancellationToken = default)
     {
         await using var context = await _factory.CreateDbContextAsync(cancellationToken);
         await context.Database.ExecuteSqlInterpolatedAsync(
-            $"INSERT INTO [scores].[ScoreHighlight] ([Id], [UserId], [MixId], [ChartId], [SessionId], [OccurredAt], [Flags], [Level], [ScoringLevel]) VALUES ({Guid.NewGuid()}, {userId}, {PhoenixMixId}, {chartId}, {sessionId}, {occurredAt}, {flags}, {level}, {null})",
+            $"INSERT INTO [scores].[ScoreHighlight] ([Id], [UserId], [MixId], [ChartId], [SessionId], [OccurredAt], [Flags], [Level], [ScoringLevel], [PumbilityRank]) VALUES ({Guid.NewGuid()}, {userId}, {PhoenixMixId}, {chartId}, {sessionId}, {occurredAt}, {flags}, {level}, {null}, {pumbilityRank})",
             cancellationToken);
     }
 

--- a/ScoreTracker/ScoreTracker.Tests.Integration/DiscordCanary/DiscordCanaryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/DiscordCanary/DiscordCanaryTests.cs
@@ -87,19 +87,20 @@ public sealed class DiscordCanaryTests
                 new RichBotDivider(),
                 new RichBotText("📈 **PUMBILITY** 21,480 → **21,530** (+50)"),
                 new RichBotDivider(),
-                new RichBotText("🏅 **Intermediate Lv. 10** completed\n" +
+                new RichBotText("🏅 **[Intermediate Lv. 10]** completed\n" +
+                                "🏅 [Advanced Lv. 3] 62% → **71%**\n" +
                                 "🎉 #DIFFICULTY|s18# **All passed!**\n" +
                                 "🏆 **#1** on Witch Doctor #DIFFICULTY|d19# weekly"),
                 new RichBotDivider(),
                 new RichBotSection(
-                    "#DIFFICULTY|d19# **Witch Doctor**\n**970,207** #LETTERGRADE|S|False##PLATE|UltimateGame#\n-# 👑 PUMBILITY top 50 · 🆕 Folder debut",
+                    "#DIFFICULTY|d19# **Witch Doctor**\n**970,207** #LETTERGRADE|S|False##PLATE|UltimateGame#\n-# 👑 #4 in your PUMBILITY · 🆕 First D19",
                     new Uri("https://piuimages.arroweclip.se/songs/WitchDoctor.png")),
                 new RichBotSection(
-                    "#DIFFICULTY|s18# **Turkey March -Minimal Tunes-**\n**999,150** #LETTERGRADE|SSSPlus|False##PLATE|UltimateGame#\n-# 📊 Top scores among peers",
+                    "#DIFFICULTY|s18# **Turkey March -Minimal Tunes-**\n**972,340** #LETTERGRADE|SSS|False##PLATE|SuperbGame#\n-# 🏅 [DRILL] Lv.4 (972k/990k) · 📊 #3 of 47 peers",
                     new Uri("https://piuimages.arroweclip.se/songs/TurkeyMarchMinimalTunes.png")),
-                new RichBotText("+1 more: S16"),
+                new RichBotText("-# More scores\n#DIFFICULTY|s16# Bad Apple — **945,120** #LETTERGRADE|SS|False##PLATE|MarvelousGame#"),
                 new RichBotDivider(),
-                new RichBotText("#DIFFICULTY|d19# 84/141 (59.6%) · #DIFFICULTY|s18# 182/195 (93.3%)")
+                new RichBotText("#DIFFICULTY|d19# 84/141 · #DIFFICULTY|s18# 182/195")
             },
             $"#MIX|Phoenix# Phoenix · PIU Scores · {marker}",
             MixEnum.Phoenix.GetAccentColor(),
@@ -117,15 +118,18 @@ public sealed class DiscordCanaryTests
                 new RichBotDivider(),
                 new RichBotText("📈 **PUMBILITY** 0 → **18,437** (+18,437)"),
                 new RichBotDivider(),
-                new RichBotText("🏅 **Intermediate Lv. 1** completed\n…and 4 more titles\n" +
+                new RichBotText("🏅 **[Intermediate Lv. 1]** completed\n…and 4 more titles\n" +
                                 "🎉 #DIFFICULTY|s13# **All passed!**"),
                 new RichBotDivider(),
                 new RichBotSection(
-                    "#DIFFICULTY|d20# **Removable Disk0**\n**962,410** #LETTERGRADE|AAAPlus|False##PLATE|FairGame#\n-# 👑 PUMBILITY top 50",
+                    "#DIFFICULTY|d20# **Removable Disk0**\n**962,410** #LETTERGRADE|AAAPlus|False##PLATE|FairGame#\n-# 👑 #7 in your PUMBILITY",
                     new Uri("https://piuimages.arroweclip.se/songs/RemovableDisk0.png")),
+                new RichBotText("-# More scores\n" +
+                                "#DIFFICULTY|d19# Yog-Sothoth — **951,020** #LETTERGRADE|SS|False##PLATE|SuperbGame#\n" +
+                                "#DIFFICULTY|s21# Errorcode 0 — **933,400** #LETTERGRADE|S|False##PLATE|MarvelousGame#"),
                 new RichBotText("+2,008 more: D23 ×12, S22 ×48, S21 ×95, CO-OP ×31"),
                 new RichBotDivider(),
-                new RichBotText("#DIFFICULTY|s13# 153/153 (100%) · #DIFFICULTY|s14# 148/151 (98.0%)")
+                new RichBotText("#DIFFICULTY|s13# 153/153 · #DIFFICULTY|s14# 148/151")
             },
             $"#MIX|Phoenix2# Phoenix2 · PIU Scores · {marker}",
             MixEnum.Phoenix2.GetAccentColor(),

--- a/ScoreTracker/ScoreTracker.Tests.Integration/ScoreHighlightRepositoryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/ScoreHighlightRepositoryTests.cs
@@ -1,0 +1,103 @@
+using ScoreTracker.PlayerProgress.Contracts;
+using ScoreTracker.PlayerProgress.Domain;
+using ScoreTracker.PlayerProgress.Infrastructure;
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.Tests.Integration.Fixtures;
+
+namespace ScoreTracker.Tests.Integration;
+
+[Collection(IntegrationTestCollection.Name)]
+[ExcludeFromCodeCoverage]
+public sealed class ScoreHighlightRepositoryTests : IAsyncLifetime
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly SqlServerFixture _fixture;
+
+    public ScoreHighlightRepositoryTests(SqlServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public Task InitializeAsync() => _fixture.ResetAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task HighlightsReadBySessionRegardlessOfTheDrainSkewedTimestamp()
+    {
+        // A highlight is stamped at batch-drain — minutes past its journal rows — so the old
+        // row-time window dropped it and the Sessions page showed nothing under "Of Note".
+        // Reading by SessionId must still return it.
+        var userId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var chartId = Guid.NewGuid();
+        var repo = new EFScoreHighlightRepository(_fixture.DbContextFactory);
+        await repo.UpsertFlags(MixEnum.Phoenix, userId, new[]
+        {
+            new ScoreHighlightWrite(chartId, sessionId, Now.AddMinutes(3), HighlightFlags.PumbilityTop50, 24, 30.0)
+        }, CancellationToken.None);
+
+        // The old windowed read, bounded to the journal rows' minute, misses it — the bug.
+        var windowed = await repo.GetHighlights(MixEnum.Phoenix, userId, Now, Now.AddMinutes(1),
+            CancellationToken.None);
+        Assert.Empty(windowed);
+
+        var bySession = await repo.GetHighlightsBySessions(userId, new[] { sessionId }, CancellationToken.None);
+        var hit = Assert.Single(bySession);
+        Assert.Equal(chartId, hit.ChartId);
+        Assert.Equal(sessionId, hit.SessionId);
+        Assert.True(hit.Flags.HasFlag(HighlightFlags.PumbilityTop50));
+    }
+
+    [Fact]
+    public async Task HighlightsBySessionScopeToTheRequestedSessionsAndUser()
+    {
+        var userId = Guid.NewGuid();
+        var otherUser = Guid.NewGuid();
+        var wantedSession = Guid.NewGuid();
+        var otherSession = Guid.NewGuid();
+        var repo = new EFScoreHighlightRepository(_fixture.DbContextFactory);
+        await repo.UpsertFlags(MixEnum.Phoenix, userId, new[]
+        {
+            new ScoreHighlightWrite(Guid.NewGuid(), wantedSession, Now, HighlightFlags.ScoreQuality90, 23, 20.0),
+            new ScoreHighlightWrite(Guid.NewGuid(), otherSession, Now, HighlightFlags.FolderDebut, 23, 20.0)
+        }, CancellationToken.None);
+        await repo.UpsertFlags(MixEnum.Phoenix, otherUser, new[]
+        {
+            new ScoreHighlightWrite(Guid.NewGuid(), wantedSession, Now, HighlightFlags.PumbilityTop50, 23, 20.0)
+        }, CancellationToken.None);
+
+        var result = (await repo.GetHighlightsBySessions(userId, new[] { wantedSession },
+            CancellationToken.None)).ToArray();
+
+        var hit = Assert.Single(result);
+        Assert.Equal(wantedSession, hit.SessionId);
+        Assert.True(hit.Flags.HasFlag(HighlightFlags.ScoreQuality90));
+    }
+
+    [Fact]
+    public async Task SessionMilestonesReadBySession()
+    {
+        var userId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var repo = new EFPlayerMilestoneRepository(_fixture.DbContextFactory);
+        await repo.Append(MixEnum.Phoenix, userId, new[]
+        {
+            new PlayerMilestoneWrite(MilestoneKind.TitleCompleted, sessionId, Now.AddMinutes(3),
+                Title: "Expert Lv. 4")
+        }, CancellationToken.None);
+
+        var bySession = await repo.GetMilestonesBySessions(userId, new[] { sessionId }, CancellationToken.None);
+        var hit = Assert.Single(bySession);
+        Assert.Equal(MilestoneKind.TitleCompleted, hit.Kind);
+        Assert.Equal("Expert Lv. 4", hit.Title);
+    }
+
+    [Fact]
+    public async Task EmptySessionSetReturnsEmpty()
+    {
+        var repo = new EFScoreHighlightRepository(_fixture.DbContextFactory);
+        Assert.Empty(await repo.GetHighlightsBySessions(Guid.NewGuid(), Array.Empty<Guid>(),
+            CancellationToken.None));
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -345,11 +345,11 @@ public sealed class CommunitySagaTests
     }
 
     [Fact]
-    public async Task UnremarkablePassesCompressEntirelyIntoTheCountAndFolderLines()
+    public async Task UnremarkablePassesFillTheMoreScoresBucketThenOverflow()
     {
-        // The snapshot's core promise: a session with nothing notable is counts, not a
-        // wall — no per-score rows at all, one "+N more" line, the folder progress
-        // capped to the top folders, and the totals in the header.
+        // Owner call: non-highlighted scores now show — up to 10 compact one-liners in the
+        // "More scores" bucket (no art), the rest compress into "+N more", and the folder
+        // progress + header totals still summarize.
         var userId = Guid.NewGuid();
         var charts = Enumerable.Range(10, 12)
             .Select(level => new ChartBuilder().WithType(ChartType.Single).WithLevel(level).Build())
@@ -366,7 +366,8 @@ public sealed class CommunitySagaTests
             It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.Count() == 1
                 && msgs.Single().Header!.Markdown.Contains("passed 12")
                 && !msgs.Single().Blocks.OfType<RichBotSection>().Any()
-                && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("+12 more"))
+                && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("-# More scores"))
+                && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("+2 more"))
                 && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("#DIFFICULTY|S21# 1/1"))),
             It.Is<IEnumerable<ulong>>(ids => ids.Contains(12345ul)),
             It.IsAny<CancellationToken>()), Times.Once);
@@ -401,8 +402,8 @@ public sealed class CommunitySagaTests
                     t.Markdown.Contains("📈 **PUMBILITY** 21,480 → **21,530** (+50)")
                     && t.Markdown.Contains("📈 **Singles competitive** 21.42 → **21.45**"))
                 && msgs.Single().Blocks.OfType<RichBotText>().Any(t =>
-                    t.Markdown.Contains("🏅 **Intermediate Lv. 10** completed")
-                    && t.Markdown.Contains("🏅 **Intermediate Lv. 7** paragon → #LETTERGRADE|SS|False#"))),
+                    t.Markdown.Contains("🏅 **[Intermediate Lv. 10]** completed")
+                    && t.Markdown.Contains("🏅 **[Intermediate Lv. 7]** paragon → #LETTERGRADE|SS|False#"))),
             It.IsAny<IEnumerable<ulong>>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -428,17 +429,19 @@ public sealed class CommunitySagaTests
 
         ctx.Bot.Verify(b => b.SendRichMessages(
             It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.Single().Blocks.OfType<RichBotText>().Any(t =>
-                t.Markdown.Contains("**Title 10** completed")
-                && !t.Markdown.Contains("**Title 11** completed")
+                t.Markdown.Contains("**[Title 10]** completed")
+                && !t.Markdown.Contains("[Title 11]")
                 && t.Markdown.Contains("…and 2 more titles")
-                && t.Markdown.Contains("🏅 **Expert Lv. 2** paragon → #PLATE|PerfectGame#"))),
+                && t.Markdown.Contains("🏅 **[Expert Lv. 2]** paragon → #PLATE|PerfectGame#"))),
             It.IsAny<IEnumerable<ulong>>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task ProgressDeltasShowOnlyWhenNothingCompleted()
+    public async Task GenericProgressDeltasAlwaysRideTheTopSectionAlongsideCompletions()
     {
+        // Owner call (D3): generic title progress shows up top ALWAYS, not only as a
+        // nothing-completed fallback — a completion and a delta coexist, both bracketed.
         var userId = Guid.NewGuid();
         var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
         var ctx = new HandlerContext();
@@ -447,13 +450,18 @@ public sealed class CommunitySagaTests
         ctx.GivenScoreAnnouncementLookups(MixEnum.Phoenix, userId, chart, score: 950000);
 
         await ctx.Saga.Consume(BuildContext(CapturedEvent(userId, MixEnum.Phoenix, null,
-                Array.Empty<PlayerMilestoneRecord>(),
+                new[]
+                {
+                    new PlayerMilestoneRecord(MilestoneKind.TitleCompleted, null, Now, null, null,
+                        "Advanced Lv. 1", null)
+                },
                 new[] { new TitleProgressDelta("Expert Lv. 4", 0.82, 0.86) },
                 (chart.Id, true, HighlightFlags.None))));
 
         ctx.Bot.Verify(b => b.SendRichMessages(
             It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.Single().Blocks.OfType<RichBotText>().Any(t =>
-                t.Markdown.Contains("🏅 Expert Lv. 4 82% → **86%**"))),
+                t.Markdown.Contains("🏅 **[Advanced Lv. 1]** completed")
+                && t.Markdown.Contains("🏅 [Expert Lv. 4] 82% → **86%**"))),
             It.IsAny<IEnumerable<ulong>>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -484,10 +492,10 @@ public sealed class CommunitySagaTests
     }
 
     [Fact]
-    public async Task CoOpsAlwaysShowCappedAtThree()
+    public async Task CoOpsShowAsACompactBucketCappedAtFive()
     {
         var userId = Guid.NewGuid();
-        var coOps = Enumerable.Range(0, 5)
+        var coOps = Enumerable.Range(0, 7)
             .Select(_ => new ChartBuilder().WithType(ChartType.CoOp).WithLevel(2).Build())
             .ToArray();
         var ctx = new HandlerContext();
@@ -498,19 +506,20 @@ public sealed class CommunitySagaTests
         await ctx.Saga.Consume(BuildContext(CapturedEvent(userId, MixEnum.Phoenix, null,
             coOps.Select(c => (c.Id, false, HighlightFlags.None)).ToArray())));
 
-        // 3 co-op rows render individually (art while slots last) and the remainder
-        // compresses with a CO-OP count; co-ops never earn S/D flags but always show.
+        // Co-ops drop their art rows (owner call): up to 5 compact one-liners in their own
+        // labelled bucket, the remainder compressing with a CO-OP count; header still marks CO-OP.
         ctx.Bot.Verify(b => b.SendRichMessages(
-            It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.Single().Blocks.OfType<RichBotSection>().Count() == 3
-                && msgs.Single().Blocks.OfType<RichBotText>().Any(t =>
-                    t.Markdown.Contains("+2 more: CO-OP ×2"))
+            It.Is<IEnumerable<RichBotMessage>>(msgs => !msgs.Single().Blocks.OfType<RichBotSection>().Any()
+                && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("-# Co-op")
+                    && t.Markdown.Split('\n').Count(l => l.Contains("#DIFFICULTY|")) == 5)
+                && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("+2 more: CO-OP ×2"))
                 && msgs.Single().Header!.Markdown.Contains("CO-OP")),
             It.IsAny<IEnumerable<ulong>>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task TheSessionsBiggestGainOverTenThousandEarnsARow()
+    public async Task TheSessionsBiggestGainEarnsAnArtRowTheOthersFallToMoreScores()
     {
         var userId = Guid.NewGuid();
         var biggest = new ChartBuilder().WithType(ChartType.Single).WithLevel(21).Build();
@@ -520,8 +529,8 @@ public sealed class CommunitySagaTests
         ctx.GivenUserCommunitiesWithChannel(userId, communityName: "Acme", channelId: 12345);
         ctx.GivenScoreAnnouncementLookups(MixEnum.Phoenix, userId, new[] { biggest, smaller }, score: 950000);
 
-        // biggest: +27,704; smaller: +12,000 — over the threshold too, but only the
-        // session's single biggest gain earns the 💥 row (owner call).
+        // biggest: +27,704; smaller: +12,000 — over the threshold too, but only the session's
+        // single biggest gain earns the 💥 art row (owner call); the other is a compact row.
         await ctx.Saga.Consume(BuildContext(ScoreHighlightsCapturedEvent.Create(Now, userId, MixEnum.Phoenix,
             null,
             new[]
@@ -536,7 +545,40 @@ public sealed class CommunitySagaTests
             It.Is<IEnumerable<RichBotMessage>>(msgs =>
                 msgs.Single().Blocks.OfType<RichBotSection>().Single().Markdown
                     .Contains("💥 Biggest gain of the session")
-                && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("+1 more: S22"))),
+                && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("-# More scores")
+                    && t.Markdown.Contains("#DIFFICULTY|S22#"))),
+            It.IsAny<IEnumerable<ulong>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EnrichedCaptionsRenderRankPeersOrdinalAndSkillScore()
+    {
+        // #5–#8: the per-row caption renders the captured detail — pumbility rank, peer
+        // standing, skill title score/threshold, folder-debut ordinal — not generic text.
+        var userId = Guid.NewGuid();
+        var chart = new ChartBuilder().WithType(ChartType.Double).WithLevel(24).Build();
+        var ctx = new HandlerContext();
+        ctx.GivenUser(userId, name: "alice");
+        ctx.GivenUserCommunitiesWithChannel(userId, communityName: "Acme", channelId: 12345);
+        ctx.GivenScoreAnnouncementLookups(MixEnum.Phoenix, userId, chart, score: 972000);
+        var detail = new HighlightDetail(PumbilityRank: 4, FolderDebutOrdinal: 1, PeerCount: 47,
+            PeerBetterCount: 2, PeerPgCount: 0, SkillTitleName: "[DRILL] Lv.10", SkillTitleScore: 972000,
+            SkillTitleThreshold: 990000);
+        var change = new ScoreHighlightsCapturedEvent.HighlightedChange(chart.Id, true, null, 972000,
+            "SuperbGame", false,
+            HighlightFlags.PumbilityTop50 | HighlightFlags.ScoreQuality90 | HighlightFlags.TitleProgress
+            | HighlightFlags.FolderDebut, detail);
+
+        await ctx.Saga.Consume(BuildContext(ScoreHighlightsCapturedEvent.Create(Now, userId, MixEnum.Phoenix,
+            null, new[] { change })));
+
+        ctx.Bot.Verify(b => b.SendRichMessages(
+            It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.Single().Blocks.OfType<RichBotSection>().Any(s =>
+                s.Markdown.Contains("👑 #4 in your PUMBILITY")
+                && s.Markdown.Contains("📊 #3 of 47 peers")
+                && s.Markdown.Contains("🏅 [DRILL] Lv.10 (972k/990k)")
+                && s.Markdown.Contains("🆕 First D24"))),
             It.IsAny<IEnumerable<ulong>>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/HighlightCaptureSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/HighlightCaptureSagaTests.cs
@@ -46,15 +46,39 @@ public sealed class HighlightCaptureSagaTests
 
         ctx.Highlights.Verify(h => h.UpsertFlags(MixEnum.Phoenix, UserId,
             It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
-                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.PumbilityTop50) && x.Level == 20)),
+                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.PumbilityTop50) && x.Level == 20
+                && x.Detail != null && x.Detail.PumbilityRank == 1)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task TitleProgressFlagsScoresCountingTowardIncompleteTitles()
+    public async Task TitleProgressFlagsChartSpecificSkillTitlesWithScoreDetail()
     {
-        // A non-broken AA on a level with an incomplete difficulty title contributes
-        // (PhoenixDifficultyTitle.CompletionProgress > 0) and gets the flag.
+        // Per-row title progress is skill titles only (owner call): Moonlight S18 is
+        // [DRILL] Lv.4, and a non-broken score below the SSS threshold carries the
+        // score/threshold the card renders as "972k/990k".
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(18)
+            .WithSongName("Moonlight").Build();
+        var ctx = new HandlerContext();
+        ctx.GivenCharts(chart);
+        ctx.GivenBest(chart, 972000);
+
+        await ctx.Saga.Consume(ctx.Context(NewPassEvent(chart)));
+
+        ctx.Highlights.Verify(h => h.UpsertFlags(MixEnum.Phoenix, UserId,
+            It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
+                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.TitleProgress)
+                && x.Detail != null && x.Detail.SkillTitleName == "[DRILL] Lv.4"
+                && x.Detail.SkillTitleScore == 972000 && x.Detail.SkillTitleThreshold == 990000)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenericDifficultyTitleProgressDoesNotFlagPerRow()
+    {
+        // A plain level-20 chart nudges the "Advanced" difficulty titles but is not
+        // chart-specific — it must NOT claim the per-row TitleProgress flag (that noise
+        // rides the card's top section as a delta instead).
         var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
         var ctx = new HandlerContext();
         ctx.GivenCharts(chart);
@@ -62,10 +86,10 @@ public sealed class HighlightCaptureSagaTests
 
         await ctx.Saga.Consume(ctx.Context(NewPassEvent(chart)));
 
-        ctx.Highlights.Verify(h => h.UpsertFlags(MixEnum.Phoenix, UserId,
+        ctx.Highlights.Verify(h => h.UpsertFlags(It.IsAny<MixEnum>(), It.IsAny<Guid>(),
             It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
-                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.TitleProgress))),
-            It.IsAny<CancellationToken>()), Times.Once);
+                x.Flags.HasFlag(HighlightFlags.TitleProgress))),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -82,7 +106,9 @@ public sealed class HighlightCaptureSagaTests
 
         ctx.Highlights.Verify(h => h.UpsertFlags(MixEnum.Phoenix, UserId,
             It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
-                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.ScoreQuality90))),
+                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.ScoreQuality90)
+                && x.Detail != null && x.Detail.PeerCount == 10 && x.Detail.PeerBetterCount == 0
+                && x.Detail.PeerPgCount == 0)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -95,6 +121,27 @@ public sealed class HighlightCaptureSagaTests
         ctx.GivenBest(chart, 910000);
         ctx.GivenCohort(chart, Enumerable.Range(0, 10)
             .Select(i => (PhoenixScore)(905000 + i * 10000)).ToArray());
+
+        await ctx.Saga.Consume(ctx.Context(NewPassEvent(chart)));
+
+        ctx.Highlights.Verify(h => h.UpsertFlags(It.IsAny<MixEnum>(), It.IsAny<Guid>(),
+            It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
+                x.Flags.HasFlag(HighlightFlags.ScoreQuality90))),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScoreQualityDoesNotFlagAPerfectGameMostPeersAlsoHold()
+    {
+        // A PG is 100th percentile tie-inclusive, but a PG most of the cohort also holds
+        // isn't noteworthy (owner call) — suppress it.
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var ctx = new HandlerContext();
+        ctx.GivenCharts(chart);
+        ctx.GivenBest(chart, 1000000);
+        // Six peers, four of them also PG (> half) — suppressed.
+        ctx.GivenCohort(chart, new[] { 940000, 960000, 1000000, 1000000, 1000000, 1000000 }
+            .Select(s => (PhoenixScore)s).ToArray());
 
         await ctx.Saga.Consume(ctx.Context(NewPassEvent(chart)));
 
@@ -120,7 +167,8 @@ public sealed class HighlightCaptureSagaTests
 
         ctx.Highlights.Verify(h => h.UpsertFlags(MixEnum.Phoenix, UserId,
             It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
-                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.FolderDebut))),
+                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.FolderDebut)
+                && x.Detail != null && x.Detail.FolderDebutOrdinal == 2)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TitleSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TitleSagaTests.cs
@@ -88,18 +88,19 @@ public sealed class TitleSagaTests
     [Fact]
     public async Task CaptureSuppressesTheLegacyAnnouncementTheCardNowCarries()
     {
-        // Score-driven completions ride the snapshot card; the legacy Discord message
-        // must NOT also fire (it survives only on the detected-titles path).
-        var charts = Enumerable.Range(0, 30)
-            .Select(_ => new ChartBuilder().WithType(ChartType.Single).WithLevel(24).Build()).ToArray();
-        var ctx = new SagaContext(MixEnum.Phoenix, charts);
-        ctx.GivenBestScores(charts.Select(c => Score(c.Id, 1000000)).ToArray());
+        // Score-driven completions ride the snapshot card; the legacy Discord message must
+        // NOT also fire (it survives only on the detected-titles path). Another Truth S6 is
+        // the [The 1st] boss breaker — passing it crosses the title incomplete → done, which
+        // the batch-crossing detects even though the site path may have saved it first.
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(6)
+            .WithSongName("Another Truth").Build();
+        var ctx = new SagaContext(MixEnum.Phoenix, chart);
+        ctx.GivenBestScores(Score(chart.Id, 950000));
 
         var result = await ctx.Saga.Handle(new TitleSaga.CaptureSessionTitles(ctx.UserId, MixEnum.Phoenix, null,
                 new[]
                 {
-                    new PlayerScoresUpdatedEvent.ScoreChange(charts[0].Id, true, null, 1000000, "PerfectGame",
-                        false)
+                    new PlayerScoresUpdatedEvent.ScoreChange(chart.Id, true, null, 950000, "SuperbGame", false)
                 }),
             CancellationToken.None);
 
@@ -167,29 +168,47 @@ public sealed class TitleSagaTests
     }
 
     [Fact]
-    public async Task CompletedTitlesAreCapturedAsMilestones()
+    public async Task DetectedBasicBadgesAreCapturedAsMilestonesAndAnnounced()
     {
-        // UserTitle rows have no acquisition date — the milestone is the only record of WHEN.
+        // Site-only badges (CompletionRequired == 0: events, play/plate counts) have no
+        // session and no card — the legacy announcement stays alive on this path only.
         var ctx = new SagaContext(MixEnum.Phoenix);
 
         await ctx.Saga.Consume(BuildContext(new TitlesDetectedEvent(ctx.UserId,
-            DetectedTitles, MixEnum.Phoenix)));
+            new[] { "RISE CHALLENGER" }, MixEnum.Phoenix)));
 
         ctx.Milestones.Verify(m => m.Append(MixEnum.Phoenix, ctx.UserId,
             It.Is<IEnumerable<PlayerMilestoneWrite>>(w => w.Any(x =>
-                x.Kind == MilestoneKind.TitleCompleted && x.Title == "Intermediate Lv. 1")),
+                x.Kind == MilestoneKind.TitleCompleted && x.Title == "RISE CHALLENGER")),
             It.IsAny<CancellationToken>()), Times.Once);
-        // Site-detected titles have no session and no card — the legacy announcement
-        // stays alive on this path only.
         ctx.Bus.Verify(b => b.Publish(It.IsAny<NewTitlesAcquiredEvent>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task DetectedComputableTitlesAreSavedButLeftToTheScorePath()
+    {
+        // A difficulty title the site reports (CompletionRequired > 0) is score-computable,
+        // so the site path saves it (DB stays correct) but does NOT announce or milestone it —
+        // the session card carries it via the score path instead.
+        var ctx = new SagaContext(MixEnum.Phoenix);
+
+        await ctx.Saga.Consume(BuildContext(new TitlesDetectedEvent(ctx.UserId,
+            new[] { "Intermediate Lv. 1" }, MixEnum.Phoenix)));
+
+        ctx.Titles.Verify(t => t.SaveTitles(MixEnum.Phoenix, ctx.UserId,
+            It.Is<IEnumerable<TitleAchievedRecord>>(titles =>
+                titles.Any(x => x.Title.ToString() == "Intermediate Lv. 1")),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Bus.Verify(b => b.Publish(It.IsAny<NewTitlesAcquiredEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        ctx.Milestones.Verify(m => m.Append(It.IsAny<MixEnum>(), It.IsAny<Guid>(),
+            It.IsAny<IEnumerable<PlayerMilestoneWrite>>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static RecordedPhoenixScore Score(Guid chartId, int score) =>
         new(chartId, score, PhoenixPlate.SuperbGame, false,
             new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
-
-    private static readonly string[] DetectedTitles = { "Intermediate Lv. 1" };
 
     private static ConsumeContext<T> BuildContext<T>(T message) where T : class
     {

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixSkillTitleTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixSkillTitleTests.cs
@@ -79,4 +79,31 @@ public sealed class PhoenixSkillTitleTests
     {
         Assert.Equal(990000, Title().CompletionRequired);
     }
+
+    [Fact]
+    public void CompletionFloorIsAtNineHundredThousand()
+    {
+        Assert.Equal(900_000, Title().CompletionFloor);
+    }
+
+    [Fact]
+    public void PercentCompleteRebasesFromTheFloorNotZero()
+    {
+        // 945k on a skill chart is halfway from the 900k floor to the 990k target — not ~95%.
+        var progress = new PhoenixTitleProgress(Title());
+        var chart = new ChartBuilder().WithSongName(Song).WithType(ChartType.Single).WithLevel(26).Build();
+        progress.ApplyAttempt(chart, Attempt(945000));
+
+        Assert.Equal(0.5, progress.PercentComplete, 3);
+    }
+
+    [Fact]
+    public void PercentCompleteClampsToZeroBelowTheFloor()
+    {
+        var progress = new PhoenixTitleProgress(Title());
+        var chart = new ChartBuilder().WithSongName(Song).WithType(ChartType.Single).WithLevel(26).Build();
+        progress.ApplyAttempt(chart, Attempt(880000));
+
+        Assert.Equal(0, progress.PercentComplete);
+    }
 }

--- a/ScoreTracker/ScoreTracker/Components/Sessions/HighlightRow.razor
+++ b/ScoreTracker/ScoreTracker/Components/Sessions/HighlightRow.razor
@@ -16,7 +16,7 @@
                 @foreach (var badge in Badges)
                 {
                     <MudTooltip Text="@badge.Tooltip">
-                        <span tabindex="0" style="font-size: .8rem">@badge.Glyph</span>
+                        <span tabindex="0" style="font-size: .8rem">@badge.Glyph@(badge.Suffix == null ? "" : $" {badge.Suffix}")</span>
                     </MudTooltip>
                 }
             </div>
@@ -39,17 +39,43 @@
     [Parameter] [EditorRequired] public RecentSessionsPage.ScoreEventRecord Row { get; set; } = null!;
     [Parameter] public Chart? Chart { get; set; }
     [Parameter] public HighlightFlags Flags { get; set; }
+    [Parameter] public HighlightDetail? Detail { get; set; }
 
-    private IEnumerable<(string Glyph, string Tooltip)> Badges
+    // Same detail the Discord card carries, rendered as compact language-neutral suffixes
+    // (the localized tooltip carries the words): 👑 #4 · 📊 #3/47 · 🏅 972k/990k · 🆕 #1.
+    private IEnumerable<(string Glyph, string? Suffix, string Tooltip)> Badges
     {
         get
         {
-            if (Flags.HasFlag(HighlightFlags.PumbilityTop50)) yield return ("👑", L["In your PUMBILITY top 50"].Value);
-            if (Flags.HasFlag(HighlightFlags.TitleProgress)) yield return ("🏅", L["Counts toward a title"].Value);
-            if (Flags.HasFlag(HighlightFlags.ScoreQuality90)) yield return ("📊", L["Top scores among comparable players"].Value);
-            if (Flags.HasFlag(HighlightFlags.FolderCompletion90)) yield return ("📁", L["Nearly complete folder"].Value);
-            if (Flags.HasFlag(HighlightFlags.CompetitiveImprover)) yield return ("⬆", L["Raised your competitive level"].Value);
-            if (Flags.HasFlag(HighlightFlags.FolderDebut)) yield return ("🆕", L["One of your first passes in this folder"].Value);
+            if (Flags.HasFlag(HighlightFlags.PumbilityTop50))
+                yield return ("👑", Detail?.PumbilityRank is { } r ? $"#{r}" : null,
+                    L["In your PUMBILITY top 50"].Value);
+            if (Flags.HasFlag(HighlightFlags.TitleProgress))
+                yield return ("🏅", SkillSuffix, L["Counts toward a title"].Value);
+            if (Flags.HasFlag(HighlightFlags.ScoreQuality90))
+                yield return ("📊", PeerSuffix, L["Top scores among comparable players"].Value);
+            if (Flags.HasFlag(HighlightFlags.FolderCompletion90))
+                yield return ("📁", null, L["Nearly complete folder"].Value);
+            if (Flags.HasFlag(HighlightFlags.CompetitiveImprover))
+                yield return ("⬆", null, L["Raised your competitive level"].Value);
+            if (Flags.HasFlag(HighlightFlags.FolderDebut))
+                yield return ("🆕", Detail?.FolderDebutOrdinal is { } o ? $"#{o}" : null,
+                    L["One of your first passes in this folder"].Value);
         }
     }
+
+    private string? PeerSuffix
+    {
+        get
+        {
+            if (Detail?.PeerCount is not { } count || count == 0) return null;
+            if (Row.Score == 1_000_000 && Detail.PeerPgCount is { } pg) return $"PG {pg}/{count}";
+            return $"#{(Detail.PeerBetterCount ?? 0) + 1}/{count}";
+        }
+    }
+
+    private string? SkillSuffix =>
+        Detail?.SkillTitleScore is { } score && Detail.SkillTitleThreshold is { } threshold
+            ? $"{score / 1000}k/{threshold / 1000}k"
+            : null;
 }

--- a/ScoreTracker/ScoreTracker/Components/Sessions/SessionRoundupCard.razor
+++ b/ScoreTracker/ScoreTracker/Components/Sessions/SessionRoundupCard.razor
@@ -43,7 +43,7 @@
     @foreach (var row in InlineRows)
     {
         <HighlightRow Row="row" Chart="Charts.GetValueOrDefault(row.ChartId)"
-                      Flags="FlagsFor(row)"></HighlightRow>
+                      Flags="FlagsFor(row)" Detail="DetailFor(row)"></HighlightRow>
     }
 
     <MudSpacer/>
@@ -69,7 +69,7 @@
             @foreach (var row in Ordered)
             {
                 <HighlightRow Row="row" Chart="Charts.GetValueOrDefault(row.ChartId)"
-                              Flags="FlagsFor(row)"></HighlightRow>
+                              Flags="FlagsFor(row)" Detail="DetailFor(row)"></HighlightRow>
             }
         </div>
     </DialogContent>
@@ -86,6 +86,8 @@
     [Parameter] public IReadOnlyDictionary<Guid, Chart> Charts { get; set; } = new Dictionary<Guid, Chart>();
     [Parameter] public IReadOnlyDictionary<(Guid? SessionId, Guid ChartId), HighlightFlags> Flags { get; set; } =
         new Dictionary<(Guid?, Guid), HighlightFlags>();
+    [Parameter] public IReadOnlyDictionary<(Guid? SessionId, Guid ChartId), HighlightDetail> Details { get; set; } =
+        new Dictionary<(Guid?, Guid), HighlightDetail>();
     [Parameter] public IReadOnlyList<PlayerMilestoneRecord> Milestones { get; set; } =
         Array.Empty<PlayerMilestoneRecord>();
     /// <summary>Show only milestones + flagged rows (the ⭐ Of-note filter).</summary>
@@ -128,6 +130,11 @@
     private HighlightFlags FlagsFor(RecentSessionsPage.ScoreEventRecord row)
     {
         return Flags.GetValueOrDefault((row.SessionId, row.ChartId));
+    }
+
+    private HighlightDetail? DetailFor(RecentSessionsPage.ScoreEventRecord row)
+    {
+        return Details.GetValueOrDefault((row.SessionId, row.ChartId));
     }
 
     private int HiddenRowCount => OfNoteOnly ? 0 : Group.Rows.Count - InlineRows.Count;

--- a/ScoreTracker/ScoreTracker/Components/TitleProgressBar.razor
+++ b/ScoreTracker/ScoreTracker/Components/TitleProgressBar.razor
@@ -23,7 +23,7 @@
         <MudText Typo="Typo.h5">@progress.Title.Name</MudText>
     </MudItem>
     <MudItem xs="12" sm="8" md="9">
-        <MudProgressLinear Color="@(progress.CompletionCount >= progress.Title.CompletionRequired ? Color.Success : Color.Primary)" Value="100.0 * (progress.CompletionCount / (double)progress.Title.CompletionRequired)">
+        <MudProgressLinear Color="@(progress.CompletionCount >= progress.Title.CompletionRequired ? Color.Success : Color.Primary)" Value="100.0 * progress.PercentComplete">
             @if (progress.CompletionCount < progress.Title.CompletionRequired)
             {
                 <MudText Typo="Typo.subtitle1">

--- a/ScoreTracker/ScoreTracker/Dtos/TitleProgressDto.cs
+++ b/ScoreTracker/ScoreTracker/Dtos/TitleProgressDto.cs
@@ -13,6 +13,7 @@ public sealed class TitleProgressDto
     public int CompletionCount { get; set; }
     public bool IsCompleted { get; set; }
     public int RequiredCount { get; set; }
+    public int Floor { get; set; }
     public string AdditionalNote { get; set; } = string.Empty;
     public int? DifficultyLevel { get; set; }
     public bool HasParagonLevel { get; set; }
@@ -26,6 +27,7 @@ public sealed class TitleProgressDto
         {
             CompletionCount = (int)progress.CompletionCount,
             RequiredCount = progress.Title.CompletionRequired,
+            Floor = progress.Title.CompletionFloor,
             TitleCategory = progress.Title.Category,
             TitleDescription = progress.Title.Description,
             TitleName = progress.Title.Name,

--- a/ScoreTracker/ScoreTracker/Pages/Progress/PlayerSessions.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/PlayerSessions.razor
@@ -120,26 +120,42 @@
         _loading = true;
         _page = await Mediator.Send(new GetRecentSessionsQuery(UserIdParam, _pageNumber, _pageSize));
 
-        // One continuous timeline across mixes: chart, flag, and milestone lookups run
-        // per mix present on the page and merge.
+        // Charts still resolve per mix (chart reads are mix-scoped).
         var charts = new Dictionary<Guid, Chart>();
-        var flags = new Dictionary<(Guid? SessionId, Guid ChartId), HighlightFlags>();
-        var milestones = new List<PlayerMilestoneRecord>();
         foreach (var mixGroups in _page.Groups.GroupBy(g => g.Mix))
         {
             var chartIds = mixGroups.SelectMany(g => g.Rows).Select(r => r.ChartId).Distinct().ToArray();
             if (!chartIds.Any()) continue;
             foreach (var chart in await Mediator.Send(new GetChartsQuery(mixGroups.Key, ChartIds: chartIds)))
                 charts[chart.Id] = chart;
+        }
 
-            var since = mixGroups.Min(g => g.Start);
-            var until = mixGroups.Max(g => g.End);
-            foreach (var pair in (await Mediator.Send(
-                             new GetScoreHighlightsQuery(UserIdParam, mixGroups.Key, since, until)))
+        // Highlights and session milestones FK straight to SessionId — never a date window.
+        // A highlight's OccurredAt is the batch-drain time, minutes past its journal rows, so
+        // a row-time window silently drops the freshest session's flags — exactly the session
+        // the Discord card deep-links to, which is why "Of Note" showed nothing.
+        var sessionIds = _page.Groups.Where(g => g.SessionId != null).Select(g => g.SessionId!.Value)
+            .Distinct().ToArray();
+        var flags = new Dictionary<(Guid? SessionId, Guid ChartId), HighlightFlags>();
+        var milestones = new List<PlayerMilestoneRecord>();
+        if (sessionIds.Any())
+        {
+            foreach (var pair in (await Mediator.Send(new GetScoreHighlightsForSessionsQuery(UserIdParam, sessionIds)))
                          .GroupBy(h => (h.SessionId, h.ChartId)))
                 flags[pair.Key] = pair.Aggregate(HighlightFlags.None, (f, h) => f | h.Flags);
-            milestones.AddRange(
-                await Mediator.Send(new GetPlayerMilestonesQuery(UserIdParam, mixGroups.Key, since, until)));
+            milestones.AddRange(await Mediator.Send(new GetPlayerMilestonesForSessionsQuery(UserIdParam, sessionIds)));
+        }
+
+        // Session-less groups (pre-capture calendar days) carry only session-less milestones
+        // — weekly placements, admin recalcs — which have no session to FK to and match by day
+        // over their own window.
+        foreach (var dayGroups in _page.Groups.Where(g => g.SessionId == null && g.Day != null).GroupBy(g => g.Mix))
+        {
+            var since = dayGroups.Min(g => g.Start);
+            var until = dayGroups.Max(g => g.End);
+            milestones.AddRange((await Mediator.Send(new GetPlayerMilestonesQuery(UserIdParam, dayGroups.Key,
+                    since, until)))
+                .Where(m => m.SessionId == null));
         }
 
         _charts = charts;

--- a/ScoreTracker/ScoreTracker/Pages/Progress/PlayerSessions.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/PlayerSessions.razor
@@ -54,7 +54,7 @@
             {
                 @* 1-up phones, 2-up medium, 3-up large, 4-up extra large. *@
                 <MudItem xs="12" md="6" lg="4" xl="3">
-                    <SessionRoundupCard Group="group" Mix="group.Mix" Charts="_charts" Flags="_flags"
+                    <SessionRoundupCard Group="group" Mix="group.Mix" Charts="_charts" Flags="_flags" Details="_details"
                                         Milestones="MilestonesFor(group)"
                                         OfNoteOnly="_filter == FilterOfNote"
                                         StartExpanded="IsDeepLinked(group)"></SessionRoundupCard>
@@ -92,6 +92,8 @@
     private IReadOnlyDictionary<Guid, Chart> _charts = new Dictionary<Guid, Chart>();
     private IReadOnlyDictionary<(Guid? SessionId, Guid ChartId), HighlightFlags> _flags =
         new Dictionary<(Guid?, Guid), HighlightFlags>();
+    private IReadOnlyDictionary<(Guid? SessionId, Guid ChartId), HighlightDetail> _details =
+        new Dictionary<(Guid?, Guid), HighlightDetail>();
     private ILookup<Guid?, PlayerMilestoneRecord> _milestones =
         Array.Empty<PlayerMilestoneRecord>().ToLookup(m => m.SessionId);
 
@@ -137,12 +139,19 @@
         var sessionIds = _page.Groups.Where(g => g.SessionId != null).Select(g => g.SessionId!.Value)
             .Distinct().ToArray();
         var flags = new Dictionary<(Guid? SessionId, Guid ChartId), HighlightFlags>();
+        var details = new Dictionary<(Guid? SessionId, Guid ChartId), HighlightDetail>();
         var milestones = new List<PlayerMilestoneRecord>();
         if (sessionIds.Any())
         {
             foreach (var pair in (await Mediator.Send(new GetScoreHighlightsForSessionsQuery(UserIdParam, sessionIds)))
                          .GroupBy(h => (h.SessionId, h.ChartId)))
+            {
                 flags[pair.Key] = pair.Aggregate(HighlightFlags.None, (f, h) => f | h.Flags);
+                // One highlight row per (session, chart) is the norm; a race can duplicate it,
+                // so keep the richest detail.
+                details[pair.Key] = pair.OrderByDescending(h => DetailFields(h.Detail)).First().Detail
+                                    ?? new HighlightDetail();
+            }
             milestones.AddRange(await Mediator.Send(new GetPlayerMilestonesForSessionsQuery(UserIdParam, sessionIds)));
         }
 
@@ -160,6 +169,7 @@
 
         _charts = charts;
         _flags = flags;
+        _details = details;
         _milestones = milestones.ToLookup(m => m.SessionId);
         _loading = false;
     }
@@ -176,6 +186,13 @@
     private bool IsDeepLinked(RecentSessionsPage.SessionGroup group)
     {
         return _deepLinkedSession != null && group.SessionId == _deepLinkedSession;
+    }
+
+    private static int DetailFields(HighlightDetail? d)
+    {
+        if (d == null) return 0;
+        return new object?[] { d.PumbilityRank, d.FolderDebutOrdinal, d.PeerCount, d.SkillTitleName }
+            .Count(x => x != null);
     }
 
     private async Task ChangePage(int page)

--- a/ScoreTracker/ScoreTracker/Pages/Progress/Titles.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/Titles.razor
@@ -56,7 +56,7 @@ else
                 <CellTemplate>
                     @if (context.Item.IsTrackable)
                     {
-                        <MudProgressLinear Color="@(context.Item.CompletionCount >= context.Item.RequiredCount ? Color.Success : Color.Primary)"  Min="@(context.Item.TitleCategory=="Skill"?PhoenixLetterGrade.AA.GetMinimumScore():0)" Max="context.Item.RequiredCount" Value="context.Item.CompletionCount">
+                        <MudProgressLinear Color="@(context.Item.CompletionCount >= context.Item.RequiredCount ? Color.Success : Color.Primary)"  Min="context.Item.Floor" Max="context.Item.RequiredCount" Value="context.Item.CompletionCount">
                             @if (context.Item.CompletionCount < context.Item.RequiredCount)
                             {
                                 @if (context.Item.TitleCategory == "Skill")

--- a/ScoreTracker/ScoreTracker/Pages/TierLists/TierLists.razor
+++ b/ScoreTracker/ScoreTracker/Pages/TierLists/TierLists.razor
@@ -214,7 +214,7 @@ else
                 <MudText Typo="Typo.h5">@progress.Title.Name</MudText>
             </MudItem>
             <MudItem xs="12" sm="8" md="9">
-                <MudProgressLinear Color="@(progress.CompletionCount >= progress.Title.CompletionRequired ? Color.Success : Color.Primary)" Value="100.0 * (progress.CompletionCount / (double)progress.Title.CompletionRequired)">
+                <MudProgressLinear Color="@(progress.CompletionCount >= progress.Title.CompletionRequired ? Color.Success : Color.Primary)" Value="100.0 * progress.PercentComplete">
                     @if (progress.CompletionCount < progress.Title.CompletionRequired)
                     {
                         <MudText Typo="Typo.subtitle1">

--- a/ScoreTracker/ScoreTracker/Pages/WhatShouldIPlay.razor
+++ b/ScoreTracker/ScoreTracker/Pages/WhatShouldIPlay.razor
@@ -42,7 +42,7 @@ else
             <MudText Typo="Typo.h4">@_progress.Title.Name</MudText>
         </MudItem>
         <MudItem xs="12">
-            <MudProgressLinear Color="Color.Primary" Value="100.0 * (_progress.CompletionCount / (double)_progress.Title.CompletionRequired)">
+            <MudProgressLinear Color="Color.Primary" Value="100.0 * _progress.PercentComplete">
                 <MudText Typo="Typo.subtitle1">
                     @((int)_progress.CompletionCount) / @_progress.Title.CompletionRequired
                 </MudText>

--- a/docs/DATABASE-SCHEMA.md
+++ b/docs/DATABASE-SCHEMA.md
@@ -42,7 +42,7 @@ One SQL Server database, one EF Core `DbContext` ([`ChartAttemptDbContext`](../S
 | `scores.UserTitle` | Titles earned per mix, with paragon progression |
 | `scores.UserHighestTitle` | Denormalized current-highest title per mix (PK UserId+MixId) for fast reads |
 | `scores.SuggestionFeedback` | User feedback on chart recommendations |
-| `scores.ScoreHighlight` | Write-time noteworthy-score flags per journal row (crown, title progress, Score Quality ≥90th, folder ≥90%, competitive improver, folder debut), denormalized Level/ScoringLevel for noteworthy ordering; joined to the journal by (SessionId, ChartId). Never backfilled |
+| `scores.ScoreHighlight` | Write-time noteworthy-score flags per journal row (crown, title progress, Score Quality ≥90th, folder ≥90%, competitive improver, folder debut), denormalized Level/ScoringLevel for noteworthy ordering plus per-flag caption detail (PumbilityRank, FolderDebutOrdinal, Peer{Count,BetterCount,PgCount}, SkillTitle{Name,Score,Threshold}); joined to the journal by (SessionId, ChartId). Never backfilled |
 | `scores.PlayerMilestone` | Session-level milestones with timestamps: Pumbility gains, Singles/Doubles competitive gains, title completions, paragon gains, folder lamps (Kind + compact Detail payload). Never backfilled |
 
 ## Chart Intelligence (vertical: `ScoreTracker.ChartIntelligence`)

--- a/docs/design/discord-rich-score-notifications.md
+++ b/docs/design/discord-rich-score-notifications.md
@@ -10,6 +10,49 @@
 > the passes/upscores/digest card split below; S1–S4 all landed. The spec below is the
 > as-built reference.
 
+## Revision 3 — iteration 2 (locked & implemented 2026-07-08)
+
+Owner feedback after the snapshot card ran live. Eight card changes plus a live-bug fix, one
+PR. Decisions and rationale:
+
+1. **Non-highlighted scores show.** Flagged rows keep art (≤5); the rest render as compact
+   one-liners — ≤10 "More scores" (non-co-op) + ≤5 "Co-op" (co-op difficulty desc) — then the
+   grouped "+N more". Co-ops lost their dedicated art rows.
+2. **Score-computable title completions ride the card.** The "piugame site detected" legacy
+   message now covers only badges the score pipeline can't compute (`CompletionRequired == 0`:
+   events, play/plate counts, staff). Difficulty, skill, boss-breaker and co-op completions
+   flow through the session card. The site-detection path fires first during imports, so the
+   score path (`CaptureSessionTitles`) detects completions by the batch's **before→after
+   crossing** against a score-only completion state — a fresh crossing surfaces even when the
+   site path already persisted the title. Both paths still `SaveTitles` the full set (replace
+   semantics — nothing is dropped); only mint/announce is scoped.
+3. **Skill-title % floored at 900k.** `Title.CompletionFloor` (0 default, 900k for skill) +
+   `TitleProgress.PercentComplete` rebase so a fresh pass isn't ~95%. The card shows
+   `score/threshold` for skill instead of a percent, so the floor is a /Titles-surface fix
+   (page, personalized tier list, `TitleProgressBar`, WhatShouldIPlay).
+4. **Folder line drops the percent** — `23/143`, not `(16%)`.
+5. **Pumbility rank** — `👑 #4 in your PUMBILITY` (position in the pumbility-ordered top 50).
+6. **Peer standing** — `📊 #3 of 47 peers`; for a PG, `📊 PG · 12 of 47 peers have it`. A PG a
+   majority of the cohort also holds is suppressed (not noteworthy); an empty cohort never flags.
+7. **Folder-debut ordinal** — `🆕 First D24` / `Second` / `Third`.
+8. **Title routing.** Completions and generic difficulty/co-op progress deltas always ride the
+   top section; chart-specific **skill** progress rides the per-row caption as
+   `🏅 [DRILL] Lv.4 (972k/990k)`. Per-row `TitleProgress` is now skill-only, which also cuts the
+   flag's noise. Titles render **bracketed** everywhere (`[Expert Lv. 4]`); already-bracketed
+   skill/co-op/boss names aren't double-wrapped.
+
+**Persistence.** The captured detail (pumbility rank, folder-debut ordinal, peer
+count/better/PG-holders, skill title name/score/threshold) persists on `ScoreHighlight` as a
+`HighlightDetail` carried on the write, the read record, and the captured event, so the Sessions
+page renders the same numbers as the card — compact language-neutral badge suffixes (`👑 #4`,
+`📊 #3/47`, `🏅 972k/990k`, `🆕 #1`) with the existing localized tooltips carrying the words.
+
+**Live-bug fix ("Of Note" showed nothing on the freshest session).** A highlight's `OccurredAt`
+is the batch-drain time — minutes past its journal rows — so the page's row-time window dropped
+exactly the session the Discord "See more" button deep-links to. The page now reads highlights
+and session-attached milestones **by SessionId** (FK, indexed), not a date window; session-less
+rows (weekly placements, admin recalcs) still match by day.
+
 ## Revision 2 — the session snapshot (locked 2026-07-05)
 
 Owner direction after seeing C0–C10 live: score events were still "a big dump of scores —


### PR DESCRIPTION
Iteration on the live session-snapshot card, from owner feedback. Eight card changes plus a live-bug fix, built as eight standalone commits (each green on the fast suites). Full spec in `docs/design/discord-rich-score-notifications.md` → **Revision 3**.

## What changed

1. **More scores show** — flagged rows keep art (≤5); non-highlighted scores now render as compact one-liners: ≤10 **More scores** (non-co-op) + ≤5 **Co-op** (co-op difficulty desc), then the grouped `+N more`. Co-ops lost their dedicated art rows.
2. **Score-computable title completions ride the card** — the "piugame site detected" legacy message now covers only badges the score pipeline can't compute (`CompletionRequired == 0`). Difficulty/skill/boss-breaker/co-op completions flow through the card. Since site-detection fires first during imports, the score path detects completions by the batch's **before→after crossing** (score-only), so a fresh crossing surfaces even when the site path already saved the title. Both paths still `SaveTitles` the full set — only mint/announce is scoped.
3. **Skill-title % floored at 900k** — `Title.CompletionFloor` + `TitleProgress.PercentComplete`, applied on `/Titles`, the personalized tier list, `TitleProgressBar`, and WhatShouldIPlay. The card shows `score/threshold` for skill instead.
4. **Folder line drops the percent** — `23/143`, not `(16%)`.
5. **Pumbility rank** — `👑 #4 in your PUMBILITY`.
6. **Peer standing** — `📊 #3 of 47 peers`; PG → `📊 PG · 12 of 47 peers have it` (a PG most peers also hold is suppressed).
7. **Folder-debut ordinal** — `🆕 First D24`.
8. **Title routing + brackets** — completions and generic difficulty/co-op deltas up top; chart-specific skill progress per-row as `🏅 [DRILL] Lv.4 (972k/990k)`. Titles render bracketed everywhere.

**Persistence** — the captured detail persists on `ScoreHighlight` (widened, one additive migration) as a `HighlightDetail` on the write, read record, and event, so the **Sessions page renders the same numbers** as the card.

**Live-bug fix** — "Of Note" showed nothing on the freshest session: a highlight's `OccurredAt` is the batch-drain time (minutes past its journal rows), so the page's row-time window dropped exactly the session the Discord "See more" button deep-links to. The page now reads highlights and session milestones **by SessionId**, not a date window.

## Tests
- Fast suites (no Docker): **817** unit/component/architecture + **57** API wire-shape — green in Release. No `api/*` contract changed.
- Integration (migration + `GetHighlightsBySessions` regression) and the Sessions E2E (enriched-badge assertion) run in CI (need Docker; unavailable locally).
- **Discord canary** is manual/opt-in — worth a run since this touches Communities + the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)