### PR TITLE
feat(home): Account Stats widget + Suggested Charts "Pumbility Push" goal

### DIFF
--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/RecommendedChartsSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/RecommendedChartsSaga.cs
@@ -106,6 +106,9 @@ namespace ScoreTracker.PlayerProgress.Application
                 result = result.Concat(
                     await GetRandomFromTop50Charts(mix, feedback, request.ChartType, cancellationToken, charts,
                         window));
+            if (Include(RecommendationCategory.PushPumbility))
+                result = result.Concat(
+                    await GetPumbilityPushes(mix, feedback, request.ChartType, cancellationToken, charts, window));
             return result.ToArray();
         }
 
@@ -266,6 +269,33 @@ namespace ScoreTracker.PlayerProgress.Application
             return result
                 .Select(c => new ChartRecommendation(RecommendationCategories.ImproveTop50, c.ChartId,
                     "These are randomly pulled from your best 100 charts based on competitive score. Push that score!"));
+        }
+
+        /// <summary>
+        ///     The projected-Pumbility targets that used to live in the Pumbility widget: each
+        ///     chart's expected gain to your overall rating, biggest first. Unlike
+        ///     <see cref="GetRandomFromTop50Charts" />, which shuffles the top 50, these are
+        ///     ranked by gain and stamp the "+N" onto the recommendation.
+        /// </summary>
+        private async Task<IEnumerable<ChartRecommendation>> GetPumbilityPushes(MixEnum mix,
+            IDictionary<string, ISet<Guid>> ignoredChartIds, ChartType? chartType,
+            CancellationToken cancellationToken, IDictionary<Guid, Chart> charts, Func<Chart, bool>? window)
+        {
+            var skipped = ignoredChartIds.TryGetValue(RecommendationCategories.PushPumbility, out var s)
+                ? s
+                : new HashSet<Guid>();
+
+            var projection =
+                await _mediator.Send(new ProjectPumbilityGainsQuery(_currentUser.User.Id, mix), cancellationToken);
+
+            return projection.ProjectedGains
+                .Where(kv => kv.Value > 0 && charts.ContainsKey(kv.Key) && !skipped.Contains(kv.Key))
+                .Where(kv => chartType == null || charts[kv.Key].Type == chartType)
+                .Where(kv => window == null || window(charts[kv.Key]))
+                .OrderByDescending(kv => kv.Value)
+                .Take(12)
+                .Select(kv => new ChartRecommendation(RecommendationCategories.PushPumbility, kv.Key,
+                    "The biggest Pumbility gains available to you right now", "+" + kv.Value.ToString("N0")));
         }
 
         private async Task<IEnumerable<ChartRecommendation>> GetSkillTitleCharts(

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/CompetitiveNeighborRecord.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/CompetitiveNeighborRecord.cs
@@ -1,0 +1,8 @@
+namespace ScoreTracker.PlayerProgress.Contracts;
+
+/// <summary>
+///     One player near you on the competitive ladder: their id and their competitive level
+///     on the dimension the lookup ranked by. The caller resolves name/avatar/privacy.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed record CompetitiveNeighborRecord(Guid UserId, double CompetitiveLevel);

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/Queries/GetCompetitiveNeighborsQuery.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/Queries/GetCompetitiveNeighborsQuery.cs
@@ -1,0 +1,16 @@
+using ScoreTracker.PlayerProgress.Contracts;
+using ScoreTracker.SharedKernel.Enums;
+
+namespace ScoreTracker.PlayerProgress.Contracts.Queries
+{
+    /// <summary>
+    ///     The players nearest you on the ladder: within ±<paramref name="Range" /> of
+    ///     <paramref name="MyLevel" /> on the chosen competitive dimension (null = combined),
+    ///     nearest first, capped at <paramref name="Count" />. No eligibility filter — the
+    ///     caller layers privacy/community rules and its own final cut on top.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public sealed record GetCompetitiveNeighborsQuery(
+        MixEnum Mix, ChartType? Dimension, double MyLevel, double Range, int Count)
+        : IQuery<IReadOnlyList<CompetitiveNeighborRecord>>;
+}

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/RecommendationCategory.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/RecommendationCategory.cs
@@ -14,7 +14,10 @@ public enum RecommendationCategory
     ImproveTop50,
     RevisitOldScores,
     FillScores,
-    WeeklyCharts
+    WeeklyCharts,
+
+    /// <summary>Charts ranked by the Pumbility they would add — the projected-gain targets.</summary>
+    PushPumbility
 }
 
 /// <summary>
@@ -31,4 +34,5 @@ public static class RecommendationCategories
     public const string RevisitOldScores = "Revisit Old Scores";
     public const string FillScores = "Fill Scores";
     public const string WeeklyCharts = "Weekly Charts";
+    public const string PushPumbility = "Pumbility Push";
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/EFPlayerStatsRepository.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Infrastructure/EFPlayerStatsRepository.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using ScoreTracker.PlayerProgress.Contracts;
 using ScoreTracker.PlayerProgress.Contracts.Queries;
 using ScoreTracker.Data.Persistence;
 using ScoreTracker.PlayerProgress.Infrastructure.Entities;
@@ -12,7 +13,8 @@ namespace ScoreTracker.PlayerProgress.Infrastructure
 {
     internal sealed class EFPlayerStatsRepository : IPlayerStatsRepository,
         IPlayerStatsReader,
-        IRequestHandler<GetPlayerStatsQuery, PlayerStatsRecord>
+        IRequestHandler<GetPlayerStatsQuery, PlayerStatsRecord>,
+        IRequestHandler<GetCompetitiveNeighborsQuery, IReadOnlyList<CompetitiveNeighborRecord>>
     {
         private readonly IMemoryCache _cache;
         private readonly IDbContextFactory<ChartAttemptDbContext> _factory;
@@ -158,6 +160,38 @@ namespace ScoreTracker.PlayerProgress.Infrastructure
         public async Task<PlayerStatsRecord> Handle(GetPlayerStatsQuery request, CancellationToken cancellationToken)
         {
             return await GetStats(request.Mix, request.UserId, cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<CompetitiveNeighborRecord>> Handle(GetCompetitiveNeighborsQuery request,
+            CancellationToken cancellationToken)
+        {
+            await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+            var mixId = MixIds.For(request.Mix);
+            var my = request.MyLevel;
+            var min = my - request.Range;
+            var max = my + request.Range;
+            var all = database.Set<PlayerStatsEntity>().Where(p => p.MixId == mixId);
+
+            // The range WHERE bounds the row set first, so the ABS ordering only sorts the
+            // handful in the band. Eligibility (public / community) is the caller's — the
+            // caller over-fetches by Count and takes its final cut after that filter.
+            var query = request.Dimension switch
+            {
+                ChartType.Single => all
+                    .Where(p => p.SinglesCompetitiveLevel >= min && p.SinglesCompetitiveLevel <= max)
+                    .OrderBy(p => Math.Abs(p.SinglesCompetitiveLevel - my))
+                    .Select(p => new CompetitiveNeighborRecord(p.UserId, p.SinglesCompetitiveLevel)),
+                ChartType.Double => all
+                    .Where(p => p.DoublesCompetitiveLevel >= min && p.DoublesCompetitiveLevel <= max)
+                    .OrderBy(p => Math.Abs(p.DoublesCompetitiveLevel - my))
+                    .Select(p => new CompetitiveNeighborRecord(p.UserId, p.DoublesCompetitiveLevel)),
+                _ => all
+                    .Where(p => p.CompetitiveLevel >= min && p.CompetitiveLevel <= max)
+                    .OrderBy(p => Math.Abs(p.CompetitiveLevel - my))
+                    .Select(p => new CompetitiveNeighborRecord(p.UserId, p.CompetitiveLevel))
+            };
+
+            return await query.Take(request.Count).ToArrayAsync(cancellationToken);
         }
 
         public async Task DeleteStats(MixEnum mix, Guid userId, CancellationToken cancellationToken)

--- a/ScoreTracker/ScoreTracker.Tests.Api/Goldens/capability-schema.json
+++ b/ScoreTracker/ScoreTracker.Tests.Api/Goldens/capability-schema.json
@@ -109,15 +109,15 @@
     },
     {
       "type": "pumbility",
-      "name": "PUMBILITY",
-      "description": "Pumbility targets tuned to your skill profile.",
+      "name": "Account Stats",
+      "description": "Your Pumbility and competitive level, plus your closest matches.",
       "category": "Progress",
       "supportedSizes": [
         "1x1",
-        "2x1",
-        "1x2"
+        "1x2",
+        "1x3"
       ],
-      "defaultSize": "2x1",
+      "defaultSize": "1x2",
       "supportedMixes": [
         "Phoenix",
         "Phoenix2"
@@ -161,15 +161,15 @@
             ],
             "nullable": true
           },
-          "showProjections": {
-            "type": "boolean"
-          },
-          "dismissedCharts": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            },
+          "matchDimension": {
+            "enum": [
+              "Single",
+              "Double",
+              "SinglePerformance",
+              "DoublePerformance",
+              "CoOp",
+              "HalfDouble"
+            ],
             "nullable": true
           }
         }
@@ -408,7 +408,8 @@
             "enum": [
               "TitleHunt",
               "ScorePush",
-              "FillGaps"
+              "FillGaps",
+              "PumbilityPush"
             ]
           },
           "mix": {
@@ -468,7 +469,8 @@
                 "ImproveTop50",
                 "RevisitOldScores",
                 "FillScores",
-                "WeeklyCharts"
+                "WeeklyCharts",
+                "PushPumbility"
               ]
             },
             "nullable": true

--- a/ScoreTracker/ScoreTracker.Tests.Api/Goldens/page-export.json
+++ b/ScoreTracker/ScoreTracker.Tests.Api/Goldens/page-export.json
@@ -7,10 +7,10 @@
       {
         "type": "pumbility",
         "title": "Doubles push",
-        "size": "2x1",
+        "size": "1x2",
         "config": {
           "mix": "Phoenix2",
-          "showProjections": true
+          "matchDimension": "Double"
         }
       },
       {

--- a/ScoreTracker/ScoreTracker.Tests.Api/HomePageDocumentContractTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Api/HomePageDocumentContractTests.cs
@@ -18,8 +18,8 @@ public sealed class HomePageDocumentContractTests
         return new HomePageRecord(Guid.Empty, "Session Day", 0, true, SharedKernel.Enums.MixEnum.Phoenix2,
             new[]
             {
-                new HomePageWidgetRecord(Guid.Empty, "pumbility", "Doubles push", 0, "2x1",
-                    "{\"mix\":\"Phoenix2\",\"showProjections\":true}", 1),
+                new HomePageWidgetRecord(Guid.Empty, "pumbility", "Doubles push", 0, "1x2",
+                    "{\"mix\":\"Phoenix2\",\"matchDimension\":\"Double\"}", 1),
                 new HomePageWidgetRecord(Guid.Empty, "weekly-challenge", null, 1, "1x1", "{}", 1)
             });
     }
@@ -66,6 +66,6 @@ public sealed class HomePageDocumentContractTests
         Assert.Equal(SharedKernel.Enums.MixEnum.Phoenix2, result.DefaultMix);
         Assert.Equal(2, result.Widgets.Count);
         Assert.Equal("pumbility", result.Widgets[0].WidgetType);
-        Assert.Equal("2x1", result.Widgets[0].SizePreset);
+        Assert.Equal("1x2", result.Widgets[0].SizePreset);
     }
 }

--- a/ScoreTracker/ScoreTracker.Tests.Components/AccountStatsWidgetTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/AccountStatsWidgetTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using ScoreTracker.Communities.Contracts.Queries;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.HomePage.Contracts;
+using ScoreTracker.PlayerProgress.Contracts;
+using ScoreTracker.PlayerProgress.Contracts.Queries;
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.Web.Components.HomeWidgets;
+using ScoreTracker.Web.Services.HomeDashboard;
+using Xunit;
+
+namespace ScoreTracker.Tests.Components;
+
+/// <summary>
+///     Account Stats widget (the renamed Pumbility widget, TypeId still "pumbility"). Two
+///     things worth pinning at this level: the glowy total + pools + competitive level
+///     render, and the closest-matches list only admits public players or your non-region
+///     community mates — with the community ones carrying the green glow.
+/// </summary>
+public sealed class AccountStatsWidgetTests : ComponentTestBase
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IUserRepository> _users = new();
+    private readonly Guid _me = Guid.NewGuid();
+    private readonly Guid _publicRival = Guid.NewGuid();
+    private readonly Guid _crewMate = Guid.NewGuid();
+    private readonly Guid _secretOutsider = Guid.NewGuid();
+
+    public AccountStatsWidgetTests()
+    {
+        CurrentUser.SetupGet(c => c.IsLoggedIn).Returns(true);
+        CurrentUser.SetupGet(c => c.User)
+            .Returns(new User(_me, "Me", true, null, new Uri("https://piu.test/me.png"), null));
+
+        _mediator.Setup(m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PlayerStatsRecord(_me, 5000, 26, 100, 0, 0,
+                SkillRating: 868, SkillScore: 900000, SkillLevel: 21.5,
+                SinglesRating: 852, SinglesScore: 900000, SinglesLevel: 21.3,
+                DoublesRating: 774, DoublesScore: 880000, DoublesLevel: 19.9,
+                CompetitiveLevel: 20.61, SinglesCompetitiveLevel: 21.34, DoublesCompetitiveLevel: 19.87));
+        _mediator.Setup(m => m.Send(It.IsAny<GetPlayerHistoryQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerRatingRecord>());
+        Services.AddSingleton(_mediator.Object);
+        Services.AddSingleton(_users.Object);
+        Services.AddScoped<CommunityGlowReader>();
+    }
+
+    private IRenderedComponent<PumbilityWidget> Render(string size, string configJson = "{}")
+    {
+        var widget = new HomePageWidgetRecord(Guid.NewGuid(), "pumbility", null, 0, size, configJson, 1);
+        return base.Render(builder =>
+        {
+            builder.OpenComponent<PumbilityWidget>(0);
+            builder.AddAttribute(1, nameof(PumbilityWidget.Widget), widget);
+            builder.AddAttribute(2, nameof(PumbilityWidget.EffectiveMix), MixEnum.Phoenix);
+            builder.CloseComponent();
+        }).FindComponent<PumbilityWidget>();
+    }
+
+    private void SetUpMatches()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<GetCompetitiveNeighborsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new CompetitiveNeighborRecord(_crewMate, 21.33),
+                new CompetitiveNeighborRecord(_publicRival, 21.36),
+                new CompetitiveNeighborRecord(_secretOutsider, 21.35)
+            });
+        _users.Setup(u => u.GetUsers(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new User(_publicRival, "PublicRival", true, null, new Uri("https://piu.test/p.png"), null),
+                new User(_crewMate, "CrewMate", false, null, new Uri("https://piu.test/c.png"), null),
+                new User(_secretOutsider, "SecretPlayer", false, null, new Uri("https://piu.test/s.png"), null)
+            });
+        // CommunityGlowReader keeps non-regional, non-"World" crews and their members.
+        _mediator.Setup(m => m.Send(It.IsAny<GetMyCommunitiesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new CommunityOverviewRecord("Crew", CommunityPrivacyType.Public, 5, false) });
+        _mediator.Setup(m => m.Send(It.IsAny<GetCommunityMembersQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { _crewMate });
+    }
+
+    [Fact]
+    public void OneByOneRendersTheGlowyTotalPoolsAndCompetitiveLevel()
+    {
+        var cut = Render("1x1");
+
+        Assert.Contains("rarity-glow-1", cut.Markup); // the glow the total keeps
+        Assert.Contains("868", cut.Markup);           // total Pumbility
+        Assert.Contains("852", cut.Markup);           // singles pool
+        Assert.Contains("774", cut.Markup);           // doubles pool
+        Assert.Contains("21.34", cut.Markup);         // singles competitive level
+        Assert.Contains("19.87", cut.Markup);         // doubles competitive level
+        // 1x1 is stats only — no match list.
+        Assert.Empty(cut.FindAll(".dash-acct-matches"));
+    }
+
+    [Fact]
+    public void OneByTwoShowsPublicAndCommunityMatchesButNotPrivateOutsiders()
+    {
+        SetUpMatches();
+
+        var cut = Render("1x2");
+
+        Assert.NotEmpty(cut.FindAll(".dash-acct-matches"));
+        Assert.Contains("PublicRival", cut.Markup);        // public → eligible
+        Assert.Contains("CrewMate", cut.Markup);           // private but shares a community → eligible
+        Assert.DoesNotContain("SecretPlayer", cut.Markup); // private, no shared community → hidden
+        // The community mate carries the green glow; the public rival does not.
+        Assert.Contains("dash-lb-community", cut.Markup);
+    }
+
+    [Fact]
+    public void CombinedDimensionMatchesOnTheCombinedCompetitiveLevelWithinRangeOne()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<GetCompetitiveNeighborsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CompetitiveNeighborRecord>());
+        _users.Setup(u => u.GetUsers(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<User>());
+        _mediator.Setup(m => m.Send(It.IsAny<GetMyCommunitiesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CommunityOverviewRecord>());
+
+        Render("1x2", "{\"matchDimension\":null}");
+
+        // Combined dimension → null ChartType, the combined competitive level, hard ±1.0 range.
+        _mediator.Verify(m => m.Send(
+            It.Is<GetCompetitiveNeighborsQuery>(q =>
+                q.Dimension == null && q.MyLevel == 20.61 && q.Range == 1),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests.Integration/EFPlayerStatsRepositoryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/EFPlayerStatsRepositoryTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Caching.Memory;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.PlayerProgress.Contracts.Queries;
+using ScoreTracker.PlayerProgress.Infrastructure;
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.Tests.Integration.Fixtures;
+
+namespace ScoreTracker.Tests.Integration;
+
+/// <summary>
+///     Real-SQL coverage for the competitive-neighbours cohort query (the Account Stats
+///     widget's match list): the range filter, the ABS ordering, the count cap, and the
+///     per-dimension column selection all run in SQL Server, not in memory. Seeds through
+///     the repo's own SaveStats (same posture as EFUserRepositoryTests).
+/// </summary>
+[Collection(IntegrationTestCollection.Name)]
+[ExcludeFromCodeCoverage]
+public sealed class EFPlayerStatsRepositoryTests : IAsyncLifetime
+{
+    private readonly SqlServerFixture _fixture;
+
+    public EFPlayerStatsRepositoryTests(SqlServerFixture fixture) => _fixture = fixture;
+
+    public Task InitializeAsync() => _fixture.ResetAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private EFPlayerStatsRepository BuildRepository() =>
+        new(_fixture.DbContextFactory, new MemoryCache(new MemoryCacheOptions()));
+
+    private static PlayerStatsRecord Stats(Guid userId, double singles, double doubles, double combined) =>
+        new(userId, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, combined, singles, doubles);
+
+    [Fact]
+    public async Task GetCompetitiveNeighborsReturnsInRangeCandidatesNearestFirst()
+    {
+        var near = Guid.NewGuid();  // 21.36 → 0.02
+        var close = Guid.NewGuid(); // 21.30 → 0.04
+        var edge = Guid.NewGuid();  // 21.50 → 0.16 (still within ±1.0)
+        var below = Guid.NewGuid(); // 20.10 → 1.24 (out)
+        var above = Guid.NewGuid(); // 22.50 → 1.16 (out)
+        var repo = BuildRepository();
+        await repo.SaveStats(MixEnum.Phoenix, near, Stats(near, 21.36, 0, 0), CancellationToken.None);
+        await repo.SaveStats(MixEnum.Phoenix, close, Stats(close, 21.30, 0, 0), CancellationToken.None);
+        await repo.SaveStats(MixEnum.Phoenix, edge, Stats(edge, 21.50, 0, 0), CancellationToken.None);
+        await repo.SaveStats(MixEnum.Phoenix, below, Stats(below, 20.10, 0, 0), CancellationToken.None);
+        await repo.SaveStats(MixEnum.Phoenix, above, Stats(above, 22.50, 0, 0), CancellationToken.None);
+
+        var result = (await repo.Handle(
+            new GetCompetitiveNeighborsQuery(MixEnum.Phoenix, ChartType.Single, 21.34, 1.0, 10),
+            CancellationToken.None)).ToArray();
+
+        Assert.Equal(new[] { near, close, edge }, result.Select(n => n.UserId).ToArray());
+        Assert.Equal(21.36, result[0].CompetitiveLevel, 2);
+    }
+
+    [Fact]
+    public async Task GetCompetitiveNeighborsCapsAtTheRequestedCount()
+    {
+        var repo = BuildRepository();
+        for (var i = 0; i < 5; i++)
+        {
+            var id = Guid.NewGuid();
+            await repo.SaveStats(MixEnum.Phoenix, id, Stats(id, 21.30 + i * 0.01, 0, 0), CancellationToken.None);
+        }
+
+        var result = (await repo.Handle(
+            new GetCompetitiveNeighborsQuery(MixEnum.Phoenix, ChartType.Single, 21.32, 1.0, 2),
+            CancellationToken.None)).ToArray();
+
+        Assert.Equal(2, result.Length);
+    }
+
+    [Fact]
+    public async Task GetCompetitiveNeighborsRanksOnTheRequestedDimension()
+    {
+        // Strong singles, weak doubles: in range on Singles, out of range on Doubles.
+        var id = Guid.NewGuid();
+        var repo = BuildRepository();
+        await repo.SaveStats(MixEnum.Phoenix, id, Stats(id, 21.30, 18.00, 20.00), CancellationToken.None);
+
+        var singles = await repo.Handle(
+            new GetCompetitiveNeighborsQuery(MixEnum.Phoenix, ChartType.Single, 21.34, 1.0, 10),
+            CancellationToken.None);
+        var doubles = await repo.Handle(
+            new GetCompetitiveNeighborsQuery(MixEnum.Phoenix, ChartType.Double, 21.34, 1.0, 10),
+            CancellationToken.None);
+        var combined = await repo.Handle(
+            new GetCompetitiveNeighborsQuery(MixEnum.Phoenix, null, 20.20, 1.0, 10),
+            CancellationToken.None);
+
+        Assert.Contains(singles, n => n.UserId == id);       // 21.30 within ±1 of 21.34
+        Assert.DoesNotContain(doubles, n => n.UserId == id); // 18.00 outside ±1 of 21.34
+        Assert.Contains(combined, n => n.UserId == id);      // 20.00 within ±1 of 20.20
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs
@@ -301,6 +301,46 @@ public sealed class RecommendedChartsSagaTests
             r => (string)r.Category == RecommendationCategories.ImproveTop50 && r.ChartId == outside.Id);
     }
 
+    [Fact]
+    public async Task PumbilityPushRanksChartsByProjectedGainAndStampsTheGain()
+    {
+        var big = new ChartBuilder().WithType(ChartType.Single).WithLevel(21).Build();
+        var small = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var ctx = new RecommendedChartsContext()
+            .WithCharts(big, small)
+            .WithPumbilityGains((small.Id, 7), (big.Id, 42));
+
+        var result = (await ctx.Saga.Handle(new GetRecommendedChartsQuery(ChartType: null, LevelOffset: 0,
+                Categories: new HashSet<RecommendationCategory> { RecommendationCategory.PushPumbility }),
+            CancellationToken.None)).ToArray();
+
+        var pushes = result.Where(r => (string)r.Category == RecommendationCategories.PushPumbility).ToArray();
+        Assert.Equal(new[] { big.Id, small.Id }, pushes.Select(p => p.ChartId).ToArray());
+        Assert.Equal("+42", pushes[0].ChartDetails);
+    }
+
+    [Fact]
+    public async Task PumbilityPushExcludesHiddenChartsAndNonPositiveGains()
+    {
+        var gainer = new ChartBuilder().WithType(ChartType.Single).WithLevel(21).Build();
+        var hidden = new ChartBuilder().WithType(ChartType.Single).WithLevel(21).Build();
+        var zeroGain = new ChartBuilder().WithType(ChartType.Single).WithLevel(21).Build();
+        var ctx = new RecommendedChartsContext()
+            .WithCharts(gainer, hidden, zeroGain)
+            .WithPumbilityGains((gainer.Id, 30), (hidden.Id, 25), (zeroGain.Id, 0))
+            .WithFeedback(new SuggestionFeedbackRecord(Name.From(RecommendationCategories.PushPumbility),
+                Name.From("NotInterested"), Notes: "", ShouldHide: true, IsPositive: false, ChartId: hidden.Id));
+
+        var result = (await ctx.Saga.Handle(new GetRecommendedChartsQuery(ChartType: null, LevelOffset: 0,
+                Categories: new HashSet<RecommendationCategory> { RecommendationCategory.PushPumbility }),
+            CancellationToken.None)).ToArray();
+
+        Assert.Contains(result,
+            r => (string)r.Category == RecommendationCategories.PushPumbility && r.ChartId == gainer.Id);
+        Assert.DoesNotContain(result, r => r.ChartId == hidden.Id);
+        Assert.DoesNotContain(result, r => r.ChartId == zeroGain.Id);
+    }
+
     private sealed class RecommendedChartsContext
     {
         public Mock<IMediator> Mediator { get; } = new();
@@ -333,6 +373,8 @@ public sealed class RecommendedChartsSagaTests
                 .ReturnsAsync(Array.Empty<SongTierListEntry>());
             Mediator.Setup(m => m.Send(It.IsAny<GetTop50CompetitiveQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Array.Empty<RecordedPhoenixScore>());
+            Mediator.Setup(m => m.Send(It.IsAny<ProjectPumbilityGainsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmptyProjection());
             Users.Setup(u => u.GetFeedback(userId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Array.Empty<SuggestionFeedbackRecord>());
             Weekly.Setup(w => w.GetWeeklyCharts(MixEnum.Phoenix, It.IsAny<CancellationToken>()))
@@ -364,6 +406,18 @@ public sealed class RecommendedChartsSagaTests
             return this;
         }
 
+        public RecommendedChartsContext WithPumbilityGains(params (Guid ChartId, int Gain)[] gains)
+        {
+            Mediator.Setup(m => m.Send(It.IsAny<ProjectPumbilityGainsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PumbilityProjection(
+                    new Dictionary<Guid, PhoenixScore>(),
+                    gains.ToDictionary(g => g.ChartId, g => g.Gain),
+                    new Dictionary<(ChartType, DifficultyLevel), int>(),
+                    new Dictionary<Guid, TierListCategory>(),
+                    new Dictionary<Guid, IReadOnlyList<SkillAdjustmentRecord>>()));
+            return this;
+        }
+
         public RecommendedChartsContext WithCompetitiveLevel(double level)
         {
             Stats.Setup(s => s.GetStats(MixEnum.Phoenix, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
@@ -388,6 +442,11 @@ public sealed class RecommendedChartsSagaTests
     private static RecordedPhoenixScore Score(Guid chartId, int score) =>
         new(chartId, score, PhoenixPlate.SuperbGame, IsBroken: false,
             new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+    private static PumbilityProjection EmptyProjection() =>
+        new(new Dictionary<Guid, PhoenixScore>(), new Dictionary<Guid, int>(),
+            new Dictionary<(ChartType, DifficultyLevel), int>(), new Dictionary<Guid, TierListCategory>(),
+            new Dictionary<Guid, IReadOnlyList<SkillAdjustmentRecord>>());
 
     private static PlayerStatsRecord ZeroStats(Guid userId) =>
         new(userId, TotalRating: 0, HighestLevel: 1, ClearCount: 0, CoOpRating: 0, CoOpScore: 0,

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityConfig.cs
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityConfig.cs
@@ -3,16 +3,15 @@ using ScoreTracker.SharedKernel.Enums;
 namespace ScoreTracker.Web.Components.HomeWidgets;
 
 /// <summary>
-///     Pumbility widget config (public contract via export/import, D19). Null Mix =
-///     follow the effective mix (D13). DismissedCharts is the per-instance permanent
-///     blacklist (owner, 2026-07-12): personal noise control, deliberately NOT the
-///     suggester's feedback system.
+///     Account Stats widget config (public contract via export/import, D19). Null Mix =
+///     follow the current mix, falling back to Phoenix 2 on pre-Phoenix mixes (owner,
+///     2026-07-13 — differs from the other widgets, which fall back to Phoenix 1).
+///     MatchDimension picks the competitive level the closest-matches list ranks on;
+///     null = combined. (TypeId stays "pumbility" — public export vocabulary, never renamed.)
 /// </summary>
 public sealed record PumbilityConfig
 {
     public MixEnum? Mix { get; set; }
 
-    public bool ShowProjections { get; set; } = true;
-
-    public List<Guid> DismissedCharts { get; set; } = new();
+    public ChartType? MatchDimension { get; set; }
 }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityConfigPanel.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityConfigPanel.razor
@@ -1,24 +1,19 @@
 @using ScoreTracker.HomePage.Contracts
 @using ScoreTracker.SharedKernel.Enums
 @using ScoreTracker.Web.Services.HomeDashboard
+@using ChartType = ScoreTracker.SharedKernel.Enums.ChartType
 
 <MudSelect T="MixEnum?" @bind-Value="_mix" Label="@L["Mix"]" Class="mb-3">
     <MudSelectItem T="MixEnum?" Value="null">@L["Follow current mix"]</MudSelectItem>
     <MudSelectItem T="MixEnum?" Value="MixEnum.Phoenix">Phoenix</MudSelectItem>
     <MudSelectItem T="MixEnum?" Value="MixEnum.Phoenix2">Phoenix 2</MudSelectItem>
 </MudSelect>
-<MudSwitch T="bool" @bind-Value="_showProjections" Color="Color.Primary"
-           Label="@L["Show projected targets"]"/>
-@if (_dismissedCount > 0)
-{
-    <div class="d-flex align-center gap-2 mt-2">
-        <MudText Typo="Typo.body2">@L["Dismissed charts"]: @_dismissedCount</MudText>
-        <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="() => _restoreAll = true"
-                   Disabled="_restoreAll">
-            @L["Restore all"]
-        </MudButton>
-    </div>
-}
+<MudSelect T="ChartType?" @bind-Value="_dimension" Label="@L["Match players on"]" Class="mb-2">
+    <MudSelectItem T="ChartType?" Value="ChartType.Single">@L["Singles competitive level"]</MudSelectItem>
+    <MudSelectItem T="ChartType?" Value="ChartType.Double">@L["Doubles competitive level"]</MudSelectItem>
+    <MudSelectItem T="ChartType?" Value="null">@L["Combined competitive level"]</MudSelectItem>
+</MudSelect>
+<MudText Typo="Typo.caption" Class="dash-muted">@L["Your closest matches show at 1×2 and taller."]</MudText>
 <div class="d-flex justify-end gap-2 mt-4">
     <MudButton OnClick="() => OnCancel.InvokeAsync()">@L["Cancel"]</MudButton>
     <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Save">@L["Save"]</MudButton>
@@ -31,28 +26,18 @@
     [Parameter] public EventCallback OnCancel { get; set; }
 
     private MixEnum? _mix;
-    private bool _showProjections = true;
-    private int _dismissedCount;
-    private bool _restoreAll;
+    private ChartType? _dimension;
 
     protected override void OnParametersSet()
     {
         var config = WidgetConfigJson.Read<PumbilityConfig>(Widget.ConfigJson);
         _mix = config.Mix;
-        _showProjections = config.ShowProjections;
-        _dismissedCount = config.DismissedCharts.Count;
-        _restoreAll = false;
+        _dimension = config.MatchDimension;
     }
 
     private async Task Save()
     {
-        var existing = WidgetConfigJson.Read<PumbilityConfig>(Widget.ConfigJson);
-        var config = new PumbilityConfig
-        {
-            Mix = _mix,
-            ShowProjections = _showProjections,
-            DismissedCharts = _restoreAll ? new List<Guid>() : existing.DismissedCharts
-        };
+        var config = new PumbilityConfig { Mix = _mix, MatchDimension = _dimension };
         await OnSave.InvokeAsync((WidgetConfigJson.Write(config), 1));
     }
 

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
@@ -45,11 +45,11 @@ else
                 </span>
                 <div class="dash-acct-pools">
                     <div class="dash-acct-poolrow">
-                        <span style="color:var(--chart-singles)">@L["Singles"]</span>
+                        <span style="color:var(--chart-singles)">S</span>
                         <span class="dash-acct-poolnum">@(((int)_stats.SinglesRating).ToString("N0"))</span>
                     </div>
                     <div class="dash-acct-poolrow">
-                        <span style="color:var(--chart-doubles)">@L["Doubles"]</span>
+                        <span style="color:var(--chart-doubles)">D</span>
                         <span class="dash-acct-poolnum">@(((int)_stats.DoublesRating).ToString("N0"))</span>
                     </div>
                 </div>
@@ -57,10 +57,10 @@ else
 
             <div class="dash-acct-eyebrow dash-acct-cl-eyebrow">@L["Competitive Level"]</div>
             <div class="dash-pools">
-                <span style="color:var(--chart-singles)">@L["Singles"]</span>
+                <span style="color:var(--chart-singles)">S</span>
                 <span class="@(_dimension == ChartType.Single ? "dash-acct-active" : "")">
                     @_stats.SinglesCompetitiveLevel.ToString("N2")</span>
-                <span style="color:var(--chart-doubles)">@L["Doubles"]</span>
+                <span style="color:var(--chart-doubles)">D</span>
                 <span class="@(_dimension == ChartType.Double ? "dash-acct-active" : "")">
                     @_stats.DoublesCompetitiveLevel.ToString("N2")</span>
             </div>

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
@@ -1,18 +1,19 @@
 @using MediatR
+@using ScoreTracker.Domain.Models
 @using ScoreTracker.Domain.Records
 @using ScoreTracker.Domain.SecondaryPorts
 @using ScoreTracker.HomePage.Contracts
-@using ScoreTracker.HomePage.Contracts.Commands
+@using ScoreTracker.PlayerProgress.Contracts
 @using ScoreTracker.PlayerProgress.Contracts.Queries
 @using ScoreTracker.SharedKernel.Enums
-@using ScoreTracker.SharedKernel.Models
 @using ScoreTracker.Web.Components
 @using ScoreTracker.Web.Services.HomeDashboard
+@using ChartType = ScoreTracker.SharedKernel.Enums.ChartType
 
-@* W2 (field-test round 1 shape): 1x1 is the stat alone (total + pools + trend);
-   2x1 adds text target rows with mini song art; 1x2 goes art + bubble + gain.
-   Skill chips dropped from the widget — the data stays on the projection contract.
-   Dismiss is an edit-mode affordance; browse-mode clicks open chart details. *@
+@* Account Stats (TypeId stays "pumbility"): the glowy total Pumbility + S/D pools stay —
+   competitive level joins them, and the projected-target list left for Suggested Charts'
+   Pumbility Push goal. 1x2 and taller add your closest competitive matches; a pinned mix
+   that differs from the current one shows as a pill in the title (via the header slot). *@
 
 @if (!_loaded)
 {
@@ -31,65 +32,66 @@ else if (_stats == null || ((int)_stats.SkillRating == 0 && _stats.ClearCount ==
 }
 else
 {
-    <div class="dash-pumbility @(_tall ? "dash-pumbility-tall" : "")">
-        <div class="dash-pumbility-left">
-            <span class="dash-stat-num rarity-glow-1">@(((int)_stats.SkillRating).ToString("N0"))</span>
-            @if (_weeklyDelta is > 0)
-            {
-                <span class="dash-stat-delta">▲ @_weeklyDelta.Value.ToString("N0")</span>
-            }
-            <MudText Typo="Typo.caption" Class="dash-pools">
+    <div class="dash-acct">
+        <div class="dash-acct-stats">
+            <div class="dash-acct-eyebrow">@L["Pumbility"]</div>
+            <div class="dash-acct-hero">
+                <span class="dash-stat-num rarity-glow-1">@(((int)_stats.SkillRating).ToString("N0"))</span>
+                @if (_weeklyDelta is > 0)
+                {
+                    <span class="dash-stat-delta">▲ @_weeklyDelta.Value.ToString("N0")</span>
+                }
+            </div>
+            <div class="dash-pools">
                 <span style="color:var(--chart-singles)">@L["Singles"]</span>
                 <span>@(((int)_stats.SinglesRating).ToString("N0"))</span>
                 <span style="color:var(--chart-doubles)">@L["Doubles"]</span>
                 <span>@(((int)_stats.DoublesRating).ToString("N0"))</span>
-            </MudText>
-            @if (_sparkPoints != null)
-            {
-                <svg class="dash-sparkline" viewBox="0 0 100 26" preserveAspectRatio="none">
-                    <polyline points="@_sparkPoints" fill="none" stroke="var(--rarity-gold)"
-                              stroke-width="2" vector-effect="non-scaling-stroke"/>
-                </svg>
-            }
-            else if (!_compact && !_targets.Any())
-            {
-                <MudText Typo="Typo.caption" Class="dash-muted">@L["Trend starts tracking from today."]</MudText>
-            }
+            </div>
+
+            <div class="dash-acct-eyebrow dash-acct-cl-eyebrow">@L["Competitive Level"]</div>
+            <div class="dash-pools">
+                <span style="color:var(--chart-singles)">@L["Singles"]</span>
+                <span class="@(_dimension == ChartType.Single ? "dash-acct-active" : "")">
+                    @_stats.SinglesCompetitiveLevel.ToString("N2")</span>
+                <span style="color:var(--chart-doubles)">@L["Doubles"]</span>
+                <span class="@(_dimension == ChartType.Double ? "dash-acct-active" : "")">
+                    @_stats.DoublesCompetitiveLevel.ToString("N2")</span>
+            </div>
         </div>
-        @if (!_compact && _showTargets && _targets.Any())
+
+        @if (_showMatches)
         {
-            <div class="dash-pumbility-targets">
-                <MudText Typo="Typo.caption" Class="dash-muted">@L["Best projected targets"]</MudText>
-                <div class="dash-targets dash-scroll">
-                    @foreach (var target in _targets.Where(t => !_dismissed.Contains(t.Chart.Id)))
-                    {
-                        var chart = target.Chart;
-                        <div class="dash-target-row @(EditMode ? "" : "dash-clickable")"
-                             @onclick="() => OnChartClick.InvokeAsync(new ChartClickContext(chart))">
-                            <span class="dash-mini-art">
-                                <SongImage Song="chart.Song" Small="true"></SongImage>
-                            </span>
-                            @if (_tall)
-                            {
-                                <DifficultyBubble Chart="chart" Small="true"></DifficultyBubble>
-                                <span class="dash-target-name">@chart.Song.Name</span>
-                            }
-                            else
-                            {
-                                <span class="dash-target-name">@chart.Song.Name @chart.DifficultyString</span>
-                            }
-                            <span class="dash-target-gain">+@target.Gain.ToString("N0")</span>
-                            @if (EditMode)
-                            {
-                                <span @onclick:stopPropagation="true">
-                                    <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Close"
-                                                   title="@L["Dismiss"]"
-                                                   OnClick="() => Dismiss(chart.Id)"/>
-                                </span>
-                            }
-                        </div>
-                    }
+            <div class="dash-acct-matches">
+                <div class="dash-acct-mhead">
+                    <span class="dash-acct-mlabel">@MatchesLabel</span>
+                    <span class="dash-acct-you">@L["You"] <b>@_myLevel.ToString("N2")</b></span>
                 </div>
+                @if (_matches.Any())
+                {
+                    <div class="dash-acct-mlist dash-scroll">
+                        @foreach (var (row, i) in _matches.Select((r, i) => (r, i)))
+                        {
+                            var r = row;
+                            <div class="dash-lb-row @(r.IsCommunity ? "dash-lb-community" : "") @(EditMode ? "" : "dash-clickable")"
+                                 @onclick="() => OpenPlayer(r)">
+                                <span class="dash-lb-place">@(i + 1)</span>
+                                <span class="dash-lb-who dash-acct-who">
+                                    <img class="dash-acct-av" src="@r.User.ProfileImage.ToString()" alt="" loading="lazy"/>
+                                    <span class="dash-acct-name"><UserLabel User="r.User"></UserLabel></span>
+                                </span>
+                                <span class="dash-acct-trail">
+                                    <span class="dash-acct-lvl">@r.Level.ToString("N2")</span>
+                                    <span class="dash-acct-gap">@GapText(r.Level)</span>
+                                </span>
+                            </div>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <div class="dash-acct-empty">@L["No close matches yet."]</div>
+                }
             </div>
         }
     </div>
@@ -97,96 +99,140 @@ else
 
 @inject IMediator Mediator
 @inject ICurrentUserAccessor CurrentUser
-@inject ChartCatalogCache ChartCatalog
+@inject IUserRepository Users
+@inject CommunityGlowReader CommunityGlow
+@inject NavigationManager Nav
 
 @code {
 
     [Parameter] public HomePageWidgetRecord Widget { get; set; } = null!;
     [Parameter] public MixEnum EffectiveMix { get; set; }
     [Parameter] public bool EditMode { get; set; }
+
+    /// <summary>Part of the five-param render contract (§2.2) — Account Stats rows link to
+    /// player pages, not charts, so this stays declared but unused.</summary>
     [Parameter] public EventCallback<ChartClickContext> OnChartClick { get; set; }
+
     [Parameter] public int RefreshToken { get; set; }
 
+    /// <summary>Title-bar slot (§2.3): a pinned mix that differs from the current one rides
+    /// here as a pill, keeping the body clear of a mix chip (owner, 2026-07-13).</summary>
+    [CascadingParameter] private WidgetHeaderSlot? HeaderSlot { get; set; }
+
+    private const int Range = 1;         // hard ±1.0 competitive-level cap (owner)
+    private const int MatchCount = 25;   // the closest N shown (owner)
+    private const int CandidateFetch = 200; // over-fetch, then keep the eligible closest 25
     private static readonly MixEnum[] Supported = { MixEnum.Phoenix, MixEnum.Phoenix2 };
 
-    private sealed record TargetRow(Chart Chart, int Gain);
+    private sealed record MatchRow(User User, double Level, bool IsCommunity);
 
     private bool _loaded;
-    private bool _compact;
-    private bool _tall;
+    private bool _showMatches;
     private string? _loadedFor;
+    private MixEnum _mix;
+    private ChartType? _dimension;
     private PlayerStatsRecord? _stats;
     private int? _weeklyDelta;
-    private string? _sparkPoints;
-    private bool _showTargets;
-    private MixEnum _mix;
-    private List<TargetRow> _targets = new();
-    private readonly HashSet<Guid> _dismissed = new();
+    private double _myLevel;
+    private List<MatchRow> _matches = new();
+    private string? _headerSlotKey;
+
+    private string MatchesLabel => _dimension switch
+    {
+        ChartType.Single => L["Closest · Singles"],
+        ChartType.Double => L["Closest · Doubles"],
+        _ => L["Closest · Combined"]
+    };
 
     protected override async Task OnParametersSetAsync()
     {
-        var signature = $"{Widget.Id}|{Widget.ConfigJson}|{Widget.SizePreset}|{EffectiveMix}";
-        if (signature == _loadedFor) return;
-        _loadedFor = signature;
-        _loaded = false;
-
-        var size = SizePreset.TryParse(Widget.SizePreset) ?? SizePreset.OneByOne;
-        _compact = size is { Columns: 1, Rows: 1 };
-        _tall = size.Columns == 1 && size.Rows > 1;
-
-        var config = WidgetConfigJson.Read<PumbilityConfig>(Widget.ConfigJson);
-        _mix = config.Mix != null && Supported.Contains(config.Mix.Value) ? config.Mix.Value
-            : Supported.Contains(EffectiveMix) ? EffectiveMix : MixEnum.Phoenix;
-        _showTargets = config.ShowProjections;
-        _dismissed.Clear();
-        foreach (var id in config.DismissedCharts) _dismissed.Add(id);
-
-        var userId = CurrentUser.User.Id;
-        var statsTask = Mediator.Send(new GetPlayerStatsQuery(userId, _mix));
-        var historyTask = Mediator.Send(new GetPlayerHistoryQuery(userId, _mix));
-        _stats = await statsTask;
-        var history = (await historyTask)
-            .Where(h => h.SkillRating != null)
-            .OrderBy(h => h.Date)
-            .ToArray();
-
-        // Trend + weekly delta light up once the history capture has data.
-        _sparkPoints = history.Length >= 2 ? BuildSparkline(history) : null;
-        var weekAgo = history.LastOrDefault(h => h.Date <= DateTimeOffset.Now.AddDays(-7));
-        _weeklyDelta = weekAgo?.SkillRating is { } baseline ? (int)_stats.SkillRating - baseline : null;
-
-        _targets.Clear();
-        if (!_compact && _showTargets && ((int)_stats.SkillRating > 0 || _stats.ClearCount > 0))
+        var signature = $"{Widget.Id}|{Widget.ConfigJson}|{Widget.SizePreset}|{EffectiveMix}|{RefreshToken}";
+        if (signature != _loadedFor)
         {
-            var projection = await Mediator.Send(new ProjectPumbilityGainsQuery(userId, _mix));
-            var charts = await ChartCatalog.GetCharts(_mix);
-            _targets = projection.ProjectedGains
-                .OrderByDescending(kv => kv.Value)
-                .Take(15)
-                .Where(kv => charts.ContainsKey(kv.Key))
-                .Select(kv => new TargetRow(charts[kv.Key], kv.Value))
-                .ToList();
+            _loadedFor = signature;
+            _loaded = false;
+
+            var size = SizePreset.TryParse(Widget.SizePreset) ?? SizePreset.OneByOne;
+            _showMatches = size is { Columns: 1, Rows: > 1 };
+
+            var config = WidgetConfigJson.Read<PumbilityConfig>(Widget.ConfigJson);
+            // Follow current mix, but Phoenix-eras only — pre-Phoenix mixes fall to Phoenix 2.
+            _mix = config.Mix != null && Supported.Contains(config.Mix.Value) ? config.Mix.Value
+                : Supported.Contains(EffectiveMix) ? EffectiveMix : MixEnum.Phoenix2;
+            _dimension = config.MatchDimension;
+
+            var userId = CurrentUser.User.Id;
+            _stats = await Mediator.Send(new GetPlayerStatsQuery(userId, _mix));
+
+            var history = (await Mediator.Send(new GetPlayerHistoryQuery(userId, _mix)))
+                .Where(h => h.SkillRating != null)
+                .OrderBy(h => h.Date)
+                .ToArray();
+            var weekAgo = history.LastOrDefault(h => h.Date <= DateTimeOffset.Now.AddDays(-7));
+            _weeklyDelta = weekAgo?.SkillRating is { } baseline && _stats != null
+                ? (int)_stats.SkillRating - baseline
+                : null;
+
+            _matches = new List<MatchRow>();
+            if (_showMatches && _stats != null) await LoadMatches(userId);
+
+            _loaded = true;
         }
 
-        _loaded = true;
+        UpdateHeaderSlot(WidgetConfigJson.Read<PumbilityConfig>(Widget.ConfigJson).Mix);
     }
 
-    private static string BuildSparkline(IReadOnlyList<PlayerRatingRecord> history)
+    private async Task LoadMatches(Guid userId)
     {
-        var values = history.Select(h => (double)h.SkillRating!.Value).ToArray();
-        var min = values.Min();
-        var range = Math.Max(1, values.Max() - min);
-        return string.Join(" ", values.Select((v, i) =>
-            $"{(values.Length == 1 ? 0 : 100.0 * i / (values.Length - 1)):0.#},{(24 - 22.0 * (v - min) / range):0.#}"));
+        _myLevel = _dimension switch
+        {
+            ChartType.Single => _stats!.SinglesCompetitiveLevel,
+            ChartType.Double => _stats!.DoublesCompetitiveLevel,
+            _ => _stats!.CompetitiveLevel
+        };
+        if (_myLevel <= 0) return;
+
+        // The cohort (in-range, nearest first) comes ranked from SQL; eligibility is applied
+        // here where the community set and privacy flags live: public players, plus anyone
+        // from your non-region communities (who also get the green glow), closest 25.
+        var neighbors = await Mediator.Send(
+            new GetCompetitiveNeighborsQuery(_mix, _dimension, _myLevel, Range, CandidateFetch));
+        var community = await CommunityGlow.GetMyCommunityMemberIds();
+        var users = (await Users.GetUsers(neighbors.Select(n => n.UserId).Where(id => id != userId)))
+            .ToDictionary(u => u.Id);
+
+        _matches = neighbors
+            .Where(n => n.UserId != userId && users.ContainsKey(n.UserId))
+            .Where(n => users[n.UserId].IsPublic || community.Contains(n.UserId))
+            .Take(MatchCount)
+            .Select(n => new MatchRow(users[n.UserId], n.CompetitiveLevel, community.Contains(n.UserId)))
+            .ToList();
     }
 
-    private async Task Dismiss(Guid chartId)
+    private void UpdateHeaderSlot(MixEnum? pinned)
     {
-        _dismissed.Add(chartId);
-        var config = WidgetConfigJson.Read<PumbilityConfig>(Widget.ConfigJson);
-        if (!config.DismissedCharts.Contains(chartId)) config.DismissedCharts.Add(chartId);
-        await Mediator.Send(new UpdateHomePageWidgetConfigCommand(Widget.Id,
-            WidgetConfigJson.Write(config), Widget.ConfigVersion));
+        if (HeaderSlot == null) return;
+        // Pill only when a specific mix is pinned that isn't the current one (owner).
+        var show = pinned is { } p && Supported.Contains(p) && p != EffectiveMix;
+        var key = show ? pinned!.Value.ToString() : null;
+        if (key == _headerSlotKey) return;
+        _headerSlotKey = key;
+        HeaderSlot.Set(show ? MixPill(pinned!.Value) : null);
+    }
+
+    private RenderFragment MixPill(MixEnum mix) =>@<span class="dash-acct-mixpill">@mix.GetName()</span>;
+
+    private string GapText(double level)
+    {
+        var diff = level - _myLevel;
+        var sign = diff > 0 ? "+" : diff < 0 ? "−" : "±";
+        return sign + Math.Abs(diff).ToString("N2");
+    }
+
+    private void OpenPlayer(MatchRow row)
+    {
+        if (EditMode) return;
+        Nav.NavigateTo($"/Player/{row.User.Id}/Sessions");
     }
 
 }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
@@ -36,17 +36,23 @@ else
         <div class="dash-acct-stats">
             <div class="dash-acct-eyebrow">@L["Pumbility"]</div>
             <div class="dash-acct-hero">
-                <span class="dash-stat-num rarity-glow-1">@(((int)_stats.SkillRating).ToString("N0"))</span>
-                @if (_weeklyDelta is > 0)
-                {
-                    <span class="dash-stat-delta">▲ @_weeklyDelta.Value.ToString("N0")</span>
-                }
-            </div>
-            <div class="dash-pools">
-                <span style="color:var(--chart-singles)">@L["Singles"]</span>
-                <span>@(((int)_stats.SinglesRating).ToString("N0"))</span>
-                <span style="color:var(--chart-doubles)">@L["Doubles"]</span>
-                <span>@(((int)_stats.DoublesRating).ToString("N0"))</span>
+                <span class="dash-acct-total">
+                    <span class="dash-stat-num rarity-glow-1">@(((int)_stats.SkillRating).ToString("N0"))</span>
+                    @if (_weeklyDelta is > 0)
+                    {
+                        <span class="dash-stat-delta">▲ @_weeklyDelta.Value.ToString("N0")</span>
+                    }
+                </span>
+                <div class="dash-acct-pools">
+                    <div class="dash-acct-poolrow">
+                        <span style="color:var(--chart-singles)">@L["Singles"]</span>
+                        <span class="dash-acct-poolnum">@(((int)_stats.SinglesRating).ToString("N0"))</span>
+                    </div>
+                    <div class="dash-acct-poolrow">
+                        <span style="color:var(--chart-doubles)">@L["Doubles"]</span>
+                        <span class="dash-acct-poolnum">@(((int)_stats.DoublesRating).ToString("N0"))</span>
+                    </div>
+                </div>
             </div>
 
             <div class="dash-acct-eyebrow dash-acct-cl-eyebrow">@L["Competitive Level"]</div>
@@ -82,7 +88,6 @@ else
                                 </span>
                                 <span class="dash-acct-trail">
                                     <span class="dash-acct-lvl">@r.Level.ToString("N2")</span>
-                                    <span class="dash-acct-gap">@GapText(r.Level)</span>
                                 </span>
                             </div>
                         }
@@ -221,13 +226,6 @@ else
     }
 
     private RenderFragment MixPill(MixEnum mix) =>@<span class="dash-acct-mixpill">@mix.GetName()</span>;
-
-    private string GapText(double level)
-    {
-        var diff = level - _myLevel;
-        var sign = diff > 0 ? "+" : diff < 0 ? "−" : "±";
-        return sign + Math.Abs(diff).ToString("N2");
-    }
 
     private void OpenPlayer(MatchRow row)
     {

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsConfig.cs
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsConfig.cs
@@ -18,7 +18,10 @@ public enum SuggestedGoal
     ScorePush,
 
     /// <summary>Approachable unpassed charts around (default: below) your level.</summary>
-    FillGaps
+    FillGaps,
+
+    /// <summary>The projected-Pumbility targets, ranked by the rating each chart would add.</summary>
+    PumbilityPush
 }
 
 public enum SuggestedLevelMode
@@ -94,6 +97,7 @@ public static class SuggestedGoals
                 RecommendationCategory.RevisitOldScores
             },
             SuggestedGoal.FillGaps => new[] { RecommendationCategory.FillScores },
+            SuggestedGoal.PumbilityPush => new[] { RecommendationCategory.PushPumbility },
             _ => new[] { RecommendationCategory.PushLevel, RecommendationCategory.SkillTitles }
         };
     }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsConfigPanel.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsConfigPanel.razor
@@ -9,6 +9,7 @@
     <MudSelectItem T="SuggestedGoal" Value="SuggestedGoal.TitleHunt">@L["Title Hunt"]</MudSelectItem>
     <MudSelectItem T="SuggestedGoal" Value="SuggestedGoal.ScorePush">@L["Score Push"]</MudSelectItem>
     <MudSelectItem T="SuggestedGoal" Value="SuggestedGoal.FillGaps">@L["Fill Gaps"]</MudSelectItem>
+    <MudSelectItem T="SuggestedGoal" Value="SuggestedGoal.PumbilityPush">@L["Pumbility Push"]</MudSelectItem>
 </MudSelect>
 @if (SuggestedGoals.CategoriesFor(_goal).Count > 1)
 {

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsWidget.razor
@@ -265,7 +265,8 @@ else
                 _sections.Add(new SuggestionSection(
                     name,
                     known != null ? L[name].Value : name,
-                    items.Select(r => BuildRow(category, charts[r.ChartId], scores.GetValueOrDefault(r.ChartId)))
+                    items.Select(r => BuildRow(category, charts[r.ChartId], scores.GetValueOrDefault(r.ChartId),
+                            r.ChartDetails))
                         .ToList()));
         }
 
@@ -351,7 +352,8 @@ else
 
     private readonly Dictionary<Guid, TierListCategory> _lensTiers = new();
 
-    private SuggestionRow BuildRow(RecommendationCategory category, Chart chart, RecordedPhoenixScore? score)
+    private SuggestionRow BuildRow(RecommendationCategory category, Chart chart, RecordedPhoenixScore? score,
+        string stampedDetail)
     {
         var detail = category switch
         {
@@ -359,6 +361,8 @@ else
                 L["{0} to PG", (1000000 - (int)score.Score.Value).ToString("N0")].Value,
             RecommendationCategory.RevisitOldScores when score != null =>
                 L["{0} days old", (int)(Clock.Now - score.RecordedDate).TotalDays].Value,
+            // The engine ranks these and stamps the projected "+N" gain onto the row.
+            RecommendationCategory.PushPumbility => stampedDetail,
             _ => null
         };
         var isFill = category == RecommendationCategory.FillScores;
@@ -386,7 +390,8 @@ else
     {
         RecommendationCategories.SkillTitles, RecommendationCategories.PushPGs,
         RecommendationCategories.ImproveTop50, RecommendationCategories.RevisitOldScores,
-        RecommendationCategories.FillScores, RecommendationCategories.WeeklyCharts
+        RecommendationCategories.FillScores, RecommendationCategories.WeeklyCharts,
+        RecommendationCategories.PushPumbility
     };
 
     private static string? CategoryName(RecommendationCategory category)
@@ -399,6 +404,7 @@ else
             RecommendationCategory.RevisitOldScores => RecommendationCategories.RevisitOldScores,
             RecommendationCategory.FillScores => RecommendationCategories.FillScores,
             RecommendationCategory.WeeklyCharts => RecommendationCategories.WeeklyCharts,
+            RecommendationCategory.PushPumbility => RecommendationCategories.PushPumbility,
             _ => null
         };
     }

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -3542,4 +3542,49 @@
   <data name="{0} on the board" xml:space="preserve">
     <value>{0} on the board</value>
   </data>
+  <data name="Account Stats" xml:space="preserve">
+    <value>Account Stats</value>
+  </data>
+  <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
+    <value>Your Pumbility and competitive level, plus your closest matches.</value>
+  </data>
+  <data name="Pumbility" xml:space="preserve">
+    <value>Pumbility</value>
+  </data>
+  <data name="Match players on" xml:space="preserve">
+    <value>Match players on</value>
+  </data>
+  <data name="Singles competitive level" xml:space="preserve">
+    <value>Singles competitive level</value>
+  </data>
+  <data name="Doubles competitive level" xml:space="preserve">
+    <value>Doubles competitive level</value>
+  </data>
+  <data name="Combined competitive level" xml:space="preserve">
+    <value>Combined competitive level</value>
+  </data>
+  <data name="Your closest matches show at 1×2 and taller." xml:space="preserve">
+    <value>Your closest matches show at 1×2 and taller.</value>
+  </data>
+  <data name="Closest · Singles" xml:space="preserve">
+    <value>Closest · Singles</value>
+  </data>
+  <data name="Closest · Doubles" xml:space="preserve">
+    <value>Closest · Doubles</value>
+  </data>
+  <data name="Closest · Combined" xml:space="preserve">
+    <value>Closest · Combined</value>
+  </data>
+  <data name="No close matches yet." xml:space="preserve">
+    <value>No close matches yet.</value>
+  </data>
+  <data name="Pumbility Push" xml:space="preserve">
+    <value>Pumbility Push</value>
+  </data>
+  <data name="Suggested · Pumbility Push" xml:space="preserve">
+    <value>Suggested · Pumbility Push</value>
+  </data>
+  <data name="The biggest Pumbility gains available to you right now." xml:space="preserve">
+    <value>The biggest Pumbility gains available to you right now.</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -3465,4 +3465,49 @@
   <data name="{0} on the board" xml:space="preserve">
     <value>{0} on the board</value>
   </data>
+  <data name="Account Stats" xml:space="preserve">
+    <value>Account Mrglstats</value>
+  </data>
+  <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
+    <value>Yer Pumbility an' competitive level, plus yer closest mrglmates.</value>
+  </data>
+  <data name="Pumbility" xml:space="preserve">
+    <value>Pumbility</value>
+  </data>
+  <data name="Match players on" xml:space="preserve">
+    <value>Mrgl players by</value>
+  </data>
+  <data name="Singles competitive level" xml:space="preserve">
+    <value>Mrglargrlrgl Grrrmrrglmrg Rglmrgl</value>
+  </data>
+  <data name="Doubles competitive level" xml:space="preserve">
+    <value>Argrlargl Grrrmrrglmrg Rglmrgl</value>
+  </data>
+  <data name="Combined competitive level" xml:space="preserve">
+    <value>Combined Grrrmrrglmrg Rglmrgl</value>
+  </data>
+  <data name="Your closest matches show at 1×2 and taller." xml:space="preserve">
+    <value>Yer closest mrglmates show at 1×2 an' bigger.</value>
+  </data>
+  <data name="Closest · Singles" xml:space="preserve">
+    <value>Closest · Mrglargrlrgl</value>
+  </data>
+  <data name="Closest · Doubles" xml:space="preserve">
+    <value>Closest · Argrlargl</value>
+  </data>
+  <data name="Closest · Combined" xml:space="preserve">
+    <value>Closest · Combined</value>
+  </data>
+  <data name="No close matches yet." xml:space="preserve">
+    <value>No close mrglmates yet.</value>
+  </data>
+  <data name="Pumbility Push" xml:space="preserve">
+    <value>Pumbility Mrgl Push</value>
+  </data>
+  <data name="Suggested · Pumbility Push" xml:space="preserve">
+    <value>Suggested · Pumbility Mrgl Push</value>
+  </data>
+  <data name="The biggest Pumbility gains available to you right now." xml:space="preserve">
+    <value>The biggest Pumbility gains available to mrgl right now.</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -3420,4 +3420,49 @@
   <data name="{0} on the board" xml:space="preserve">
     <value>{0} en el tablero</value>
   </data>
+  <data name="Account Stats" xml:space="preserve">
+    <value>Estadísticas de cuenta</value>
+  </data>
+  <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
+    <value>Tu Pumbility y nivel competitivo, además de tus rivales más cercanos.</value>
+  </data>
+  <data name="Pumbility" xml:space="preserve">
+    <value>Pumbility</value>
+  </data>
+  <data name="Match players on" xml:space="preserve">
+    <value>Emparejar jugadores por</value>
+  </data>
+  <data name="Singles competitive level" xml:space="preserve">
+    <value>Nivel competitivo de Singles</value>
+  </data>
+  <data name="Doubles competitive level" xml:space="preserve">
+    <value>Nivel competitivo de Doubles</value>
+  </data>
+  <data name="Combined competitive level" xml:space="preserve">
+    <value>Nivel competitivo combinado</value>
+  </data>
+  <data name="Your closest matches show at 1×2 and taller." xml:space="preserve">
+    <value>Tus rivales más cercanos aparecen en 1×2 o más grande.</value>
+  </data>
+  <data name="Closest · Singles" xml:space="preserve">
+    <value>Más cercanos · Singles</value>
+  </data>
+  <data name="Closest · Doubles" xml:space="preserve">
+    <value>Más cercanos · Doubles</value>
+  </data>
+  <data name="Closest · Combined" xml:space="preserve">
+    <value>Más cercanos · Combinado</value>
+  </data>
+  <data name="No close matches yet." xml:space="preserve">
+    <value>Aún no hay rivales cercanos.</value>
+  </data>
+  <data name="Pumbility Push" xml:space="preserve">
+    <value>Subida de Pumbility</value>
+  </data>
+  <data name="Suggested · Pumbility Push" xml:space="preserve">
+    <value>Sugeridos · Subida de Pumbility</value>
+  </data>
+  <data name="The biggest Pumbility gains available to you right now." xml:space="preserve">
+    <value>Las mayores subidas de Pumbility disponibles para ti ahora mismo.</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -3422,4 +3422,49 @@
   <data name="{0} on the board" xml:space="preserve">
     <value>{0} en el tablero</value>
   </data>
+  <data name="Account Stats" xml:space="preserve">
+    <value>Estadísticas de cuenta</value>
+  </data>
+  <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
+    <value>Tu Pumbility y nivel competitivo, además de tus rivales más cercanos.</value>
+  </data>
+  <data name="Pumbility" xml:space="preserve">
+    <value>Pumbility</value>
+  </data>
+  <data name="Match players on" xml:space="preserve">
+    <value>Emparejar jugadores por</value>
+  </data>
+  <data name="Singles competitive level" xml:space="preserve">
+    <value>Nivel competitivo de Simples</value>
+  </data>
+  <data name="Doubles competitive level" xml:space="preserve">
+    <value>Nivel competitivo de Dobles</value>
+  </data>
+  <data name="Combined competitive level" xml:space="preserve">
+    <value>Nivel competitivo combinado</value>
+  </data>
+  <data name="Your closest matches show at 1×2 and taller." xml:space="preserve">
+    <value>Tus rivales más cercanos aparecen en 1×2 o más grande.</value>
+  </data>
+  <data name="Closest · Singles" xml:space="preserve">
+    <value>Más cercanos · Simples</value>
+  </data>
+  <data name="Closest · Doubles" xml:space="preserve">
+    <value>Más cercanos · Dobles</value>
+  </data>
+  <data name="Closest · Combined" xml:space="preserve">
+    <value>Más cercanos · Combinado</value>
+  </data>
+  <data name="No close matches yet." xml:space="preserve">
+    <value>Aún no hay rivales cercanos.</value>
+  </data>
+  <data name="Pumbility Push" xml:space="preserve">
+    <value>Subida de Pumbility</value>
+  </data>
+  <data name="Suggested · Pumbility Push" xml:space="preserve">
+    <value>Sugeridos · Subida de Pumbility</value>
+  </data>
+  <data name="The biggest Pumbility gains available to you right now." xml:space="preserve">
+    <value>Las mayores subidas de Pumbility disponibles para ti ahora mismo.</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -3540,4 +3540,49 @@
   <data name="{0} on the board" xml:space="preserve">
     <value>{0} au classement</value>
   </data>
+  <data name="Account Stats" xml:space="preserve">
+    <value>Statistiques du compte</value>
+  </data>
+  <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
+    <value>Ton Pumbility et ton niveau compétitif, plus tes rivaux les plus proches.</value>
+  </data>
+  <data name="Pumbility" xml:space="preserve">
+    <value>Pumbility</value>
+  </data>
+  <data name="Match players on" xml:space="preserve">
+    <value>Associer les joueurs selon</value>
+  </data>
+  <data name="Singles competitive level" xml:space="preserve">
+    <value>Niveau compétitif Singles</value>
+  </data>
+  <data name="Doubles competitive level" xml:space="preserve">
+    <value>Niveau compétitif Doubles</value>
+  </data>
+  <data name="Combined competitive level" xml:space="preserve">
+    <value>Niveau compétitif combiné</value>
+  </data>
+  <data name="Your closest matches show at 1×2 and taller." xml:space="preserve">
+    <value>Tes rivaux les plus proches apparaissent en 1×2 et plus grand.</value>
+  </data>
+  <data name="Closest · Singles" xml:space="preserve">
+    <value>Plus proches · Singles</value>
+  </data>
+  <data name="Closest · Doubles" xml:space="preserve">
+    <value>Plus proches · Doubles</value>
+  </data>
+  <data name="Closest · Combined" xml:space="preserve">
+    <value>Plus proches · Combiné</value>
+  </data>
+  <data name="No close matches yet." xml:space="preserve">
+    <value>Pas encore de rivaux proches.</value>
+  </data>
+  <data name="Pumbility Push" xml:space="preserve">
+    <value>Poussée de Pumbility</value>
+  </data>
+  <data name="Suggested · Pumbility Push" xml:space="preserve">
+    <value>Suggérés · Poussée de Pumbility</value>
+  </data>
+  <data name="The biggest Pumbility gains available to you right now." xml:space="preserve">
+    <value>Les plus gros gains de Pumbility disponibles pour toi en ce moment.</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -3542,4 +3542,49 @@
   <data name="{0} on the board" xml:space="preserve">
     <value>{0} in classifica</value>
   </data>
+  <data name="Account Stats" xml:space="preserve">
+    <value>Statistiche account</value>
+  </data>
+  <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
+    <value>Il tuo Pumbility e livello competitivo, più i rivali più vicini a te.</value>
+  </data>
+  <data name="Pumbility" xml:space="preserve">
+    <value>Pumbility</value>
+  </data>
+  <data name="Match players on" xml:space="preserve">
+    <value>Abbina i giocatori per</value>
+  </data>
+  <data name="Singles competitive level" xml:space="preserve">
+    <value>Livello competitivo Singles</value>
+  </data>
+  <data name="Doubles competitive level" xml:space="preserve">
+    <value>Livello competitivo Doubles</value>
+  </data>
+  <data name="Combined competitive level" xml:space="preserve">
+    <value>Livello competitivo combinato</value>
+  </data>
+  <data name="Your closest matches show at 1×2 and taller." xml:space="preserve">
+    <value>I tuoi rivali più vicini compaiono in 1×2 e formati più grandi.</value>
+  </data>
+  <data name="Closest · Singles" xml:space="preserve">
+    <value>Più vicini · Singles</value>
+  </data>
+  <data name="Closest · Doubles" xml:space="preserve">
+    <value>Più vicini · Doubles</value>
+  </data>
+  <data name="Closest · Combined" xml:space="preserve">
+    <value>Più vicini · Combinato</value>
+  </data>
+  <data name="No close matches yet." xml:space="preserve">
+    <value>Ancora nessun rivale vicino.</value>
+  </data>
+  <data name="Pumbility Push" xml:space="preserve">
+    <value>Spinta al Pumbility</value>
+  </data>
+  <data name="Suggested · Pumbility Push" xml:space="preserve">
+    <value>Suggeriti · Spinta al Pumbility</value>
+  </data>
+  <data name="The biggest Pumbility gains available to you right now." xml:space="preserve">
+    <value>I maggiori guadagni di Pumbility disponibili per te in questo momento.</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -3543,4 +3543,49 @@
   <data name="{0} on the board" xml:space="preserve">
     <value>{0}人が参加中</value>
   </data>
+  <data name="Account Stats" xml:space="preserve">
+    <value>アカウント統計</value>
+  </data>
+  <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
+    <value>あなたのPumbilityと競技レベル、そして最も近いライバル。</value>
+  </data>
+  <data name="Pumbility" xml:space="preserve">
+    <value>Pumbility</value>
+  </data>
+  <data name="Match players on" xml:space="preserve">
+    <value>プレイヤーの一致基準</value>
+  </data>
+  <data name="Singles competitive level" xml:space="preserve">
+    <value>Singlesの競技レベル</value>
+  </data>
+  <data name="Doubles competitive level" xml:space="preserve">
+    <value>Doublesの競技レベル</value>
+  </data>
+  <data name="Combined competitive level" xml:space="preserve">
+    <value>総合競技レベル</value>
+  </data>
+  <data name="Your closest matches show at 1×2 and taller." xml:space="preserve">
+    <value>最も近いライバルは1×2以上のサイズで表示されます。</value>
+  </data>
+  <data name="Closest · Singles" xml:space="preserve">
+    <value>最も近い · Singles</value>
+  </data>
+  <data name="Closest · Doubles" xml:space="preserve">
+    <value>最も近い · Doubles</value>
+  </data>
+  <data name="Closest · Combined" xml:space="preserve">
+    <value>最も近い · 総合</value>
+  </data>
+  <data name="No close matches yet." xml:space="preserve">
+    <value>近いライバルはまだいません。</value>
+  </data>
+  <data name="Pumbility Push" xml:space="preserve">
+    <value>Pumbility更新</value>
+  </data>
+  <data name="Suggested · Pumbility Push" xml:space="preserve">
+    <value>おすすめ · Pumbility更新</value>
+  </data>
+  <data name="The biggest Pumbility gains available to you right now." xml:space="preserve">
+    <value>今のあなたが狙えるPumbilityの伸びが大きい順。</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -3423,4 +3423,49 @@
   <data name="{0} on the board" xml:space="preserve">
     <value>{0}명 참여 중</value>
   </data>
+  <data name="Account Stats" xml:space="preserve">
+    <value>계정 통계</value>
+  </data>
+  <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
+    <value>당신의 Pumbility와 경쟁 레벨, 그리고 가장 가까운 상대.</value>
+  </data>
+  <data name="Pumbility" xml:space="preserve">
+    <value>Pumbility</value>
+  </data>
+  <data name="Match players on" xml:space="preserve">
+    <value>매칭 기준</value>
+  </data>
+  <data name="Singles competitive level" xml:space="preserve">
+    <value>싱글 경쟁 레벨</value>
+  </data>
+  <data name="Doubles competitive level" xml:space="preserve">
+    <value>더블 경쟁 레벨</value>
+  </data>
+  <data name="Combined competitive level" xml:space="preserve">
+    <value>종합 경쟁 레벨</value>
+  </data>
+  <data name="Your closest matches show at 1×2 and taller." xml:space="preserve">
+    <value>가장 가까운 상대는 1×2 이상 크기에서 표시됩니다.</value>
+  </data>
+  <data name="Closest · Singles" xml:space="preserve">
+    <value>가장 가까움 · 싱글</value>
+  </data>
+  <data name="Closest · Doubles" xml:space="preserve">
+    <value>가장 가까움 · 더블</value>
+  </data>
+  <data name="Closest · Combined" xml:space="preserve">
+    <value>가장 가까움 · 종합</value>
+  </data>
+  <data name="No close matches yet." xml:space="preserve">
+    <value>아직 가까운 상대가 없습니다.</value>
+  </data>
+  <data name="Pumbility Push" xml:space="preserve">
+    <value>Pumbility 올리기</value>
+  </data>
+  <data name="Suggested · Pumbility Push" xml:space="preserve">
+    <value>추천 · Pumbility 올리기</value>
+  </data>
+  <data name="The biggest Pumbility gains available to you right now." xml:space="preserve">
+    <value>지금 당신이 얻을 수 있는 가장 큰 Pumbility 상승.</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -3491,4 +3491,49 @@
   <data name="{0} on the board" xml:space="preserve">
     <value>{0} no ranking</value>
   </data>
+  <data name="Account Stats" xml:space="preserve">
+    <value>Estatísticas da conta</value>
+  </data>
+  <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
+    <value>Seu Pumbility e nível competitivo, além dos seus rivais mais próximos.</value>
+  </data>
+  <data name="Pumbility" xml:space="preserve">
+    <value>Pumbility</value>
+  </data>
+  <data name="Match players on" xml:space="preserve">
+    <value>Combinar jogadores por</value>
+  </data>
+  <data name="Singles competitive level" xml:space="preserve">
+    <value>Nível competitivo de Singles</value>
+  </data>
+  <data name="Doubles competitive level" xml:space="preserve">
+    <value>Nível competitivo de Doubles</value>
+  </data>
+  <data name="Combined competitive level" xml:space="preserve">
+    <value>Nível competitivo combinado</value>
+  </data>
+  <data name="Your closest matches show at 1×2 and taller." xml:space="preserve">
+    <value>Seus rivais mais próximos aparecem em 1×2 ou maior.</value>
+  </data>
+  <data name="Closest · Singles" xml:space="preserve">
+    <value>Mais próximos · Singles</value>
+  </data>
+  <data name="Closest · Doubles" xml:space="preserve">
+    <value>Mais próximos · Doubles</value>
+  </data>
+  <data name="Closest · Combined" xml:space="preserve">
+    <value>Mais próximos · Combinado</value>
+  </data>
+  <data name="No close matches yet." xml:space="preserve">
+    <value>Ainda não há rivais próximos.</value>
+  </data>
+  <data name="Pumbility Push" xml:space="preserve">
+    <value>Subida de Pumbility</value>
+  </data>
+  <data name="Suggested · Pumbility Push" xml:space="preserve">
+    <value>Sugeridos · Subida de Pumbility</value>
+  </data>
+  <data name="The biggest Pumbility gains available to you right now." xml:space="preserve">
+    <value>Os maiores ganhos de Pumbility disponíveis para você agora.</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Services/HomeDashboard/WidgetRegistry.cs
+++ b/ScoreTracker/ScoreTracker/Services/HomeDashboard/WidgetRegistry.cs
@@ -27,13 +27,15 @@ public static class WidgetRegistry
             typeof(CompetitiveLevelWidget),
             typeof(CompetitiveLevelConfigPanel),
             typeof(CompetitiveLevelConfig)),
+        // TypeId stays "pumbility" (public export vocabulary, never renamed) though the
+        // widget is now Account Stats. 1x2+ adds the closest-competitive-matches list.
         new("pumbility",
-            "PUMBILITY",
-            "Pumbility targets tuned to your skill profile.",
+            "Account Stats",
+            "Your Pumbility and competitive level, plus your closest matches.",
             WidgetCategory.Progress,
-            Icons.Material.Filled.TrendingUp,
-            new[] { SizePreset.OneByOne, SizePreset.TwoByOne, SizePreset.OneByTwo },
-            SizePreset.TwoByOne,
+            Icons.Material.Filled.Leaderboard,
+            new[] { SizePreset.OneByOne, SizePreset.OneByTwo, SizePreset.OneByThree },
+            SizePreset.OneByTwo,
             new[] { MixEnum.Phoenix, MixEnum.Phoenix2 },
             typeof(PumbilityWidget),
             typeof(PumbilityConfigPanel),
@@ -110,7 +112,10 @@ public static class WidgetRegistry
                         // Fills reach down by identity; nothing above by default.
                         SpreadBelow = 3,
                         SpreadAbove = 0
-                    }))
+                    })),
+                new WidgetDrawerPreset("Suggested · Pumbility Push",
+                    "The biggest Pumbility gains available to you right now.",
+                    WidgetConfigJson.Write(new SuggestedChartsConfig { Goal = SuggestedGoal.PumbilityPush }))
             },
             // Instance titles follow the configured goal so rapid-firing all three
             // presets never yields three "Suggested Charts" (owner, field test).
@@ -119,6 +124,7 @@ public static class WidgetRegistry
                 {
                     SuggestedGoal.ScorePush => "Suggested · Score Push",
                     SuggestedGoal.FillGaps => "Suggested · Fill Gaps",
+                    SuggestedGoal.PumbilityPush => "Suggested · Pumbility Push",
                     _ => "Suggested · Title Hunt"
                 },
             RefreshIcon: Icons.Material.Filled.Shuffle,

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -2868,8 +2868,40 @@ html.nav-away .page-dock,
 
 .dash-acct-hero {
     display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.dash-acct-total {
+    display: inline-flex;
     align-items: baseline;
-    gap: 10px;
+    gap: 8px;
+    flex: none;
+}
+
+/* S/D Pumbility pools stacked to the right of the big total (owner, field-test). */
+.dash-acct-pools {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+    font-size: .82rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.dash-acct-poolrow {
+    display: flex;
+    gap: 6px;
+    align-items: baseline;
+    white-space: nowrap;
+}
+
+.dash-acct-poolrow > span:first-child {
+    font-weight: 600;
+}
+
+.dash-acct-poolnum {
+    font-weight: 700;
 }
 
 .dash-acct-active {
@@ -2951,12 +2983,6 @@ html.nav-away .page-dock,
 
 .dash-acct-lvl {
     font-weight: 700;
-    font-variant-numeric: tabular-nums;
-}
-
-.dash-acct-gap {
-    font-size: .68rem;
-    color: var(--mud-palette-text-disabled);
     font-variant-numeric: tabular-nums;
 }
 

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -2838,6 +2838,147 @@ html.nav-away .page-dock,
     font-variant-numeric: tabular-nums;
 }
 
+/* Account Stats widget: glowy Pumbility + competitive level, then the closest matches. */
+.dash-acct {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    flex: 1;
+    min-height: 0;
+}
+
+.dash-acct-stats {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: none;
+}
+
+.dash-acct-eyebrow {
+    font-size: .6rem;
+    text-transform: uppercase;
+    letter-spacing: .1em;
+    font-weight: 700;
+    color: var(--mud-palette-text-disabled);
+}
+
+.dash-acct-cl-eyebrow {
+    margin-top: 6px;
+}
+
+.dash-acct-hero {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+}
+
+.dash-acct-active {
+    box-shadow: 0 2px 0 var(--mix-primary);
+}
+
+.dash-acct-matches {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    border-top: 1px solid rgba(255, 255, 255, .06);
+    padding-top: 8px;
+}
+
+.dash-acct-mhead {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.dash-acct-mlabel {
+    font-size: .6rem;
+    text-transform: uppercase;
+    letter-spacing: .1em;
+    font-weight: 700;
+    color: var(--mud-palette-text-disabled);
+}
+
+.dash-acct-you {
+    font-size: .72rem;
+    color: var(--mud-palette-text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+
+.dash-acct-you b {
+    color: var(--daily-you);
+    font-weight: 700;
+}
+
+.dash-acct-mlist {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    overflow-y: auto;
+    min-height: 0;
+}
+
+.dash-acct-who {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+}
+
+.dash-acct-av {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex: none;
+}
+
+.dash-acct-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+
+.dash-acct-trail {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    white-space: nowrap;
+}
+
+.dash-acct-lvl {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+.dash-acct-gap {
+    font-size: .68rem;
+    color: var(--mud-palette-text-disabled);
+    font-variant-numeric: tabular-nums;
+}
+
+.dash-acct-empty {
+    font-size: .72rem;
+    font-style: italic;
+    color: var(--mud-palette-text-disabled);
+    padding: 8px 4px;
+    text-align: center;
+}
+
+.dash-acct-mixpill {
+    font-size: .58rem;
+    font-weight: 800;
+    letter-spacing: .03em;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--mix-primary) 16%, transparent);
+    color: var(--mix-primary);
+    border: 1px solid color-mix(in srgb, var(--mix-primary) 40%, transparent);
+}
+
 /* Daily Step widget (docs/design/daily-step.md): the shared daily chart as a leaderboard card. */
 
 /* Row-highlight tokens, global so the leaderboard dialog can glow too: you (blue), community (green). */

--- a/docs/design/home-page-widgets.md
+++ b/docs/design/home-page-widgets.md
@@ -231,7 +231,20 @@ Pumbility widget consumes finished contracts.
   next import." Error isolated.
 - **Mixes**: Phoenix, Phoenix 2 (multi).
 
-### W2 — Pumbility (data: PlayerProgress)
+### W2 — Account Stats (data: PlayerProgress)
+
+> **Refactor (2026-07-13): Pumbility widget → Account Stats.** The glowy total Pumbility + S/D pools
+> stay and **competitive level (S/D)** joins them. The **projected-target list moved out** to Suggested
+> Charts' new **Pumbility Push** goal (§4) — gain-ranked, not the random Improve-Top-50 category. At
+> **1×2 and taller** the widget adds your **closest competitive matches**: the nearest 25 players within
+> **±1.0** on the configured dimension (Singles / Doubles / Combined → `GetCompetitiveNeighborsQuery`,
+> range + top-N ordered in SQL), eligibility = **public OR in your non-region communities** (the
+> `CommunityGlowReader` set, which also drives the **green glow**, mirroring the weekly/daily boards);
+> rows link to `/Player/{id}/Sessions`. Config drops show-projections / dismissed-charts and gains a
+> **Match dimension**; the **Mix** override follows the current mix but falls back to **Phoenix 2** on
+> pre-Phoenix mixes, and a pinned mix that differs from the current one shows as a pill in the title.
+> Sizes are now **1×1 / 1×2 / 1×3**. TypeId stays `pumbility` (export vocabulary). The historical W2
+> spec below describes the original Pumbility widget.
 
 - **Data**: `GetPlayerStatsQuery` → `SkillRating` (the merged top-50; + `SinglesRating`/`DoublesRating`
   for the per-pool sub-line — note `SkillRating` is NOT their sum); `ProjectPumbilityGainsQuery` → `PumbilityProjection.ProjectedGains` → top entry(ies),
@@ -353,7 +366,10 @@ scoring-level basis** toggle (`GetChartScoringLevelsQuery`, printed-level fallba
 re-roll in the body meta row. The page's vestigial `LevelOffset` UI is superseded by the level modes.
 
 - **Goal bundles** (`SuggestedGoal` → engine categories): *Title Hunt* = PushLevel + SkillTitles ·
-  *Score Push* = PushPGs + ImproveTop50 + RevisitOldScores · *Fill Gaps* = FillScores. The Weekly
+  *Score Push* = PushPGs + ImproveTop50 + RevisitOldScores · *Fill Gaps* = FillScores · *Pumbility
+  Push* = PushPumbility (2026-07-13: the gain-ranked projected targets that moved off the Account Stats
+  widget — `ProjectPumbilityGainsQuery`, biggest overall-rating gain first, stamps "+N"; distinct from
+  the random ImproveTop50, and has its own drawer preset). The Weekly
   category is dropped from the widget — the Weekly widget owns that board. Defaults per drawer preset:
   Score Push = Any level; Fill Gaps = Dynamic ±3.
 - **Engine** (`RecommendedChartsSaga`): `GetRecommendedChartsQuery` gained additive `Categories` +


### PR DESCRIPTION
## What

Renames the **Pumbility** widget to **Account Stats** (TypeId `pumbility` unchanged — export vocabulary) and reshapes it, and moves the projected-target list into **Suggested Charts** as a new goal.

### Account Stats widget
- Keeps the glowy total Pumbility + S/D pools (now stacked right of the total); adds **competitive level** (S/D) beneath.
- At **1×2 / 1×3**, shows your **closest 25 competitive matches** within **±1.0** on the configured dimension — **public players or your non-region community mates** (green glow, same set the weekly/daily boards use); rows link to `/Player/{id}/Sessions`.
- Config: **Mix** (Follow current → Phoenix 2 on pre-Phoenix mixes / P1 / P2, with a title pill on mismatch) + **Match dimension** (Singles / Doubles / Combined). Sizes now 1×1 / 1×2 / 1×3.

### Suggested Charts › Pumbility Push (new goal + drawer preset)
- New `PushPumbility` category wrapping the existing `ProjectPumbilityGainsQuery`, **gain-ranked** with a "+N" — distinct from the random *Improve Your Top 50*.

## How
- New `GetCompetitiveNeighbors` read query (range + top-N ordered in SQL; eligibility/community layered in Web where `CommunityGlowReader`/`IsPublic` live — no cross-vertical join). No new tables/migrations.
- l10n across all 9 locales; `docs/design/home-page-widgets.md` updated.

## Tests
Fast suites green — Tests **1259** / Api **60** (goldens regenerated) / Components **48** (3 new Account Stats tests) — and a Release solution build with 0 errors. New saga tests cover Pumbility Push ranking/exclusions; component tests cover stats render + match eligibility/glow + the combined-dimension query.

## Notes
- Old 2×1 instances render stats-only (2×1 dropped from the size list); legacy config fields (`showProjections`/`dismissedCharts`) are ignored by the tolerant importer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)