### PR TITLE
perf: stop cohort ranking queries from melting the database

### DIFF
--- a/ScoreTracker/ScoreTracker.Data/Migrations/20260710031131_PhoenixRecordCohortReadIndex.Designer.cs
+++ b/ScoreTracker/ScoreTracker.Data/Migrations/20260710031131_PhoenixRecordCohortReadIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScoreTracker.Data.Persistence;
 
@@ -11,9 +12,11 @@ using ScoreTracker.Data.Persistence;
 namespace ScoreTracker.Data.Migrations
 {
     [DbContext(typeof(ChartAttemptDbContext))]
-    partial class ChartAttemptDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710031131_PhoenixRecordCohortReadIndex")]
+    partial class PhoenixRecordCohortReadIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ScoreTracker/ScoreTracker.Data/Migrations/20260710031131_PhoenixRecordCohortReadIndex.cs
+++ b/ScoreTracker/ScoreTracker.Data/Migrations/20260710031131_PhoenixRecordCohortReadIndex.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScoreTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class PhoenixRecordCohortReadIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_PhoenixRecord_MixId_ChartId",
+                schema: "scores",
+                table: "PhoenixRecord",
+                columns: new[] { "MixId", "ChartId" })
+                .Annotation("SqlServer:Include", new[] { "UserId", "Score", "Plate", "IsBroken" })
+                .Annotation("SqlServer:Online", true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PhoenixRecord_MixId_ChartId",
+                schema: "scores",
+                table: "PhoenixRecord");
+        }
+    }
+}

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/ScoreQualitySaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/ScoreQualitySaga.cs
@@ -73,20 +73,29 @@ internal sealed class ScoreQualitySaga :
                 });
     }
 
+    // Half-level buckets let players of similar strength share cached cohorts and
+    // cohort scores; exact-level keys made every cache entry per-user, so each visitor
+    // paid for their own copy of the same near-identical ledger query.
+    private async Task<double> GetCompetitiveLevelBucket(MixEnum mix, ChartType chartType,
+        CancellationToken cancellationToken)
+    {
+        var myStats = await _playerStats.GetStats(mix, _user.User.Id, cancellationToken);
+        var competitiveLevel = chartType == ChartType.Single
+            ? myStats.SinglesCompetitiveLevel
+            : myStats.DoublesCompetitiveLevel;
+        return Math.Round(competitiveLevel * 2, MidpointRounding.AwayFromZero) / 2.0;
+    }
+
     private async Task<IEnumerable<Guid>> GetComparablePlayers(MixEnum mix, ChartType chartType,
         CancellationToken cancellationToken)
     {
-        var userId = _user.User.Id;
+        var bucket = await GetCompetitiveLevelBucket(mix, chartType, cancellationToken);
         return await _cache.GetOrCreateAsync(
-            $"{nameof(ScoreQualitySaga)}__{nameof(GetComparablePlayers)}__{mix}__{userId}__{chartType}",
+            $"{nameof(ScoreQualitySaga)}__{nameof(GetComparablePlayers)}__{mix}__{bucket}__{chartType}",
             async o =>
             {
                 o.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
-                var myStats = await _playerStats.GetStats(mix, userId, cancellationToken);
-                var competitiveLevel = chartType == ChartType.Single
-                    ? myStats.SinglesCompetitiveLevel
-                    : myStats.DoublesCompetitiveLevel;
-                return (await _playerStats.GetPlayersByCompetitiveRange(mix, chartType, competitiveLevel,
+                return (await _playerStats.GetPlayersByCompetitiveRange(mix, chartType, bucket,
                     .5, cancellationToken)).ToArray().AsEnumerable();
             }) ?? Array.Empty<Guid>();
     }
@@ -94,9 +103,9 @@ internal sealed class ScoreQualitySaga :
     private async Task<IDictionary<Guid, PhoenixScore[]>> GetPlayerScores(MixEnum mix, ChartType chartType,
         DifficultyLevel level, CancellationToken cancellationToken)
     {
-        var userId = _user.User.Id;
+        var bucket = await GetCompetitiveLevelBucket(mix, chartType, cancellationToken);
         return await _cache.GetOrCreateAsync(
-            $"{nameof(ScoreQualitySaga)}__{nameof(GetPlayerHistoryQuery)}__{mix}__{userId}__{level}__{chartType}",
+            $"{nameof(ScoreQualitySaga)}__{nameof(GetPlayerHistoryQuery)}__{mix}__{bucket}__{level}__{chartType}",
             async o =>
             {
                 o.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
@@ -114,11 +123,7 @@ internal sealed class ScoreQualitySaga :
         ISet<Guid> chartIds,
         CancellationToken cancellationToken)
     {
-        var players = await GetComparablePlayers(mix, chartType, cancellationToken);
-        var playerScores = (await _scores.GetPlayerScores(mix, players, chartIds, cancellationToken))
-            .GroupBy(c => c.ChartId)
-            .ToDictionary(g => g.Key,
-                g => g.OrderBy(s => s.Score).Select(s => s.Score).ToArray());
+        var playerScores = await GetCohortScoresByChart(mix, chartType, chartIds, cancellationToken);
 
         return (await _scores.GetBestScores(mix, _user.User.Id, cancellationToken))
             .Where(s => chartIds.Contains(s.ChartId))
@@ -140,6 +145,52 @@ internal sealed class ScoreQualitySaga :
                     return new ScoreRankingRecord(index / (double)playerScores[c.ChartId].Length,
                         playerScores[c.ChartId].Length);
                 });
+    }
+
+    // Cohort score distributions are cached per chart (not per requested chart set) so
+    // overlapping pages — home recommendations, uploads, breakdowns — hit the same
+    // entries, and only genuinely unseen charts reach the ledger.
+    private async Task<IReadOnlyDictionary<Guid, PhoenixScore[]>> GetCohortScoresByChart(MixEnum mix,
+        ChartType chartType, ISet<Guid> chartIds, CancellationToken cancellationToken)
+    {
+        var bucket = await GetCompetitiveLevelBucket(mix, chartType, cancellationToken);
+        var result = new Dictionary<Guid, PhoenixScore[]>();
+        var missing = new List<Guid>();
+        foreach (var chartId in chartIds)
+            if (_cache.TryGetValue(CohortScoresKey(mix, chartType, bucket, chartId),
+                    out PhoenixScore[]? cached) && cached != null)
+            {
+                if (cached.Length > 0) result[chartId] = cached;
+            }
+            else
+            {
+                missing.Add(chartId);
+            }
+
+        if (!missing.Any()) return result;
+
+        var players = await GetComparablePlayers(mix, chartType, cancellationToken);
+        var fetched = (await _scores.GetPlayerScores(mix, players, missing, cancellationToken))
+            .GroupBy(c => c.ChartId)
+            .ToDictionary(g => g.Key,
+                g => g.OrderBy(s => s.Score).Select(s => s.Score).ToArray());
+        foreach (var chartId in missing)
+        {
+            var scores = fetched.TryGetValue(chartId, out var chartScores)
+                ? chartScores
+                : Array.Empty<PhoenixScore>();
+            // Charts nobody in the cohort has played are cached as empty so they don't
+            // re-trigger the ledger query on every page load.
+            _cache.Set(CohortScoresKey(mix, chartType, bucket, chartId), scores, TimeSpan.FromHours(1));
+            if (scores.Length > 0) result[chartId] = scores;
+        }
+
+        return result;
+    }
+
+    private static string CohortScoresKey(MixEnum mix, ChartType chartType, double bucket, Guid chartId)
+    {
+        return $"{nameof(ScoreQualitySaga)}__CohortScores__{mix}__{chartType}__{bucket}__{chartId}";
     }
 
     public async Task<IEnumerable<Guid>> Handle(GetCompetitivePlayersQuery request, CancellationToken cancellationToken)

--- a/ScoreTracker/ScoreTracker.ScoreLedger/Wiring/ScoreLedgerModelContribution.cs
+++ b/ScoreTracker/ScoreTracker.ScoreLedger/Wiring/ScoreLedgerModelContribution.cs
@@ -25,6 +25,14 @@ public sealed class ScoreLedgerModelContribution : IDbModelContribution
             .WithMany()
             .HasForeignKey(ba => ba.UserId);
 
+        // Covers the cohort ranking reads (mix + chart-set lookups projecting
+        // user/score/plate); without it they scan the whole table. Built ONLINE because
+        // the migration bundle applies against the live table during deploys.
+        modelBuilder.Entity<PhoenixRecordEntity>()
+            .HasIndex(e => new { e.MixId, e.ChartId })
+            .IncludeProperties(e => new { e.UserId, e.Score, e.Plate, e.IsBroken })
+            .IsCreatedOnline();
+
         modelBuilder.Entity<ScoreEventJournalEntity>().ToTable("ScoreEventJournal");
         // Session lookups skip the pre-capture rows (SessionId is never backfilled).
         modelBuilder.Entity<ScoreEventJournalEntity>().HasIndex(e => e.SessionId)

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/ScoreQualitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/ScoreQualitySagaTests.cs
@@ -147,4 +147,66 @@ public sealed class ScoreQualitySagaTests
         Assert.Equal(1.0, result[chart.Id].Ranking);
         Assert.Equal(1, result[chart.Id].PlayerCount);
     }
+
+    [Fact]
+    public async Task ChartScoreRankingsAreCachedPerChartAcrossUsersInTheSameCompetitiveBucket()
+    {
+        var (accessor1, userId1) = UserAccessor();
+        var (accessor2, userId2) = UserAccessor();
+        var playedChart = new ChartBuilder().WithLevel(20).WithType(ChartType.Single).Build();
+        var unplayedChart = new ChartBuilder().WithLevel(21).WithType(ChartType.Single).Build();
+        var competitor = Guid.NewGuid();
+        var recordedDate = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var playerStats = new Mock<IPlayerStatsReader>();
+        var charts = new Mock<IChartRepository>();
+        var scores = new Mock<IScoreReader>();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+
+        // 19.8 and 20.2 both round to the 20.0 half-level bucket.
+        playerStats.Setup(p => p.GetStats(MixEnum.Phoenix, userId1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Stats(userId1, singlesCompetitive: 19.8));
+        playerStats.Setup(p => p.GetStats(MixEnum.Phoenix, userId2, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Stats(userId2, singlesCompetitive: 20.2));
+        playerStats.Setup(p => p.GetPlayersByCompetitiveRange(MixEnum.Phoenix, ChartType.Single, 20.0, .5,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { competitor });
+
+        charts.Setup(r => r.GetCharts(MixEnum.Phoenix, null, null, It.IsAny<IEnumerable<Guid>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { playedChart, unplayedChart });
+
+        scores.Setup(r => r.GetPlayerScores(MixEnum.Phoenix, It.IsAny<IEnumerable<Guid>>(),
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new UserPhoenixScore(competitor, playedChart.Id, "Competitor", 900000,
+                    PhoenixPlate.PerfectGame, false)
+            });
+
+        scores.Setup(r => r.GetBestScores(MixEnum.Phoenix, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new RecordedPhoenixScore(playedChart.Id, 950000, PhoenixPlate.PerfectGame, false, recordedDate),
+                new RecordedPhoenixScore(unplayedChart.Id, 940000, PhoenixPlate.PerfectGame, false, recordedDate)
+            });
+
+        var chartIds = new[] { playedChart.Id, unplayedChart.Id };
+        var saga1 = new ScoreQualitySaga(accessor1.Object, playerStats.Object, cache, charts.Object, scores.Object);
+        var saga2 = new ScoreQualitySaga(accessor2.Object, playerStats.Object, cache, charts.Object, scores.Object);
+
+        var result1 = await saga1.Handle(new GetChartScoreRankingsQuery(chartIds), CancellationToken.None);
+        var result2 = await saga2.Handle(new GetChartScoreRankingsQuery(chartIds), CancellationToken.None);
+
+        Assert.Equal(1.0, result1[playedChart.Id].Ranking);
+        Assert.Equal(1, result1[playedChart.Id].PlayerCount);
+        Assert.Equal(1.0, result1[unplayedChart.Id].Ranking);
+        Assert.Equal(result1[playedChart.Id], result2[playedChart.Id]);
+        Assert.Equal(result1[unplayedChart.Id], result2[unplayedChart.Id]);
+
+        // The second user's rankings — including the chart nobody in the cohort has
+        // played — must come from cache, not a second ledger query.
+        scores.Verify(r => r.GetPlayerScores(MixEnum.Phoenix, It.IsAny<IEnumerable<Guid>>(),
+            It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
 }


### PR DESCRIPTION
## Incident context

Tonight (from ~01:15 UTC) the production database pinned at 100% CPU, exhausted the S0 worker limit (\"The request limit for the database is 60 and has been reached\"), and stayed pinned after scaling to S1. App Insights traced it to one query pattern: `EFPhoenixRecordsRepository.GetPlayerScores(mix, userIds, chartIds)` — 535 executions in 2h, 496 failed, avg 20.5s, with up to ~450 chart-ID and ~460 user-ID parameters per query.

Call chain: home page (`WhatShouldIPlay`) and `UploadPhoenixScores` → `GetChartScoreRankingsQuery` → `ScoreQualitySaga.GetRankings` → cohort (players within ±0.5 competitive level) × requested charts in one giant uncached `IN`-list query, scanning `PhoenixRecord`. Every failed/timed-out execution burned its full CPU cost and got retried, keeping the DB in a death spiral.

## Fixes

**1. Cache the cohort rankings (`ScoreQualitySaga`)**
- Cohort and cohort-score cache keys switch from per-user to half-level competitive **bucket** (e.g. 19.8 and 20.2 both → 20.0), so players of similar strength share entries instead of each paying for a near-identical query.
- Cohort score distributions are cached **per chart** (1h TTL), so overlapping pages hit the same entries and only genuinely unseen charts reach the ledger. Charts nobody in the cohort played are cached as empty to avoid re-querying them every page load.
- Behavior change: cohort is computed from the bucketed level rather than the exact level — a ≤0.25-level shift in the comparison band for a percentile display.

**2. Covering index on `PhoenixRecord`**
- `IX_PhoenixRecord_MixId_ChartId` INCLUDE `(UserId, Score, Plate, IsBroken)` — turns the cohort-read scans into seeks. Created `ONLINE` so the migration bundle can apply against the live table mid-incident.

## Tests

- New component test pins the collapse: two users in the same bucket, second request served entirely from cache (`Times.Once` on the ledger port), including the unplayed-chart empty-cache path.
- `ScoreTracker.Tests`: 827/827 passed. `ScoreTracker.Tests.Api`: 57/57 passed.

## Deploy note

DB is temporarily on S3 for the deploy; scale back to S1 after the index lands and CPU settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)