### PR TITLE
Pumbility history capture + Projections v2 (two pools, skill profile, plate curve)

### DIFF
--- a/ScoreTracker/ScoreTracker.Catalog/Contracts/ChartSkillChipRecord.cs
+++ b/ScoreTracker/ScoreTracker.Catalog/Contracts/ChartSkillChipRecord.cs
@@ -8,4 +8,14 @@ namespace ScoreTracker.Catalog.Contracts;
 ///     it (null when only the dominance pick carried it).
 /// </summary>
 [ExcludeFromCodeCoverage]
-public sealed record ChartSkillChipRecord(Skill Skill, bool Highlighted, decimal? SegmentFraction);
+public sealed record ChartSkillChipRecord(Skill Skill, bool Highlighted, decimal? SegmentFraction)
+{
+    /// <summary>
+    ///     The weight a chip carries when SegmentFraction is null (dominance-only picks
+    ///     and pre-crawl boolean tags). Every chip consumer weighs the same way — the
+    ///     tier-list Skill source and the PUMBILITY projection must not drift.
+    /// </summary>
+    public const double DefaultSegmentWeight = 0.5;
+
+    public double Weight => SegmentFraction != null ? (double)SegmentFraction.Value : DefaultSegmentWeight;
+}

--- a/ScoreTracker/ScoreTracker.ChartIntelligence/Application/PlayerSkillDeviationsHandler.cs
+++ b/ScoreTracker/ScoreTracker.ChartIntelligence/Application/PlayerSkillDeviationsHandler.cs
@@ -1,0 +1,41 @@
+using MediatR;
+using ScoreTracker.ChartIntelligence.Contracts;
+using ScoreTracker.ChartIntelligence.Contracts.Queries;
+using ScoreTracker.ChartIntelligence.Domain;
+using ScoreTracker.Domain.SecondaryPorts;
+
+namespace ScoreTracker.ChartIntelligence.Application;
+
+/// <summary>
+///     Publishes the Skill source's pooled evidence as a contract (Pumbility
+///     projections v2 consumes it from PlayerProgress). Deviations convert from the
+///     internal proficiency scale to score units at this boundary — consumers never
+///     learn the floored-band internals.
+/// </summary>
+internal sealed class PlayerSkillDeviationsHandler
+    : IRequestHandler<GetPlayerSkillDeviationsQuery, PlayerSkillDeviations>
+{
+    private readonly TierListBlendBuilder _builder;
+
+    public PlayerSkillDeviationsHandler(IMediator mediator, IChartRepository charts, IScoreReader scores,
+        IPlayerStatsReader playerStats, IUserTierListRepository userTierLists, IDateTimeOffsetAccessor clock)
+    {
+        _builder = new TierListBlendBuilder(mediator, charts, scores, playerStats, userTierLists, clock);
+    }
+
+    public async Task<PlayerSkillDeviations> Handle(GetPlayerSkillDeviationsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var evidence = await _builder.ComputeSkillEvidence(request.ChartType, request.AnchorLevel,
+            request.Mix, request.UserId, Array.Empty<Guid>(), cancellationToken);
+
+        var skills = evidence.PooledSkills.ToDictionary(kv => kv.Key, kv => new SkillDeviationRecord(
+            kv.Value.Deviation * TierListBlendBuilder.SkillScoreRange,
+            kv.Value.Evidence,
+            kv.Value.Usable));
+
+        return new PlayerSkillDeviations(skills,
+            skills.Count(kv => kv.Value.Usable) >= TierListBlendBuilder.MinUsableSkills,
+            evidence.ScoredChartCount);
+    }
+}

--- a/ScoreTracker/ScoreTracker.ChartIntelligence/Application/TierListBlendBuilder.cs
+++ b/ScoreTracker/ScoreTracker.ChartIntelligence/Application/TierListBlendBuilder.cs
@@ -158,7 +158,6 @@ internal sealed class TierListBlendBuilder
     private const int FolderWindow = 3;
     public const double MinSkillEvidence = 2.0; // effective weighted observations per skill
     public const int MinUsableSkills = 3;
-    private const double DefaultSkillWeight = 0.5; // top3-only chips and pre-crawl boolean tags
     private const double EstimateOffset = 500_000; // ProcessIntoTierList treats exactly 0 as Unrecorded
 
     // Proficiency lives in the 900k-1M band (owner): 990,000 = 90%, anything at or
@@ -269,11 +268,8 @@ internal sealed class TierListBlendBuilder
         IReadOnlyDictionary<Guid, IReadOnlyList<ChartSkillChipRecord>> chips, Chart chart)
     {
         return chips.TryGetValue(chart.Id, out var chartChips) && chartChips.Count > 0
-            ? chartChips
-                .Select(c => (c.Skill,
-                    c.SegmentFraction != null ? (double)c.SegmentFraction.Value : DefaultSkillWeight))
-                .ToArray()
-            : chart.Skills.Select(s => (s, DefaultSkillWeight)).ToArray();
+            ? chartChips.Select(c => (c.Skill, c.Weight)).ToArray()
+            : chart.Skills.Select(s => (s, ChartSkillChipRecord.DefaultSegmentWeight)).ToArray();
     }
 
     private async Task<SkillSourceComputation> ComputeSkillSource(ChartType chartType, DifficultyLevel level,

--- a/ScoreTracker/ScoreTracker.ChartIntelligence/Application/TierListBlendBuilder.cs
+++ b/ScoreTracker/ScoreTracker.ChartIntelligence/Application/TierListBlendBuilder.cs
@@ -164,8 +164,10 @@ internal sealed class TierListBlendBuilder
     // Proficiency lives in the 900k-1M band (owner): 990,000 = 90%, anything at or
     // under 900,000 = 0%. Deviations pool over this floored scale so sub-900k scores
     // read as zero proficiency instead of dragging skill estimates linearly.
+    // SkillScoreRange is public: PlayerSkillDeviationsHandler converts pooled
+    // deviations to score units with it (proficiency × range).
     private const double SkillScoreFloor = 900_000;
-    private const double SkillScoreRange = 100_000;
+    public const double SkillScoreRange = 100_000;
 
     // Score-age workshop (owner-corrected 2026-07-12): a score is "old" only when it
     // is BOTH past the grace floor AND an age OUTLIER in the player's own record —
@@ -202,10 +204,17 @@ internal sealed class TierListBlendBuilder
         return Math.Clamp(score - SkillScoreFloor, 0, SkillScoreRange) / SkillScoreRange;
     }
 
-    private async Task<SkillSourceComputation> ComputeSkillSource(ChartType chartType, DifficultyLevel level,
-        MixEnum mix, Guid userId, IReadOnlyCollection<Chart> folderCharts, CancellationToken cancellationToken)
+    /// <summary>
+    ///     The pooled per-skill evidence around an anchor folder — the reusable core of
+    ///     the Skill source, also served cross-vertical through
+    ///     GetPlayerSkillDeviationsQuery (Pumbility projections v2). extraChipChartIds
+    ///     lets ComputeSkillSource keep its single bulk chips fetch for the
+    ///     folder-estimate stage that follows.
+    /// </summary>
+    public async Task<SkillEvidencePool> ComputeSkillEvidence(ChartType chartType, DifficultyLevel anchorLevel,
+        MixEnum mix, Guid userId, IReadOnlyCollection<Guid> extraChipChartIds, CancellationToken cancellationToken)
     {
-        var intLevel = (int)level;
+        var intLevel = (int)anchorLevel;
         var bestScores = (await _scores.GetBestScores(mix, userId, cancellationToken))
             .Where(s => s is { Score: not null, IsBroken: false })
             .ToDictionary(s => s.ChartId);
@@ -216,18 +225,8 @@ internal sealed class TierListBlendBuilder
             .ToArray();
 
         var chips = await _mediator.Send(new GetChartSkillChipsQuery(
-                scoredWindowCharts.Select(c => c.Id).Union(folderCharts.Select(c => c.Id)).ToArray()),
+                scoredWindowCharts.Select(c => c.Id).Union(extraChipChartIds).ToArray()),
             cancellationToken);
-
-        IReadOnlyList<(Skill Skill, double Weight)> WeightsFor(Chart chart)
-        {
-            return chips.TryGetValue(chart.Id, out var chartChips) && chartChips.Count > 0
-                ? chartChips
-                    .Select(c => (c.Skill,
-                        c.SegmentFraction != null ? (double)c.SegmentFraction.Value : DefaultSkillWeight))
-                    .ToArray()
-                : chart.Skills.Select(s => (s, DefaultSkillWeight)).ToArray();
-        }
 
         // Age outliers over the whole ±3 window: scores much older than the rest of
         // the record vote quietly. Baselines MUST use the same weights — a stale
@@ -249,7 +248,7 @@ internal sealed class TierListBlendBuilder
         {
             var decay = FolderDecay[Math.Abs((int)chart.Level - intLevel)];
             var deviation = Proficiency((int)bestScores[chart.Id].Score!.Value) - folderBaselines[(int)chart.Level];
-            foreach (var (skill, weight) in WeightsFor(chart))
+            foreach (var (skill, weight) in WeightsFor(chips, chart))
             {
                 var observationWeight = decay * weight * ageWeights[chart.Id];
                 var current = pooled.TryGetValue(skill, out var sums) ? sums : (0.0, 0.0);
@@ -263,20 +262,41 @@ internal sealed class TierListBlendBuilder
             kv.Value.Evidence,
             kv.Value.Evidence >= MinSkillEvidence));
 
-        var skillDeviations = pooledSkills
+        return new SkillEvidencePool(pooledSkills, chips, scoredWindowCharts.Length, outdatedScoreCount);
+    }
+
+    private static IReadOnlyList<(Skill Skill, double Weight)> WeightsFor(
+        IReadOnlyDictionary<Guid, IReadOnlyList<ChartSkillChipRecord>> chips, Chart chart)
+    {
+        return chips.TryGetValue(chart.Id, out var chartChips) && chartChips.Count > 0
+            ? chartChips
+                .Select(c => (c.Skill,
+                    c.SegmentFraction != null ? (double)c.SegmentFraction.Value : DefaultSkillWeight))
+                .ToArray()
+            : chart.Skills.Select(s => (s, DefaultSkillWeight)).ToArray();
+    }
+
+    private async Task<SkillSourceComputation> ComputeSkillSource(ChartType chartType, DifficultyLevel level,
+        MixEnum mix, Guid userId, IReadOnlyCollection<Chart> folderCharts, CancellationToken cancellationToken)
+    {
+        var evidence = await ComputeSkillEvidence(chartType, level, mix, userId,
+            folderCharts.Select(c => c.Id).ToArray(), cancellationToken);
+
+        var skillDeviations = evidence.PooledSkills
             .Where(kv => kv.Value.Usable)
             .ToDictionary(kv => kv.Key, kv => kv.Value.Deviation);
         if (skillDeviations.Count < MinUsableSkills)
             return new SkillSourceComputation(
                 folderCharts.ToDictionary(c => c.Id,
                     c => new SongTierListEntry("Skill", c.Id, TierListCategory.Unrecorded, 0)),
-                pooledSkills, false, scoredWindowCharts.Length, outdatedScoreCount);
+                evidence.PooledSkills, false, evidence.ScoredChartCount, evidence.OutdatedScoreCount);
 
         var estimates = new Dictionary<Guid, double>();
         var silent = new List<SongTierListEntry>();
         foreach (var chart in folderCharts)
         {
-            var usable = WeightsFor(chart).Where(p => skillDeviations.ContainsKey(p.Skill)).ToArray();
+            var usable = WeightsFor(evidence.Chips, chart).Where(p => skillDeviations.ContainsKey(p.Skill))
+                .ToArray();
             if (usable.Length == 0)
             {
                 silent.Add(new SongTierListEntry("Skill", chart.Id, TierListCategory.Unrecorded, 9999));
@@ -291,7 +311,7 @@ internal sealed class TierListBlendBuilder
         return new SkillSourceComputation(
             TierListProcessor.ProcessIntoTierList("Skill", estimates).Concat(silent)
                 .ToDictionary(e => e.ChartId, e => e),
-            pooledSkills, true, scoredWindowCharts.Length, outdatedScoreCount);
+            evidence.PooledSkills, true, evidence.ScoredChartCount, evidence.OutdatedScoreCount);
     }
 
     // Similar players, re-architected on C1's materialization: neighbors' folder
@@ -376,6 +396,16 @@ internal sealed record BlendComputation(
 
 /// <summary>Per-skill pooled deviation on the proficiency scale + its effective evidence.</summary>
 internal sealed record SkillEvidence(double Deviation, double Evidence, bool Usable);
+
+/// <summary>
+///     The pooled evidence around an anchor folder, plus the chips fetched to build it
+///     (returned so ComputeSkillSource's folder-estimate stage reuses the one bulk read).
+/// </summary>
+internal sealed record SkillEvidencePool(
+    IReadOnlyDictionary<Skill, SkillEvidence> PooledSkills,
+    IReadOnlyDictionary<Guid, IReadOnlyList<ChartSkillChipRecord>> Chips,
+    int ScoredChartCount,
+    int OutdatedScoreCount);
 
 internal sealed record SkillSourceComputation(
     IReadOnlyDictionary<Guid, SongTierListEntry> Entries,

--- a/ScoreTracker/ScoreTracker.ChartIntelligence/Contracts/PlayerSkillDeviations.cs
+++ b/ScoreTracker/ScoreTracker.ChartIntelligence/Contracts/PlayerSkillDeviations.cs
@@ -16,7 +16,16 @@ namespace ScoreTracker.ChartIntelligence.Contracts;
 public sealed record PlayerSkillDeviations(
     IReadOnlyDictionary<Skill, SkillDeviationRecord> Skills,
     bool Usable,
-    int ScoredChartCount);
+    int ScoredChartCount)
+{
+    /// <summary>
+    ///     Deviations are measured on this floored band. They only say something about
+    ///     scores INSIDE it — don't apply them to expectations below the floor.
+    /// </summary>
+    public const int BandFloor = 900_000;
+
+    public const int BandCeiling = 1_000_000;
+}
 
 [ExcludeFromCodeCoverage]
 public sealed record SkillDeviationRecord(double ScoreDeviation, double Evidence, bool Usable);

--- a/ScoreTracker/ScoreTracker.ChartIntelligence/Contracts/PlayerSkillDeviations.cs
+++ b/ScoreTracker/ScoreTracker.ChartIntelligence/Contracts/PlayerSkillDeviations.cs
@@ -1,0 +1,22 @@
+using ScoreTracker.SharedKernel.Enums;
+
+namespace ScoreTracker.ChartIntelligence.Contracts;
+
+/// <summary>
+///     Per-skill deviations from the player's own folder baselines, pooled over the
+///     ±3-folder window around the query's anchor — the same computation the tier-list
+///     Skill source runs (one implementation, no drift; see TierListBlendBuilder).
+///     ScoreDeviation is in score units measured on the floored 900k–1M proficiency
+///     band: +5,800 means charts highlighting this skill run ~5,800 above the player's
+///     folder norm. Consumers must skip skill-based adjustments unless
+///     <see cref="Usable" /> — fewer than three sufficiently-evidenced skills means
+///     the picture is noise, not signal.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed record PlayerSkillDeviations(
+    IReadOnlyDictionary<Skill, SkillDeviationRecord> Skills,
+    bool Usable,
+    int ScoredChartCount);
+
+[ExcludeFromCodeCoverage]
+public sealed record SkillDeviationRecord(double ScoreDeviation, double Evidence, bool Usable);

--- a/ScoreTracker/ScoreTracker.ChartIntelligence/Contracts/Queries/GetPlayerSkillDeviationsQuery.cs
+++ b/ScoreTracker/ScoreTracker.ChartIntelligence/Contracts/Queries/GetPlayerSkillDeviationsQuery.cs
@@ -1,0 +1,15 @@
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.SharedKernel.ValueTypes;
+
+namespace ScoreTracker.ChartIntelligence.Contracts.Queries;
+
+/// <summary>
+///     The player's skill-deviation profile around an anchor folder: how their scores
+///     on charts highlighting each skill deviate from their own folder baselines,
+///     within the ±3-folder window the tier-list Skill source uses. Anchor at the
+///     folder whose charts you are reasoning about (Pumbility projections anchor at
+///     the player's per-type competitive level).
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed record GetPlayerSkillDeviationsQuery(Guid UserId, ChartType ChartType,
+    DifficultyLevel AnchorLevel, MixEnum Mix = MixEnum.Phoenix) : IQuery<PlayerSkillDeviations>;

--- a/ScoreTracker/ScoreTracker.Data/Migrations/20260712161402_PlayerHistorySkillRating.Designer.cs
+++ b/ScoreTracker/ScoreTracker.Data/Migrations/20260712161402_PlayerHistorySkillRating.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScoreTracker.Data.Persistence;
 
@@ -11,9 +12,11 @@ using ScoreTracker.Data.Persistence;
 namespace ScoreTracker.Data.Migrations
 {
     [DbContext(typeof(ChartAttemptDbContext))]
-    partial class ChartAttemptDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712161402_PlayerHistorySkillRating")]
+    partial class PlayerHistorySkillRating
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ScoreTracker/ScoreTracker.Data/Migrations/20260712161402_PlayerHistorySkillRating.cs
+++ b/ScoreTracker/ScoreTracker.Data/Migrations/20260712161402_PlayerHistorySkillRating.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScoreTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class PlayerHistorySkillRating : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SkillRating",
+                schema: "scores",
+                table: "PlayerHistory",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SkillRating",
+                schema: "scores",
+                table: "PlayerHistory");
+        }
+    }
+}

--- a/ScoreTracker/ScoreTracker.Domain/Records/PlayerRatingRecord.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Records/PlayerRatingRecord.cs
@@ -1,9 +1,11 @@
 ﻿namespace ScoreTracker.Domain.Records
 {
+    // SkillRating (PUMBILITY) is nullable: capture started 2026-07 — rows from before then never
+    // recorded it, and null (not 0) is how consumers distinguish "not captured" from a real zero.
     [ExcludeFromCodeCoverage]
     public sealed record PlayerRatingRecord(Guid UserId, DateTimeOffset Date, double CompetitiveLevel,
         double SinglesLevel,
-        double DoublesLevel, int CoOpRating, int PassCount)
+        double DoublesLevel, int CoOpRating, int PassCount, int? SkillRating = null)
     {
     }
 }

--- a/ScoreTracker/ScoreTracker.Domain/Records/PumbilityProjection.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Records/PumbilityProjection.cs
@@ -8,5 +8,14 @@ namespace ScoreTracker.Domain.Records
         IReadOnlyDictionary<Guid, PhoenixScore> ExpectedScores,
         IReadOnlyDictionary<Guid, int> ProjectedGains,
         IReadOnlyDictionary<(ChartType ChartType, DifficultyLevel Level), int> InsufficientDataGains,
-        IReadOnlyDictionary<Guid, TierListCategory> ChartDifficulty);
+        IReadOnlyDictionary<Guid, TierListCategory> ChartDifficulty,
+        IReadOnlyDictionary<Guid, IReadOnlyList<SkillAdjustmentRecord>> SkillAdjustments);
+
+    /// <summary>
+    ///     Why a chart's expected score moved: the damped, chip-weighted share of the
+    ///     player's deviation on one skill, in score units. Positive = this skill is a
+    ///     strength that raised the projection ("+Twists"), negative = it dragged it.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public sealed record SkillAdjustmentRecord(Skill Skill, double ScoreDelta);
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PlayerHistorySaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PlayerHistorySaga.cs
@@ -14,7 +14,8 @@ namespace ScoreTracker.PlayerProgress.Application
                 dateTime.Now,
                 context.Message.NewCompetitive,
                 context.Message.NewSinglesCompetitive, context.Message.NewDoublesCompetitive,
-                context.Message.CoOpRating, context.Message.PassCount), context.CancellationToken);
+                context.Message.CoOpRating, context.Message.PassCount,
+                context.Message.NewTop50), context.CancellationToken);
         }
     }
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
@@ -1,6 +1,7 @@
 using ScoreTracker.Domain.Services;
 using MediatR;
 using ScoreTracker.Catalog.Contracts.Queries;
+using ScoreTracker.ChartIntelligence.Contracts;
 using ScoreTracker.ChartIntelligence.Contracts.Queries;
 using ScoreTracker.PlayerProgress.Contracts.Queries;
 using ScoreTracker.SharedKernel.Enums;
@@ -73,7 +74,8 @@ namespace ScoreTracker.PlayerProgress.Application
                     new Dictionary<Guid, PhoenixScore>(),
                     new Dictionary<Guid, int>(),
                     new Dictionary<(ChartType ChartType, DifficultyLevel Level), int>(),
-                    new Dictionary<Guid, TierListCategory>());
+                    new Dictionary<Guid, TierListCategory>(),
+                    new Dictionary<Guid, IReadOnlyList<SkillAdjustmentRecord>>());
 
             var lowestLevel = DifficultyLevel.From(levelRange.Min());
             var highestLevel = DifficultyLevel.From(levelRange.Max());
@@ -150,6 +152,9 @@ namespace ScoreTracker.PlayerProgress.Application
                 }
             }
 
+            var skillAdjustments = await ApplySkillAdjustments(expectedScore, charts, request.UserId, mix,
+                singlesLevel, doublesLevel, cancellationToken);
+
             var projectedGains = new Dictionary<Guid, int>();
             foreach (var kv in expectedScore)
             {
@@ -171,7 +176,75 @@ namespace ScoreTracker.PlayerProgress.Application
                 projectedGains[kv.Key] = (int)expectedGains;
             }
 
-            return new PumbilityProjection(expectedScore, projectedGains, insufficientData, chartDifficulty);
+            return new PumbilityProjection(expectedScore, projectedGains, insufficientData, chartDifficulty,
+                skillAdjustments);
+        }
+
+        // Half-voice on purpose: cohort interpolation is the primary signal; the skill
+        // profile nudges it toward charts whose demands match the player's strengths.
+        private const double SkillDamping = 0.5;
+
+        /// <summary>
+        ///     Skill-weights each expected score (docs/design/home-page-widgets.md §5):
+        ///     a chart's banked skill chips pull its projection toward the player's
+        ///     per-skill deviations (GetPlayerSkillDeviationsQuery — the tier-list
+        ///     competence machinery). Mutates <paramref name="expectedScore" /> and
+        ///     returns the per-chart "why" so targets can explain themselves.
+        /// </summary>
+        private async Task<Dictionary<Guid, IReadOnlyList<SkillAdjustmentRecord>>> ApplySkillAdjustments(
+            Dictionary<Guid, PhoenixScore> expectedScore, IReadOnlyDictionary<Guid, Chart> charts, Guid userId,
+            MixEnum mix, double singlesLevel, double doublesLevel, CancellationToken cancellationToken)
+        {
+            var adjustments = new Dictionary<Guid, IReadOnlyList<SkillAdjustmentRecord>>();
+            if (!expectedScore.Any()) return adjustments;
+
+            var profiles = new Dictionary<ChartType, PlayerSkillDeviations>();
+            foreach (var (type, level) in new[]
+                         { (ChartType.Single, singlesLevel), (ChartType.Double, doublesLevel) })
+            {
+                if (expectedScore.Keys.All(id => charts[id].Type != type)) continue;
+                var anchor = DifficultyLevel.From(Math.Clamp((int)Math.Round(level), 1, DifficultyLevel.Max));
+                var profile = await _mediator.Send(
+                    new GetPlayerSkillDeviationsQuery(userId, type, anchor, mix), cancellationToken);
+                if (profile.Usable) profiles[type] = profile;
+            }
+
+            if (!profiles.Any()) return adjustments;
+
+            var chips = await _mediator.Send(new GetChartSkillChipsQuery(expectedScore.Keys.ToArray()),
+                cancellationToken);
+
+            foreach (var chartId in expectedScore.Keys.ToArray())
+            {
+                var raw = (int)expectedScore[chartId];
+                // Deviations are measured on the floored band — below it they say nothing.
+                if (raw < PlayerSkillDeviations.BandFloor) continue;
+                if (!profiles.TryGetValue(charts[chartId].Type, out var profile)) continue;
+                // Charts without banked step analysis get no adjustment, same as the tier list.
+                if (!chips.TryGetValue(chartId, out var chartChips) || chartChips.Count == 0) continue;
+
+                var weighted = chartChips
+                    .Where(c => profile.Skills.TryGetValue(c.Skill, out var deviation) && deviation.Usable)
+                    .ToArray();
+                if (!weighted.Any()) continue;
+
+                var totalWeight = weighted.Sum(c => c.Weight);
+                var perSkill = weighted
+                    .Select(c => new SkillAdjustmentRecord(c.Skill,
+                        SkillDamping * c.Weight * profile.Skills[c.Skill].ScoreDeviation / totalWeight))
+                    .Where(a => Math.Abs(a.ScoreDelta) >= 1)
+                    .OrderByDescending(a => Math.Abs(a.ScoreDelta))
+                    .ToArray();
+                if (!perSkill.Any()) continue;
+
+                var adjusted = Math.Clamp(raw + (int)perSkill.Sum(a => a.ScoreDelta),
+                    PlayerSkillDeviations.BandFloor, PlayerSkillDeviations.BandCeiling);
+                if (adjusted == raw) continue;
+                expectedScore[chartId] = adjusted;
+                adjustments[chartId] = perSkill;
+            }
+
+            return adjustments;
         }
 
         private async Task<PoolState> BuildPool(ChartType? chartType, Guid userId, MixEnum mix,

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
@@ -155,7 +155,11 @@ namespace ScoreTracker.PlayerProgress.Application
             {
                 var chart = charts[kv.Key];
                 var pool = pools[chart.Type];
-                var expectedPumbility = scoring.GetScore(chart, kv.Value, PhoenixPlate.ExtremeGame, false);
+                // Plate rides the projected score through the empirical curve — a flat
+                // EG assumption overpriced plate bonuses everywhere under Phoenix 2's
+                // additive formula.
+                var expectedPumbility = scoring.GetScore(chart, kv.Value,
+                    ScoringConfiguration.ExpectedPlateForScore(kv.Value), false);
                 var expectedGains = expectedPumbility - pool.Baseline;
                 if (expectedGains <= 0) continue;
                 if (pool.Ratings.TryGetValue(kv.Key, out var rating))

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
@@ -36,23 +36,30 @@ namespace ScoreTracker.PlayerProgress.Application
             var allScores = (await _scores.GetBestScores(mix, request.UserId, cancellationToken))
                 .Where(r => r.Score != null)
                 .ToDictionary(s => s.ChartId);
-            var topScores = (await _mediator.Send(
-                    new GetTop50ForPlayerQuery(request.UserId, null, 100, mix), cancellationToken))
-                .ToDictionary(s => s.ChartId);
-            // TODO(P2-pumbility): projections still model ONE mixed top-50 pool. Phoenix 2
-            // uses two independent pools (S+D), so its gain baseline ("lowest of top 50")
-            // should be per-pool. The page is disabled on Phoenix 2; proper two-pool
-            // projection lands with the What-Should-I-Play overhaul.
             var scoring = ScoringConfiguration.PumbilityScoring(mix, false);
-            var ratings = topScores.ToDictionary(kv => kv.Key,
-                kv => (int)scoring.GetScore(charts[kv.Key], kv.Value.Score!.Value,
-                    kv.Value.Plate ?? PhoenixPlate.RoughGame, kv.Value.IsBroken));
 
-            var top50ForTierList = topScores.Values
-                .OrderByDescending(s => ratings[s.ChartId])
-                .Take(50)
-                .ToDictionary(s => s.ChartId, s => ratings[s.ChartId]);
-            var tierList = TierListProcessor.ProcessIntoTierList("PUMBILITY", top50ForTierList)
+            // Phoenix ranks ONE mixed top-50 pool; Phoenix 2's official PUMBILITY is two
+            // independent per-type pools, so gain baselines ("lowest of the top 50") are
+            // per-pool — a doubles chart can only ever displace a doubles chart.
+            var pools = new Dictionary<ChartType, PoolState>();
+            if (mix == MixEnum.Phoenix2)
+            {
+                pools[ChartType.Single] = await BuildPool(ChartType.Single, request.UserId, mix, charts, scoring,
+                    cancellationToken);
+                pools[ChartType.Double] = await BuildPool(ChartType.Double, request.UserId, mix, charts, scoring,
+                    cancellationToken);
+            }
+            else
+            {
+                var mixed = await BuildPool(null, request.UserId, mix, charts, scoring, cancellationToken);
+                pools[ChartType.Single] = mixed;
+                pools[ChartType.Double] = mixed;
+            }
+
+            var pooledTop50 = pools.Values.Distinct()
+                .SelectMany(p => p.Top50)
+                .ToDictionary(kv => kv.Key, kv => kv.Value);
+            var tierList = TierListProcessor.ProcessIntoTierList("PUMBILITY", pooledTop50)
                 .Where(e => e.Category != TierListCategory.Unrecorded)
                 .GroupBy(e => e.Category)
                 .ToDictionary(g => g.Key, g => g.Select(e => e.ChartId).ToArray());
@@ -73,7 +80,6 @@ namespace ScoreTracker.PlayerProgress.Application
             var stats = await _stats.GetStats(mix, request.UserId, cancellationToken);
             var singlesLevel = stats.SinglesCompetitiveLevel <= 10 ? 10.0 : stats.SinglesCompetitiveLevel;
             var doublesLevel = stats.DoublesCompetitiveLevel <= 10 ? 10.0 : stats.DoublesCompetitiveLevel;
-            var lowestScore = ratings.OrderByDescending(kv => kv.Value).Take(50).Min(kv => kv.Value);
 
             var singlesPlayers = (await _stats.GetPlayersByCompetitiveRange(mix, ChartType.Single, singlesLevel, 1,
                 cancellationToken)).ToArray();
@@ -120,7 +126,7 @@ namespace ScoreTracker.PlayerProgress.Application
                     if (myScores.Count() < (int)Math.Floor(.2 * chartAverages.Count()))
                     {
                         var diff = scoring.GetScore(chartType, levelGroup.Key, PhoenixLetterGrade.AA.GetMinimumScore())
-                                   - lowestScore;
+                                   - pools[chartType].Baseline;
                         if (myScores.Any() && diff > 0)
                             insufficientData[(chartType, levelGroup.Key)] = (int)diff;
                         continue;
@@ -147,10 +153,12 @@ namespace ScoreTracker.PlayerProgress.Application
             var projectedGains = new Dictionary<Guid, int>();
             foreach (var kv in expectedScore)
             {
-                var expectedPumbility = scoring.GetScore(charts[kv.Key], kv.Value, PhoenixPlate.ExtremeGame, false);
-                var expectedGains = expectedPumbility - lowestScore;
+                var chart = charts[kv.Key];
+                var pool = pools[chart.Type];
+                var expectedPumbility = scoring.GetScore(chart, kv.Value, PhoenixPlate.ExtremeGame, false);
+                var expectedGains = expectedPumbility - pool.Baseline;
                 if (expectedGains <= 0) continue;
-                if (ratings.TryGetValue(kv.Key, out var rating))
+                if (pool.Ratings.TryGetValue(kv.Key, out var rating))
                 {
                     expectedGains = expectedPumbility - rating;
                     if (expectedGains <= 0) continue;
@@ -161,5 +169,27 @@ namespace ScoreTracker.PlayerProgress.Application
 
             return new PumbilityProjection(expectedScore, projectedGains, insufficientData, chartDifficulty);
         }
+
+        private async Task<PoolState> BuildPool(ChartType? chartType, Guid userId, MixEnum mix,
+            IReadOnlyDictionary<Guid, Chart> charts, ScoringConfiguration scoring,
+            CancellationToken cancellationToken)
+        {
+            var topScores = (await _mediator.Send(
+                    new GetTop50ForPlayerQuery(userId, chartType, 100, mix), cancellationToken))
+                .ToDictionary(s => s.ChartId);
+            var ratings = topScores.ToDictionary(kv => kv.Key,
+                kv => (int)scoring.GetScore(charts[kv.Key], kv.Value.Score!.Value,
+                    kv.Value.Plate ?? PhoenixPlate.RoughGame, kv.Value.IsBroken));
+            var top50 = ratings.OrderByDescending(kv => kv.Value)
+                .Take(50)
+                .ToDictionary(kv => kv.Key, kv => kv.Value);
+            // A pool that isn't full displaces nothing — a new chart contributes whole.
+            // This matters most at a mix launch, when nobody has fifty scores yet.
+            var baseline = ratings.Count >= 50 ? top50.Values.Min() : 0;
+            return new PoolState(ratings, top50, baseline);
+        }
+
+        private sealed record PoolState(IReadOnlyDictionary<Guid, int> Ratings,
+            IReadOnlyDictionary<Guid, int> Top50, int Baseline);
     }
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/EFPlayerHistoryRepository.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/EFPlayerHistoryRepository.cs
@@ -25,7 +25,8 @@ namespace ScoreTracker.PlayerProgress.Infrastructure
                 CompetitiveLevel = record.CompetitiveLevel,
                 SinglesLevel = record.SinglesLevel,
                 DoublesLevel = record.DoublesLevel,
-                PassCount = record.PassCount
+                PassCount = record.PassCount,
+                SkillRating = record.SkillRating
             }, cancellationToken);
             await database.SaveChangesAsync(cancellationToken);
         }
@@ -39,7 +40,7 @@ namespace ScoreTracker.PlayerProgress.Infrastructure
             return await database.Set<PlayerHistoryEntity>()
                 .Where(r => r.UserId == request.UserId && r.MixId == mixId)
                 .Select(r => new PlayerRatingRecord(r.UserId, r.Date, r.CompetitiveLevel, r.SinglesLevel,
-                    r.DoublesLevel, r.CoOpRating, r.PassCount)).ToArrayAsync(cancellationToken);
+                    r.DoublesLevel, r.CoOpRating, r.PassCount, r.SkillRating)).ToArrayAsync(cancellationToken);
         }
 
         public async Task DeleteHistoryForUser(Guid userId, CancellationToken cancellationToken)

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/Entities/PlayerHistoryEntity.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/Entities/PlayerHistoryEntity.cs
@@ -17,5 +17,6 @@ namespace ScoreTracker.PlayerProgress.Infrastructure.Entities
         public double DoublesLevel { get; set; }
         public int CoOpRating { get; set; }
         public int PassCount { get; set; }
+        public int? SkillRating { get; set; }
     }
 }

--- a/ScoreTracker/ScoreTracker.SharedKernel/Models/ScoringConfiguration.cs
+++ b/ScoreTracker/ScoreTracker.SharedKernel/Models/ScoringConfiguration.cs
@@ -250,6 +250,29 @@ namespace ScoreTracker.SharedKernel.Models
             };
         }
 
+        /// <summary>
+        ///     The plate a score most plausibly carries when the score is all you know —
+        ///     the modal plate per band across 922,765 real non-broken Phoenix records
+        ///     (prod-synced local data, 2026-07-12), crossovers measured at 2k-band
+        ///     granularity. SG/EG/RG are never the population mode in any band (real
+        ///     plate progression ladders FG → TG → MG → UG), so the expectation never
+        ///     emits them. Used by the PUMBILITY projection for unplayed charts;
+        ///     deliberately not an exact science — recalibrate per mix once its plate
+        ///     data accumulates (same query, new constants;
+        ///     docs/design/home-page-widgets.md §5).
+        /// </summary>
+        public static PhoenixPlate ExpectedPlateForScore(PhoenixScore score)
+        {
+            return (int)score switch
+            {
+                >= 1_000_000 => PhoenixPlate.PerfectGame,
+                >= 996_000 => PhoenixPlate.UltimateGame,
+                >= 972_000 => PhoenixPlate.MarvelousGame,
+                >= 964_000 => PhoenixPlate.TalentedGame,
+                _ => PhoenixPlate.FairGame
+            };
+        }
+
         private static ScoringConfiguration PhoenixPumbilityScoring(bool includeCoOp)
         {
             var config = new ScoringConfiguration

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerHistorySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerHistorySagaTests.cs
@@ -46,7 +46,8 @@ public sealed class PlayerHistorySagaTests
                                             && r.SinglesLevel == 17.0
                                             && r.DoublesLevel == 18.0
                                             && r.CoOpRating == 200
-                                            && r.PassCount == 42),
+                                            && r.PassCount == 42
+                                            && r.SkillRating == 100),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerSkillDeviationsHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerSkillDeviationsHandlerTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Moq;
+using ScoreTracker.Catalog.Contracts;
+using ScoreTracker.Catalog.Contracts.Queries;
+using ScoreTracker.ChartIntelligence.Application;
+using ScoreTracker.ChartIntelligence.Contracts.Queries;
+using ScoreTracker.ChartIntelligence.Domain;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.SharedKernel.Models;
+using ScoreTracker.SharedKernel.ValueTypes;
+using ScoreTracker.Tests.TestData;
+using ScoreTracker.Tests.TestHelpers;
+using Xunit;
+
+namespace ScoreTracker.Tests.ApplicationTests;
+
+/// <summary>
+///     Pins the published skill-deviation numbers to the tier-list Skill source's
+///     semantics (TierListBlendBuilder): same floored proficiency scale, same
+///     folder-baseline normalization, same evidence thresholds. The fixture is small
+///     enough to hand-compute — if these numbers move, the shared machinery moved,
+///     and that is breaking-change review for both consumers.
+/// </summary>
+public sealed class PlayerSkillDeviationsHandlerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 1, 12, 0, 0, TimeSpan.Zero);
+
+    // Six S18 charts, all scored recently (no age outliers), single-skill chips at
+    // full segment coverage. Folder baseline = mean proficiency = 0.5:
+    //   980k→.8  960k→.6 (Twists: +.3, +.1 → mean +0.2 → +20,000 score units)
+    //   940k→.4  920k→.2 (Brackets: −.1, −.3 → mean −0.2 → −20,000)
+    //   970k→.7  930k→.3 (Stamina: +.2, −.2 → mean 0 → 0)
+    private static (PlayerSkillDeviationsHandler Handler, Guid UserId) BuildFixture(
+        bool includeStaminaChips = true)
+    {
+        var userId = Guid.NewGuid();
+        var charts = Enumerable.Range(0, 6)
+            .Select(_ => new ChartBuilder().WithLevel(18).WithType(ChartType.Single).Build())
+            .ToArray();
+        var scores = new[] { 980_000, 960_000, 940_000, 920_000, 970_000, 930_000 };
+
+        var chartRepo = new Mock<IChartRepository>();
+        chartRepo.Setup(c => c.GetCharts(MixEnum.Phoenix, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(charts);
+
+        var scoreReader = new Mock<IScoreReader>();
+        scoreReader.Setup(s => s.GetBestScores(MixEnum.Phoenix, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(charts.Select((c, i) =>
+                new RecordedPhoenixScore(c.Id, scores[i], PhoenixPlate.FairGame, false, Now.AddDays(-5))));
+
+        var chips = new Dictionary<Guid, IReadOnlyList<ChartSkillChipRecord>>
+        {
+            [charts[0].Id] = new[] { new ChartSkillChipRecord(Skill.Twists, true, 1.0m) },
+            [charts[1].Id] = new[] { new ChartSkillChipRecord(Skill.Twists, true, 1.0m) },
+            [charts[2].Id] = new[] { new ChartSkillChipRecord(Skill.Brackets, true, 1.0m) },
+            [charts[3].Id] = new[] { new ChartSkillChipRecord(Skill.Brackets, true, 1.0m) }
+        };
+        if (includeStaminaChips)
+        {
+            chips[charts[4].Id] = new[] { new ChartSkillChipRecord(Skill.Stamina, true, 1.0m) };
+            chips[charts[5].Id] = new[] { new ChartSkillChipRecord(Skill.Stamina, true, 1.0m) };
+        }
+
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetChartSkillChipsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chips);
+
+        var handler = new PlayerSkillDeviationsHandler(mediator.Object, chartRepo.Object, scoreReader.Object,
+            Mock.Of<IPlayerStatsReader>(), Mock.Of<IUserTierListRepository>(), FakeDateTime.At(Now).Object);
+        return (handler, userId);
+    }
+
+    [Fact]
+    public async Task DeviationsMatchTheSkillSourceMathInScoreUnits()
+    {
+        var (handler, userId) = BuildFixture();
+
+        var result = await handler.Handle(
+            new GetPlayerSkillDeviationsQuery(userId, ChartType.Single, DifficultyLevel.From(18)),
+            CancellationToken.None);
+
+        Assert.True(result.Usable);
+        Assert.Equal(6, result.ScoredChartCount);
+        Assert.Equal(20_000, result.Skills[Skill.Twists].ScoreDeviation, 3);
+        Assert.Equal(-20_000, result.Skills[Skill.Brackets].ScoreDeviation, 3);
+        Assert.Equal(0, result.Skills[Skill.Stamina].ScoreDeviation, 3);
+        Assert.All(result.Skills.Values, s => Assert.True(s.Usable));
+        Assert.All(result.Skills.Values, s => Assert.Equal(2.0, s.Evidence, 3));
+    }
+
+    [Fact]
+    public async Task FewerThanThreeEvidencedSkillsIsUnusable()
+    {
+        var (handler, userId) = BuildFixture(includeStaminaChips: false);
+
+        var result = await handler.Handle(
+            new GetPlayerSkillDeviationsQuery(userId, ChartType.Single, DifficultyLevel.From(18)),
+            CancellationToken.None);
+
+        Assert.False(result.Usable);
+        Assert.True(result.Skills[Skill.Twists].Usable);
+        Assert.True(result.Skills[Skill.Brackets].Usable);
+    }
+
+    [Fact]
+    public async Task NoScoresYieldsEmptyUnusableProfile()
+    {
+        var userId = Guid.NewGuid();
+        var chartRepo = new Mock<IChartRepository>();
+        chartRepo.Setup(c => c.GetCharts(MixEnum.Phoenix, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Chart>());
+        var scoreReader = new Mock<IScoreReader>();
+        scoreReader.Setup(s => s.GetBestScores(MixEnum.Phoenix, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RecordedPhoenixScore>());
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetChartSkillChipsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<ChartSkillChipRecord>>());
+
+        var handler = new PlayerSkillDeviationsHandler(mediator.Object, chartRepo.Object, scoreReader.Object,
+            Mock.Of<IPlayerStatsReader>(), Mock.Of<IUserTierListRepository>(), FakeDateTime.At(Now).Object);
+
+        var result = await handler.Handle(
+            new GetPlayerSkillDeviationsQuery(userId, ChartType.Single, DifficultyLevel.From(18)),
+            CancellationToken.None);
+
+        Assert.False(result.Usable);
+        Assert.Empty(result.Skills);
+        Assert.Equal(0, result.ScoredChartCount);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
@@ -223,7 +223,7 @@ public sealed class PumbilityProjectionSagaTests
             .WithCharts(poolCharts.Concat(new[] { doublesChart, singleCandidate, doubleCandidate }).ToArray())
             .WithTopScore(doublesChart.Id, 951_000)
             .WithCohortUser()
-            .WithCohortScores(ChartType.Single, singleCandidate.Id, 970_000, 960_000, 950_000, 940_000)
+            .WithCohortScores(ChartType.Single, singleCandidate.Id, 992_000, 991_000, 990_000, 989_000)
             .WithCohortScores(ChartType.Double, doubleCandidate.Id, 970_000, 960_000, 950_000, 940_000);
         foreach (var poolChart in poolCharts) ctx.WithTopScore(poolChart.Id, 951_000);
 
@@ -231,14 +231,17 @@ public sealed class PumbilityProjectionSagaTests
             CancellationToken.None);
 
         // No cohort data on my played charts → percentile defaults to 0.5, which lands
-        // exactly on sorted[2] = 950,000 for both candidates.
-        Assert.Equal(950_000, (int)result.ExpectedScores[singleCandidate.Id]);
+        // exactly on sorted[2] for both candidates.
+        Assert.Equal(990_000, (int)result.ExpectedScores[singleCandidate.Id]);
         Assert.Equal(950_000, (int)result.ExpectedScores[doubleCandidate.Id]);
 
+        // Projected scores ride the empirical plate curve (pinned in
+        // ExpectedPlateForScoreTests): 990k → Marvelous Game, 950k → Fair Game. The
+        // doubles gain is full contribution — its pool is underfilled, baseline 0.
         var singlesBaseline = (int)scoring.GetScore(poolCharts[0], 951_000, PhoenixPlate.SuperbGame, false);
-        var expectedSingleGain = (int)(scoring.GetScore(singleCandidate, 950_000, PhoenixPlate.ExtremeGame, false)
+        var expectedSingleGain = (int)(scoring.GetScore(singleCandidate, 990_000, PhoenixPlate.MarvelousGame, false)
                                        - singlesBaseline);
-        var expectedDoubleGain = (int)scoring.GetScore(doubleCandidate, 950_000, PhoenixPlate.ExtremeGame, false);
+        var expectedDoubleGain = (int)scoring.GetScore(doubleCandidate, 950_000, PhoenixPlate.FairGame, false);
         Assert.Equal(expectedSingleGain, result.ProjectedGains[singleCandidate.Id]);
         Assert.Equal(expectedDoubleGain, result.ProjectedGains[doubleCandidate.Id]);
     }

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
@@ -5,8 +5,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Moq;
+using ScoreTracker.Catalog.Contracts;
 using ScoreTracker.Catalog.Contracts.Commands;
 using ScoreTracker.Catalog.Contracts.Queries;
+using ScoreTracker.ChartIntelligence.Contracts;
 using ScoreTracker.ChartIntelligence.Contracts.Commands;
 using ScoreTracker.ChartIntelligence.Contracts.Queries;
 using ScoreTracker.Application.Queries;
@@ -205,6 +207,57 @@ public sealed class PumbilityProjectionSagaTests
     }
 
     [Fact]
+    public async Task SkillProfileNudgesExpectedScoreAndExplainsItself()
+    {
+        // Cohort interpolation projects c2 at 955,750 (see the percentile test). A
+        // usable Twists deviation of +8,000 on a full-coverage Twists chart nudges it
+        // by damping·weight·deviation/Σweight = 0.5·1·8,000 = +4,000 → 959,750, and
+        // the why-record carries (Twists, +4,000). c1 has no banked chips → untouched.
+        var c1 = new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build();
+        var c2 = new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build();
+        var ctx = new ProjectionContext()
+            .WithCharts(c1, c2)
+            .WithTopScore(c1.Id, 950_000)
+            .WithBestScore(c1.Id, 950_000)
+            .WithCohortUser()
+            .WithCohortScores(ChartType.Single, c1.Id, 960_000, 950_000, 940_000, 930_000)
+            .WithCohortScores(ChartType.Single, c2.Id, 970_000, 955_000, 945_000, 935_000)
+            .WithSkillProfile(ChartType.Single, (Skill.Twists, 8_000))
+            .WithChartChips(c2.Id, (Skill.Twists, 1.0m));
+
+        var result = await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+
+        Assert.Equal(959_750, (int)result.ExpectedScores[c2.Id]);
+        Assert.Equal(950_500, (int)result.ExpectedScores[c1.Id]);
+        var why = Assert.Single(result.SkillAdjustments[c2.Id]);
+        Assert.Equal(Skill.Twists, why.Skill);
+        Assert.Equal(4_000, why.ScoreDelta, 3);
+        Assert.False(result.SkillAdjustments.ContainsKey(c1.Id));
+    }
+
+    [Fact]
+    public async Task UnusableSkillProfileLeavesProjectionsUntouched()
+    {
+        // No usable profile (the fixture default) → no deviation queries can nudge
+        // anything; expected scores stay pure cohort interpolation.
+        var c1 = new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build();
+        var c2 = new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build();
+        var ctx = new ProjectionContext()
+            .WithCharts(c1, c2)
+            .WithTopScore(c1.Id, 950_000)
+            .WithBestScore(c1.Id, 950_000)
+            .WithCohortUser()
+            .WithCohortScores(ChartType.Single, c1.Id, 960_000, 950_000, 940_000, 930_000)
+            .WithCohortScores(ChartType.Single, c2.Id, 970_000, 955_000, 945_000, 935_000)
+            .WithChartChips(c2.Id, (Skill.Twists, 1.0m));
+
+        var result = await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+
+        Assert.Equal(955_750, (int)result.ExpectedScores[c2.Id]);
+        Assert.Empty(result.SkillAdjustments);
+    }
+
+    [Fact]
     public async Task Phoenix2GainsMeasureAgainstTheChartsOwnPool()
     {
         // Singles pool is FULL (50 rated charts) → its baseline is the lowest of those
@@ -303,8 +356,37 @@ public sealed class PumbilityProjectionSagaTests
                 });
             Mediator.Setup(m => m.Send(It.IsAny<GetTierListQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => _passCountTierList.AsEnumerable());
+            Mediator.Setup(m => m.Send(It.IsAny<GetPlayerSkillDeviationsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IRequest<PlayerSkillDeviations> request, CancellationToken _) =>
+                    _skillProfiles.TryGetValue(((GetPlayerSkillDeviationsQuery)request).ChartType, out var p)
+                        ? p
+                        : new PlayerSkillDeviations(new Dictionary<Skill, SkillDeviationRecord>(), false, 0));
+            Mediator.Setup(m => m.Send(It.IsAny<GetChartSkillChipsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => _chartChips);
 
             Saga = new PumbilityProjectionSaga(Mediator.Object, Stats.Object, PhoenixRecords.Object);
+        }
+
+        private readonly Dictionary<ChartType, PlayerSkillDeviations> _skillProfiles = new();
+
+        private readonly Dictionary<Guid, IReadOnlyList<ChartSkillChipRecord>> _chartChips = new();
+
+        public ProjectionContext WithSkillProfile(ChartType type,
+            params (Skill Skill, double ScoreDeviation)[] deviations)
+        {
+            _skillProfiles[type] = new PlayerSkillDeviations(
+                deviations.ToDictionary(d => d.Skill,
+                    d => new SkillDeviationRecord(d.ScoreDeviation, Evidence: 5.0, Usable: true)),
+                Usable: true, ScoredChartCount: deviations.Length * 2);
+            return this;
+        }
+
+        public ProjectionContext WithChartChips(Guid chartId, params (Skill Skill, decimal Fraction)[] chips)
+        {
+            _chartChips[chartId] = chips
+                .Select(c => new ChartSkillChipRecord(c.Skill, Highlighted: true, c.Fraction))
+                .ToArray();
+            return this;
         }
 
         public ProjectionContext WithCharts(params Chart[] charts)

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
@@ -151,6 +151,98 @@ public sealed class PumbilityProjectionSagaTests
         Assert.Empty(result.ProjectedGains);
     }
 
+    [Fact]
+    public async Task PhoenixRanksOneMixedPool()
+    {
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build();
+        var ctx = new ProjectionContext().WithCharts(chart).WithTopScore(chart.Id);
+
+        await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+
+        ctx.Mediator.Verify(m => m.Send(It.Is<GetTop50ForPlayerQuery>(q => q.ChartType == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Mediator.Verify(m => m.Send(It.Is<GetTop50ForPlayerQuery>(q => q.ChartType != null),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Phoenix2RanksIndependentSinglesAndDoublesPools()
+    {
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build();
+        var ctx = new ProjectionContext().WithCharts(chart).WithTopScore(chart.Id);
+
+        await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId, MixEnum.Phoenix2),
+            CancellationToken.None);
+
+        ctx.Mediator.Verify(m => m.Send(It.Is<GetTop50ForPlayerQuery>(q => q.ChartType == ChartType.Single),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Mediator.Verify(m => m.Send(It.Is<GetTop50ForPlayerQuery>(q => q.ChartType == ChartType.Double),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Mediator.Verify(m => m.Send(It.Is<GetTop50ForPlayerQuery>(q => q.ChartType == null),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExpectedScoreInterpolatesCohortDistributionAtMyPercentile()
+    {
+        // My 950k on c1 sits at index 1 of the cohort's descending c1 scores
+        // [960, 950, 940, 930]k → percentile (1/4)·0.95 = 0.2375. On c2's distribution
+        // [970, 955, 945, 935]k the target (0.95) interpolates between index 0 and 1:
+        // 955,000 + (970,000 − 955,000)·(1 − 0.95) = 955,750.
+        var c1 = new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build();
+        var c2 = new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build();
+        var ctx = new ProjectionContext()
+            .WithCharts(c1, c2)
+            .WithTopScore(c1.Id, 950_000)
+            .WithBestScore(c1.Id, 950_000)
+            .WithCohortUser()
+            .WithCohortScores(ChartType.Single, c1.Id, 960_000, 950_000, 940_000, 930_000)
+            .WithCohortScores(ChartType.Single, c2.Id, 970_000, 955_000, 945_000, 935_000);
+
+        var result = await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+
+        Assert.Equal(955_750, (int)result.ExpectedScores[c2.Id]);
+    }
+
+    [Fact]
+    public async Task Phoenix2GainsMeasureAgainstTheChartsOwnPool()
+    {
+        // Singles pool is FULL (50 rated charts) → its baseline is the lowest of those
+        // ratings; the doubles pool has one score → underfilled, baseline 0. The same
+        // expected score therefore yields a full-contribution gain on a doubles chart
+        // and a baseline-reduced gain on a singles chart.
+        var scoring = ScoringConfiguration.PumbilityScoring(MixEnum.Phoenix2, false);
+        var poolCharts = Enumerable.Range(0, 50)
+            .Select(_ => new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build())
+            .ToArray();
+        var doublesChart = new ChartBuilder().WithType(ChartType.Double).WithLevel(18).Build();
+        var singleCandidate = new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build();
+        var doubleCandidate = new ChartBuilder().WithType(ChartType.Double).WithLevel(18).Build();
+
+        var ctx = new ProjectionContext()
+            .WithCharts(poolCharts.Concat(new[] { doublesChart, singleCandidate, doubleCandidate }).ToArray())
+            .WithTopScore(doublesChart.Id, 951_000)
+            .WithCohortUser()
+            .WithCohortScores(ChartType.Single, singleCandidate.Id, 970_000, 960_000, 950_000, 940_000)
+            .WithCohortScores(ChartType.Double, doubleCandidate.Id, 970_000, 960_000, 950_000, 940_000);
+        foreach (var poolChart in poolCharts) ctx.WithTopScore(poolChart.Id, 951_000);
+
+        var result = await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId, MixEnum.Phoenix2),
+            CancellationToken.None);
+
+        // No cohort data on my played charts → percentile defaults to 0.5, which lands
+        // exactly on sorted[2] = 950,000 for both candidates.
+        Assert.Equal(950_000, (int)result.ExpectedScores[singleCandidate.Id]);
+        Assert.Equal(950_000, (int)result.ExpectedScores[doubleCandidate.Id]);
+
+        var singlesBaseline = (int)scoring.GetScore(poolCharts[0], 951_000, PhoenixPlate.SuperbGame, false);
+        var expectedSingleGain = (int)(scoring.GetScore(singleCandidate, 950_000, PhoenixPlate.ExtremeGame, false)
+                                       - singlesBaseline);
+        var expectedDoubleGain = (int)scoring.GetScore(doubleCandidate, 950_000, PhoenixPlate.ExtremeGame, false);
+        Assert.Equal(expectedSingleGain, result.ProjectedGains[singleCandidate.Id]);
+        Assert.Equal(expectedDoubleGain, result.ProjectedGains[doubleCandidate.Id]);
+    }
+
     private sealed class ProjectionContext
     {
         public Guid UserId { get; } = Guid.NewGuid();
@@ -166,9 +258,12 @@ public sealed class PumbilityProjectionSagaTests
         private double _singlesCompetitive = 17.0;
         private double _doublesCompetitive = 17.0;
 
+        private readonly List<Guid> _cohortUsers = new();
+        private readonly List<(ChartType Type, RecordedPhoenixScore Score)> _cohortScores = new();
+
         public ProjectionContext()
         {
-            Stats.Setup(s => s.GetStats(MixEnum.Phoenix, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            Stats.Setup(s => s.GetStats(It.IsAny<MixEnum>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => new PlayerStatsRecord(UserId,
                     TotalRating: 0, HighestLevel: 1, ClearCount: 0, CoOpRating: 0, CoOpScore: 0,
                     SkillRating: 0, SkillScore: 0, SkillLevel: 0,
@@ -180,20 +275,29 @@ public sealed class PumbilityProjectionSagaTests
 
             Stats.Setup(s => s.GetPlayersByCompetitiveRange(
                     It.IsAny<MixEnum>(), It.IsAny<ChartType?>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Array.Empty<Guid>());
+                .ReturnsAsync(() => _cohortUsers.AsEnumerable());
 
             PhoenixRecords.Setup(s => s.GetScores(
-                    MixEnum.Phoenix, It.IsAny<IEnumerable<Guid>>(), It.IsAny<ChartType>(),
+                    It.IsAny<MixEnum>(), It.IsAny<IEnumerable<Guid>>(), It.IsAny<ChartType>(),
                     It.IsAny<DifficultyLevel>(), It.IsAny<DifficultyLevel>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Array.Empty<RecordedPhoenixScore>());
+                .ReturnsAsync((MixEnum _, IEnumerable<Guid> _, ChartType type, DifficultyLevel _,
+                        DifficultyLevel _, CancellationToken _) =>
+                    _cohortScores.Where(cs => cs.Type == type).Select(cs => cs.Score).ToArray());
 
             Mediator.Setup(m => m.Send(It.IsAny<GetChartsQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => _charts.AsEnumerable());
-            PhoenixRecords.Setup(s => s.GetBestScores(MixEnum.Phoenix, It.IsAny<Guid>(),
+            PhoenixRecords.Setup(s => s.GetBestScores(It.IsAny<MixEnum>(), It.IsAny<Guid>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => _allUserScores.AsEnumerable());
+            // Per-type filtering mirrors the real handler: ChartType == null is the mixed
+            // pool; a typed query only returns that type's charts.
             Mediator.Setup(m => m.Send(It.IsAny<GetTop50ForPlayerQuery>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(() => _topScores.AsEnumerable());
+                .ReturnsAsync((IRequest<IEnumerable<RecordedPhoenixScore>> request, CancellationToken _) =>
+                {
+                    var query = (GetTop50ForPlayerQuery)request;
+                    return _topScores.Where(ts => query.ChartType == null ||
+                                                  _charts.First(c => c.Id == ts.ChartId).Type == query.ChartType);
+                });
             Mediator.Setup(m => m.Send(It.IsAny<GetTierListQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => _passCountTierList.AsEnumerable());
 
@@ -223,6 +327,27 @@ public sealed class PumbilityProjectionSagaTests
         {
             _singlesCompetitive = singles;
             _doublesCompetitive = doubles;
+            return this;
+        }
+
+        public ProjectionContext WithBestScore(Guid chartId, int score)
+        {
+            _allUserScores.Add(new RecordedPhoenixScore(chartId, score, PhoenixPlate.SuperbGame,
+                IsBroken: false, RecordedDate: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+            return this;
+        }
+
+        public ProjectionContext WithCohortUser()
+        {
+            _cohortUsers.Add(Guid.NewGuid());
+            return this;
+        }
+
+        public ProjectionContext WithCohortScores(ChartType type, Guid chartId, params int[] scores)
+        {
+            _cohortScores.AddRange(scores.Select(s => (type,
+                new RecordedPhoenixScore(chartId, s, PhoenixPlate.SuperbGame, IsBroken: false,
+                    RecordedDate: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)))));
             return this;
         }
     }

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/ExpectedPlateForScoreTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/ExpectedPlateForScoreTests.cs
@@ -1,0 +1,43 @@
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.SharedKernel.Models;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+/// <summary>
+///     Pins the empirically calibrated score→plate expectation (modal plate of
+///     922,765 real records; boundaries measured at 2k granularity — see
+///     docs/design/home-page-widgets.md §5). Moving a boundary is a deliberate
+///     recalibration, not a refactor.
+/// </summary>
+public sealed class ExpectedPlateForScoreTests
+{
+    [Theory]
+    [InlineData(850_000, PhoenixPlate.FairGame)]
+    [InlineData(963_999, PhoenixPlate.FairGame)]
+    [InlineData(964_000, PhoenixPlate.TalentedGame)]
+    [InlineData(971_999, PhoenixPlate.TalentedGame)]
+    [InlineData(972_000, PhoenixPlate.MarvelousGame)]
+    [InlineData(995_999, PhoenixPlate.MarvelousGame)]
+    [InlineData(996_000, PhoenixPlate.UltimateGame)]
+    [InlineData(999_999, PhoenixPlate.UltimateGame)]
+    [InlineData(1_000_000, PhoenixPlate.PerfectGame)]
+    public void ExpectedPlateFollowsTheCalibratedBands(int score, PhoenixPlate expected)
+    {
+        Assert.Equal(expected, ScoringConfiguration.ExpectedPlateForScore(score));
+    }
+
+    [Fact]
+    public void ExpectationNeverEmitsMinorityPlates()
+    {
+        // SG/EG/RG are never the population mode in any band; the modal ladder is
+        // FG → TG → MG → UG (→ PG at exactly 1M).
+        for (var score = 850_000; score <= 1_000_000; score += 1_000)
+        {
+            var plate = ScoringConfiguration.ExpectedPlateForScore(score);
+            Assert.NotEqual(PhoenixPlate.SuperbGame, plate);
+            Assert.NotEqual(PhoenixPlate.ExtremeGame, plate);
+            Assert.NotEqual(PhoenixPlate.RoughGame, plate);
+        }
+    }
+}

--- a/ScoreTracker/ScoreTracker/Pages/Progress/Pumbility.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/Pumbility.razor
@@ -153,6 +153,15 @@
                         <MudText Style=@($"color:{TierListColor(difficulty)}")>@difficulty</MudText>
                     }
                     <MudText>+@_projectedGains[chart.Id].ToString("N0") PUMBILITY</MudText>
+                    @if (_skillAdjustments.TryGetValue(chart.Id, out var skillWhy))
+                    {
+                        @* Why this target: the skill-profile nudge (Projections v2). *@
+                        <MudTooltip Text="@string.Join(", ", skillWhy.Select(a => a.Skill.GetName() + " " + (a.ScoreDelta >= 0 ? "+" : "") + ((int)a.ScoreDelta).ToString("N0")))">
+                            <MudText Typo="Typo.caption">
+                                @string.Join(" ", skillWhy.Take(2).Select(a => (a.ScoreDelta >= 0 ? "+" : "-") + a.Skill.GetName()))
+                            </MudText>
+                        </MudTooltip>
+                    }
                 </MudCardContent>
                 <MudCardActions>
                     <MudSpacer></MudSpacer>
@@ -238,8 +247,12 @@
         _projectedGains = projection.ProjectedGains.ToDictionary(kv => kv.Key, kv => kv.Value);
         _insufficientData = projection.InsufficientDataGains.ToDictionary(kv => kv.Key, kv => kv.Value);
         _chartDifficulty = projection.ChartDifficulty.ToDictionary(kv => kv.Key, kv => kv.Value);
+        _skillAdjustments = projection.SkillAdjustments.ToDictionary(kv => kv.Key, kv => kv.Value);
         _finishedProjecting = true;
     }
+
+    private IDictionary<Guid, IReadOnlyList<SkillAdjustmentRecord>> _skillAdjustments =
+        new Dictionary<Guid, IReadOnlyList<SkillAdjustmentRecord>>();
 
     private IDictionary<Guid, RecordedPhoenixScore> _allScores = new Dictionary<Guid, RecordedPhoenixScore>();
     private PlayerStatsRecord? _stats;

--- a/docs/design/home-page-widgets.md
+++ b/docs/design/home-page-widgets.md
@@ -1,8 +1,9 @@
 # Home Page Widget Builder
 
-**Status**: spec locked 2026-07-12; implementation not started. Sequencing (owner): **PR #1 = Pumbility
-history capture + Projections v2 (§5)** — small, merged fast so trend data accrues immediately;
-**PR #2 = the shell + starter trio (§2–§3)**. Mocks: [dashboard](https://claude.ai/code/artifact/d55215b1-ce72-4623-ba10-9950266f4847)
+**Status**: spec locked 2026-07-12; **PR #1 (§5 + history capture) implemented — this PR**;
+PR #2 (shell + trio) next. Sequencing (owner): **PR #1 = Pumbility history capture + Projections v2
+(§5)** — small, merged fast so trend data accrues immediately; **PR #2 = the shell + starter trio
+(§2–§3)**. Mocks: [dashboard](https://claude.ai/code/artifact/d55215b1-ce72-4623-ba10-9950266f4847)
 · [widget spec sheets](https://claude.ai/code/artifact/809e2710-c596-4454-96fd-f5a8fc765871).
 
 `/WhatShouldIPlay` is being retired. In its place: a fully customizable, multi-page, cross-mix widget
@@ -389,7 +390,9 @@ mixed top-50 pool. Phoenix 2 is explicitly disabled — the in-code TODO defers 
    function with the table pinned by a DomainTest; recalibrate for P2 once its plate data accumulates
    (same query, one constant swap) — explicitly not an exact science.
 4. While in there: assert `PlayerRatingsImprovedEvent.NewTop50` equals the P2 two-pool combined value
-   (feeds the P1 history capture in this same PR).
+   (feeds the P1 history capture in this same PR). *Verified: `PlayerRatingSaga` sums the int-floored
+   S+D pools so `SkillRating == SinglesRating + DoublesRating` exactly, and the same variable feeds
+   the stats record and the event.*
 
 **Tests**: pool math + proficiency adjustment as pure DomainTests; saga component tests with mocked
 readers over a fixed cohort fixture; the skill-deviation query handler gets tests pinning equivalence

--- a/docs/design/home-page-widgets.md
+++ b/docs/design/home-page-widgets.md
@@ -1,0 +1,419 @@
+# Home Page Widget Builder
+
+**Status**: spec locked 2026-07-12; implementation not started. Sequencing (owner): **PR #1 = Pumbility
+history capture + Projections v2 (§5)** — small, merged fast so trend data accrues immediately;
+**PR #2 = the shell + starter trio (§2–§3)**. Mocks: [dashboard](https://claude.ai/code/artifact/d55215b1-ce72-4623-ba10-9950266f4847)
+· [widget spec sheets](https://claude.ai/code/artifact/809e2710-c596-4454-96fd-f5a8fc765871).
+
+`/WhatShouldIPlay` is being retired. In its place: a fully customizable, multi-page, cross-mix widget
+dashboard. This doc is the working spec for PR #1 and PR #2; later phases (WSIP parity, cutover, widget
+catalog) get their sections as they start.
+
+---
+
+## 1. Locked decisions (owner, 2026-07-12)
+
+| # | Decision |
+|---|---|
+| D1 | Clean-slate curated default at cutover — **no migration** of WSIP settings. Missing-thing complaints are answered with "add it to your page." Default templates ship, including a solid "Home" built for the 90% who never customize. |
+| D2 | Pages are **private** in v1. Widget configs must never contain secrets — sharing may come later. |
+| D3 | Mobile layout is **derived**: single column in desktop grid reading order. Mobile edit = ↑↓ reorder arrows + size sheet (no touch drag). Pages swipe on mobile. |
+| D4 | Caps: **8 widgets per page, 8 pages per user**. Raised only on pain points + healthy telemetry. |
+| D5 | Grid: 4 columns desktop, per-widget **size presets** (1×1, 2×1, 1×2, 2×2, 3×1…), auto-flow, snap. No freeform resize. |
+| D6 | Placement model is an **ordered list + spans** (CSS grid auto-flow) — not x/y coordinates. Drag = reorder (insertion index), same operation as the mobile arrows. |
+| D7 | The dashboard stays **hidden until market release** — an unlisted route, NOT admin-gated: no nav links, but anyone who finds it may use it. Edit mode shows non-admins a disclaimer: *configurations may be wiped if the schema changes before final release*. Each widget after the shell trio is its own PR. |
+| D8 | Time-sensitive widgets v1: **Weekly Challenge only**. New-charts and tournaments widgets are HELD. |
+| D9 | **Rivals ships later as one complete project** — the registry must let a new vertical contribute widget types with zero home-page changes. |
+| D10 | Suggester = **one widget type**; the goal (Title Hunt / level push / skill gaps) is config. The add-drawer lists preset-configured entries for discoverability. Feedback/veto machinery survives. |
+| D11 | **Mix Migration is its own widget type** (re-pass tracker, source→target mix; `GetCrossMixPassesQuery` exists). Featured at P2 launch, de-featured later. |
+| D12 | **Daily Step** (renamed from "Daily Dance" — community says *step*, not *dance*): **one site-wide shared** daily chart + mini leaderboard (owner-confirmed), level 16–24; once a week on a random day = **Limbo Day**: level ≤ 15, *lowest passing score wins*. Lives beside WeeklyChallenge; own PR in catalog phase, not shell scope. The owner also has plans for a **per-player daily challenge — a separate concept, its own future session**; do not conflate. |
+| D13 | Mix resolution cascade: **widget override → page default → current mix**. |
+| D14 | Widget lifecycle contract (§3.3) — the page **never gates as a whole** (kills today's all-or-nothing P2 gate on WSIP). |
+| D15 | Verticals own data/queries/precompute; **Web owns the registry + render components**; layout persistence is a new small vertical. |
+| D16 | Widget telemetry (add/remove/move/resize/configure + page events) from day 1. |
+| D17 | **PR sequencing** (owner, 2026-07-12): PR #1 = SkillRating history capture + Projections v2, shipped first and merged fast; PR #2 = shell + trio. PR #1 branches only after PR #140 (personalized breakdown) merges — it relocated the skill machinery into `TierListBlendBuilder`. |
+| D18 | **Catalog process**: after the PoC trio ships, the owner walks the §4 backlog **one widget at a time**. Rivals and the per-player daily challenge are standalone future sessions — not part of the walk. |
+| D19 | **Page config export/import + capability schema** (owner, 2026-07-12): edit mode exports/imports a page's configuration as JSON, and the full "what's available" schema is exportable so people can build dashboards with AI. Both documents are **public API DTOs** — breaking-change discipline like `api/*`, pinned by approval tests in `ScoreTracker.Tests.Api`. See §2.6. |
+
+---
+
+## 2. Architecture
+
+### 2.1 New vertical: `ScoreTracker.HomePage`
+
+Owns dashboard layout persistence — pages and widget instances. Standard vertical shape
+(`Contracts/`, `Wiring/` public; everything else internal; `IDbModelContribution` registered in
+`VerticalModelContributions.All()` — **forgetting this silently drops the tables from migrations**).
+
+Tables (rows to be added to DATABASE-SCHEMA.md in the shell PR):
+
+| Table | Columns (sketch) |
+|---|---|
+| `HomePage` | Id PK, UserId (idx), Name nvarchar(64), Ordinal tinyint, IsDefault bit, DefaultMix tinyint NULL |
+| `HomePageWidget` | Id PK, PageId FK (idx), WidgetType varchar(64), Title nvarchar(64) NULL, Ordinal tinyint, SizePreset varchar(8), ConfigJson nvarchar(2000), ConfigVersion int |
+
+Contracts (all `[ExcludeFromCodeCoverage]` records; caps enforced in handlers, not just UI):
+
+- **Queries**: `GetMyHomePagesQuery` → pages + widget instances in one shot (max 8×8, trivially small).
+- **Commands**: `CreateHomePageCommand` (name, optional template), `RenameHomePageCommand`,
+  `DeleteHomePageCommand`, `ReorderHomePageCommand`, `SetDefaultHomePageCommand`, `SetHomePageMixCommand`;
+  `AddHomePageWidgetCommand`, `RemoveHomePageWidgetCommand`, `MoveHomePageWidgetCommand` (newOrdinal —
+  the one operation both drag and arrows dispatch), `ResizeHomePageWidgetCommand`,
+  `RenameHomePageWidgetCommand`, `UpdateHomePageWidgetConfigCommand`.
+
+Every mutation persists immediately (Blazor Server circuits are not to be trusted with staged edits).
+
+### 2.2 Widget registry (Web)
+
+Razor components can't live in the plain-classlib verticals, so render components live in Web under
+`Components/HomeWidgets/`, and a static registry maps type → everything the shell needs:
+
+```csharp
+public sealed record WidgetDescriptor(
+    string TypeId,              // stable, stored in HomePageWidget.WidgetType — never renamed
+    string NameKey,             // L10n keys
+    string DescriptionKey,
+    WidgetCategory Category,    // Play / Progress / Compete / Utility (drawer grouping)
+    string Icon,
+    SizePreset[] SupportedSizes,
+    SizePreset DefaultSize,
+    MixEnum[] SupportedMixes,   // config UI restricts; resolution clamps
+    Type RenderComponent,       // gets the WidgetInstance (config + size + resolved mix)
+    Type? ConfigComponent);     // null = no per-widget config beyond title/mix
+```
+
+Verticals contribute *data* (contract queries, precompute jobs); Web contributes the descriptor +
+components. A future vertical (Rivals) adds descriptors without touching shell code (D9).
+
+### 2.3 Widget lifecycle contract (D14)
+
+Every render component must provide:
+
+1. **Skeleton** at fixed footprint for its size preset (no layout shift on load).
+2. **Empty state** with a setup CTA (no scores → import link; no data yet → what will make it appear).
+   A widget with no data is an onboarding surface, not a blank box.
+3. **Isolated errors** — each grid cell wraps its widget in `<ErrorBoundary>`; one vertical throwing
+   never takes the board down.
+4. **Freshness** — precomputed widgets show a quiet "as of …"; live widgets may offer refresh.
+5. **Config JSON + `ConfigVersion`** — old blobs are tolerated or migrated forever. Config records are
+   additionally **public contract** via export/import and the capability schema (§2.6): shape changes
+   are breaking-change review, not refactoring.
+6. Distinction between persisted config and session-transient state (a randomizer's "already rolled"
+   list never hits the DB).
+
+Rendering rules: widgets render with `@key="InstanceId"` (reorders move component subtrees, preserving
+internal state); **widget data refresh is paused while edit mode is active** (nothing re-renders the
+grid mid-drag, and a board shouldn't reshuffle while being rearranged).
+
+### 2.4 Grid + drag
+
+- CSS grid, 4 columns desktop, auto-flow; widgets are `(Ordinal, SizePreset)` — D6.
+- **Arrow-move baseline ships first** (desktop too): keyboard-accessible, forces `MoveHomePageWidgetCommand`
+  to be right before any JS exists, and is the mobile mechanism anyway.
+- **Drag is a client-side enhancement**: `wwwroot/js/dashboard-grid.js` (~200–250 lines, pointer events —
+  not HTML5 DnD, not `MudDropContainer`, which is list/zone-shaped and would fight a spanning grid).
+  Pointerdown on handle → ghost → insertion-gap highlight from cell geometry → drop → one `[JSInvokable]`
+  call `(instanceId, newIndex)`. 60Hz pointermove never crosses SignalR; only the drop does.
+  Precedent for JS interop modules: `helpers.js`, `phoenix-recap.js`.
+- Escape hatch if field-testing demands true x/y pinning: vendor Gridstack.js. Not v1.
+
+### 2.5 Shell infrastructure
+
+- **`ChartCatalogCache`** (Web, circuit-scoped): memoizes `GetChartsQuery` per mix so N widgets share
+  one chart dictionary instead of each loading it (Weekly needs it in the trio; Suggested/Randomizer
+  later).
+- **Chart series palette**: ApexCharts needs literal colors at config time (can't read CSS vars), so
+  `MixPalette` gains `ChartSingles`/`ChartDoubles`/`ChartCombined` per mix, exposed the same way
+  `DifficultyHex` serves the share card. Values (validated CVD-safe, worst adjacent ΔE 16.3, contrast
+  ≥ 5.1:1 on their surfaces): Phoenix `#FF6B35/#38B6FF/#CBD5E1`, Phoenix 2 `#E93CF2/#29C9F7/#CBDCD0`,
+  XX `#FF2FA0/#3B9EFF/#D5CDE3`. This also retires WSIP's hardcoded red/green/cyan trio, which has a
+  deutan collision.
+- **Telemetry**: Clarity custom events via `helpers.js` (`widget_added/removed/moved/resized/configured`,
+  `page_created/deleted/switched`, `edit_entered`), tagged with `WidgetType`.
+- **Beta gate**: unlisted route — no nav entry anywhere, open to anyone who finds it (D7). Edit mode
+  renders a banner for non-admin users: "This page is pre-release — your layout and widget settings may
+  be reset if the schema changes before launch." WSIP keeps `/` until cutover.
+- **Localization**: every widget commit lands its keys in **all** locales in the same pass (coordinate
+  with the es-ES PR #133 if it merges first).
+
+### 2.6 Page config export/import + capability schema (D19)
+
+Two JSON documents, both treated as **public API contracts** (camelCase, stable names, versioned
+envelope, golden-JSON approval tests in `ScoreTracker.Tests.Api` — a failing approval is
+breaking-change review, exactly like `api/*`):
+
+**1. Page export/import** (edit-mode buttons: Copy / Download / Import):
+
+```json
+{
+  "version": 1,
+  "page": {
+    "name": "Session Day",
+    "defaultMix": "Phoenix2",
+    "widgets": [
+      { "type": "pumbility", "title": "Doubles push", "size": "2x1", "config": { "mix": "Current", "showProjections": true, "dismissedCharts": [] } }
+    ]
+  }
+}
+```
+
+- `type` = registry `TypeId` (stable forever); array order **is** widget order (no ordinals in the
+  public shape); `size` = preset token. Per-widget `config` shapes are part of the contract.
+- **Import replaces the current page** after validation + a confirm dialog summarizing what will be
+  replaced. Validation is exhaustive and human-readable (errors will be pasted back into an AI):
+  unknown type, unsupported size for that type, invalid mix, config schema violations, cap violations
+  (> 8 widgets), payload size cap. Applied via a single transactional
+  `ReplaceHomePageWidgetsCommand` — the one mutation that is *not* per-interaction.
+- Side benefit: pre-release schema wipes (D7) are survivable — export first, re-import after.
+
+**2. Capability schema** (downloadable from the add-drawer: "Building with AI? Download the schema"):
+
+```json
+{
+  "version": 1,
+  "limits": { "widgetsPerPage": 8, "pagesPerUser": 8 },
+  "sizes": ["1x1", "2x1", "1x2", "2x2", "3x1"],
+  "mixes": ["Phoenix", "Phoenix2", "XX"],
+  "widgets": [
+    { "type": "competitive-level", "name": "Competitive Level", "description": "…", "category": "Progress",
+      "supportedSizes": ["2x1", "2x2"], "defaultSize": "2x1", "supportedMixes": ["Phoenix", "Phoenix2"],
+      "configSchema": { "…JSON Schema for this widget's config…": true } }
+  ]
+}
+```
+
+- Generated from the registry + each widget's config record (small hand-rolled JSON-Schema emitter for
+  the constrained shapes we use — no new package; enums emit as string unions). The C# config record
+  stays the single source of truth; the approval test pins the emitted document so any drift is a
+  reviewed diff.
+- v1 surfaces both documents in the page UI only; a public `api/*` endpoint (and docs/API.md entry)
+  ships at cutover when the dashboard goes public. The DTO discipline starts now so the format never
+  churns.
+
+---
+
+## 3. Shell PR (PR #2) — starter trio specs
+
+Chosen because all three are existing single-query reads with zero new business logic in the shell
+itself — they prove the registry, live-pull rendering, per-widget states, and the chart pipeline.
+The one domain prerequisite (Projections v2 + history capture, §5) ships first as **PR #1**, so the
+Pumbility widget consumes finished contracts.
+
+### W1 — Competitive Level graph (data: PlayerProgress)
+
+- **Data**: `GetPlayerHistoryQuery(userId, mix)`, one call **per selected mix**. Live pull.
+- **Multi-mix (owner, 2026-07-12)**: Phoenix and Phoenix 2 are selectable **together** — P2 lines start
+  at 0 and climb (players enjoy the re-grind); Phoenix lines tell the pre-switch story. XX excluded.
+- **No Combined series** — removed as an option entirely (owner). Series = Singles / Doubles only,
+  per selected mix (max 4 lines).
+- **Series encoding**: color = chart type (`--chart-singles`/`--chart-doubles` from the active theme);
+  era = line *style* — current mix solid, the other mix dashed at reduced opacity. Style is a
+  CVD-independent channel, so four series stay separable with two hues.
+- **"Where you left off" marker**: when Phoenix is selected but all its points fall left of the visible
+  range (typical post-P2-switch), render left-edge ghost ticks at Phoenix's final Singles/Doubles values
+  with a small "Phoenix: S 20.4 · D 21.1" label — the regrind's reference line. Values are just the last
+  records of the Phoenix history call; no new query.
+- **Config v1**: mixes (multi-select: Phoenix / Phoenix 2; default = current mix); range
+  (3/6/12 months/all — default 6); series toggles (Singles / Doubles, both on).
+- **Sizes**: 2×1 (default), 2×2. No 1×1 — line charts need width; per-widget `SupportedSizes` exists
+  for exactly this.
+- **Render**: Blazor-ApexCharts (existing dependency; WSIP renders this chart today) with series colors
+  from the new `MixPalette` chart pair (§2.5). Legend + end-of-line labels; identity never color-alone.
+- **States**: < 2 history points in every selected mix → "Your level history starts tracking with your
+  next import." Error isolated.
+- **Mixes**: Phoenix, Phoenix 2 (multi).
+
+### W2 — Pumbility (data: PlayerProgress)
+
+- **Data**: `GetPlayerStatsQuery` → `SkillRating` (+ `SinglesRating`/`DoublesRating` for the two-pool
+  sub-line); `ProjectPumbilityGainsQuery` → `PumbilityProjection.ProjectedGains` → top entry(ies),
+  chart names via `ChartCatalogCache`. Live pull, queries fanned with `Task.WhenAll`.
+- **Config v1**: mix scope; show-projection toggle (default on); **dismissed-charts blacklist** (see below).
+- **Sizes**: 1×1 (big number + top next-best-gain line), 2×1 (adds S/D pool breakdown + a **scrollable**
+  target list — top ~15 by gain, inner scroll; never a hard snap to 3, players who are stuck on the top
+  suggestions need to see past them — owner, 2026-07-12).
+- **Target dismissal**: every target row carries a permanent-dismiss ✕ → chart id joins a blacklist in
+  the widget's config JSON; the widget filters `ProjectedGains` against it. The config panel manages the
+  list ("Dismissed charts (3) — restore"). Per-instance by design: your "Doubles push" Pumbility widget
+  can dismiss different charts than your singles one. Distinct from the suggester's veto/feedback system —
+  no feedback record, just personal noise control.
+- **States**: no scores → CTA to `/UploadPhoenixScores`. Error isolated.
+- **Mixes**: Phoenix, Phoenix 2 (two-pool formula live since PR #128).
+- **Data gap — sparkline/delta**: `PlayerRatingRecord` does **not** carry Pumbility, so there is no
+  trend source today. Archaeology (484e58ad, June 2024): the `PlayerHistory` table was *born* with
+  exactly today's columns — competitive levels, co-op rating, pass count — and has only ever fed the
+  Competitive Level graph. Pumbility was never persisted; nothing was dropped in the vertical
+  extraction. However `PlayerRatingsImprovedEvent` already carries `NewTop50` and `PlayerHistorySaga`
+  simply doesn't persist it. **Capture lands in PR #1** (owner: "get that PR in first and I'll push it
+  quick"): `SkillRating` on the history entity + record + saga mapping + migration — forward-only data;
+  the widget renders its sparkline/weekly-delta conditionally once ≥ 2 points exist ("trend starts
+  tracking from today" until then). Implementation note: verify `NewTop50` equals the P2 two-pool
+  combined value before mapping. Optional backfill: Pumbility-as-of-date is reconstructible from the
+  ScoreLedger journal, but only back to journal capture start (weeks) — likely not worth a job.
+- **Projected targets consume Projections v2 (PR #1) from day one** — per-pool P2 baselines, skill-match
+  chips, the plate curve. The widget's stats/pools render from `GetPlayerStatsQuery` regardless, and
+  insufficient-data degradation stays (per-widget degradation, D14).
+
+### W3 — Weekly Challenge (data: WeeklyChallenge)
+
+- **Data**: `GetWeeklyChartsQuery(mix)` → `WeeklyTournamentChart(ChartId, ExpirationDate)` —
+  **expiration is per chart** (staggered rotation, not one board reset; the mock's single countdown was
+  a simplification). `GetWeeklyChartEntriesQuery(mix)` → my entries **and** per-chart entrant totals;
+  `GetUserWeeklyPlacementsQuery(userId, mix, chartIds)` → `(ChartId, Place)`. Percentile =
+  `1 − place/total` → `ThemeScales.RarityStyle` (never hand-rolled bands). Live pull.
+- **Config v1**: mix scope (boards are parallel per mix); **board filter mode** (owner, 2026-07-12):
+  - **Match my range** (default) — reuses `WeeklyChartSuggestionPolicy.GetSuggestedCharts`, the exact
+    logic behind the WeeklyCharts page's competitive filter (including its "only when both competitive
+    levels ≥ 10" auto-enable; below that, fall back to all charts).
+  - **Custom preset** — a filter the player wants every week: chart types (S/D/co-op), level range,
+    and it applies to every future board without re-configuring.
+  - **All charts** — the whole board.
+- **Sizes**: 1×1 compact (name + placement rows, soonest expiry as "Next rotation in …"), 2×1 (art
+  cards, `ScoreBreakdown` of my entry, per-chart expiry chips, link to `/WeeklyCharts`).
+- **States**: board gap → "New board soon." Unplayed charts are content, not emptiness (muted "—").
+  Error isolated.
+- **Mixes**: per board availability.
+
+### PR #2 (shell) commit plan
+
+| C | Content |
+|---|---|
+| C1 | `ScoreTracker.HomePage` vertical skeleton: assembly, wiring, model contribution (+ `VerticalModelContributions.All()`), entities, migration |
+| C2 | Contracts + handlers (pages + widgets CRUD, caps, templates) + component tests |
+| C3 | Registry + unlisted route + read-only board render (grid, tabs, skeletons, error boundaries) |
+| C4 | Edit mode: add-drawer, remove, arrow-move, resize, rename, per-mutation persistence + the non-admin pre-release disclaimer banner (D7) |
+| C5 | W1 Competitive Level graph (multi-mix, no Combined, left-off markers) + `MixPalette` chart-series colors |
+| C6 | W2 Pumbility — consumes PR #1's Projections v2 (pools, skill chips, plate curve) + scrollable targets + dismiss blacklist + conditional sparkline |
+| C7 | W3 Weekly Challenge (filter modes via `WeeklyChartSuggestionPolicy`) + `ChartCatalogCache` |
+| C8 | Page export/import + capability schema (D19/§2.6): DTOs, validation, `ReplaceHomePageWidgetsCommand`, schema emitter, edit-mode UI, golden-JSON approval tests in Tests.Api |
+| C9 | `dashboard-grid.js` drag module + Playwright drag fact |
+| C10 | Telemetry events; docs (DATABASE-SCHEMA rows, UX-GUIDELINES widget section, ARCHITECTURE vertical list); starter-template seeding |
+
+---
+
+## 4. Widget catalog (planned — NOT fully scoped; each is its own PR when its turn comes)
+
+Readiness: ✅ published contract already serves it · 🔨 needs new data/query · ⏸ HELD by owner (D8) ·
+🔮 gated on a later project. One-liners only — each widget gets its spec section when it's picked up.
+
+| Vertical | Widget | Ready | Note |
+|---|---|---|---|
+| PlayerProgress | Suggested Charts | ✅ | D10 — one type, goal config; feedback/veto survives. WSIP-parity phase |
+| PlayerProgress | Title Progress | ✅ | pushing title + remaining-charts math from WSIP |
+| PlayerProgress | Stats snapshot | ✅ | competitive levels block (Pumbility has its own widget) |
+| PlayerProgress | Recent Highlights | ✅ | `GetScoreHighlightsQuery` — the Discord-card engine, on the home page |
+| PlayerProgress | Milestones | ✅ | `GetPlayerMilestonesQuery` |
+| PlayerProgress | Season-recap teaser | ✅ | permanent front door to `/Player/{id}/PhoenixRecap` |
+| ScoreLedger | Session Journal | ✅ | `GetRecentSessionsQuery`; score history was a top user ask |
+| ScoreLedger | Chart Journey | ✅ | pin a white-whale chart, `GetChartScoreJourneyQuery` sparkline |
+| ScoreLedger | To-Do List | ✅ | must survive WSIP (parity phase) |
+| ScoreLedger | Quick Record | ✅ | ChartSelector + EditChartGrid inline; the arcade widget |
+| ScoreLedger | On the bubble | 🔨 | near-miss grades/plates ("18,797 from AAA+"); compute from records |
+| ScoreLedger | Activity heatmap | 🔨 | calendar of play days from the journal |
+| ScoreLedger | Mix Migration | ✅ | D11 — own widget; `GetCrossMixPassesQuery`; featured at P2 launch |
+| ChartIntelligence | Tier-list folder peek | ✅ | 28% of traffic deserves a home-page hook |
+| ChartIntelligence | Next breaks | ✅ | closest-to-passing from tier data |
+| ChartIntelligence | Vote prompt | 🔨 | "you played X — rate it"; community-rating engagement |
+| Catalog | Randomizer | ✅ | port = the moment to kill the transitional Catalog→Application ref |
+| Catalog | Skill spotlight | ✅ | chart skills / step analysis surface |
+| Catalog | New content feed | ⏸ | HELD (D8) despite P2 cadence fit |
+| OfficialMirror | Rankings snapshot | ✅ | world/regional position; movement arrows need rank history 🔨 |
+| OfficialMirror | Import nudge | ✅ | "last sync 9 days ago" + one-tap re-import; upload is the #2 page |
+| OfficialMirror | Benchmark player | 🔮 | rivals-lite on mirror data; decided during the catalog walk (D18), rival machinery stays out until the Rivals project |
+| WeeklyChallenge | Weekly Challenge | ✅ | shell trio (W3) |
+| WeeklyChallenge | Daily Step | 🔨 | D12 — daily rotation job + shared board + Limbo Day; own PR |
+| WeeklyChallenge | Per-player daily challenge | 🔮 | owner has plans — separate concept from Daily Step; its own future session (D12/D18) |
+| EventCompetition | Active tournaments | ⏸ | HELD (D8) |
+| EventCompetition | Qualifiers countdown | ⏸ | HELD (D8) |
+| Communities | Community Feed | ✅ | scoping selector: specific / non-region / non-world / all |
+| Communities | Leaderboard position | ✅ | mini "where you stand" per community |
+| Ucs | UCS spotlight | 🔨 | new UCS + leaderboard activity |
+| — (utility) | Note / Quick Links / Countdown / Divider | n/a | no data; disproportionate personalization value |
+
+Standing rules: folder-completion widgets frame as **self-progress, never peer comparison** (owner);
+rarity/difficulty coloring only ever via `ThemeScales`; every chart row carries the standard card
+affordances (video / record / todo) as shared components.
+
+## 5. Pumbility Projections v2 — **PR #1**, ships before the shell (D17)
+
+Bundled with the SkillRating history capture into one small PR the owner merges fast — trend data starts
+accruing immediately, and v2 goes live on the existing `/Pumbility` page (including enabling Phoenix 2
+there) before the widget exists.
+
+**Current algorithm** ([PumbilityProjectionSaga](../../ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs)):
+cohort = players within ±1 competitive level per chart type; my expected score on a candidate chart =
+cohort score distribution interpolated at my average percentile across played charts in that (type, level)
+slice (×0.95 damping); expected pumbility assumes an EG plate; gains measured against the lowest of ONE
+mixed top-50 pool. Phoenix 2 is explicitly disabled — the in-code TODO defers two-pool projection to
+"the What-Should-I-Play overhaul," i.e. this project.
+
+**V2 scope:**
+
+1. **Two-pool P2 correctness.** Pools abstraction: Phoenix = one mixed pool; Phoenix 2 = independent
+   S and D pools (`GetTop50ForPlayerQuery` already takes `ChartType?`). Baseline ("lowest of top 50")
+   and gain comparisons run against the chart's own pool. `ScoringConfiguration.PumbilityScoring(mix)`
+   already encodes each mix's rating math (P2 = Base × (Grade + PlateBonus), additive).
+2. **Skill-distribution adjustment** — reuse the tier-list competence machinery, never re-derive it:
+   - New ChartIntelligence contract: `GetPlayerSkillDeviationsQuery(userId, mix, levelWindow)` →
+     per-`Skill` deviation on the floored proficiency scale. **PR #140 already did the extraction step**:
+     the machinery now lives in `TierListBlendBuilder` (shared by the blended-tier-list and Personalized
+     Breakdown handlers), constants unchanged (proficiency = clamp(score − 900k, 0, 100k)/100k;
+     segment-fraction weights with 0.5 default; `FolderDecay {1, .6, .3, .15}`; `MinSkillEvidence 2.0`;
+     `MinUsableSkills 3`), with per-skill `SkillEvidence(Deviation, Evidence, Usable)` records already
+     structured. #140's final revision also **freshness-weights the folder baselines** (age weights on
+     proficiency evidence) — the deviation query inherits that automatically, which is desirable:
+     deviations reflect current ability, not stale scores. P2 exposes the computation through the
+     published query — PlayerProgress consumes the contract; cross-vertical reads stay contract-only.
+     **PR #1 branches only after #140 merges.**
+   - Application: expected score → proficiency scale → + damping × Σ(chart skill weight × my skill
+     deviation) → back to score, clamped. Damping starts at 0.5, tunable. Charts without banked chips
+     (`GetChartSkillChipsQuery` absent) get no adjustment.
+   - **"Why" surface**: `PumbilityProjection` gains per-chart skill-match contributions (signed) so the
+     widget renders "+Twist / −Bracket" chips — targets should explain themselves.
+3. **Plate assumption: empirically calibrated score→plate step function** (owner direction 2026-07-12:
+   map expected plate from the projected score — plate contribution is small, precision not required).
+   Calibrated against the local dev database (prod-synced, n = 922,765 non-broken plated Phoenix records,
+   modal plate per score band):
+
+   | Projected score | Expected plate |
+   |---|---|
+   | 1,000,000 | Perfect Game |
+   | ≥ 996,000 | Ultimate Game |
+   | ≥ 972,000 | Marvelous Game |
+   | ≥ 964,000 | Talented Game |
+   | below | Fair Game |
+
+   Data notes: Superb and Extreme are *never* the population mode in any band — real plate progression
+   modally ladders FG → TG → MG → UG, so the expectation function never emits SG/EG/RG. Crossovers were
+   measured at 2k-band granularity (FG→TG at 964k, TG→MG at 972k, MG→UG at 996k). Ship as a pure Domain
+   function with the table pinned by a DomainTest; recalibrate for P2 once its plate data accumulates
+   (same query, one constant swap) — explicitly not an exact science.
+4. While in there: assert `PlayerRatingsImprovedEvent.NewTop50` equals the P2 two-pool combined value
+   (feeds the P1 history capture in this same PR).
+
+**Tests**: pool math + proficiency adjustment as pure DomainTests; saga component tests with mocked
+readers over a fixed cohort fixture; the skill-deviation query handler gets tests pinning equivalence
+with `TierListBlendBuilder`'s computation (same inputs → same deviations — #140's handler tests already
+pin the builder's behavior from the tier-list side).
+
+### PR #1 commit plan
+
+| P | Content |
+|---|---|
+| P1 | **History capture**: `SkillRating` column on the history entity + migration; `PlayerRatingRecord` field; `PlayerHistorySaga` maps `NewTop50`; repository read/write mapping; NewTop50 ≡ two-pool-combined assertion; DATABASE-SCHEMA row |
+| P2 | **Skill-deviation query**: expose `TierListBlendBuilder`'s skill computation (post-#140 home of the machinery) through a published `GetPlayerSkillDeviationsQuery`; equivalence tests pin same-inputs-same-outputs |
+| P3 | **Pools abstraction** in `PumbilityProjectionSaga`: Phoenix single mixed pool, P2 independent S+D pools; DomainTests for the pool math |
+| P4 | **Plate curve**: pure Domain step function (empirical table pinned by DomainTest) replaces the flat-EG assumption |
+| P5 | **Skill adjustment + "why"**: damped deviation adjustment on expected scores; signed skill-match contributions on `PumbilityProjection`; enable Phoenix 2 on `/Pumbility` (delete the in-code TODO) |
+| P6 | Docs + localization for any new `/Pumbility` strings (all locales, one pass) |
+
+## 6. Later phases (parked)
+
+1. **WSIP parity**: Suggested Charts (goal config, feedback/veto), Title Progress, To-Do, Quick Record.
+   WSIP inventory that must find homes: pushing-title bar + remaining-charts math, category hide/show →
+   per-instance config, thumbs/veto dialog, top-50 crowns (chart-card affordance, not a widget), XX→Phoenix
+   `_dataMix` fallback (handled by `SupportedMixes` + cascade), dev empty-DB redirect (page level).
+2. **Cutover**: default templates, curated Home for everyone, `/WhatShouldIPlay` → `/`, WSIP deleted.
+3. **Catalog**: §4, one widget per PR — sequenced by the owner's one-at-a-time walk (D18).
+4. **Rivals**: entire ecosystem, one standalone project/session (D9).
+5. **Per-player daily challenge**: owner has plans; separate concept from Daily Step, its own session.


### PR DESCRIPTION
PR #1 of the home-page widget builder plan ([design doc](docs/design/home-page-widgets.md), §5). Ships first so Pumbility trend data starts accruing immediately; the shell + starter trio comes as PR #2.

## What's here (one commit per P-step)

- **P0 — design doc**: the full widget-builder spec (locked decisions D1–D19, shell plan C1–C10, Projections v2 spec).
- **P1 — history capture**: `PlayerHistory` gains a nullable `SkillRating` column; `PlayerHistorySaga` maps `NewTop50` (which `PlayerRatingSaga` already computes mix-correctly — on Phoenix 2 the int-floored S+D pool sums, so `SkillRating == SinglesRating + DoublesRating` exactly). Null = 'not captured yet' (pre-2026-07 rows), distinct from a real zero. **Forward-only: accrual starts at deploy.**
- **P2 — `GetPlayerSkillDeviationsQuery`**: the tier-list Skill source's pooled-evidence stage (post-#140 `TierListBlendBuilder`) published as a ChartIntelligence contract. Deviations convert to score units at the boundary; `Usable=false` under three evidenced skills. Hand-computable fixture pins the numbers — if they move, the shared machinery moved, which is review for the tier lists too.
- **P3 — two-pool baselines**: Phoenix keeps one mixed top-50; Phoenix 2 ranks independent S/D pools, gains measured against the chart's own pool. Refinement: an **underfilled pool's baseline is 0** (nothing gets displaced until 50 rated charts) — the exact state everyone is in at P2 launch; the old min-of-what-exists baseline understated early-mix gains.
- **P4 — empirical plate curve**: `ScoringConfiguration.ExpectedPlateForScore` replaces the flat-EG assumption. Modal plate of **922,765 real non-broken records** (2k-band crossovers): FG < 964k ≤ TG < 972k ≤ MG < 996k ≤ UG, PG at 1M. SG/EG/RG are never the population mode anywhere. Deliberately not an exact science (owner) — per-mix recalibration is a constant swap.
- **P5 — skill-profile adjustment + why chips**: expected scores nudge toward the player's skill strengths (damping 0.5, 900k+ band only, usable profiles only, banked-chips charts only). Per-skill deltas ship on `PumbilityProjection` as `SkillAdjustmentRecord`s; /Pumbility renders them as a caption + numeric tooltip. Chip weighting unified on `ChartSkillChipRecord.DefaultSegmentWeight` so the projection and tier lists can't drift.

## Behavior changes to eyeball on /Pumbility

- **Phoenix 2 projections now produce real numbers** (two-pool math; previously single-pool-wrong).
- Projected targets can move ± a few thousand score from the skill profile, with a small "+Twists −Brackets" caption explaining why.
- Low projections that priced below your pool floor's plate no longer show as gains (flat-EG inflation removed).

## Tests

Fast suite 1129/1129 · Api approvals 57/57 · Integration 103/104 (the one failure is the manual-only Discord canary wanting the AppHost dev-DB proxy — unrelated, skips on CI). New pins: plate-curve boundaries, percentile interpolation (hand-computed 955,750), per-pool P2 gains, skill-nudge math (+4,000 fixture), skill-deviation equivalence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)