### PR TITLE
feat(tooling): check-new-charts repo skill (YouTube walk + site oracle + batch builder)

### DIFF
--- a/.claude/skills/check-new-charts/SKILL.md
+++ b/.claude/skills/check-new-charts/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: check-new-charts
+description: Check @PUMPITUPOfficial on YouTube for new Pump It Up chart videos since the last watermark and build the /Admin/BulkAddCharts JSON batch (canonical names/images from piugame.com). Use when the owner asks for a chart/video import, a new-songs batch, to "check for new charts", or to refresh the new-song oracle.
+---
+
+# Check for new charts
+
+Automates the owner's most-hated maintenance task: finding newly released songs/charts and
+producing the upload blob for `/Admin/BulkAddCharts` (schema + tool behavior:
+[docs/design/new-charts-json.md](../../../docs/design/new-charts-json.md)). Three PowerShell 5.1
+scripts in `scripts/`, glued by durable state. **The watermark IS the diff** — no catalog
+sweep is needed to find new videos, only to refresh the oracle.
+
+## State (durable, outside the repo)
+
+`%USERPROFILE%\.piu-score-tracker\check-new-charts\`
+
+| File | What |
+|---|---|
+| `state.json` | `watermark` (newest processed video id), `channelHandle`, `channelId`, `updatedUtc` |
+| `oracle.json` | Site-truth for not-yet-imported songs: canonical EN `name`, `imageUrl`, song `type`, over-20 chart list. Same schema as the upload blob; `koreanName`/`artist`/`stepArtist`/`youtubeHash` are `TODO` until the YouTube pass fills them |
+| `shipped.json` | Songs emitted in previous batches (name + chart keys + batch file). Excluded from new batches |
+| `catalog.csv` (+`catalog-prev.csv`) | Last full site sweep (Name/Type/Level/Id); the diff baseline for oracle candidates |
+| `videos\<id>.json` | Watch-page cache (title/description/length). Accumulates forever — this is what lets a song complete across multiple runs |
+
+If the state dir is missing, this is a first-run bootstrap: ask the owner for the newest
+already-processed video id, write `state.json` by hand (`channelId` is
+`UC1zVbfSZSKz9r2AzF50l9sA`), and run `rebuild-oracle.ps1` twice conceptually — the first sweep
+is only a baseline, so seed `oracle.json` from whatever new-song list the owner confirms.
+
+## Normal run
+
+```powershell
+& scripts\walk-and-fetch.ps1      # YouTube: walk newest -> watermark, cache watch pages
+& scripts\build-batch.ps1         # emit Downloads\phoenix2-batch-<date>.json + -report.txt
+```
+
+Run `rebuild-oracle.ps1` **first** when: the report shows `NO BLOB MATCH` entries (a song not
+in the oracle), the oracle is known-exhausted (everything shipped), or the owner asks to check
+for new site songs. It sweeps piugame.com's over-20 boards (login-gated; uses the
+owner-authorized PiuTest account from the AppHost user-secrets store — **never print the
+secret values**), rotates `catalog.csv`, and appends new-to-the-site songs to the oracle.
+
+## Agent review duties (the scripts flag, you judge)
+
+- **Oracle candidates are site-new, not necessarily tracker-new.** A returning song (cut in
+  Phoenix, back in P2 — e.g. KUGUTSU) already exists in the tracker and must go the
+  ChartMix-seed path, not BulkAddCharts. Verify each candidate against the tracker (site
+  `/Charts` search across mixes, or ask the owner) and remove returners from `oracle.json`.
+- **Read the report top to bottom.** `FLAG` lines are decisions the script made for you
+  (title-vs-description disagreements — title wins, Andamiro typos descriptions; consensus
+  picks; no-BGA duration fallbacks — slight overshoot, display-only). Confirm they're sane.
+- **`DEFERRED` songs are normal** — Andamiro uploads a song's charts across days. The cache
+  means they complete automatically on a later run. Never force a partial song through.
+- **Chart-set drift on a shipped song** means a new chart video for an already-imported song.
+  The admin tool skips already-in-P2 songs on Confirm, so this needs manual chart addition —
+  tell the owner.
+- **Handoff**: give the owner the batch + report paths. Preview in `/Admin/BulkAddCharts` is
+  the human checkpoint (its already-in-catalog warnings are the dedup net for stale
+  watermarks). With real blob creds the images mirror to the production CDN for real.
+- **If the owner decides not to upload a batch**, remove its songs from `shipped.json` —
+  otherwise they never re-emit.
+
+## Hard-won gotchas (do not relearn these)
+
+- The channel grid's id↔title pairing is **off-by-one** in the innertube payload — watch pages
+  are the only truth. The continuation POST needs the page's own `INNERTUBE_CONTEXT_CLIENT_VERSION`.
+- Title format drift is real: subtitled songs get the Korean annotation **mid-title**
+  (`INFiNiTE ENERZY (인피니트 에너지) -Overdoze-`); the matcher's fallback strips the Hangul
+  paren group and compares paren-insensitively, taking the Korean name from the group.
+- `koreanName` is **import-critical, not cosmetic** (a missing ko-KR row silently drops the
+  song from Korean users' imports). YouTube-title Korean names are the accepted source; the
+  site-truth reconcile (session language via POST `/ajax/language_update.php`, `lang=kr`,
+  **always restore `en`**) is a separate owner-planned pass.
+- Site boards: `lv=` filters are `20`..`26`, `27over`, `coop` (empty lv = capped top-80 "All"
+  view); out-of-range pages serve **repeated** content (stop on no-new-rows); page-1-empty
+  means bounced login, not an empty filter. P2 boards are login-gated for anonymous traffic.
+- Level art that renders `??` (e.g. 1948 D29 = functionally 29) parses to an empty level —
+  the sweep flags those rows; resolve by hand.
+- PS 5.1: no Hangul literals in BOM-less `.ps1` (build from `[char]0xAC00` codes), no
+  `Write-Output` inside value-returning functions (use `Write-Host`), wrap pipeline results in
+  `@()`, never `return ,$arr` into `@(...)` callers.
+
+## Update this skill
+
+When Andamiro changes a format (video titles, board markup, login flow) and you fix a script,
+commit the fix and note the drift here — the next agent should not rediscover it.

--- a/.claude/skills/check-new-charts/scripts/build-batch.ps1
+++ b/.claude/skills/check-new-charts/scripts/build-batch.ps1
@@ -1,0 +1,380 @@
+# check-new-charts step 3: build the /Admin/BulkAddCharts JSON batch from the cached watch pages.
+#
+# Scans the WHOLE video cache (not just the last window) so a song whose chart videos arrive
+# across several weeks completes automatically once its last video lands. Songs already emitted
+# in a previous batch (shipped.json) are excluded - with a loud flag if their chart set changed.
+#
+# Schema contract: docs/design/new-charts-json.md. Validation problems block the JSON write.
+param(
+    [string]$StateDir = "$env:USERPROFILE\.piu-score-tracker\check-new-charts",
+    [string]$OutDir = "$env:USERPROFILE\Downloads"
+)
+$ErrorActionPreference = 'Stop'
+$stamp = Get-Date -Format 'yyyy-MM-dd'
+$outJson = Join-Path $OutDir "phoenix2-batch-$stamp.json"
+$outReport = Join-Path $OutDir "phoenix2-batch-$stamp-report.txt"
+# hangul range from char codes: hangul literals in BOM-less .ps1 files are read as ANSI by
+# PS 5.1 and silently mangle - never put them in source
+$hg = '[' + [char]0xAC00 + '-' + [char]0xD7A3 + ']'
+
+function Normalize([string]$s) {
+    if ($null -eq $s) { return '' }
+    ($s -replace [char]0x2019, "'" -replace '\s+', ' ').Trim().ToUpperInvariant()
+}
+
+# some historical oracle blobs carried strings serialized as {"value": "..."} objects
+# (Get-Content note-property leak) - unwrap defensively
+function BlobString($v) {
+    if ($v -is [string]) { return $v }
+    if ($null -ne $v -and $v.PSObject.Properties['value']) { return [string]$v.value }
+    return [string]$v
+}
+
+# ---- load the oracle (canonical names, images, types, >=20 chart lists from the site) ----
+$oraclePath = Join-Path $StateDir 'oracle.json'
+if (-not (Test-Path $oraclePath)) { throw "no $oraclePath - run rebuild-oracle.ps1 first (see SKILL.md)" }
+$blob = Get-Content $oraclePath -Raw -Encoding UTF8 | ConvertFrom-Json
+$siteSongs = @()
+foreach ($s in $blob.songs) {
+    $n = BlobString $s.name
+    $siteSongs += [pscustomobject]@{
+        Name     = $n
+        Norm     = Normalize $n
+        Type     = BlobString $s.type
+        ImageUrl = BlobString $s.imageUrl
+        Site20   = @($s.charts | ForEach-Object { "$(BlobString $_.type)|$([int]$_.level)" })
+    }
+}
+
+# ---- load already-shipped songs (previous batches) ----
+$shippedPath = Join-Path $StateDir 'shipped.json'
+$shippedCharts = @{}
+if (Test-Path $shippedPath) {
+    $shipped = Get-Content $shippedPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    foreach ($ss in $shipped.songs) { $shippedCharts[(Normalize $ss.name)] = @($ss.charts | Sort-Object) -join ',' }
+}
+
+# ---- load fetched videos ----
+$videos = @()
+foreach ($f in Get-ChildItem (Join-Path $StateDir 'videos\*.json')) {
+    $videos += (Get-Content $f.FullName -Raw -Encoding UTF8 | ConvertFrom-Json)
+}
+$expectChannelId = $null
+$statePath = Join-Path $StateDir 'state.json'
+if (Test-Path $statePath) { $expectChannelId = (Get-Content $statePath -Raw -Encoding UTF8 | ConvertFrom-Json).channelId }
+
+$report = New-Object System.Collections.ArrayList
+# Write-Host, NOT Write-Output: Note is called inside functions whose return values
+# would otherwise absorb the message (PS returns all pipeline output)
+function Note([string]$line) { [void]$report.Add($line); Write-Host $line }
+
+Note "videos in cache: $($videos.Count)"
+
+# ---- classify + parse ----
+function DescField([string]$desc, [string]$field) {
+    $m = [regex]::Match($desc, "(?m)^\s*$field\s*:\s*(.+?)\s*$")
+    if ($m.Success) { return $m.Groups[1].Value.Trim() } else { return $null }
+}
+
+function ParseChartCodes([string]$raw) {
+    # "D24" | "S17, S20" | "CO-OP x2" -> list of @{Type;Level}; unparseable tokens returned as strings
+    $out = @()
+    foreach ($tok in ($raw -split ',')) {
+        $t = $tok.Trim()
+        $m = [regex]::Match($t, '^(?i)(S|D)(\d{1,2})$')
+        if ($m.Success) {
+            $type = 'Single'
+            if ($m.Groups[1].Value -match '(?i)d') { $type = 'Double' }
+            $out += ,([pscustomobject]@{ Type = $type; Level = [int]$m.Groups[2].Value })
+            continue
+        }
+        $c = [regex]::Match($t, '^(?i)CO-?OP\s*[xX]?\s*(\d)$')
+        if ($c.Success) {
+            $out += ,([pscustomobject]@{ Type = 'CoOp'; Level = [int]$c.Groups[1].Value })
+            continue
+        }
+        $out += ,$t
+    }
+    return $out
+}
+
+function ParseBpm([string]$raw) {
+    $nums = [regex]::Matches($raw, '\d+(?:\.\d+)?') | ForEach-Object { [decimal]$_.Value }
+    if ($nums.Count -eq 0) { return $null }
+    $sorted = $nums | Sort-Object
+    return @{ Min = $sorted[0]; Max = $sorted[-1] }
+}
+
+# song accumulator keyed by canonical site name
+$songData = @{}
+$unmatched = @()
+$skipped = @()
+
+foreach ($v in $videos) {
+    if ($expectChannelId -and $v.channelId -ne $expectChannelId) { $skipped += "WRONG CHANNEL: $($v.videoId) $($v.title)"; continue }
+    $desc = $v.description
+    if ($null -eq $desc) { $desc = '' }
+    $titleField = DescField $desc 'Title'
+    $isBga = ($v.title -match '\]\s*BGA') -or ($desc -match '(?m)^\s*(Illustrator|Visualizer)\s*:')
+    $stepChart = DescField $desc 'Step Chart'
+    $isChart = -not $isBga -and $null -ne $stepChart
+
+    if (-not $isBga -and -not $isChart) { $skipped += "OTHER: $($v.videoId) $($v.title)"; continue }
+    if ($null -eq $titleField) { $unmatched += "NO TITLE FIELD: $($v.videoId) $($v.title)"; continue }
+
+    # canonical song match: oracle name with the longest normalized prefix of the Title field
+    $normTitle = Normalize $titleField
+    $match = $null
+    $krFromParen = $null
+    foreach ($s in ($siteSongs | Sort-Object { $_.Norm.Length } -Descending)) {
+        if ($normTitle -eq $s.Norm -or $normTitle.StartsWith($s.Norm + ' ')) { $match = $s; break }
+    }
+    if ($null -eq $match) {
+        # fallback: songs with subtitles get the Korean annotation MID-title
+        # ("INFiNiTE ENERZY (X) -Overdoze-", "Pull me up (X) Feat. Monya");
+        # strip the hangul paren group and compare paren-insensitively
+        $hangulParen = [regex]::Match($titleField, "\(([^()]*$hg[^()]*)\)")
+        $stripped = [regex]::Replace($titleField, "\s*\([^()]*$hg[^()]*\)", ' ')
+        $normStripped = (Normalize $stripped) -replace '[()]', ''
+        if ($normStripped -ne '') {
+            foreach ($s in ($siteSongs | Sort-Object { $_.Norm.Length } -Descending)) {
+                if ($normStripped -eq ($s.Norm -replace '[()]', '')) {
+                    $match = $s
+                    if ($hangulParen.Success) { $krFromParen = $hangulParen.Groups[1].Value.Trim() }
+                    if (-not $songData.ContainsKey($s.Name)) { Note "FLAG [$($s.Name)] matched via mid-title Korean annotation: [$titleField]" }
+                    break
+                }
+            }
+        }
+    }
+    if ($null -eq $match) { $unmatched += "NO BLOB MATCH: $($v.videoId) [$titleField] $($v.title)"; continue }
+
+    if ($null -ne $krFromParen) {
+        $kr = $krFromParen
+    }
+    else {
+        # korean name = remainder after the english name, outer parens stripped
+        $remainder = $titleField.Substring([math]::Min($match.Name.Length, $titleField.Length)).Trim()
+        $kr = $remainder -replace '^\(', '' -replace '\)$', ''
+        $kr = $kr.Trim()
+        if ($kr -eq '') { $kr = $match.Name }
+    }
+
+    if (-not $songData.ContainsKey($match.Name)) {
+        $songData[$match.Name] = [pscustomobject]@{
+            Site      = $match
+            Artists   = New-Object System.Collections.ArrayList
+            Bpms      = New-Object System.Collections.ArrayList
+            KrNames   = New-Object System.Collections.ArrayList
+            BgaLength = $null
+            Charts    = New-Object System.Collections.ArrayList  # Type|Level -> per-chart record
+        }
+    }
+    $agg = $songData[$match.Name]
+
+    $artist = DescField $desc 'Artist'
+    if ($artist) { [void]$agg.Artists.Add($artist) }
+    $bpmRaw = DescField $desc 'BPM'
+    if ($bpmRaw) { $b = ParseBpm $bpmRaw; if ($b) { [void]$agg.Bpms.Add($b) } }
+    [void]$agg.KrNames.Add($kr)
+
+    if ($isBga) {
+        $agg.BgaLength = $v.lengthSeconds
+        continue
+    }
+
+    $stepArtist = DescField $desc 'Step Artist'
+    $parsed = @(ParseChartCodes $stepChart)
+    $codes = @($parsed | Where-Object { $_ -isnot [string] })
+    foreach ($bt in @($parsed | Where-Object { $_ -is [string] })) { $unmatched += "UNPARSED CHART TOKEN '$bt': $($v.videoId) $($v.title)" }
+
+    # cross-check against the title's trailing chart codes - Andamiro typos descriptions
+    # (e.g. T.B.H "S2, S4" titled video with "Step Chart : S2, S24"); title wins on mismatch
+    $tsm = [regex]::Match($v.title, '((?:(?:S|D)\d{1,2}|CO-?OP\s*[xX]?\s*\d)(?:\s*,\s*(?:(?:S|D)\d{1,2}|CO-?OP\s*[xX]?\s*\d))*)\s*$', 'IgnoreCase')
+    if ($tsm.Success) {
+        $titleCodes = @(ParseChartCodes $tsm.Groups[1].Value | Where-Object { $_ -isnot [string] })
+        $descSet = @($codes | ForEach-Object { "$($_.Type)|$($_.Level)" } | Sort-Object) -join ','
+        $titleSet = @($titleCodes | ForEach-Object { "$($_.Type)|$($_.Level)" } | Sort-Object) -join ','
+        if ($titleCodes.Count -gt 0 -and $descSet -ne $titleSet) {
+            Note "FLAG [$($match.Name)] title/description chart codes disagree on $($v.videoId): title [$titleSet] vs desc [$descSet] -- using title"
+            $codes = $titleCodes
+        }
+    }
+
+    # split step artists across a multi-chart video only when counts line up
+    $stepArtists = @()
+    if ($stepArtist -and $stepArtist.Contains('/')) {
+        $parts = @($stepArtist -split '/' | ForEach-Object { $_.Trim() })
+        if ($parts.Count -eq $codes.Count) { $stepArtists = $parts }
+        else { $unmatched += "STEP ARTIST SPLIT MISMATCH '$stepArtist' vs $($codes.Count) charts: $($v.videoId)" }
+    }
+
+    for ($i = 0; $i -lt $codes.Count; $i++) {
+        $sa = $stepArtist
+        if ($stepArtists.Count -gt 0) { $sa = $stepArtists[$i] }
+        [void]$agg.Charts.Add([pscustomobject]@{
+            Type       = $codes[$i].Type
+            Level      = $codes[$i].Level
+            StepArtist = $sa
+            Hash       = $v.videoId
+            Length     = $v.lengthSeconds
+        })
+    }
+}
+
+# ---- per-song consolidation + completeness ----
+function Consensus($list, [string]$label, [string]$song) {
+    $grouped = @($list | Group-Object | Sort-Object Count -Descending)
+    if ($grouped.Count -gt 1) { Note "FLAG [$song] $label disagrees across videos: $(($grouped | ForEach-Object { $_.Name + ' x' + $_.Count }) -join '; ') -- using most common" }
+    return $grouped[0].Name
+}
+
+$included = @()
+$deferred = @()
+$problems = @()
+
+foreach ($name in ($songData.Keys | Sort-Object)) {
+    $agg = $songData[$name]
+    $site = $agg.Site
+
+    # dedupe charts by Type|Level
+    $chartMap = [ordered]@{}
+    foreach ($c in $agg.Charts) {
+        $key = "$($c.Type)|$($c.Level)"
+        if ($chartMap.Contains($key)) { Note "FLAG [$name] duplicate chart $key across videos (keeping first)" }
+        else { $chartMap[$key] = $c }
+    }
+
+    $missing = @($site.Site20 | Where-Object { -not $chartMap.Contains($_) })
+    if ($missing.Count -gt 0) {
+        $deferred += "$name -- site charts not yet on YouTube: $($missing -join ', ') (have $($chartMap.Count) videos-charts)"
+        continue
+    }
+
+    # the site's over-20 list is complete: a YouTube-only chart at >=20 is a phantom
+    # (typo that survived title/desc cross-check) or a real site-sweep gap - block either way
+    foreach ($key in $chartMap.Keys) {
+        $lvl = [int]($key -split '\|')[1]
+        if ($lvl -ge 20 -and $chartMap[$key].Type -ne 'CoOp' -and $site.Site20 -notcontains $key) {
+            $problems += "$name : YouTube chart $key is >=20 but absent from the site's over-20 list -- verify before shipping"
+        }
+    }
+
+    $artist = Consensus $agg.Artists 'artist' $name
+    $kr = Consensus $agg.KrNames 'koreanName' $name
+    $bpmMin = ($agg.Bpms | ForEach-Object { $_.Min } | Sort-Object | Select-Object -First 1)
+    $bpmMax = ($agg.Bpms | ForEach-Object { $_.Max } | Sort-Object | Select-Object -Last 1)
+    $duration = $agg.BgaLength
+    if ($null -eq $duration) {
+        $duration = ($agg.Charts | ForEach-Object { $_.Length } | Sort-Object | Select-Object -First 1)
+        Note "FLAG [$name] no BGA video -- duration from shortest chart video ($duration s)"
+    }
+
+    $charts = @()
+    $typeOrder = @{ Single = 0; Double = 1; CoOp = 2 }
+    foreach ($c in ($chartMap.Values | Sort-Object { $typeOrder[$_.Type] }, Level)) {
+        $chart = [ordered]@{
+            type        = $c.Type
+            level       = $c.Level
+            stepArtist  = $c.StepArtist
+            youtubeHash = $c.Hash
+        }
+        $charts += ,$chart
+    }
+
+    $included += ,([ordered]@{
+        name            = $site.Name
+        koreanName      = $kr
+        artist          = $artist
+        type            = $site.Type
+        minBpm          = $bpmMin
+        maxBpm          = $bpmMax
+        durationSeconds = [int]$duration
+        imageUrl        = $site.ImageUrl
+        charts          = $charts
+    })
+}
+
+# ---- exclude songs already shipped in a previous batch ----
+# (chart-set drift on a shipped song = a new video since shipping - the tool skips
+# already-in-P2 songs on Confirm, so a drifted song needs MANUAL chart addition; flag loudly)
+$previouslyShipped = @()
+$kept = @()
+foreach ($s in $included) {
+    $norm = Normalize $s.name
+    if ($shippedCharts.ContainsKey($norm)) {
+        $nowSet = @($s.charts | ForEach-Object { "$($_.type)|$($_.level)" } | Sort-Object) -join ','
+        if ($nowSet -ne $shippedCharts[$norm]) {
+            Note "FLAG [$($s.name)] shipped in a previous batch but chart set CHANGED since: was [$($shippedCharts[$norm])] now [$nowSet] -- excluded from JSON, needs manual handling"
+        }
+        $previouslyShipped += $s.name
+    }
+    else { $kept += ,$s }
+}
+$included = $kept
+
+# oracle songs with no videos at all (not yet uploaded by Andamiro)
+$shippedNorms = @($shippedCharts.Keys)
+$noVideos = @($siteSongs | Where-Object { -not $songData.ContainsKey($_.Name) -and $shippedNorms -notcontains $_.Norm } | ForEach-Object { $_.Name })
+
+# ---- validation gate ----
+foreach ($s in $included) {
+    if ($s.koreanName -match 'TODO' -or [string]::IsNullOrWhiteSpace($s.koreanName)) { $problems += "$($s.name): bad koreanName" }
+    if ([string]::IsNullOrWhiteSpace($s.artist)) { $problems += "$($s.name): missing artist" }
+    if ($null -eq $s.minBpm -or $s.minBpm -le 0 -or $s.maxBpm -lt $s.minBpm) { $problems += "$($s.name): bad bpm $($s.minBpm)-$($s.maxBpm)" }
+    if ($s.durationSeconds -le 0 -or $s.durationSeconds -gt 3600) { $problems += "$($s.name): bad duration $($s.durationSeconds)" }
+    if ($s.charts.Count -eq 0) { $problems += "$($s.name): zero charts" }
+    foreach ($c in $s.charts) {
+        if ([string]::IsNullOrWhiteSpace($c.stepArtist)) { $problems += "$($s.name) $($c.type)$($c.level): missing stepArtist" }
+        if ($c.youtubeHash -notmatch '^[A-Za-z0-9_-]{11}$') { $problems += "$($s.name) $($c.type)$($c.level): bad hash" }
+    }
+}
+
+Note ''
+Note "=== INCLUDED ($($included.Count) songs, $(($included | ForEach-Object { $_.charts.Count } | Measure-Object -Sum).Sum) charts) ==="
+foreach ($s in $included) { Note ("  {0}  [{1}]  {2} charts  {3}-{4}bpm  {5}s  by {6}" -f $s.name, $s.koreanName, $s.charts.Count, $s.minBpm, $s.maxBpm, $s.durationSeconds, $s.artist) }
+Note ''
+Note "=== PREVIOUSLY SHIPPED ($($previouslyShipped.Count)) - excluded from this JSON ==="
+foreach ($p in $previouslyShipped) { Note "  $p" }
+Note ''
+Note "=== DEFERRED - incomplete uploads ($($deferred.Count)) ==="
+foreach ($d in $deferred) { Note "  $d" }
+Note ''
+Note "=== NO VIDEOS YET ($($noVideos.Count)) ==="
+foreach ($n in $noVideos) { Note "  $n" }
+Note ''
+Note "=== UNMATCHED / ODD VIDEOS ($($unmatched.Count)) ==="
+foreach ($u in $unmatched) { Note "  $u" }
+Note ''
+Note "=== SKIPPED NON-CHART/BGA VIDEOS ($($skipped.Count)) ==="
+foreach ($k in $skipped) { Note "  $k" }
+Note ''
+if ($problems.Count -gt 0) {
+    Note "=== VALIDATION PROBLEMS ($($problems.Count)) -- JSON NOT WRITTEN ==="
+    foreach ($p in $problems) { Note "  $p" }
+}
+elseif ($included.Count -eq 0) {
+    Note 'NOTHING NEW TO SHIP - JSON not written'
+}
+else {
+    $json = [ordered]@{ songs = $included } | ConvertTo-Json -Depth 6
+    [IO.File]::WriteAllText($outJson, $json, (New-Object System.Text.UTF8Encoding($true)))
+    Note "WROTE $outJson"
+
+    # record the emitted songs so the next run excludes them (if the owner decides NOT to
+    # upload this batch, remove its entries from shipped.json or they will never re-emit)
+    $shippedList = @()
+    if (Test-Path $shippedPath) { $shippedList = @((Get-Content $shippedPath -Raw -Encoding UTF8 | ConvertFrom-Json).songs) }
+    foreach ($s in $included) {
+        $shippedList += ,([ordered]@{
+            name    = $s.name
+            charts  = @($s.charts | ForEach-Object { "$($_.type)|$($_.level)" } | Sort-Object)
+            batch   = Split-Path $outJson -Leaf
+            dateUtc = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
+        })
+    }
+    [IO.File]::WriteAllText($shippedPath, ([ordered]@{ songs = $shippedList } | ConvertTo-Json -Depth 4), (New-Object System.Text.UTF8Encoding($false)))
+    Note "shipped.json updated (+$($included.Count) songs)"
+}
+[IO.File]::WriteAllLines($outReport, $report, (New-Object System.Text.UTF8Encoding($false)))
+Note "WROTE $outReport"

--- a/.claude/skills/check-new-charts/scripts/rebuild-oracle.ps1
+++ b/.claude/skills/check-new-charts/scripts/rebuild-oracle.ps1
@@ -1,0 +1,181 @@
+# check-new-charts step 1 (when needed): rebuild the site-truth oracle from piugame.com.
+#
+# Sweeps the over-20 leaderboard filters (the only public P2 catalog surface), rotates the
+# catalog checkpoint, diffs against the previous sweep, and appends genuinely-new songs to
+# oracle.json with canonical name/image/chart-list (koreanName/artist/stepArtist/youtubeHash
+# stay TODO until the YouTube pass fills them).
+#
+# CANDIDATES REQUIRE REVIEW: a song new to the SITE is not necessarily new to the TRACKER -
+# returning songs (cut in Phoenix, back in Phoenix 2, e.g. KUGUTSU) already exist and go the
+# ChartMix-seed path, NOT BulkAddCharts. The agent verifies each candidate before shipping it.
+#
+# Login uses the owner-authorized PiuTest account from the shared AppHost user-secrets store.
+# NEVER print or persist the secret values.
+param(
+    [string]$StateDir = "$env:USERPROFILE\.piu-score-tracker\check-new-charts",
+    [string]$BaseUrl = 'https://piugame.com'
+)
+$ErrorActionPreference = 'Stop'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/126.0'
+New-Item -ItemType Directory -Force $StateDir | Out-Null
+
+$sec = Get-Content "$env:APPDATA\Microsoft\UserSecrets\2957ac5b-8cbb-49cf-be12-3b607ea9b818\secrets.json" -Raw | ConvertFrom-Json
+$user = $sec.'PiuTest:Username'; $pass = $sec.'PiuTest:Password'
+if (-not $user) { $user = $sec.PiuTest.Username; $pass = $sec.PiuTest.Password }
+if (-not $user) { throw 'no PiuTest creds in the user-secrets store' }
+
+# P2 leaderboards are login-gated (anonymous traffic gets a marketing shell with 0 rows)
+$sess = $null
+try { Invoke-WebRequest -Uri "$BaseUrl/" -SessionVariable sess -UserAgent $ua -TimeoutSec 15 -UseBasicParsing | Out-Null } catch { if ($null -eq $sess) { $sess = New-Object Microsoft.PowerShell.Commands.WebRequestSession } }
+Invoke-WebRequest -Uri "$BaseUrl/bbs/login_check.php" -Method Post -Body @{ url = '/'; mb_id = $user; mb_password = $pass } -WebSession $sess -UserAgent $ua -TimeoutSec 20 -UseBasicParsing | Out-Null
+# song names follow the SESSION language, not Accept-Language; the oracle needs canonical
+# English, and en is also the account's required resting state (English-parsing tests use it)
+try { Invoke-WebRequest -Uri "$BaseUrl/ajax/language_update.php" -Method Post -Body @{ lang = 'en' } -WebSession $sess -UserAgent $ua -TimeoutSec 15 -UseBasicParsing | Out-Null } catch { Write-Output "language_update en failed ($($_.Exception.Message)) - names may come back Korean, verify the catalog" }
+
+function Parse-Rows([string]$html) {
+    # plain return: callers collect with @(...) - `return ,$rows` would smuggle the whole
+    # page array through as ONE element and ConvertTo-Csv serializes array metadata
+    $rows = @()
+    foreach ($seg in ($html -split 'class="li_in"' | Select-Object -Skip 1)) {
+        $id = [regex]::Match($seg, 'over_ranking_view\.php\?no=([A-Za-z0-9+/=%]+)')
+        $tt = [regex]::Match($seg, 'class="tt">([^<]+)<')
+        # stepball art carries type+level: <t>_bg.png + <t>_num_<d>.png digits in order
+        # (P2 serves them from l_img/p2/stepball/ - the regex tolerates both hosts' paths)
+        $ty = [regex]::Match($seg, '([sdc])_bg\.png')
+        $digits = @([regex]::Matches($seg, '_num_(\d)\.png') | ForEach-Object { $_.Groups[1].Value })
+        if ($id.Success -and $tt.Success) {
+            $lvl = ''
+            if ($digits.Count -gt 0) { $lvl = -join $digits }
+            $rows += ,([pscustomobject]@{
+                Name  = [System.Net.WebUtility]::HtmlDecode($tt.Groups[1].Value).Trim()
+                Type  = $ty.Groups[1].Value
+                Level = $lvl
+                Id    = $id.Groups[1].Value
+            })
+        }
+    }
+    return $rows
+}
+
+# ---- sweep: iterate the lv FILTERS (empty lv = capped top-80 "All" view, useless) ----
+$levels = @('20', '21', '22', '23', '24', '25', '26', '27over', 'coop')
+$all = @()
+$seen = @{}
+$failedLevels = @()
+foreach ($lv in $levels) {
+    $lvCount = 0
+    $ok = $true
+    for ($p = 1; $p -le 80; $p++) {
+        $rows = @()
+        foreach ($attempt in 1..3) {
+            try {
+                $r = Invoke-WebRequest -Uri "$BaseUrl/leaderboard/over_ranking.php?lv=$lv&search=&&page=$p" -WebSession $sess -UserAgent $ua -TimeoutSec 12 -UseBasicParsing
+                $rows = @(Parse-Rows $r.Content)
+            } catch { $rows = @() }
+            if ($rows.Count -gt 0) { break }
+            Start-Sleep -Milliseconds (400 * $attempt)
+        }
+        if ($rows.Count -eq 0) {
+            if ($p -eq 1) { $ok = $false }   # a filter with zero page-1 rows = bounce/limit, not "end"
+            break
+        }
+        # the board serves REPEATED content for out-of-range pages - stop when nothing new
+        $fresh = @($rows | Where-Object { -not $seen.ContainsKey("$($_.Id)|$($_.Type)|$($_.Level)") })
+        if ($fresh.Count -eq 0) { break }
+        foreach ($f in $fresh) { $seen["$($f.Id)|$($f.Type)|$($f.Level)"] = $true }
+        $all += $fresh
+        $lvCount += $fresh.Count
+        Start-Sleep -Milliseconds 400
+    }
+    if ($ok) { Write-Output "lv=$lv : $lvCount rows" } else { $failedLevels += $lv; Write-Output "lv=$lv : FAILED (page1 empty after retries)" }
+}
+if ($failedLevels.Count -gt 0) { throw "sweep incomplete (failed filters: $($failedLevels -join ', ')) - catalog NOT rotated; check login/session and rerun" }
+$badRows = @($all | Where-Object { $_.Type -eq '' -or $_.Level -eq '' })
+foreach ($b in $badRows) { Write-Output "FLAG unparsed stepball (?? level art like 1948 D29?): [$($b.Name)] type='$($b.Type)' level='$($b.Level)' id=$($b.Id)" }
+
+# ---- rotate the catalog checkpoint and diff ----
+$catalogPath = Join-Path $StateDir 'catalog.csv'
+$prevNames = @{}
+if (Test-Path $catalogPath) {
+    foreach ($row in (Import-Csv $catalogPath)) { $prevNames[$row.Name] = $true }
+    Copy-Item $catalogPath (Join-Path $StateDir 'catalog-prev.csv') -Force
+}
+$all | Select-Object Name, Type, Level, Id | ConvertTo-Csv -NoTypeInformation | Out-File $catalogPath -Encoding UTF8
+Write-Output "catalog: $($all.Count) rows, $(($all | Group-Object Name).Count) songs -> $catalogPath"
+
+$newNames = @(($all | Group-Object Name | ForEach-Object { $_.Name }) | Where-Object { $prevNames.Count -gt 0 -and -not $prevNames.ContainsKey($_) })
+if ($prevNames.Count -eq 0) { Write-Output 'no previous catalog - first sweep is the baseline, no candidates derived' }
+
+# ---- append genuinely-new candidates to the oracle ----
+$oraclePath = Join-Path $StateDir 'oracle.json'
+$oracleSongs = @()
+if (Test-Path $oraclePath) { $oracleSongs = @((Get-Content $oraclePath -Raw -Encoding UTF8 | ConvertFrom-Json).songs) }
+$oracleNames = @{}
+foreach ($o in $oracleSongs) { $oracleNames[[string]$o.name] = $true }
+$shippedNames = @{}
+$shippedPath = Join-Path $StateDir 'shipped.json'
+if (Test-Path $shippedPath) { foreach ($s in (Get-Content $shippedPath -Raw -Encoding UTF8 | ConvertFrom-Json).songs) { $shippedNames[[string]$s.name] = $true } }
+
+$typeMap = @{ s = 'Single'; d = 'Double'; c = 'CoOp' }
+$added = @()
+foreach ($name in $newNames) {
+    if ($oracleNames.ContainsKey($name) -or $shippedNames.ContainsKey($name)) { continue }
+    $rows = @($all | Where-Object { $_.Name -eq $name })
+
+    $img = 'TODO'
+    try {
+        $page = Invoke-WebRequest -Uri "$BaseUrl/leaderboard/over_ranking_view.php?no=$($rows[0].Id)" -WebSession $sess -UserAgent $ua -TimeoutSec 30 -UseBasicParsing
+        $m = [regex]::Match($page.Content, 'song_img2/[a-f0-9]+\.png')
+        if ($m.Success) { $img = "$BaseUrl/data/" + $m.Value }
+    } catch { Write-Output "IMGFAIL: $name" }
+
+    $songType = 'Arcade'
+    if ($name -match 'SHORT CUT') { $songType = 'ShortCut' }
+    elseif ($name -match 'FULL SONG') { $songType = 'FullSong' }
+    elseif ($name -match 'Remix') { $songType = 'Remix' }
+
+    $charts = @($rows | Where-Object { $_.Level -ne '' } | Sort-Object { $typeMap[$_.Type] }, { [int]$_.Level } | ForEach-Object {
+        [ordered]@{ type = $typeMap[$_.Type]; level = [int]$_.Level; stepArtist = 'TODO'; youtubeHash = 'TODO' }
+    })
+
+    $oracleSongs += ,([ordered]@{
+        name            = $name
+        koreanName      = 'TODO'
+        artist          = 'TODO'
+        type            = $songType
+        minBpm          = 1
+        maxBpm          = 1
+        durationSeconds = 105
+        imageUrl        = $img
+        charts          = $charts
+    })
+    $added += $name
+    Start-Sleep -Milliseconds 350
+}
+
+# existing unshipped oracle entries whose site chart set GREW (new chart on a pending song):
+# append the missing rows so the completeness gate demands their videos too
+foreach ($o in $oracleSongs) {
+    $oName = [string]$o.name
+    if ($shippedNames.ContainsKey($oName) -or $added -contains $oName) { continue }
+    $siteRows = @($all | Where-Object { $_.Name -eq $oName -and $_.Level -ne '' })
+    if ($siteRows.Count -eq 0) { continue }
+    $have = @($o.charts | ForEach-Object { "$($_.type)|$([int]$_.level)" })
+    foreach ($rowKey in ($siteRows | ForEach-Object { "$($typeMap[$_.Type])|$([int]$_.Level)" })) {
+        if ($have -notcontains $rowKey) {
+            $parts = $rowKey -split '\|'
+            $o.charts = @($o.charts) + ,([ordered]@{ type = $parts[0]; level = [int]$parts[1]; stepArtist = 'TODO'; youtubeHash = 'TODO' })
+            Write-Output "ORACLE UPDATED [$oName]: site grew chart $rowKey - added"
+        }
+    }
+}
+
+[IO.File]::WriteAllText($oraclePath, ([ordered]@{ songs = $oracleSongs } | ConvertTo-Json -Depth 6), (New-Object System.Text.UTF8Encoding($true)))
+Write-Output "oracle: $($oracleSongs.Count) songs -> $oraclePath"
+Write-Output ''
+if ($added.Count -gt 0) {
+    Write-Output "=== NEW CANDIDATES ($($added.Count)) - VERIFY EACH IS NEW TO THE TRACKER (not a returning song) BEFORE SHIPPING ==="
+    foreach ($a in $added) { Write-Output "  $a" }
+}
+else { Write-Output 'no new site songs since the previous sweep' }

--- a/.claude/skills/check-new-charts/scripts/walk-and-fetch.ps1
+++ b/.claude/skills/check-new-charts/scripts/walk-and-fetch.ps1
@@ -1,0 +1,111 @@
+# check-new-charts step 2: walk @PUMPITUPOfficial uploads newest -> watermark, fetch watch pages.
+#
+# The channel grid's id<->title pairing is OFF-BY-ONE in the innertube payload - never trust it.
+# Watch pages (ytInitialPlayerResponse.videoDetails) are authoritative for title/description/length
+# and are cached one JSON per video id, so re-runs and multi-run song completion are cheap.
+#
+# Advances state.json's watermark to the newest id seen ONLY when the watermark was reached and
+# every watch page fetched - a partial window never loses videos because the cache accumulates.
+param(
+    [string]$StateDir = "$env:USERPROFILE\.piu-score-tracker\check-new-charts",
+    [string]$Watermark  # override; default = state.json's watermark
+)
+$ErrorActionPreference = 'Stop'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+
+$statePath = Join-Path $StateDir 'state.json'
+if (-not (Test-Path $statePath)) { throw "no $statePath - bootstrap the state dir first (see SKILL.md)" }
+$state = Get-Content $statePath -Raw -Encoding UTF8 | ConvertFrom-Json
+if (-not $Watermark) { $Watermark = $state.watermark }
+if (-not $Watermark) { throw 'no watermark in state.json and none passed via -Watermark' }
+$channelHandle = $state.channelHandle
+if (-not $channelHandle) { $channelHandle = '@PUMPITUPOfficial' }
+$videoDir = Join-Path $StateDir 'videos'
+New-Item -ItemType Directory -Force $videoDir | Out-Null
+
+# ---- Phase A: walk the uploads tab newest -> watermark, collecting video ids ----
+$r = Invoke-WebRequest -Uri "https://www.youtube.com/$channelHandle/videos" -UserAgent $ua -TimeoutSec 30 -UseBasicParsing -Headers @{ 'Accept-Language' = 'en-US,en;q=0.9' }
+$content = $r.Content
+$apiKey = [regex]::Match($content, '"INNERTUBE_API_KEY":"([^"]+)"').Groups[1].Value
+if (-not $apiKey) { throw 'no innertube key on the channel page - YouTube markup changed?' }
+# the continuation POST rejects stale client versions - always take the page's own
+$clientVersion = [regex]::Match($content, '"INNERTUBE_CONTEXT_CLIENT_VERSION":"([^"]+)"').Groups[1].Value
+if (-not $clientVersion) { $clientVersion = '2.20250620.00.00' }
+
+$ids = New-Object System.Collections.ArrayList
+$seen = @{}
+$found = $false
+$page = 0
+while ($true) {
+    $page++
+    # 2025 lockupViewModel shape; whitespace-tolerant because the browse API pretty-prints
+    foreach ($m in [regex]::Matches($content, '"contentId":\s*"([^"]{11})",\s*"contentType":\s*"LOCKUP_CONTENT_TYPE_VIDEO"')) {
+        $id = $m.Groups[1].Value
+        if ($seen.ContainsKey($id)) { continue }
+        $seen[$id] = $true
+        if ($id -eq $Watermark) { $found = $true; break }
+        [void]$ids.Add($id)
+    }
+    if ($found) { break }
+    $tm = [regex]::Match($content, '"continuationCommand":\s*\{\s*"token":\s*"([^"]+)"')
+    if (-not $tm.Success -or $page -ge 20) { break }
+    $body = @{ context = @{ client = @{ clientName = 'WEB'; clientVersion = $clientVersion } }; continuation = $tm.Groups[1].Value } | ConvertTo-Json -Depth 5
+    $resp = Invoke-WebRequest -Uri "https://www.youtube.com/youtubei/v1/browse?key=$apiKey" -Method Post -Body $body -ContentType 'application/json' -UserAgent $ua -TimeoutSec 30 -UseBasicParsing
+    $content = $resp.Content
+    Start-Sleep -Milliseconds 400
+}
+
+[IO.File]::WriteAllLines((Join-Path $StateDir 'ids-new.txt'), [string[]]$ids, (New-Object System.Text.UTF8Encoding($false)))
+Write-Output "WALK: $($ids.Count) new ids (newest -> watermark) over $page page(s); watermark reached: $found"
+if (-not $found) { Write-Output 'WARNING: watermark not reached within the page cap - window may be incomplete; watermark will NOT advance' }
+if ($ids.Count -eq 0) { Write-Output 'NO NEW VIDEOS since the watermark - nothing to do'; return }
+
+# ---- Phase B: fetch each watch page (cached; authoritative title/desc/length) ----
+$done = 0
+$failed = 0
+foreach ($id in $ids) {
+    $file = Join-Path $videoDir "$id.json"
+    if (Test-Path $file) { $done++; continue }
+    try {
+        $w = Invoke-WebRequest -Uri "https://www.youtube.com/watch?v=$id" -UserAgent $ua -TimeoutSec 30 -UseBasicParsing -Headers @{ 'Accept-Language' = 'en-US,en;q=0.9' }
+        $pm = [regex]::Match($w.Content, 'ytInitialPlayerResponse\s*=\s*(\{.+?\})\s*;\s*(?:var\s|</script>)', 'Singleline')
+        if (-not $pm.Success) { throw 'no player response' }
+        $d = ($pm.Groups[1].Value | ConvertFrom-Json).videoDetails
+        $out = [ordered]@{
+            videoId       = $d.videoId
+            title         = $d.title
+            channelId     = $d.channelId
+            lengthSeconds = [int]$d.lengthSeconds
+            description   = $d.shortDescription
+        } | ConvertTo-Json -Depth 4
+        [IO.File]::WriteAllText($file, $out, (New-Object System.Text.UTF8Encoding($false)))
+        $done++
+    }
+    catch {
+        $failed++
+        Write-Output "FETCHFAIL $id : $($_.Exception.Message)"
+    }
+    Start-Sleep -Milliseconds 350
+}
+Write-Output "FETCH: $done ok, $failed failed, of $($ids.Count)"
+
+# ---- advance the watermark (two-phase: only on a complete, fully-cached window) ----
+if ($found -and $failed -eq 0) {
+    $state.watermark = $ids[0]
+    $state | Add-Member -NotePropertyName updatedUtc -NotePropertyValue ([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')) -Force
+    [IO.File]::WriteAllText($statePath, ($state | ConvertTo-Json -Depth 4), (New-Object System.Text.UTF8Encoding($false)))
+    Write-Output "WATERMARK advanced to $($ids[0])"
+}
+else {
+    Write-Output 'WATERMARK unchanged (incomplete window or fetch failures) - fix and rerun; fetched pages are cached'
+}
+
+# ---- window summary (titles of just this window, for the report/agent) ----
+foreach ($id in $ids) {
+    $file = Join-Path $videoDir "$id.json"
+    if (Test-Path $file) {
+        $v = Get-Content $file -Raw -Encoding UTF8 | ConvertFrom-Json
+        Write-Output ("NEW  {0}  {1}s  {2}" -f $v.videoId, $v.lengthSeconds, $v.title)
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ msbuild.wrn
 # Visual Studio 2015
 .vs/
 
-# Claude Code local settings and worktrees
-.claude/
+# Claude Code local settings and worktrees stay untracked; repo skills are committed
+.claude/*
+!.claude/skills/

--- a/docs/design/new-charts-json.md
+++ b/docs/design/new-charts-json.md
@@ -112,10 +112,12 @@ failure is reported in the results table and the remaining songs still run. The 
 cleared once at the end. Re-parsing after a partial run marks the songs that did get created
 as "already exists", so re-Confirm only retries the failures.
 
-## Collection workflow (future automation)
+## Collection workflow
 
-The intended pipeline that will emit this JSON — a direct automation of the owner's manual
-process, so the blob stays the contract between the tool and the workflow:
+Automated as the repo skill [.claude/skills/check-new-charts/](../../.claude/skills/check-new-charts/SKILL.md)
+(scripts + durable state under `%USERPROFILE%\.piu-score-tracker\check-new-charts\`) — a
+direct automation of the owner's manual process, so the blob stays the contract between the
+tool and the workflow:
 
 1. **YouTube watermark walk** — new charts are announced as per-chart videos on
    `youtube.com/@PUMPITUPOfficial` (batches of ~5 songs, BGA videos mixed in between). Given


### PR DESCRIPTION
## What

Packages the twice-proven new-chart collection pipeline as a committed repo skill, **`.claude/skills/check-new-charts/`**, so future "check for new charts" runs need no arguments and no archaeology. This is the automation the design doc's "Collection workflow (future automation)" section promised — that section now points here.

Three PowerShell 5.1 scripts + a SKILL.md orchestration guide:

| Script | Does |
|---|---|
| `walk-and-fetch.ps1` | Walks `@PUMPITUPOfficial` uploads newest → watermark (innertube continuation, page-fresh clientVersion), caches authoritative watch pages, advances the watermark two-phase (only on a complete, fully-fetched window) |
| `build-batch.ps1` | Groups cached videos by song against the site-truth oracle, title-wins chart-code cross-check (Andamiro typos descriptions), over-20 completeness gate, previously-shipped exclusion with chart-drift flagging, validation-gated `Downloads\phoenix2-batch-<date>.json` + report |
| `rebuild-oracle.ps1` | Login-gated `over_ranking` sweep of piugame.com (lv filters, repeated-page stop, retry ladder), catalog checkpoint rotation + diff, new-song candidate detection, oracle append with canonical name/image/chart list |

Durable state (watermark, oracle, shipped list, catalog checkpoints, watch-page cache) lives **outside the repo** in `%USERPROFILE%\.piu-score-tracker\check-new-charts\` — seeded on this machine with the current state (watermark `1SNf5k67Q4M`, all 29 P2 debut songs shipped).

## .gitignore change

`.claude/` → `.claude/*` + `!.claude/skills/`: repo skills become trackable while local settings, worktrees, and everything else under `.claude/` stay ignored. Nothing previously tracked changes.

## Verified

All three scripts live-tested end to end after seeding:

- **walk**: 0 new ids since watermark, watermark reached, clean no-op exit
- **build**: all 29 shipped songs recognized and excluded, zero drift, "nothing new to ship" path (no JSON written)
- **sweep**: 1,434 rows / 536 songs — byte-for-byte the 2026-07-04 baseline, correct "no new site songs" verdict, and 1948's ??-stepball (the known functionally-D29 rendering) flagged by the designed path

No product code touched — the app, tests, and API are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
