### PR TITLE
Discord card iteration 3: length budget, site titles, peer cutoff

### DIFF
--- a/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
@@ -182,7 +182,15 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
             .ToArray();
         var notable = standard.Where(Notable).Take(NotableRowCap).ToArray();
         var notableIds = notable.Select(c => c.ChartId).ToHashSet();
-        var moreScores = standard.Where(c => !notableIds.Contains(c.ChartId)).Take(MoreScoresCap).ToArray();
+        // Re-sort the remainder purely by level (owner call): when notable overflows its cap
+        // the extra flagged rows are lower-level, and leaving them in the notable-first order
+        // would float them above higher-level unflagged charts. "More scores" is one clean run.
+        var moreScores = standard.Where(c => !notableIds.Contains(c.ChartId))
+            .OrderByDescending(c => (int)charts[c.ChartId].Level)
+            .ThenByDescending(c => scoringLevels.TryGetValue(c.ChartId, out var sl) ? sl : 0)
+            .ThenByDescending(c => (int)(bests[c.ChartId].Score ?? 0))
+            .Take(MoreScoresCap)
+            .ToArray();
 
         // Co-ops get their own compact bucket (owner call): up to 5, community co-op pass
         // difficulty descending. They no longer take art rows.

--- a/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
@@ -48,11 +48,12 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     private readonly IMediator _mediator;
     private readonly IScoreReader _scores;
     private readonly IUserReader _users;
+    private readonly IPlayerStatsReader _playerStats;
     private readonly IDateTimeOffsetAccessor _dateTime;
 
     public CommunitySaga(ICurrentUserAccessor currentUser, ICommunityRepository communities, IBotClient bot,
         IUserReader users, IChartRepository charts, IScoreReader scores, IMediator mediator,
-        IDateTimeOffsetAccessor dateTime)
+        IPlayerStatsReader playerStats, IDateTimeOffsetAccessor dateTime)
     {
         _currentUser = currentUser;
         _communities = communities;
@@ -61,6 +62,7 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         _charts = charts;
         _scores = scores;
         _mediator = mediator;
+        _playerStats = playerStats;
         _dateTime = dateTime;
     }
 
@@ -198,12 +200,16 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         }
 
         // The weekly read: current placements for whichever batch charts sit on this
-        // week's board. Failure costs the weekly lines, never the card.
+        // week's board. Gated on competitive − 5 (owner call) exactly like the peer flag —
+        // a 23-competitive player placing on a weekly D10 is the same noise. Failure costs
+        // the weekly lines, never the card.
         var weekly = Array.Empty<WeeklyPlacementRecord>();
         try
         {
+            var stats = await _playerStats.GetStats(e.Mix, e.UserId, context.CancellationToken);
             weekly = (await _mediator.Send(new GetUserWeeklyPlacementsQuery(e.UserId, e.Mix,
                     known.Select(c => c.ChartId).Distinct().ToArray()), context.CancellationToken))
+                .Where(w => (int)charts[w.ChartId].Level >= CompetitiveFor(charts[w.ChartId].Type, stats) - 5)
                 .OrderByDescending(w => (int)charts[w.ChartId].Level)
                 .Take(WeeklyLineCap)
                 .ToArray();
@@ -578,6 +584,18 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     private static string Charts(int count)
     {
         return count == 1 ? "chart" : "charts";
+    }
+
+    // The competitive level for a chart's type; co-op (and anything without a competitive
+    // side) returns 0, so its gate threshold is −5 and it never gets filtered.
+    private static double CompetitiveFor(ChartType type, PlayerStatsRecord stats)
+    {
+        return type switch
+        {
+            ChartType.Single => stats.SinglesCompetitiveLevel,
+            ChartType.Double => stats.DoublesCompetitiveLevel,
+            _ => 0
+        };
     }
 
     public async Task Consume(ConsumeContext<UserUpdatedEvent> context)

--- a/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
@@ -130,11 +130,21 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     private const int MoreScoresCap = 10;
     private const int CoOpScoresCap = 5;
     private const int WeeklyLineCap = 4;
-    private const int TitleNameCap = 10;
     private const int ProgressDeltaCap = 3;
     private const int FolderLineCap = 6;
     private const int BigGainThreshold = 10000;
     private const string SiteBase = "https://piuscores.arroweclip.se";
+
+    // Discord's Components V2 text ceiling is 4000 chars measured AFTER emoji tokens expand
+    // (#DIFFICULTY|…# → <:piu_…:snowflake>). The saga can't see the real snowflakes, so it
+    // packs against a conservative estimate: literal length + a per-token width, kept under a
+    // margin so nothing reaches the renderer's mid-line truncation. The stats, achievements
+    // (all titles), and folder line are reserved first; only the score buckets flex to fit.
+    private const int TokenWidth = 30;
+    private const int CardCharBudget = 3600;
+    private const int FooterReserve = 90;
+    private static readonly string[] EmojiTokenPrefixes =
+        { "#DIFFICULTY|", "#LETTERGRADE|", "#PLATE|", "#MIX|" };
 
     public async Task Consume(ConsumeContext<ScoreHighlightsCapturedEvent> context)
     {
@@ -247,35 +257,73 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     private async Task<RichBotMessage> BuildSnapshotCard(SnapshotInputs inputs,
         CancellationToken cancellationToken)
     {
-        var blocks = new List<IRichBotBlock> { new RichBotDivider() };
+        var header = HeaderSection(inputs);
+        var statLines = StatLines(inputs.E.Milestones);
+        var achievementLines = AchievementLines(inputs.E, inputs.Weekly, inputs.Charts);
 
-        // ① Stats that moved (capture already floored the noise).
-        AddSection(blocks, StatLines(inputs.E.Milestones));
-        // ② Achievements: titles, paragon, folder lamps, weekly placements — or the
-        // per-title progress deltas when nothing completed.
-        AddSection(blocks, AchievementLines(inputs.E, inputs.Weekly, inputs.Charts));
-        // ③ Notable scores: art while the slots last, individual text rows after,
-        // everything else one grouped count line.
-        AddNotableRows(blocks, inputs);
-        AddCompactBucket(blocks, inputs.MoreScores, inputs, "More scores");
-        AddCompactBucket(blocks, inputs.CoOpScores, inputs, "Co-op");
-        AddOverflowLine(blocks, inputs);
-
+        // The folder breakdown is computed and reserved up front (owner call): scores yield
+        // to it, never the reverse, so a title-heavy or score-heavy card still ends with it.
         var passCharts = inputs.Known
             .Where(c => c.IsNewPass && !c.IsBroken)
             .Select(c => inputs.Charts[c.ChartId])
             .Where(c => c.Type is ChartType.Single or ChartType.Double);
         var folderStats = await FolderProgress(inputs.E.Mix, inputs.E.UserId, passCharts, FolderLineCap,
             cancellationToken);
+
+        var remaining = CardCharBudget - FooterReserve
+            - Estimate(header.Markdown)
+            - EstimateLines(statLines)
+            - EstimateLines(achievementLines)
+            - (string.IsNullOrWhiteSpace(folderStats) ? 0 : Estimate(folderStats));
+
+        var blocks = new List<IRichBotBlock> { new RichBotDivider() };
+
+        // ① Stats that moved (capture already floored the noise).
+        AddSection(blocks, statLines);
+        // ② Achievements: titles, paragon, folder lamps, weekly placements — or the
+        // per-title progress deltas when nothing completed.
+        AddSection(blocks, achievementLines);
+        // ③ Notable scores lead, then the compact buckets — each filling only what the
+        // reserved sections leave. Whatever doesn't fit (or overruns a cap) is a count line.
+        var shown = new HashSet<Guid>();
+        AddNotableRows(blocks, inputs, ref remaining, shown);
+        AddCompactBucket(blocks, inputs.MoreScores, inputs, "More scores", ref remaining, shown);
+        AddCompactBucket(blocks, inputs.CoOpScores, inputs, "Co-op", ref remaining, shown);
+        AddOverflowLine(blocks, inputs, shown);
+
         if (!string.IsNullOrWhiteSpace(folderStats))
         {
             blocks.Add(new RichBotDivider());
             blocks.Add(new RichBotText(folderStats));
         }
 
-        return new RichBotMessage(HeaderSection(inputs), blocks,
+        return new RichBotMessage(header, blocks,
             $"#MIX|{inputs.E.Mix}# {inputs.E.Mix.GetName()} · PIU Scores",
             inputs.E.Mix.GetAccentColor(), Links(inputs));
+    }
+
+    // Estimated rendered width of a block once emoji tokens expand — literal length plus a
+    // conservative per-token width. Over-estimating is safe: it trims early, never late.
+    private static int Estimate(string? markdown)
+    {
+        if (string.IsNullOrEmpty(markdown)) return 0;
+        var tokens = 0;
+        foreach (var prefix in EmojiTokenPrefixes)
+        {
+            var idx = markdown.IndexOf(prefix, StringComparison.Ordinal);
+            while (idx >= 0)
+            {
+                tokens++;
+                idx = markdown.IndexOf(prefix, idx + prefix.Length, StringComparison.Ordinal);
+            }
+        }
+
+        return markdown.Length + tokens * TokenWidth;
+    }
+
+    private static int EstimateLines(List<string> lines)
+    {
+        return lines.Count == 0 ? 0 : Estimate(string.Join("\n", lines));
     }
 
     private static void AddSection(List<IRichBotBlock> blocks, List<string> lines)
@@ -285,25 +333,46 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         blocks.Add(new RichBotDivider());
     }
 
-    private static void AddNotableRows(List<IRichBotBlock> blocks, SnapshotInputs inputs)
+    private static void AddNotableRows(List<IRichBotBlock> blocks, SnapshotInputs inputs, ref int remaining,
+        HashSet<Guid> shown)
     {
         var artLeft = ArtRowCap;
         foreach (var change in inputs.Notable)
         {
             var chart = inputs.Charts[change.ChartId];
             var text = RowText(change, chart, inputs.Bests[change.ChartId], IsBigGain(change, inputs.Known));
+            var cost = Estimate(text);
+            // Notable rows are the priciest; when one won't fit, the rest fall to overflow
+            // (the cheaper compact buckets still get their turn at the leftover budget).
+            if (cost > remaining) break;
+            remaining -= cost;
+            shown.Add(change.ChartId);
             blocks.Add(artLeft-- > 0 ? new RichBotSection(text, chart.Song.ImagePath) : new RichBotText(text));
         }
     }
 
     // The low-ceremony buckets (owner call): one compact line per score in a single text
     // block — difficulty, song, score, grade — no art, no caption. Non-co-op "More scores"
-    // and co-op each get their own labelled block.
+    // and co-op each get their own labelled block, filling as many rows as the budget allows.
     private static void AddCompactBucket(List<IRichBotBlock> blocks,
-        ScoreHighlightsCapturedEvent.HighlightedChange[] rows, SnapshotInputs inputs, string label)
+        ScoreHighlightsCapturedEvent.HighlightedChange[] rows, SnapshotInputs inputs, string label,
+        ref int remaining, HashSet<Guid> shown)
     {
         if (rows.Length == 0) return;
-        var lines = rows.Select(c => CompactRow(inputs.Charts[c.ChartId], inputs.Bests[c.ChartId]));
+        var used = Estimate($"-# {label}");
+        var lines = new List<string>();
+        foreach (var c in rows)
+        {
+            var row = CompactRow(inputs.Charts[c.ChartId], inputs.Bests[c.ChartId]);
+            var cost = Estimate(row) + 1; // + newline
+            if (used + cost > remaining) break;
+            used += cost;
+            lines.Add(row);
+            shown.Add(c.ChartId);
+        }
+
+        if (lines.Count == 0) return;
+        remaining -= used;
         blocks.Add(new RichBotText($"-# {label}\n" + string.Join("\n", lines)));
     }
 
@@ -313,10 +382,10 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
                $"#LETTERGRADE|{best.Score!.Value.LetterGrade}|{best.IsBroken}##PLATE|{best.Plate}#";
     }
 
-    private static void AddOverflowLine(List<IRichBotBlock> blocks, SnapshotInputs inputs)
+    private static void AddOverflowLine(List<IRichBotBlock> blocks, SnapshotInputs inputs, HashSet<Guid> shown)
     {
-        var shown = inputs.Notable.Concat(inputs.MoreScores).Concat(inputs.CoOpScores)
-            .Select(c => c.ChartId).ToHashSet();
+        // `shown` is what actually rendered (budget-trimmed), so the count reflects the real
+        // remainder — not just what the row caps would have dropped.
         var rest = inputs.Known.Where(c => !shown.Contains(c.ChartId)).ToArray();
         if (rest.Length == 0) return;
 
@@ -409,9 +478,9 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     {
         var lines = new List<string>();
         var titles = e.Milestones.Where(m => m.Kind == MilestoneKind.TitleCompleted).ToArray();
-        lines.AddRange(titles.Take(TitleNameCap).Select(t => $"🏅 **{Bracket(t.Title)}** completed"));
-        if (titles.Length > TitleNameCap)
-            lines.Add($"…and {titles.Length - TitleNameCap} more titles");
+        // Every completion is listed — titles are the card's top priority (owner call), and
+        // the 4000-char budget (not a name cap) is the only backstop.
+        lines.AddRange(titles.Select(t => $"🏅 **{Bracket(t.Title)}** completed"));
 
         // Paragon gains are never counted or aggregated — the new grade IS the content
         // (owner call), so every gain is its own grade-named line.

--- a/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
@@ -114,9 +114,10 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     // that moved, achievements earned, and only the scores worth reading; everything
     // else is a count. Renders from ScoreHighlightsCapturedEvent, which the capture
     // orchestrator publishes AFTER the rating/title steps ran, so every section is
-    // deterministic. This is the only score-triggered community Discord message; the
-    // old ratings/weekly messages are retired (titles keep a legacy announcement only
-    // for site-detected titles, which no card covers).
+    // deterministic. This is the only score-triggered community Discord message; the old
+    // ratings/weekly messages are retired. Site-detected title completions ride this card
+    // too when their import saved scores (iteration 3); a zero-score import's titles get
+    // their own rich card via NewTitlesAcquiredEvent instead.
     private const int ArtRowCap = 5;
     private const int NotableRowCap = 10;
     private const int MoreScoresCap = 10;

--- a/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
@@ -66,56 +66,48 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         _dateTime = dateTime;
     }
 
+    // Titles with no session — a zero-score import that still detected new badges, or an admin
+    // recompute — get their own rich card in the session card's visual language (owner call:
+    // ALL title completions show in a card). Chunked so a rare big badge dump never overruns
+    // the char ceiling.
     public async Task Consume(ConsumeContext<NewTitlesAcquiredEvent> context)
     {
-        var prefix = MixPrefix(context.Message.Mix);
-        var user = await _users.GetUser(context.Message.UserId, context.CancellationToken);
-        var message = string.Empty;
-        var count = 0;
-        if (context.Message.NewTitles.Any())
-        {
-            message = $"**{user.Name}** completed the Titles:";
-            foreach (var title in context.Message.NewTitles.OrderBy(t => t))
-            {
-                message += $@"
-- {title}";
+        var e = context.Message;
+        var user = await _users.GetUser(e.UserId, context.CancellationToken);
+        if (user == null) return;
+        var cards = BuildTitlesCards(user, e.Mix, e.NewTitles.ToArray(), e.ParagonUpgrades);
+        await SendRichToCommunityDiscords(user.Id, cards, context.CancellationToken);
+    }
 
-                count++;
-                if (count != 10) continue;
+    private IReadOnlyList<RichBotMessage> BuildTitlesCards(User user, MixEnum mix,
+        IReadOnlyList<string> newTitles, IDictionary<string, string> paragonUpgrades)
+    {
+        var lines = new List<string>();
+        lines.AddRange(newTitles.OrderBy(t => t).Select(t => $"🏅 **{Bracket(t)}** completed"));
+        lines.AddRange(paragonUpgrades.OrderBy(p => p.Key)
+            .Select(p => $"🏅 **{Bracket(p.Key)}** paragon → {ParagonEmoji(p.Value)}"));
+        if (lines.Count == 0) return Array.Empty<RichBotMessage>();
 
-                await SendToCommunityDiscords(user.Id, prefix + message,
-                    context.CancellationToken);
-                message = "";
-                count = 0;
-            }
-        }
+        var earned = TitlesEarnedText(newTitles.Count, paragonUpgrades.Count);
+        var links = user.IsPublic
+            ? new[] { new RichBotLink("See more", new Uri($"{SiteBase}/Player/{user.Id}/Sessions")) }
+            : Array.Empty<RichBotLink>();
 
-        if (context.Message.ParagonUpgrades.Any())
-        {
-            if (!string.IsNullOrWhiteSpace(message))
-                message += @"
-";
-            message += $"**{user.Name}** Advanced their Paragon Title Levels:";
-            foreach (var upgradedTitle in context.Message.ParagonUpgrades.OrderBy(t => t.Key))
-            {
-                var emoji = upgradedTitle.Value == "PG"
-                    ? "#PLATE|PerfectGame#"
-                    : "#LETTERGRADE|" + upgradedTitle.Value + "#";
-                message += $@"
-- {upgradedTitle.Key} {emoji}";
-                count++;
-                if (count != 10) continue;
+        return lines.Chunk(TitleCardLineCap)
+            .Select(chunk => new RichBotMessage(
+                new RichBotSection($"### {MixPrefix(mix)}**{user.Name}** — {earned}", user.ProfileImage),
+                new IRichBotBlock[] { new RichBotDivider(), new RichBotText(string.Join("\n", chunk)) },
+                $"#MIX|{mix}# {mix.GetName()} · PIU Scores",
+                mix.GetAccentColor(), links))
+            .ToArray();
+    }
 
-                await SendToCommunityDiscords(user.Id,
-                    prefix + message, context.CancellationToken);
-                message = "";
-                count = 0;
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(message))
-            await SendToCommunityDiscords(user.Id,
-                prefix + message, context.CancellationToken);
+    private static string TitlesEarnedText(int titles, int paragons)
+    {
+        var parts = new List<string>();
+        if (titles > 0) parts.Add($"{titles} {(titles == 1 ? "title" : "titles")}");
+        if (paragons > 0) parts.Add($"{paragons} paragon{(paragons == 1 ? string.Empty : "s")}");
+        return string.Join(" · ", parts);
     }
 
     // The session snapshot (design doc revision 2): ONE card per score batch — stats
@@ -132,6 +124,7 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     private const int WeeklyLineCap = 4;
     private const int ProgressDeltaCap = 3;
     private const int FolderLineCap = 6;
+    private const int TitleCardLineCap = 20;
     private const int BigGainThreshold = 10000;
     private const string SiteBase = "https://piuscores.arroweclip.se";
 

--- a/ScoreTracker/ScoreTracker.Domain/Events/TitlesDetectedEvent.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Events/TitlesDetectedEvent.cs
@@ -2,8 +2,12 @@
 
 namespace ScoreTracker.Domain.Events
 {
+    // SessionId is set when the detecting import also saved scores (so the session's snapshot
+    // card will carry these completions); null when the run saved no scores, in which case the
+    // titles get their own announcement instead.
     [ExcludeFromCodeCoverage]
-    public sealed record TitlesDetectedEvent(Guid UserId, IEnumerable<string> TitlesFound, MixEnum Mix)
+    public sealed record TitlesDetectedEvent(Guid UserId, IEnumerable<string> TitlesFound, MixEnum Mix,
+        Guid? SessionId = null)
     {
     }
 }

--- a/ScoreTracker/ScoreTracker.OfficialMirror/Application/OfficialLeaderboardSaga.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Application/OfficialLeaderboardSaga.cs
@@ -333,10 +333,6 @@ namespace ScoreTracker.OfficialMirror.Application
                 new UpdateUserGameProfileCommand(accountData.AccountName, accountData.AvatarUrl),
                 cancellationToken);
 
-            await _bus.Publish(new TitlesDetectedEvent(userId, accountData.Titles.Select(t => t.ToString()),
-                    request.Mix),
-                cancellationToken);
-
             var maxPages =
                 await _officialSite.GetScorePageCount(request.Mix, request.Username, request.Password,
                     cancellationToken);
@@ -397,6 +393,13 @@ namespace ScoreTracker.OfficialMirror.Application
                     batch.ToArray(), request.Mix),
                 cancellationToken);
             batch.Clear();
+
+            // Titles are announced last, now that we know whether this run saved any scores.
+            // With a score batch, they ride its session snapshot card (SessionId flows to the
+            // title path); with none, SessionId stays null and they get their own announcement.
+            await _bus.Publish(new TitlesDetectedEvent(userId, accountData.Titles.Select(t => t.ToString()),
+                    request.Mix, toSave.Length > 0 ? importSessionId : null),
+                cancellationToken);
 
             await _mediator.Send(new SaveUserUiSettingCommand(pageCountSetting, maxPages.ToString()),
                 cancellationToken);

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/HighlightCaptureSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/HighlightCaptureSaga.cs
@@ -195,7 +195,9 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
         PhoenixTitleProgress[] IncompleteTitles,
         IDictionary<Guid, double> ScoringLevels,
         Dictionary<(ChartType Type, DifficultyLevel Level), int> FolderSizes,
-        Dictionary<(ChartType Type, DifficultyLevel Level), int> FolderClears);
+        Dictionary<(ChartType Type, DifficultyLevel Level), int> FolderClears,
+        double SinglesCompetitive,
+        double DoublesCompetitive);
 
     private async Task<List<ScoreHighlightWrite>> ComputeFlags(PlayerScoresUpdatedEvent e,
         Dictionary<Guid, HighlightFlags> flags, Dictionary<Guid, HighlightDetail> details,
@@ -243,6 +245,11 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
             .ToArray();
         var scoringLevels = await _mediator.Send(new GetChartScoringLevelsQuery(e.Mix), cancellationToken);
 
+        // Competitive levels gate Score Quality (and are cheap to carry): a back-filled chart
+        // more than 5 levels under the player's competitive level for its type is noise, not a
+        // peer flag — the cohort is never even built for it.
+        var stats = await _playerStats.GetStats(e.Mix, e.UserId, cancellationToken);
+
         // Folder totals and clears come from data already in hand — no extra queries.
         var folderSizes = charts.Values.GroupBy(c => (c.Type, c.Level))
             .ToDictionary(g => g.Key, g => g.Count());
@@ -250,7 +257,8 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
             .Where(b => !b.IsBroken && b.Score != null && charts.ContainsKey(b.ChartId))
             .GroupBy(b => (charts[b.ChartId].Type, charts[b.ChartId].Level))
             .ToDictionary(g => g.Key, g => g.Count());
-        return new CaptureData(charts, bests, top50, incompleteTitles, scoringLevels, folderSizes, folderClears);
+        return new CaptureData(charts, bests, top50, incompleteTitles, scoringLevels, folderSizes, folderClears,
+            stats.SinglesCompetitiveLevel, stats.DoublesCompetitiveLevel);
     }
 
     private const int PerfectGameScore = 1_000_000;
@@ -308,7 +316,14 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
         CancellationToken cancellationToken)
     {
         if (folder.Type is not (ChartType.Single or ChartType.Double)) return;
-        var cohort = await GetCohortScores(e.Mix, e.UserId, folder.Type, folder.Level, cancellationToken);
+
+        // Owner call: below (competitive − 5) for the chart's type, peer comparison is noise
+        // (a 23-competitive player back-filling S5s). Skip the whole folder — no cohort, no flag.
+        var competitive = folder.Type == ChartType.Single ? data.SinglesCompetitive : data.DoublesCompetitive;
+        if ((int)folder.Level < competitive - 5) return;
+
+        var cohort = await GetCohortScores(e.Mix, e.UserId, folder.Type, folder.Level, competitive,
+            cancellationToken);
         foreach (var change in folderChanges)
         {
             var best = data.Bests[change.ChartId];
@@ -408,17 +423,13 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
     }
 
     private async Task<IReadOnlyDictionary<Guid, PhoenixScore[]>> GetCohortScores(MixEnum mix, Guid userId,
-        ChartType type, DifficultyLevel level, CancellationToken cancellationToken)
+        ChartType type, DifficultyLevel level, double competitive, CancellationToken cancellationToken)
     {
         return await _cache.GetOrCreateAsync(
             $"{nameof(HighlightCaptureSaga)}__Cohort__{mix}__{userId}__{type}__{(int)level}",
             async o =>
             {
                 o.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
-                var stats = await _playerStats.GetStats(mix, userId, cancellationToken);
-                var competitive = type == ChartType.Single
-                    ? stats.SinglesCompetitiveLevel
-                    : stats.DoublesCompetitiveLevel;
                 var players = await _playerStats.GetPlayersByCompetitiveRange(mix, type, competitive, .5,
                     cancellationToken);
                 return (IReadOnlyDictionary<Guid, PhoenixScore[]>)(await _scores.GetPlayerScores(mix, players, type,

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/TitleSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/TitleSaga.cs
@@ -144,12 +144,16 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
     public async Task Consume(ConsumeContext<TitlesDetectedEvent> context)
     {
         // The site path owns only the badges the score pipeline can't compute
-        // (CompletionRequired == 0): events, play/plate counts, staff. Difficulty, skill,
-        // boss-breaker and co-op completions ride the session card via the score path, so
-        // this path stops announcing them (it still saves everything — DB stays correct).
+        // (CompletionRequired == 0): events, play/plate counts, staff. When the detecting
+        // import also saved scores, these completions are attributed to that session and ride
+        // its snapshot card (no legacy announce — the card carries them); when it saved none,
+        // SessionId is null and they get their own announcement. Either way everything is
+        // saved — the DB stays correct.
+        var sessionId = context.Message.SessionId;
         await ProcessCharts(context.Message.Mix, context.Message.UserId,
             context.Message.TitlesFound.Select(Name.From),
-            context.CancellationToken, siteOnlyAnnounce: true);
+            context.CancellationToken, sessionId: sessionId,
+            announceLegacy: sessionId == null, siteOnlyAnnounce: true);
     }
 
     private ParagonLevel GetLevel(TitleProgress tp)
@@ -249,8 +253,21 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
         await ProcessCharts(request.Mix, request.UserId, Array.Empty<Name>(), cancellationToken,
             request.SessionId, announceLegacy: false, mint: false);
 
-        var milestones = await ComputeBatchCompletions(request, cancellationToken);
+        var scoreMilestones = await ComputeBatchCompletions(request, cancellationToken);
         var progress = await ComputeProgressDeltas(request, cancellationToken);
+
+        // The card shows ALL of the session's title completions (owner call), so single-source
+        // them from the milestone table by session: this folds in the site-detection path's
+        // basic-badge completions (written against this same SessionId before the batch
+        // drained) alongside the score-crossing ones just computed — no double-count, since the
+        // two paths own disjoint title sets (CompletionRequired == 0 vs > 0). A null-session
+        // batch (manual entry) has no site path, so it uses the score-crossing list directly.
+        IReadOnlyList<PlayerMilestoneRecord> milestones = request.SessionId == null
+            ? scoreMilestones
+            : (await _milestones.GetMilestonesBySessions(request.UserId, new[] { request.SessionId.Value },
+                    cancellationToken))
+                .Where(m => m.Kind is MilestoneKind.TitleCompleted or MilestoneKind.ParagonLevelGain)
+                .ToArray();
         return new SessionTitlesResult(milestones, progress);
     }
 

--- a/ScoreTracker/ScoreTracker.Tests.Integration/DiscordCanary/DiscordCanaryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/DiscordCanary/DiscordCanaryTests.cs
@@ -56,7 +56,8 @@ public sealed class DiscordCanaryTests
         });
         await ready.Task.WaitAsync(TimeSpan.FromSeconds(30));
 
-        await bot.SendRichMessages(new[] { SamplePassesCard(marker), SampleDigestCard(marker) },
+        await bot.SendRichMessages(
+            new[] { SamplePassesCard(marker), SampleDigestCard(marker), SampleTitlesCard(marker) },
             new[] { ChannelId!.Value });
 
         // Independent REST readback — proves the messages actually landed with V2
@@ -67,7 +68,7 @@ public sealed class DiscordCanaryTests
         var recent = (await channel.GetMessagesAsync(15).FlattenAsync()).ToArray();
         var mine = recent.Where(m => ComponentTexts(m.Components).Any(t => t.Contains(marker))).ToArray();
 
-        Assert.Equal(2, mine.Length);
+        Assert.Equal(3, mine.Length);
         await bot.Stop();
     }
 
@@ -118,7 +119,9 @@ public sealed class DiscordCanaryTests
                 new RichBotDivider(),
                 new RichBotText("📈 **PUMBILITY** 0 → **18,437** (+18,437)"),
                 new RichBotDivider(),
-                new RichBotText("🏅 **[Intermediate Lv. 1]** completed\n…and 4 more titles\n" +
+                new RichBotText("🏅 **[Intermediate Lv. 1]** completed\n" +
+                                "🏅 **[Advanced Lv. 1]** completed\n" +
+                                "🏅 **[RISE CHALLENGER]** completed\n" +
                                 "🎉 #DIFFICULTY|s13# **All passed!**"),
                 new RichBotDivider(),
                 new RichBotSection(
@@ -133,6 +136,26 @@ public sealed class DiscordCanaryTests
             },
             $"#MIX|Phoenix2# Phoenix2 · PIU Scores · {marker}",
             MixEnum.Phoenix2.GetAccentColor(),
+            new[] { new RichBotLink("See more", new Uri("https://piuscores.arroweclip.se")) });
+    }
+
+    // Iteration 3: the standalone titles-card — a zero-score import (detected badges but saved
+    // no scores) or an admin recompute renders completions and paragon gains in the session
+    // card's language, no scores/folder sections.
+    private static RichBotMessage SampleTitlesCard(string marker)
+    {
+        return new RichBotMessage(
+            new RichBotSection("### **Canary** — 3 titles · 1 paragon", Avatar),
+            new IRichBotBlock[]
+            {
+                new RichBotDivider(),
+                new RichBotText("🏅 **[RISE CHALLENGER]** completed\n" +
+                                "🏅 **[The 1st]** completed\n" +
+                                "🏅 **[Extra Stage Clearer]** completed\n" +
+                                "🏅 **[Expert Lv. 2]** paragon → #PLATE|PerfectGame#")
+            },
+            $"#MIX|Phoenix# Phoenix · PIU Scores · {marker}",
+            MixEnum.Phoenix.GetAccentColor(),
             new[] { new RichBotLink("See more", new Uri("https://piuscores.arroweclip.se")) });
     }
 

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -202,8 +202,10 @@ public sealed class CommunitySagaTests
     }
 
     [Fact]
-    public async Task NewTitlesAcquiredBroadcastsTitleListToCommunityChannels()
+    public async Task NewTitlesWithNoSessionRenderAsARichTitlesCard()
     {
+        // Zero-score imports (and admin recomputes) still surface title completions — now as
+        // a rich card in the session card's language, not a plain-text list (owner Q1=a).
         var userId = Guid.NewGuid();
         var ctx = new HandlerContext();
         ctx.GivenUser(userId, name: "alice");
@@ -214,14 +216,39 @@ public sealed class CommunitySagaTests
             ParagonUpgrades: new Dictionary<string, string>(),
             Mix: MixEnum.Phoenix)));
 
-        ctx.Bot.Verify(b => b.SendMessages(
-            It.Is<IEnumerable<string>>(msgs => msgs.Any(m => m.Contains("alice") && m.Contains("First Title"))),
+        ctx.Bot.Verify(b => b.SendRichMessages(
+            It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.Any(m =>
+                m.Header!.Markdown.Contains("alice")
+                && m.Blocks.OfType<RichBotText>().Any(t =>
+                    t.Markdown.Contains("🏅 **[First Title]** completed")
+                    && t.Markdown.Contains("🏅 **[Second Title]** completed")))),
             It.Is<IEnumerable<ulong>>(ids => ids.Contains(12345ul)),
-            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task Phoenix2TitleBroadcastCarriesTheMixPrefix()
+    public async Task TitlesCardRendersParagonGainsWithTheirGradeEmoji()
+    {
+        var userId = Guid.NewGuid();
+        var ctx = new HandlerContext();
+        ctx.GivenUser(userId, name: "alice");
+        ctx.GivenUserCommunitiesWithChannel(userId, communityName: "Acme", channelId: 12345);
+
+        await ctx.Saga.Consume(BuildContext(new NewTitlesAcquiredEvent(userId,
+            NewTitles: Array.Empty<string>(),
+            ParagonUpgrades: new Dictionary<string, string> { ["Expert Lv. 2"] = "PG" },
+            Mix: MixEnum.Phoenix)));
+
+        ctx.Bot.Verify(b => b.SendRichMessages(
+            It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.Any(m =>
+                m.Blocks.OfType<RichBotText>().Any(t =>
+                    t.Markdown.Contains("🏅 **[Expert Lv. 2]** paragon → #PLATE|PerfectGame#")))),
+            It.Is<IEnumerable<ulong>>(ids => ids.Contains(12345ul)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Phoenix2TitlesCardCarriesTheMixPrefix()
     {
         var userId = Guid.NewGuid();
         var ctx = new HandlerContext();
@@ -233,8 +260,8 @@ public sealed class CommunitySagaTests
             ParagonUpgrades: new Dictionary<string, string>(),
             Mix: MixEnum.Phoenix2)));
 
-        ctx.Bot.Verify(b => b.SendMessages(
-            It.Is<IEnumerable<string>>(msgs => msgs.All(m => m.StartsWith("[Phoenix 2] "))),
+        ctx.Bot.Verify(b => b.SendRichMessages(
+            It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.All(m => m.Header!.Markdown.Contains("[Phoenix 2] "))),
             It.Is<IEnumerable<ulong>>(ids => ids.Contains(12345ul)),
             It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -450,8 +450,10 @@ public sealed class CommunitySagaTests
     }
 
     [Fact]
-    public async Task TitleListingCapsAtTenNamesAndParagonLinesNeverAggregate()
+    public async Task EveryTitleCompletionIsListedWithNoNameCap()
     {
+        // Owner call: titles are the card's top priority — list them ALL (the 4000-char
+        // budget is the only backstop), never "…and N more titles". Paragons don't aggregate.
         var userId = Guid.NewGuid();
         var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
         var ctx = new HandlerContext();
@@ -470,9 +472,10 @@ public sealed class CommunitySagaTests
 
         ctx.Bot.Verify(b => b.SendRichMessages(
             It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.Single().Blocks.OfType<RichBotText>().Any(t =>
-                t.Markdown.Contains("**[Title 10]** completed")
-                && !t.Markdown.Contains("[Title 11]")
-                && t.Markdown.Contains("…and 2 more titles")
+                t.Markdown.Contains("**[Title 1]** completed")
+                && t.Markdown.Contains("**[Title 11]** completed")
+                && t.Markdown.Contains("**[Title 12]** completed")
+                && !t.Markdown.Contains("more titles")
                 && t.Markdown.Contains("🏅 **[Expert Lv. 2]** paragon → #PLATE|PerfectGame#"))),
             It.IsAny<IEnumerable<ulong>>(),
             It.IsAny<CancellationToken>()), Times.Once);
@@ -765,6 +768,30 @@ public sealed class CommunitySagaTests
             It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.Count() == 1
                 && msgs.Single().Blocks.OfType<RichBotText>().Any(t =>
                     t.Markdown.Contains("#DIFFICULTY|S18# **All passed!**"))),
+            It.IsAny<IEnumerable<ulong>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TheFolderBreakdownSurvivesAScoreHeavyCard()
+    {
+        // Owner call: the folder line is reserved before scores fill in, so a card packed
+        // with notable rows still ends with it — the scores overflow to the count line.
+        var userId = Guid.NewGuid();
+        var charts = Enumerable.Range(0, 40)
+            .Select(_ => new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build()).ToArray();
+        var ctx = new HandlerContext();
+        ctx.GivenUser(userId, name: "alice");
+        ctx.GivenUserCommunitiesWithChannel(userId, communityName: "Acme", channelId: 12345);
+        ctx.GivenScoreAnnouncementLookups(MixEnum.Phoenix, userId, charts, score: 950000);
+
+        await ctx.Saga.Consume(BuildContext(CapturedEvent(userId, MixEnum.Phoenix, null,
+            charts.Select(c => (c.Id, true, HighlightFlags.ScoreQuality90)).ToArray())));
+
+        ctx.Bot.Verify(b => b.SendRichMessages(
+            It.Is<IEnumerable<RichBotMessage>>(msgs =>
+                msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("#DIFFICULTY|S20# 1/40"))
+                && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains(" more:"))),
             It.IsAny<IEnumerable<ulong>>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -374,6 +374,47 @@ public sealed class CommunitySagaTests
     }
 
     [Fact]
+    public async Task MoreScoresStayDescendingByLevelWhenNotableOverflows()
+    {
+        // Bug: when the notable bucket overflows its cap, the extra flagged (low-level) rows
+        // used to leak into "More scores" ahead of higher-level unflagged charts — two
+        // descending runs, not one. The bucket must be a single level-desc run.
+        var userId = Guid.NewGuid();
+        var flaggedLow = Enumerable.Range(0, 11)
+            .Select(_ => new ChartBuilder().WithType(ChartType.Single).WithLevel(5).Build()).ToArray();
+        var plainHigh = new ChartBuilder().WithType(ChartType.Single).WithLevel(23).Build();
+        var all = flaggedLow.Append(plainHigh).ToArray();
+        var ctx = new HandlerContext();
+        ctx.GivenUser(userId, name: "alice");
+        ctx.GivenUserCommunitiesWithChannel(userId, communityName: "Acme", channelId: 12345);
+        ctx.GivenScoreAnnouncementLookups(MixEnum.Phoenix, userId, all, score: 950000);
+
+        var changes = flaggedLow.Select(c => (c.Id, true, HighlightFlags.ScoreQuality90))
+            .Append((plainHigh.Id, true, HighlightFlags.None)).ToArray();
+        await ctx.Saga.Consume(BuildContext(CapturedEvent(userId, MixEnum.Phoenix, null, changes)));
+
+        ctx.Bot.Verify(b => b.SendRichMessages(
+            It.Is<IEnumerable<RichBotMessage>>(msgs => MoreScoresAreLevelDescending(msgs)),
+            It.IsAny<IEnumerable<ulong>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // The "More scores" bucket, minus its label line, must be sorted by level descending.
+    private static bool MoreScoresAreLevelDescending(IEnumerable<RichBotMessage> msgs)
+    {
+        var rows = msgs.Single().Blocks.OfType<RichBotText>()
+            .First(t => t.Markdown.StartsWith("-# More scores")).Markdown
+            .Split('\n').Skip(1).ToArray();
+        var levels = rows.Select(r =>
+        {
+            var start = r.IndexOf("#DIFFICULTY|", StringComparison.Ordinal) + "#DIFFICULTY|S".Length;
+            var end = r.IndexOf('#', start);
+            return int.Parse(r[start..end]);
+        }).ToArray();
+        return levels.SequenceEqual(levels.OrderByDescending(l => l));
+    }
+
+    [Fact]
     public async Task StatsAndAchievementsOpenTheCardAsTheirOwnSections()
     {
         var userId = Guid.NewGuid();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -492,6 +492,35 @@ public sealed class CommunitySagaTests
     }
 
     [Fact]
+    public async Task WeeklyPlacementsBelowCompetitiveMinusFiveAreDropped()
+    {
+        // Owner call: weekly inclusion follows the same competitive − 5 gate as the peer
+        // flag. For a 22-competitive player, weekly placements on S16/S12 are noise; the
+        // S21/S18 placements stay.
+        var userId = Guid.NewGuid();
+        var all = new[] { 21, 18, 16, 12 }
+            .Select(l => new ChartBuilder().WithType(ChartType.Single).WithLevel(l).Build()).ToArray();
+        var ctx = new HandlerContext();
+        ctx.GivenUser(userId, name: "alice");
+        ctx.GivenUserCommunitiesWithChannel(userId, communityName: "Acme", channelId: 12345);
+        ctx.GivenScoreAnnouncementLookups(MixEnum.Phoenix, userId, all, score: 950000);
+        ctx.GivenCompetitive(singles: 22);
+        ctx.GivenWeeklyPlacements(all.Select(c => new WeeklyPlacementRecord(c.Id, 3)).ToArray());
+
+        await ctx.Saga.Consume(BuildContext(CapturedEvent(userId, MixEnum.Phoenix, null,
+            all.Select(c => (c.Id, true, HighlightFlags.None)).ToArray())));
+
+        ctx.Bot.Verify(b => b.SendRichMessages(
+            It.Is<IEnumerable<RichBotMessage>>(msgs => msgs.Single().Blocks.OfType<RichBotText>().Any(t =>
+                t.Markdown.Contains("#DIFFICULTY|S21# weekly")
+                && t.Markdown.Contains("#DIFFICULTY|S18# weekly")
+                && !t.Markdown.Contains("#DIFFICULTY|S16# weekly")
+                && !t.Markdown.Contains("#DIFFICULTY|S12# weekly"))),
+            It.IsAny<IEnumerable<ulong>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task CoOpsShowAsACompactBucketCappedAtFive()
     {
         var userId = Guid.NewGuid();
@@ -851,6 +880,7 @@ public sealed class CommunitySagaTests
         public Mock<IUserReader> Users { get; } = new();
         public Mock<IChartRepository> Charts { get; } = new();
         public Mock<IScoreReader> Scores { get; } = new();
+        public Mock<IPlayerStatsReader> PlayerStats { get; } = new();
         public Mock<IMediator> Mediator { get; } = new();
         public Mock<IDateTimeOffsetAccessor> DateTime { get; } = FakeDateTime.At(Now);
         public CommunitySaga Saga { get; }
@@ -862,8 +892,24 @@ public sealed class CommunitySagaTests
             CurrentUser.SetupGet(u => u.IsLoggedIn).Returns(isLoggedIn);
             Communities.Setup(c => c.GetCommunities(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Array.Empty<CommunityOverviewRecord>());
+            // Default competitive levels of 0 leave the weekly gate wide open (threshold −5);
+            // tests exercising the gate raise them with GivenCompetitive.
+            PlayerStats.Setup(p => p.GetStats(It.IsAny<MixEnum>(), It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(Stats(0, 0));
             Saga = new CommunitySaga(CurrentUser.Object, Communities.Object, Bot.Object, Users.Object,
-                Charts.Object, Scores.Object, Mediator.Object, DateTime.Object);
+                Charts.Object, Scores.Object, Mediator.Object, PlayerStats.Object, DateTime.Object);
+        }
+
+        private static PlayerStatsRecord Stats(double singlesCompetitive, double doublesCompetitive)
+        {
+            return new PlayerStatsRecord(Guid.Empty, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1,
+                0, singlesCompetitive, doublesCompetitive);
+        }
+
+        public void GivenCompetitive(double singles, double doubles = 0)
+        {
+            PlayerStats.Setup(p => p.GetStats(It.IsAny<MixEnum>(), It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(Stats(singles, doubles));
         }
 
         public void GivenCommunityExists(string name)

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/HighlightCaptureSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/HighlightCaptureSagaTests.cs
@@ -152,6 +152,43 @@ public sealed class HighlightCaptureSagaTests
     }
 
     [Fact]
+    public async Task ScoreQualityIsSuppressedMoreThanFiveLevelsBelowCompetitive()
+    {
+        // Owner call: the default player's competitive level is 20, so a level-14 back-fill
+        // (more than 5 below) never earns a peer flag — even against a cohort it would top.
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(14).Build();
+        var ctx = new HandlerContext();
+        ctx.GivenCharts(chart);
+        ctx.GivenBest(chart, 950000);
+        ctx.GivenCohort(chart, Enumerable.Range(0, 10).Select(i => (PhoenixScore)(900000 + i)).ToArray());
+
+        await ctx.Saga.Consume(ctx.Context(NewPassEvent(chart)));
+
+        ctx.Highlights.Verify(h => h.UpsertFlags(It.IsAny<MixEnum>(), It.IsAny<Guid>(),
+            It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
+                x.Flags.HasFlag(HighlightFlags.ScoreQuality90))),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScoreQualityStillFlagsExactlyFiveLevelsBelowCompetitive()
+    {
+        // The cutoff is inclusive: level == competitive − 5 (20 − 5 = 15) still compares.
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(15).Build();
+        var ctx = new HandlerContext();
+        ctx.GivenCharts(chart);
+        ctx.GivenBest(chart, 950000);
+        ctx.GivenCohort(chart, Enumerable.Range(0, 10).Select(i => (PhoenixScore)(900000 + i)).ToArray());
+
+        await ctx.Saga.Consume(ctx.Context(NewPassEvent(chart)));
+
+        ctx.Highlights.Verify(h => h.UpsertFlags(MixEnum.Phoenix, UserId,
+            It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
+                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.ScoreQuality90))),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task FolderDebutFlagsTheFirstPassesInAFolder()
     {
         // Folder has 10 charts; this is the player's second-ever pass there.

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/OfficialLeaderboardSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/OfficialLeaderboardSagaTests.cs
@@ -370,6 +370,31 @@ public sealed class OfficialLeaderboardSagaTests
     }
 
     [Fact]
+    public async Task DetectedTitlesCarryTheRunSessionWhenScoresWereSaved()
+    {
+        // When the run saved scores, the detected titles ride that session's snapshot card —
+        // the event carries the same run id the scores were stamped with.
+        var chart = new ChartBuilder().Build();
+        var f = ArrangeImport(
+            officialScores: new[] { new OfficialRecordedScore(chart, 920000, PhoenixPlate.FairGame) },
+            existingScores: Array.Empty<RecordedPhoenixScore>());
+        var saga = BuildImportSaga(f);
+        Guid? scoreSession = null;
+        f.Mediator.Setup(m => m.Send(It.IsAny<UpdatePhoenixBestAttemptCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest, CancellationToken>((cmd, _) =>
+                scoreSession = ((UpdatePhoenixBestAttemptCommand)cmd).SessionId);
+        Guid? titleSession = null;
+        f.Bus.Setup(b => b.Publish(It.IsAny<TitlesDetectedEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<TitlesDetectedEvent, CancellationToken>((e, _) => titleSession = e.SessionId)
+            .Returns(Task.CompletedTask);
+
+        await saga.Handle(ImportCommand(), CancellationToken.None);
+
+        Assert.NotNull(titleSession);
+        Assert.Equal(scoreSession, titleSession);
+    }
+
+    [Fact]
     public async Task ImportUpdatesGameTagAndAvatarPreservingOtherProfileFields()
     {
         var f = ArrangeImport();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TitleSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TitleSagaTests.cs
@@ -165,6 +165,13 @@ public sealed class TitleSagaTests
             Scores.Setup(s => s.GetBestScores(_mix, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(scores);
         }
+
+        public void GivenSessionMilestones(Guid sessionId, params PlayerMilestoneRecord[] milestones)
+        {
+            Milestones.Setup(m => m.GetMilestonesBySessions(It.IsAny<Guid>(),
+                    It.Is<IEnumerable<Guid>>(ids => ids.Contains(sessionId)), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(milestones);
+        }
     }
 
     [Fact]
@@ -204,6 +211,60 @@ public sealed class TitleSagaTests
             Times.Never);
         ctx.Milestones.Verify(m => m.Append(It.IsAny<MixEnum>(), It.IsAny<Guid>(),
             It.IsAny<IEnumerable<PlayerMilestoneWrite>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DetectedBadgesRideTheSessionWhenTheImportSavedScores()
+    {
+        // With a SessionId (the import saved scores), a site-only badge is attributed to that
+        // session and the legacy announcement is suppressed — the snapshot card carries it.
+        var sessionId = Guid.NewGuid();
+        var ctx = new SagaContext(MixEnum.Phoenix);
+
+        await ctx.Saga.Consume(BuildContext(new TitlesDetectedEvent(ctx.UserId,
+            new[] { "RISE CHALLENGER" }, MixEnum.Phoenix, sessionId)));
+
+        ctx.Milestones.Verify(m => m.Append(MixEnum.Phoenix, ctx.UserId,
+            It.Is<IEnumerable<PlayerMilestoneWrite>>(w => w.Any(x =>
+                x.Kind == MilestoneKind.TitleCompleted && x.Title == "RISE CHALLENGER"
+                && x.SessionId == sessionId)),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Bus.Verify(b => b.Publish(It.IsAny<NewTitlesAcquiredEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CaptureSingleSourcesTheSessionsTitleMilestonesFoldingInSiteBadges()
+    {
+        // The card shows ALL of a session's completions: with a SessionId, CaptureSessionTitles
+        // single-sources from the milestone table, folding the site path's basic badges and
+        // paragon gains in with the score-crossing ones — and dropping non-title milestones.
+        var when = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+        var sessionId = Guid.NewGuid();
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(6)
+            .WithSongName("Another Truth").Build();
+        var ctx = new SagaContext(MixEnum.Phoenix, chart);
+        ctx.GivenBestScores(Score(chart.Id, 950000));
+        ctx.GivenSessionMilestones(sessionId,
+            new PlayerMilestoneRecord(MilestoneKind.TitleCompleted, sessionId, when, null, null,
+                "RISE CHALLENGER", null),
+            new PlayerMilestoneRecord(MilestoneKind.ParagonLevelGain, sessionId, when, null, null,
+                "Expert Lv. 2", "PG"),
+            new PlayerMilestoneRecord(MilestoneKind.PumbilityGain, sessionId, when, 1, 2, null, null));
+
+        var result = await ctx.Saga.Handle(new TitleSaga.CaptureSessionTitles(ctx.UserId, MixEnum.Phoenix,
+                sessionId,
+                new[]
+                {
+                    new PlayerScoresUpdatedEvent.ScoreChange(chart.Id, true, null, 950000, "SuperbGame", false)
+                }),
+            CancellationToken.None);
+
+        Assert.Contains(result.Milestones,
+            m => m.Kind == MilestoneKind.TitleCompleted && m.Title == "RISE CHALLENGER");
+        Assert.Contains(result.Milestones,
+            m => m.Kind == MilestoneKind.ParagonLevelGain && m.Title == "Expert Lv. 2");
+        Assert.DoesNotContain(result.Milestones, m => m.Kind == MilestoneKind.PumbilityGain);
     }
 
     private static RecordedPhoenixScore Score(Guid chartId, int score) =>

--- a/docs/design/discord-rich-score-notifications.md
+++ b/docs/design/discord-rich-score-notifications.md
@@ -10,6 +10,39 @@
 > the passes/upscores/digest card split below; S1–S4 all landed. The spec below is the
 > as-built reference.
 
+## Revision 4 — iteration 3 (locked & implemented 2026-07-09)
+
+Owner feedback after iteration 2 ran live. Three asks plus a sort bug, one PR:
+
+1. **Long cards were truncating.** The Components V2 text ceiling (4000 chars) is measured
+   *after* emoji tokens expand to `<:piu_…:snowflake>` mentions (~30 chars each), but the saga
+   only capped by row count, so dense cards overran and the renderer chopped a row mid-line. The
+   saga now estimates rendered width (literal length + a per-token width) and packs against a
+   margin: header, stats, achievements (**all** titles, uncapped — owner call, the budget is the
+   only backstop), and the **folder line are reserved first**; only the score buckets flex to
+   fit, overflowing the rest into the "+N more" count. The folder breakdown always survives on
+   the bottom.
+2. **Site-detected titles ride the main card.** All title completions are top priority and show
+   in a card. The import stamps `TitlesDetectedEvent` with the run's `SessionId` when it saved
+   scores; the title path attributes the site-only badges (`CompletionRequired == 0`) to that
+   session instead of announcing them, and `CaptureSessionTitles` single-sources the card's
+   completions from the milestone table by session — folding site badges in with the
+   score-crossing ones (disjoint title sets, no double-count). A **zero-score** import (detected
+   a badge but saved no scores) keeps a null `SessionId` and its titles render as their own rich
+   **titles-card** (`NewTitlesAcquiredEvent`, upgraded from the old plain-text list — owner Q1=a),
+   not the session card. Big fresh imports showing nothing but titles is intended.
+3. **Peer comparison stops below competitive − 5.** A chart more than 5 levels under the player's
+   competitive level for its type (singles competitive → singles charts, doubles → doubles) is
+   noise (a 23-competitive player back-filling S5s). The `ScoreQuality90` flag is skipped
+   entirely below the cutoff (no cohort built), so those scores fall to folder/overflow. The same
+   gate applies to the card's **weekly** placement lines. No cohort-size floor (owner call: strong
+   high-level players legitimately have thin peer groups). Prod validation (query in the PR
+   thread): of 1,420 peer-flagged highlights, ~15% sit >5 levels below competitive, and those are
+   exactly the tiny-cohort S-low back-fills.
+4. **"More scores" sort fix.** When the notable bucket overflowed its cap, the extra flagged rows
+   (lower-level) leaked into "More scores" ahead of higher-level unflagged charts (two descending
+   runs). The bucket is re-sorted into one level-descending run.
+
 ## Revision 3 — iteration 2 (locked & implemented 2026-07-08)
 
 Owner feedback after the snapshot card ran live. Eight card changes plus a live-bug fix, one


### PR DESCRIPTION
Third pass on the live session-snapshot card, from owner feedback after iteration 2. Three asks plus a sort bug the feedback surfaced, one PR, each commit green on the fast suites.

## What changed

**1 · Cards were truncating** (`f675cad6`). Discord's Components V2 text ceiling (4000 chars) is measured *after* emoji tokens expand to `<:piu_…:snowflake>` mentions (~30 chars each), but the saga only capped by row count — so dense cards overran and the renderer chopped a row mid-line. The saga now estimates rendered width and packs against a margin: header, stats, achievements (**all** titles, uncapped — the budget is the only backstop) and the **folder line are reserved first**; only the score buckets flex, overflowing the rest into the "+N more" count. The folder breakdown always survives on the bottom.

**2 · Site-detected titles ride the card** (`1689ee49`, `305dcc82`). All title completions are top priority and show in a card. The import stamps `TitlesDetectedEvent` with the run's `SessionId` when it saved scores; the title path attributes the site-only badges (`CompletionRequired == 0`) to that session instead of announcing them, and `CaptureSessionTitles` single-sources the card's completions from the milestone table by session — folding site badges in with the score-crossing ones (disjoint title sets, no double-count). A **zero-score** import (detected a badge but saved no scores) keeps a null `SessionId` and its titles render as their own rich **titles-card**, upgraded from the old plain-text list.

**3 · Peer comparison stops below competitive − 5** (`d14d07b1`, `117604ad`). A chart more than 5 levels under the player's competitive level for its type (singles competitive → singles charts, doubles → doubles) is noise — a 23-competitive player back-filling S5s. The `ScoreQuality90` flag is skipped entirely below the cutoff (no cohort built), so those scores fall to folder/overflow; the same gate applies to the card's **weekly** lines. No cohort-size floor (strong high-level players legitimately have thin peer groups). Prod validation: of 1,420 peer-flagged highlights, ~15% sit >5 levels below competitive.

**4 · "More scores" sort fix** (`7c922ad1`). When the notable bucket overflowed its cap, the extra flagged (lower-level) rows leaked into "More scores" ahead of higher-level unflagged charts — the `S5→S4→S21` ordering the owner spotted. The bucket is re-sorted into one level-descending run.

Docs (`0e642733`) record all of this as design-doc Revision 4; canary (`72da3b76`) gains a titles-card sample.

## Testing
- **826** unit/component/architecture + **57** API wire-shape, Release, green. No `api/*` contract changed.
- Full solution builds clean in Release.
- **Live Discord canary green** — posted the passes, digest, and new titles-card to the lab channel and read all three back with V2 components attached.
- Integration + E2E run in CI (Docker not available locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)