### PR TITLE
fix(recap): private players can view their own recap and sessions

### DIFF
--- a/ScoreTracker/ScoreTracker.ScoreLedger/Application/SessionFeedHandler.cs
+++ b/ScoreTracker/ScoreTracker.ScoreLedger/Application/SessionFeedHandler.cs
@@ -17,19 +17,24 @@ internal sealed class SessionFeedHandler : IRequestHandler<GetRecentSessionsQuer
 {
     private readonly IScoreJournalRepository _journal;
     private readonly IUserReader _users;
+    private readonly ICurrentUserAccessor _currentUser;
 
-    public SessionFeedHandler(IScoreJournalRepository journal, IUserReader users)
+    public SessionFeedHandler(IScoreJournalRepository journal, IUserReader users, ICurrentUserAccessor currentUser)
     {
         _journal = journal;
         _users = users;
+        _currentUser = currentUser;
     }
 
     public async Task<RecentSessionsPage> Handle(GetRecentSessionsQuery request,
         CancellationToken cancellationToken)
     {
-        // Defense in depth behind the page's redirect: non-public players read as empty.
+        // Defense in depth behind the page's redirect: non-public players read as empty
+        // to everyone but themselves.
         var user = await _users.GetUser(request.UserId, cancellationToken);
-        if (user is not { IsPublic: true }) return new RecentSessionsPage(0, Array.Empty<RecentSessionsPage.SessionGroup>());
+        var isOwner = _currentUser.IsLoggedIn && _currentUser.User.Id == request.UserId;
+        if (user is not { IsPublic: true } && !isOwner)
+            return new RecentSessionsPage(0, Array.Empty<RecentSessionsPage.SessionGroup>());
 
         var (total, groups) = await _journal.GetSessionGroups(request.UserId,
             Math.Max(1, request.Page), Math.Clamp(request.PageSize, 1, 50), cancellationToken);

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SessionFeedHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SessionFeedHandlerTests.cs
@@ -24,7 +24,7 @@ public sealed class SessionFeedHandlerTests
     private static readonly Guid ChartId = Guid.NewGuid();
 
     [Fact]
-    public async Task NonPublicPlayersReadAsAnEmptyPage()
+    public async Task NonPublicPlayersReadAsAnEmptyPageToAnonymousViewers()
     {
         // Defense in depth behind the page's redirect-to-home.
         var ctx = new HandlerContext(isPublic: false);
@@ -36,6 +36,35 @@ public sealed class SessionFeedHandlerTests
         Assert.Empty(page.Groups);
         ctx.Journal.Verify(j => j.GetSessionGroups(It.IsAny<Guid>(), It.IsAny<int>(),
             It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task NonPublicPlayersReadAsAnEmptyPageToOtherPlayers()
+    {
+        var ctx = new HandlerContext(isPublic: false, viewerId: Guid.NewGuid());
+
+        var page = await ctx.Handler.Handle(new GetRecentSessionsQuery(UserId),
+            CancellationToken.None);
+
+        Assert.Equal(0, page.TotalGroups);
+        Assert.Empty(page.Groups);
+        ctx.Journal.Verify(j => j.GetSessionGroups(It.IsAny<Guid>(), It.IsAny<int>(),
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task NonPublicPlayersStillReadTheirOwnSessions()
+    {
+        var ctx = new HandlerContext(isPublic: false, viewerId: UserId);
+        var rows = new[] { Entry(Now, 950000) };
+        ctx.GivenGroups(new JournalSessionRows(null, DateOnly.FromDateTime(Now.Date), MixEnum.Phoenix, rows));
+        ctx.GivenHistories(rows);
+
+        var page = await ctx.Handler.Handle(new GetRecentSessionsQuery(UserId),
+            CancellationToken.None);
+
+        Assert.Equal(1, page.TotalGroups);
+        Assert.Single(page.Groups.Single().Rows);
     }
 
     [Fact]
@@ -119,13 +148,19 @@ public sealed class SessionFeedHandlerTests
     {
         public Mock<IScoreJournalRepository> Journal { get; } = new();
         public Mock<IUserReader> Users { get; } = new();
+        public Mock<ICurrentUserAccessor> CurrentUser { get; } = new();
         public SessionFeedHandler Handler { get; }
 
-        public HandlerContext(bool isPublic = true)
+        public HandlerContext(bool isPublic = true, Guid? viewerId = null)
         {
             Users.Setup(u => u.GetUser(UserId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new UserBuilder().WithId(UserId).WithIsPublic(isPublic).Build());
-            Handler = new SessionFeedHandler(Journal.Object, Users.Object);
+            if (viewerId is { } viewer)
+            {
+                CurrentUser.Setup(c => c.IsLoggedIn).Returns(true);
+                CurrentUser.Setup(c => c.User).Returns(new UserBuilder().WithId(viewer).Build());
+            }
+            Handler = new SessionFeedHandler(Journal.Object, Users.Object, CurrentUser.Object);
         }
 
         public void GivenGroups(params JournalSessionRows[] groups)

--- a/ScoreTracker/ScoreTracker/Pages/Progress/PhoenixRecap.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/PhoenixRecap.razor
@@ -1,5 +1,6 @@
 @using MediatR
 @using ScoreTracker.Domain.Models
+@using ScoreTracker.Domain.SecondaryPorts
 @using ScoreTracker.Identity.Contracts.Queries
 @using ScoreTracker.PlayerProgress.Contracts.Queries
 @using ScoreTracker.PlayerProgress.Contracts.Recap
@@ -523,6 +524,7 @@ else if (_user != null && _recap != null)
 @inject IMediator Mediator
 @inject NavigationManager NavManager
 @inject IJSRuntime JS
+@inject ICurrentUserAccessor CurrentUser
 @code {
     [Parameter] public Guid UserIdParam { get; set; }
 
@@ -549,9 +551,11 @@ else if (_user != null && _recap != null)
 
     protected override async Task OnInitializedAsync()
     {
-        // Public players only, same gate as the Sessions page.
+        // Public players only — except the owner, whose recap is always theirs to see.
+        // Same gate as the Sessions page.
         _user = await Mediator.Send(new GetUserByIdQuery(UserIdParam));
-        if (_user is not { IsPublic: true })
+        var isOwner = CurrentUser.IsLoggedIn && CurrentUser.User.Id == UserIdParam;
+        if (_user == null || (!_user.IsPublic && !isOwner))
         {
             NavManager.NavigateTo("/");
             return;

--- a/ScoreTracker/ScoreTracker/Pages/Progress/PlayerSessions.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/PlayerSessions.razor
@@ -1,6 +1,7 @@
 @using MediatR
 @using ScoreTracker.Catalog.Contracts.Queries
 @using ScoreTracker.Domain.Models
+@using ScoreTracker.Domain.SecondaryPorts
 @using ScoreTracker.Identity.Contracts.Queries
 @using ScoreTracker.PlayerProgress.Contracts
 @using ScoreTracker.PlayerProgress.Contracts.Queries
@@ -75,6 +76,7 @@
 @inject IMediator Mediator
 @inject NavigationManager NavManager
 @inject IUiSettingsAccessor UiSettings
+@inject ICurrentUserAccessor CurrentUser
 @code {
     private const string FilterAll = "all";
     private const string FilterOfNote = "ofNote";
@@ -101,10 +103,12 @@
 
     protected override async Task OnInitializedAsync()
     {
-        // Public players only: anyone else's page redirects home. The query behind it
-        // independently returns an empty page, so this is presentation, not the guard.
+        // Public players only: anyone else's private page redirects home; your own never
+        // does. The query behind it independently returns an empty page to non-owners, so
+        // this is presentation, not the guard.
         _user = await Mediator.Send(new GetUserByIdQuery(UserIdParam));
-        if (_user is not { IsPublic: true })
+        var isOwner = CurrentUser.IsLoggedIn && CurrentUser.User.Id == UserIdParam;
+        if (_user == null || (!_user.IsPublic && !isOwner))
         {
             NavManager.NavigateTo("/");
             return;


### PR DESCRIPTION
## The bug

Player AED #9740 reported their recap "isn't loading" (screen recording). What actually happens: their profile is private, so tapping **My Recap** hits the recap page's public-only gate and silently redirects to `/`. From the player's seat the page flashes and dumps them back on the home page with zero feedback.

The gates disagreed with the surfaces advertising the feature:

- The **My Recap** nav link and the one-time "Your Phoenix Story is ready" popup (`MainLayout.razor`) show whenever the recap row exists — no `IsPublic` check.
- `PhoenixRecap.razor` redirected **any** non-public profile home, including the owner viewing their own recap.
- `PlayerSessions.razor` had the identical gate (the recap gate was copied from it), and its comment — "anyone else's page redirects home" — suggests blocking self-view was never the intent there either.

## The fix

Owners can always see their own pages; privacy keeps *other people* out, unchanged:

- `PhoenixRecap.razor` and `PlayerSessions.razor`: gate becomes "redirect unless public **or** viewer is the owner" (`ICurrentUserAccessor`, same injection pattern as the other Progress pages).
- `SessionFeedHandler`: the defense-in-depth query guard gets the same owner exception, since the page fix alone would render an empty sessions page for private owners. `ICurrentUserAccessor` is already an established dependency in other ScoreLedger handlers.
- Anonymous viewers short-circuit on `IsLoggedIn` before touching `CurrentUser.User`.

No change for public profiles, and private profiles still read as redirect/empty to everyone else. The recap query (`GetPlayerRecapQuery`) has no `IsPublic` guard today (page-gate only); adding sessions-style defense-in-depth there is a possible follow-up, not done here.

## Tests

- `SessionFeedHandlerTests`: existing private-reads-empty test now pinned to anonymous viewers, plus new cases — private + other logged-in player reads empty, private + owner reads their sessions.
- Fast suites green: `ScoreTracker.Tests` 1023/1023, `ScoreTracker.Tests.Api` 57/57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
