### PR TITLE
fix(recap): sitewide-dead PG card, Top 0.0% wording, off-by-one arc callout

### DIFF
--- a/ScoreTracker/ScoreTracker.ScoreLedger/Infrastructure/EFPhoenixRecordsRepository.cs
+++ b/ScoreTracker/ScoreTracker.ScoreLedger/Infrastructure/EFPhoenixRecordsRepository.cs
@@ -280,7 +280,9 @@ internal sealed class EFPhoenixRecordsRepository : IPhoenixRecordRepository,
         CancellationToken cancellationToken)
     {
         var mixId = MixIds.For(mix);
-        var perfectGame = PhoenixPlate.PerfectGame.ToString();
+        // The Plate column stores GetName() spellings ("Perfect Game", with the space) —
+        // matching ToString() ("PerfectGame") counts zero PGs on every chart.
+        var perfectGame = PhoenixPlate.PerfectGame.GetName();
         await using var database = await _factory.CreateDbContextAsync(cancellationToken);
         return await (from pba in database.Set<PhoenixRecordEntity>()
             where pba.Score != null && pba.MixId == mixId

--- a/ScoreTracker/ScoreTracker.Tests.Integration/PhoenixRecordsRepositoryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/PhoenixRecordsRepositoryTests.cs
@@ -148,6 +148,35 @@ public sealed class PhoenixRecordsRepositoryTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ChartScoreAggregatesCountPgsWrittenThroughUpdateBestAttempt()
+    {
+        // The Plate column stores GetName() spellings ("Perfect Game"), so the aggregate's
+        // PG count must compare against the same spelling. Regression: it compared
+        // ToString() ("PerfectGame"), every chart aggregated to zero PGs, and the recap
+        // page's Perfect Games card vanished sitewide.
+        var pgUser = await _seed.SeedUserAsync();
+        var passUser = await _seed.SeedUserAsync();
+        var breakUser = await _seed.SeedUserAsync();
+        var chartId = await _seed.SeedChartAsync();
+
+        var writer = BuildRepository();
+        await writer.UpdateBestAttempt(MixEnum.Phoenix, pgUser, new RecordedPhoenixScore(chartId,
+            PhoenixScore.From(1000000), PhoenixPlate.PerfectGame, IsBroken: false, RecordedAt));
+        await writer.UpdateBestAttempt(MixEnum.Phoenix, passUser, new RecordedPhoenixScore(chartId,
+            PhoenixScore.From(950000), PhoenixPlate.SuperbGame, IsBroken: false, RecordedAt));
+        await writer.UpdateBestAttempt(MixEnum.Phoenix, breakUser, new RecordedPhoenixScore(chartId,
+            PhoenixScore.From(900000), PhoenixPlate.RoughGame, IsBroken: true, RecordedAt));
+
+        var aggregates = await BuildRepository().GetAllChartScoreAggregates(
+            MixEnum.Phoenix, CancellationToken.None);
+
+        var aggregate = Assert.Single(aggregates, a => a.ChartId == chartId);
+        Assert.Equal(3, aggregate.Count);
+        Assert.Equal(2, aggregate.PassCount);
+        Assert.Equal(1, aggregate.PgCount);
+    }
+
+    [Fact]
     public async Task LevelRangeQueryReturnsOnlyChartsWhosePhoenixMixLevelIsInRange()
     {
         // Exercises the ChartMix → Chart → PhoenixBestAttempt join chain plus the level-range

--- a/ScoreTracker/ScoreTracker/Pages/Progress/PhoenixRecap.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/PhoenixRecap.razor
@@ -48,7 +48,7 @@ else if (_user != null && _recap != null)
                 <div class="precap-inner">
                     <div class="precap-eyebrow">@L["The arc"]</div>
                     <h2 class="precap-h2">@arc.StartCompetitive.ToString("F1") <span class="precap-hl">&#8599;</span> @arc.EndCompetitive.ToString("F1")</h2>
-                    <p class="precap-lede">@L["You walked in a {0}. You're walking out a {1}.", ((int)arc.StartCompetitive).ToString(), ((int)arc.EndCompetitive).ToString()]</p>
+                    <p class="precap-lede">@L["You walked in a {0}. You're walking out a {1}.", WholeLevel(arc.StartCompetitive).ToString(), WholeLevel(arc.EndCompetitive).ToString()]</p>
                     <div class="precap-panel">
                         @* Rendered as one markup string: Razor treats lowercase <text> (SVG) as its own construct. *@
                         @((MarkupString)ArcSvg())
@@ -94,7 +94,7 @@ else if (_user != null && _recap != null)
                         <div class="precap-stat">
                             <div class="precap-num">#@sRank</div>
                             <div class="precap-cap">@L["competitive singles, all PIUScores players"]</div>
-                            <div class="precap-rank">@TopShare(_recap.Rollup.SinglesPercentile)</div>
+                            <div class="precap-rank">@TopShare(_recap.Rollup.SinglesPercentile, sRank)</div>
                         </div>
                     }
                     @if (_recap.Rollup.DoublesRank is { } dRank)
@@ -102,13 +102,13 @@ else if (_user != null && _recap != null)
                         <div class="precap-stat">
                             <div class="precap-num">#@dRank</div>
                             <div class="precap-cap">@L["competitive doubles, all PIUScores players"]</div>
-                            <div class="precap-rank">@TopShare(_recap.Rollup.DoublesPercentile)</div>
+                            <div class="precap-rank">@TopShare(_recap.Rollup.DoublesPercentile, dRank)</div>
                         </div>
                     }
                     <div class="precap-stat">
                         <div class="precap-num">#@_recap.Rollup.ChartsPassedRank</div>
                         <div class="precap-cap">@L["total charts passed"]</div>
-                        <div class="precap-rank">@TopShare(_recap.Rollup.ChartsPassedPercentile)</div>
+                        <div class="precap-rank">@TopShare(_recap.Rollup.ChartsPassedPercentile, _recap.Rollup.ChartsPassedRank)</div>
                     </div>
                 </div>
                 @if (_recap.Rollup.TopStepArtists.Any())
@@ -218,7 +218,7 @@ else if (_user != null && _recap != null)
                                 <span class="precap-cat precap-cat-hl">@L["Perfect Games"]</span>
                                 @foreach (var pg in _recap.ImpressivePgs)
                                 {
-                                    <div class="precap-row">@Pill(pg.ChartType, pg.Level)<span class="precap-song">@pg.SongName</span><span class="precap-meta precap-hot">@L["only {0} have it", pg.PassRate.ToString("P1")]</span></div>
+                                    <div class="precap-row">@Pill(pg.ChartType, pg.Level)<span class="precap-song">@pg.SongName</span><span class="precap-meta precap-hot">@L["only {0} have it", RareShare(pg.PassRate)]</span></div>
                                 }
                             </div>
                         }
@@ -238,7 +238,7 @@ else if (_user != null && _recap != null)
                                 <span class="precap-cat precap-cat-gold">@L["Rarest passes"]</span>
                                 @foreach (var rare in _recap.RarestPasses)
                                 {
-                                    <div class="precap-row">@Pill(rare.ChartType, rare.Level)<span class="precap-song">@rare.SongName</span><span class="precap-meta precap-hot">@L["only {0} pass it", rare.PassRate.ToString("P1")]</span></div>
+                                    <div class="precap-row">@Pill(rare.ChartType, rare.Level)<span class="precap-song">@rare.SongName</span><span class="precap-meta precap-hot">@L["only {0} pass it", RareShare(rare.PassRate)]</span></div>
                                 }
                             </div>
                         }
@@ -312,7 +312,7 @@ else if (_user != null && _recap != null)
                                 @* Title names run long — stack the rarity under a wrapping title. *@
                                 <div class="precap-row precap-row-block">
                                     <span class="precap-song precap-song-wrap">[@title.Title]</span>
-                                    <span class="precap-meta precap-hot">@L["held by {0} of titled players", title.HolderShare.ToString("P1")]</span>
+                                    <span class="precap-meta precap-hot">@L["held by {0} of titled players", RareShare(title.HolderShare)]</span>
                                 </div>
                             }
                         }
@@ -596,9 +596,28 @@ else if (_user != null && _recap != null)
     private bool IsFreshImporter =>
         _recap!.Rollup.FirstRecordedOn is { } first && (_recap.ComputedAt - first).TotalDays < 7;
 
-    private string TopShare(double? percentile)
+    private string TopShare(double? percentile, int? rank = null)
     {
-        return percentile == null ? string.Empty : L["Top {0}", percentile.Value.ToString("P1")];
+        if (percentile == null) return string.Empty;
+        // Below .05% the share renders "Top 0.0%", which reads as a bug. That deep in the
+        // tail it's first place in practice — say so; clamp the rare non-first case instead.
+        if (percentile.Value < .0005)
+            return rank is > 1 ? L["Top {0}", 0.001.ToString("P1")] : L["1st"];
+        return L["Top {0}", percentile.Value.ToString("P1")];
+    }
+
+    // The arc headline rounds to one decimal (25.96 → "26.0"), so the whole-level callout
+    // must floor that displayed value, not the raw one — or "26.0" reads as "a 25".
+    private static int WholeLevel(double competitive)
+    {
+        return (int)Math.Floor(Math.Round(competitive, 1));
+    }
+
+    // Rarity shares can drop below the 0.1% display grain (one PG holder sitewide);
+    // add a decimal there instead of rendering "only 0.0% have it".
+    private static string RareShare(double share)
+    {
+        return share.ToString(share < .0005 ? "P2" : "P1");
     }
 
     private string FormatDuration(long seconds)
@@ -659,7 +678,7 @@ else if (_user != null && _recap != null)
                 or RecapBadge.LeaveSomeTitlesForTheRestOfUs when badge.Share != null =>
                 L["{0} of all Phoenix titles collected", badge.Share.Value.ToString("P0")],
             RecapBadge.SpecialSnowflake when badge is { Subject: not null, Share: not null } =>
-                $"[{badge.Subject}] — " + L["held by {0} of titled players", badge.Share.Value.ToString("P1")],
+                $"[{badge.Subject}] — " + L["held by {0} of titled players", RareShare(badge.Share.Value)],
             RecapBadge.Completionist or RecapBadge.CompletionistPlus or RecapBadge.CompletionistSupreme
                 or RecapBadge.CompletionistUltra or RecapBadge.YouKnowPumpItUpDoesntDoLamps when badge.Count != null =>
                 L["{0} folders at 90% or better", badge.Count.Value.ToString()],

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -2530,6 +2530,9 @@
   <data name="Top {0}" xml:space="preserve">
     <value>Top {0}</value>
   </data>
+  <data name="1st" xml:space="preserve">
+    <value>1st</value>
+  </data>
   <data name="{0} of all Phoenix titles collected" xml:space="preserve">
     <value>{0} of all Phoenix titles collected</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -2454,6 +2454,9 @@
   <data name="Top {0}" xml:space="preserve">
     <value>Mrgl {0}</value>
   </data>
+  <data name="1st" xml:space="preserve">
+    <value>1st, mrgl</value>
+  </data>
   <data name="{0} of all Phoenix titles collected" xml:space="preserve">
     <value>{0} mrgl titles</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -2409,6 +2409,9 @@
   <data name="Top {0}" xml:space="preserve">
     <value>Top {0}</value>
   </data>
+  <data name="1st" xml:space="preserve">
+    <value>1er lugar</value>
+  </data>
   <data name="{0} of all Phoenix titles collected" xml:space="preserve">
     <value>{0} de todos los títulos Phoenix</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -2528,6 +2528,9 @@
   <data name="Top {0}" xml:space="preserve">
     <value>Top {0}</value>
   </data>
+  <data name="1st" xml:space="preserve">
+    <value>1re place</value>
+  </data>
   <data name="{0} of all Phoenix titles collected" xml:space="preserve">
     <value>{0} de tous les titres Phoenix</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -2530,6 +2530,9 @@
   <data name="Top {0}" xml:space="preserve">
     <value>Top {0}</value>
   </data>
+  <data name="1st" xml:space="preserve">
+    <value>1° posto</value>
+  </data>
   <data name="{0} of all Phoenix titles collected" xml:space="preserve">
     <value>{0} di tutti i titoli Phoenix</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -2531,6 +2531,9 @@
   <data name="Top {0}" xml:space="preserve">
     <value>上位{0}</value>
   </data>
+  <data name="1st" xml:space="preserve">
+    <value>1位</value>
+  </data>
   <data name="{0} of all Phoenix titles collected" xml:space="preserve">
     <value>全フェニックス称号の{0}を収集</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -2410,6 +2410,9 @@
   <data name="Top {0}" xml:space="preserve">
     <value>상위 {0}</value>
   </data>
+  <data name="1st" xml:space="preserve">
+    <value>1위</value>
+  </data>
   <data name="{0} of all Phoenix titles collected" xml:space="preserve">
     <value>전체 피닉스 타이틀의 {0} 수집</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -2481,6 +2481,9 @@
   <data name="Top {0}" xml:space="preserve">
     <value>Top {0}</value>
   </data>
+  <data name="1st" xml:space="preserve">
+    <value>1º lugar</value>
+  </data>
   <data name="{0} of all Phoenix titles collected" xml:space="preserve">
     <value>{0} de todos os títulos Phoenix</value>
   </data>


### PR DESCRIPTION
Three fixes for the Phoenix Recap page.

## 1. PG card was dead sitewide (not a level floor)

`GetAllChartScoreAggregates` counted PGs with `Plate == PhoenixPlate.PerfectGame.ToString()` (`"PerfectGame"`), but the `Plate` column is persisted via `GetName()` (`"Perfect Game"`, with the space). Every chart aggregated to **zero** PGs, and the recap's rarest-5 selection filters on `PgCount > 0` — so the Perfect Games card vanished for every player, and "Rebuild Recap PG Cards" faithfully recomputed empty lists.

- One-line fix in `EFPhoenixRecordsRepository.GetAllChartScoreAggregates`.
- New integration test writes a PG through `UpdateBestAttempt` and asserts the aggregate counts it against real SQL Server, pinning the write/aggregate spelling agreement.

> ⚠️ **Post-deploy step:** press **Rebuild Recap PG Cards** on `/Admin` once — stored payloads hold empty `ImpressivePgs` until the patch sweep rewrites them.

## 2. "Top 0.0%" → "1st"

`TopShare` now renders **1st** whenever the share would round to 0.0% (new `1st` key populated in all 8 locales). The rank tiles pass their rank, so a non-first rank that deep in the tail clamps to "Top 0.1%" instead of claiming first.

Adjacent artifact this PR would otherwise expose: with PG counts fixed, a one-holder PG renders "only 0.0% have it". Rarity shares ("only X have it" / "only X pass it" / "held by X of titled players") now gain a second decimal below the 0.1% grain — "only 0.03% have it".

## 3. Arc callout off by one ("25.0 ↗ 26.0" said "walking out a 25")

The headline rounds to one decimal (raw 25.96 displays "26.0"), but the callout used a plain `(int)` cast that truncated 25.96 → 25. It now floors the *displayed* value (`floor(round(x, 1))`): whenever the headline says 26.0 the callout says 26, while 25.5 still reads "a 25".

## Testing

- `ScoreTracker.Tests` — 1,024 passed
- `ScoreTracker.Tests.Api` — 57 passed
- `ScoreTracker.Tests.Integration` (PhoenixRecordsRepositoryTests incl. new PG-count pin, real SQL via Testcontainers) — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
