### PR TITLE
Mobile: a Search slot, because a phone had no way to reach a chart page

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.E2E/StaticShellTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/StaticShellTests.cs
@@ -71,7 +71,10 @@ public sealed class StaticShellTests : IAsyncLifetime
 
         await _page.GotoAsync("/TierLists");
 
-        var search = _page.Locator(".appbar-search input");
+        // Scoped to the header: the same island is mounted twice now — app bar on desktop,
+        // search sheet on mobile — so ".appbar-search" alone names two inputs. This one is
+        // the desktop's; the sheet's is the phone's only door to a chart page.
+        var search = _page.Locator("header .appbar-search input");
         await Expect(search).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 60_000 });
 
         // Typed, not filled: MudAutocomplete opens off the keystrokes.

--- a/ScoreTracker/ScoreTracker.Tests.E2E/StaticShellTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/StaticShellTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using ScoreTracker.Tests.E2E.Support;
 using static Microsoft.Playwright.Assertions;
@@ -88,6 +89,35 @@ public sealed class StaticShellTests : IAsyncLifetime
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
         await Expect(_page.Locator(".mud-popover-open").GetByText("Conflict").First).ToBeVisibleAsync();
 
+        Assert.Empty(errors);
+    }
+
+    /// <summary>
+    ///     A phone's only door to /Chart/{id} — /Charts lists charts without linking to one, so
+    ///     before this sheet existed there was no route at all. Three things have to hold at
+    ///     once and only a hosted run can see any of them: nav.js opens a sheet it did not
+    ///     render, an INTERACTIVE island renders inside STATIC shell chrome (the first place
+    ///     the shell does this), and the field is focused by the opening click so the keyboard
+    ///     comes up with it.
+    /// </summary>
+    [Fact]
+    public async Task TheMobileSearchSheetOpensFocusedOnItsField()
+    {
+        var errors = new List<string>();
+        _page.PageError += (_, e) => errors.Add(e);
+
+        // Below the shell's 960px breakpoint, where the bottom nav takes over from the top nav.
+        await _page.SetViewportSizeAsync(390, 844);
+        await _page.GotoAsync("/TierLists");
+
+        var field = _page.Locator("[data-search-sheet] input");
+        // The island fills static chrome, so it arrives with the circuit rather than the HTML.
+        await Expect(field).ToBeAttachedAsync(new LocatorAssertionsToBeAttachedOptions { Timeout = 60_000 });
+
+        await _page.Locator("[data-search-btn]").ClickAsync();
+
+        await Expect(_page.Locator("[data-search-sheet]")).ToHaveClassAsync(new Regex(@"\bopen\b"));
+        await Expect(field).ToBeFocusedAsync();
         Assert.Empty(errors);
     }
 }

--- a/ScoreTracker/ScoreTracker/App.razor
+++ b/ScoreTracker/ScoreTracker/App.razor
@@ -70,6 +70,7 @@
     <ShellUserMenu Model="_shell" />
 </header>
 <ShellMoreSheet Model="_shell" />
+<ShellSearchSheet Model="_shell" />
 <ShellBottomNav Model="_shell" />
 @* Renders nothing; it drives the hidden pulse dot the shell put in the avatar. *@
 <ShellImportPulse @rendermode="Interactive" />

--- a/ScoreTracker/ScoreTracker/Components/AppBarSearch.razor
+++ b/ScoreTracker/ScoreTracker/Components/AppBarSearch.razor
@@ -2,9 +2,11 @@
 @using ScoreTracker.SharedKernel.Enums
 @inject NavigationManager NavManager
 
-@* The app bar's chart search. An island: the shell around it is static HTML, but an
-   autocomplete needs a circuit. Desktop only, as it was under MudHidden. *@
-<div class="d-flex align-center appbar-search mr-3 shell-desktop-only" style="min-width: 170px; max-width: 220px;">
+@* The chart search. An island: the shell around it is static HTML, but an autocomplete needs
+   a circuit. Mounted twice — the app bar on desktop, the search sheet on mobile — because it
+   is the same question in two places and the answer must not drift; the caller supplies the
+   frame, this owns the behaviour. *@
+<div class="@Class" style="@Style">
     <ChartSelector Mix="Mix" Label="" Placeholder="@L["Find a chart"].Value" Variant="Variant.Outlined"
                    Margin="Margin.Dense" ChartIdSelected="GoToChart"></ChartSelector>
 </div>
@@ -12,8 +14,15 @@
 @code {
     [Parameter] public MixEnum Mix { get; set; } = MixEnum.Phoenix;
 
+    /// <summary>The frame is the caller's — an app-bar slot and a sheet want different boxes.</summary>
+    [Parameter] public string Class { get; set; } = "d-flex align-center appbar-search mr-3 shell-desktop-only";
+
+    [Parameter] public string? Style { get; set; } = "min-width: 170px; max-width: 220px;";
+
     private Task GoToChart(Chart chart)
     {
+        // nav.js closes the mobile sheet off the history push this causes — the sheet is
+        // chrome over the page you left, and no link click happens here to catch.
         NavManager.NavigateTo($"/Chart/{chart.Id}");
         return Task.CompletedTask;
     }

--- a/ScoreTracker/ScoreTracker/Components/Shell/ShellBottomNav.razor
+++ b/ScoreTracker/ScoreTracker/Components/Shell/ShellBottomNav.razor
@@ -12,7 +12,6 @@
         <a href="/" data-href="/" class="@BnClass("/")"><MudIcon Icon="@Icons.Material.Filled.Home" Size="Size.Small"></MudIcon><span>@L["Play"]</span></a>
     }
     <a href="/TierLists" data-href="/TierLists" class="@BnClass("/TierLists")"><MudIcon Icon="@Icons.Material.Filled.Topic" Size="Size.Small"></MudIcon><span>@L["Tiers"]</span></a>
-    <a href="/Charts" data-href="/Charts" class="@BnClass("/Charts")"><MudIcon Icon="@Icons.Material.Filled.List" Size="Size.Small"></MudIcon><span>@L["Charts"]</span></a>
     @if (!Model.IsGatedMix)
     {
         <a href="/WeeklyCharts" data-href="/WeeklyCharts" class="@BnClass("/WeeklyCharts")"><MudIcon Icon="@Icons.Material.Filled.ViewWeek" Size="Size.Small"></MudIcon><span>@L["Weekly"]</span></a>
@@ -22,11 +21,16 @@
         @* The front door is a Razor Page, not a Blazor route. *@
         <a href="/Login" data-href="/Login" target="_top" class="@BnClass("/Login")"><MudIcon Icon="@Icons.Material.Filled.Login" Size="Size.Small"></MudIcon><span>@L["Login"]</span></a>
     }
-    @* Extra slot for squarish viewports (fold phones, landscape) — hidden on tall phones. *@
     @if (!Model.IsGatedMix)
     {
+        @* Extra slot for squarish viewports (fold phones, landscape) — hidden on tall phones. *@
         <a href="/Communities" data-href="/Communities" class="@($"{BnClass("/Communities")} bn-wide")"><MudIcon Icon="@Icons.Material.Filled.Group" Size="Size.Small"></MudIcon><span>@L["Communities"]</span></a>
     }
+    @* The phone's only door to a chart page. The full list took its slot into More: browsing
+       4,400 charts is rare and deliberate, while "take me to THIS chart" is the trip people
+       actually make — and it had no door here at all. Slot count is unchanged, so the wide-only
+       Communities slot still behaves as it did. *@
+    <button type="button" class="bn" data-search-btn aria-expanded="false"><MudIcon Icon="@Icons.Material.Filled.Search" Size="Size.Small"></MudIcon><span>@L["Search"]</span></button>
     <button type="button" class="bn" data-more-btn aria-expanded="false"><MudIcon Icon="@Icons.Material.Filled.MoreHoriz" Size="Size.Small"></MudIcon><span>@L["More"]</span></button>
 </nav>
 

--- a/ScoreTracker/ScoreTracker/Components/Shell/ShellMoreSheet.razor
+++ b/ScoreTracker/ScoreTracker/Components/Shell/ShellMoreSheet.razor
@@ -14,6 +14,11 @@
         {
             <ShellMenuItem Href="/UploadXXScores" Icon="@Icons.Material.Filled.CloudDownload">@L["Import Scores"]</ShellMenuItem>
         }
+        @* Top, because desktop keeps it in the Play menu and this sheet mirrors those groups.
+           It gave up its bottom-nav slot to Search: the list is where you go to browse, the
+           search is where you go when you already know the chart, and only one of those is
+           worth a permanent slot on a phone. *@
+        <ShellMenuItem Href="/Charts" Icon="@Icons.Material.Filled.List">@L["Charts"]</ShellMenuItem>
         @if (!Model.IsGatedMix)
         {
             <div class="nav-section">@L["My Progress"]</div>

--- a/ScoreTracker/ScoreTracker/Components/Shell/ShellSearchSheet.razor
+++ b/ScoreTracker/ScoreTracker/Components/Shell/ShellSearchSheet.razor
@@ -1,0 +1,26 @@
+@namespace ScoreTracker.Web.Components
+@using ScoreTracker.Web.Services
+
+@* The phone's door to a chart page. Before this there was none: /Charts listed charts but
+   never linked to one, so every route into /Chart/{id} ran through the app bar's search —
+   which is desktop-only — or a session highlight.
+   Static chrome, island filling: nav.js toggles .open exactly as it does for the More sheet,
+   and only the autocomplete inside pays for a circuit. Anchored to the top rather than the
+   bottom like More — the phone keyboard eats the bottom half of the screen the moment the
+   input takes focus, and a bottom-anchored field would open underneath it. *@
+<div class="more-sheet-scrim" data-sheet-scrim></div>
+<div class="search-sheet shell-mobile-only" data-search-sheet aria-hidden="true">
+    <div class="search-sheet-body">
+        <span class="search-sheet-label">@L["Find a chart"]</span>
+        @* Same pill as the app bar's — it is the same control, so it should not look like a
+           different one. Only the box around it changes. *@
+        <AppBarSearch @rendermode="Interactive" Mix="Model.CurrentMix"
+                      Class="appbar-search search-sheet-input" Style="" />
+    </div>
+</div>
+
+@code {
+    [Parameter] [EditorRequired] public ShellViewModel Model { get; set; } = null!;
+
+    private static readonly IComponentRenderMode Interactive = new InteractiveServerRenderMode(prerender: false);
+}

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -4409,4 +4409,7 @@
   <data name="The opposite is picked from everything in reach, so ranges don't apply to it" xml:space="preserve">
     <value>The opposite is picked from everything in reach, so ranges don't apply to it</value>
   </data>
+  <data name="Search" xml:space="preserve">
+    <value>Search</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -4332,4 +4332,7 @@
   <data name="The opposite is picked from everything in reach, so ranges don't apply to it" xml:space="preserve">
     <value>Da opposite gets picked from everythin in reachrgl, so rangesrgl don't apply to it</value>
   </data>
+  <data name="Search" xml:space="preserve">
+    <value>Srgl</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -4287,4 +4287,7 @@
   <data name="The opposite is picked from everything in reach, so ranges don't apply to it" xml:space="preserve">
     <value>El opuesto se elige entre todo lo que está al alcance, así que los rangos no se le aplican</value>
   </data>
+  <data name="Search" xml:space="preserve">
+    <value>Buscar</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -4289,4 +4289,7 @@
   <data name="The opposite is picked from everything in reach, so ranges don't apply to it" xml:space="preserve">
     <value>El opuesto se elige entre todo lo que está al alcance, así que los rangos no se le aplican</value>
   </data>
+  <data name="Search" xml:space="preserve">
+    <value>Buscar</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -4407,4 +4407,7 @@
   <data name="The opposite is picked from everything in reach, so ranges don't apply to it" xml:space="preserve">
     <value>L'opposé est choisi parmi tout ce qui est à portée, les plages ne s'y appliquent donc pas</value>
   </data>
+  <data name="Search" xml:space="preserve">
+    <value>Chercher</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -4409,4 +4409,7 @@
   <data name="The opposite is picked from everything in reach, so ranges don't apply to it" xml:space="preserve">
     <value>L'opposto è scelto fra tutto ciò che è a portata, quindi gli intervalli non si applicano</value>
   </data>
+  <data name="Search" xml:space="preserve">
+    <value>Cerca</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -4410,4 +4410,7 @@
   <data name="The opposite is picked from everything in reach, so ranges don't apply to it" xml:space="preserve">
     <value>対極は対象範囲全体から選ばれるため、範囲指定は適用されません</value>
   </data>
+  <data name="Search" xml:space="preserve">
+    <value>検索</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -4290,4 +4290,7 @@
   <data name="The opposite is picked from everything in reach, so ranges don't apply to it" xml:space="preserve">
     <value>정반대 채보는 비교 범위 전체에서 뽑히므로 범위 설정이 적용되지 않습니다</value>
   </data>
+  <data name="Search" xml:space="preserve">
+    <value>검색</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -4355,4 +4355,7 @@
   <data name="The opposite is picked from everything in reach, so ranges don't apply to it" xml:space="preserve">
     <value>O oposto é escolhido entre tudo que está ao alcance, então os intervalos não se aplicam a ele</value>
   </data>
+  <data name="Search" xml:space="preserve">
+    <value>Buscar</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -509,6 +509,60 @@ html.sheet-open .more-sheet-scrim {
     pointer-events: auto;
 }
 
+/* The search sheet drops from the TOP, unlike More. The phone keyboard takes the bottom half
+   of the screen the moment the input focuses, so a bottom-anchored field opens underneath the
+   thing typing into it. It is only as tall as it needs to be — this asks one question. */
+.search-sheet {
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: 0;
+    z-index: 1400;
+    background: var(--mix-nav);
+    border-bottom: 1px solid rgba(255, 255, 255, .10);
+    transform: translateY(-100%);
+    transition: transform .225s cubic-bezier(0, 0, .2, 1);
+}
+
+.search-sheet.open {
+    transform: translateY(0);
+}
+
+.search-sheet-body {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 14px 16px 18px;
+}
+
+.search-sheet-label {
+    font-family: var(--font-display);
+    font-size: .6875rem;
+    letter-spacing: .08em;
+    line-height: 1.4;
+    text-transform: uppercase;
+    color: var(--mix-ink-muted);
+}
+
+/* The autocomplete's popover is teleported to the provider at the document root, so it is
+   never clipped by this box — the sheet only has to frame the input. */
+.search-sheet-input {
+    display: flex;
+    align-items: center;
+}
+
+/* A thumb target, not an app-bar accent: taller than the desktop pill, and never under 16px
+   — iOS Safari zooms the whole viewport when a smaller input takes focus. */
+.search-sheet-input .mud-input.mud-input-outlined {
+    width: 100%;
+    border-radius: 10px;
+}
+
+.search-sheet-input .mud-input.mud-input-outlined input {
+    padding: 11px 14px;
+    font-size: 1rem;
+}
+
 .more-sheet .nav-section {
     padding: 12px 16px 2px;
     font-family: var(--font-display);

--- a/ScoreTracker/ScoreTracker/wwwroot/js/nav.js
+++ b/ScoreTracker/ScoreTracker/wwwroot/js/nav.js
@@ -42,21 +42,44 @@
         positionMenu(menu);
     }
 
-    // ===== More sheet =====
+    // ===== Sheets (More, Search) =====
 
-    function sheetIsOpen() {
-        var sheet = document.querySelector('[data-more-sheet]');
-        return !!sheet && sheet.classList.contains('open');
+    // Scrim-backed panels, at most one open at a time — they share the scrim, so two at once
+    // would fight over it. More rises from the bottom for thumb reach; Search drops from the
+    // top, because the keyboard takes the bottom half the moment its input focuses.
+    // Both are static shell HTML; the search sheet's autocomplete is an island INSIDE it,
+    // which is why the chrome opens from here and not from a circuit.
+    var SHEETS = [
+        { sheet: '[data-more-sheet]', button: '[data-more-btn]' },
+        { sheet: '[data-search-sheet]', button: '[data-search-btn]' }
+    ];
+
+    function sheetNode(spec) {
+        return document.querySelector(spec.sheet);
     }
 
-    function setSheet(open) {
-        var sheet = document.querySelector('[data-more-sheet]');
-        if (!sheet) return;
-        sheet.classList.toggle('open', open);
-        sheet.setAttribute('aria-hidden', String(!open));
-        var button = document.querySelector('[data-more-btn]');
+    function openSheet() {
+        for (var i = 0; i < SHEETS.length; i++) {
+            var node = sheetNode(SHEETS[i]);
+            if (node && node.classList.contains('open')) return SHEETS[i];
+        }
+        return null;
+    }
+
+    function setSheet(spec, open) {
+        var node = sheetNode(spec);
+        if (!node) return;
+        node.classList.toggle('open', open);
+        node.setAttribute('aria-hidden', String(!open));
+        var button = document.querySelector(spec.button);
         if (button) button.setAttribute('aria-expanded', String(open));
-        document.documentElement.classList.toggle('sheet-open', open);
+        // Read back rather than trust `open`: the flag means "some sheet is up".
+        document.documentElement.classList.toggle('sheet-open', !!openSheet());
+    }
+
+    function closeSheets() {
+        var spec = openSheet();
+        if (spec) setSheet(spec, false);
     }
 
     // ===== Bottom nav active slot =====
@@ -83,6 +106,10 @@
         history[name] = function () {
             var result = original.apply(this, arguments);
             refreshActiveNav();
+            // A sheet is chrome over the page it was opened from, so leaving that page
+            // closes it. The click handler catches links; it cannot catch the search
+            // autocomplete, which navigates from a circuit without one.
+            closeSheets();
             return result;
         };
     }
@@ -101,9 +128,13 @@
             return;
         }
 
-        if (el(target, '[data-more-btn]')) {
+        for (var i = 0; i < SHEETS.length; i++) {
+            if (!el(target, SHEETS[i].button)) continue;
             e.preventDefault();
-            setSheet(!sheetIsOpen());
+            var node = sheetNode(SHEETS[i]);
+            var wasOpen = !!node && node.classList.contains('open');
+            closeSheets();
+            if (!wasOpen) setSheet(SHEETS[i], true);
             return;
         }
 
@@ -112,8 +143,9 @@
 
         if (openMenu && !isSummary && (!el(target, '[data-menu]') || el(target, 'a'))) closeMenu();
 
-        if (sheetIsOpen() && !isSummary) {
-            if (el(target, '[data-sheet-scrim]') || el(target, 'a')) setSheet(false);
+        var open = openSheet();
+        if (open && !isSummary) {
+            if (el(target, '[data-sheet-scrim]') || el(target, 'a')) setSheet(open, false);
         }
     }
 
@@ -123,9 +155,14 @@
             var activator = openMenu.querySelector('[data-menu-activator]');
             closeMenu();
             if (activator) activator.focus();
-        } else if (sheetIsOpen()) {
-            setSheet(false);
-            var button = document.querySelector('[data-more-btn]');
+            return;
+        }
+
+        var spec = openSheet();
+        if (spec) {
+            setSheet(spec, false);
+            // Focus goes back to whichever button opened it, not always More.
+            var button = document.querySelector(spec.button);
             if (button) button.focus();
         }
     }

--- a/ScoreTracker/ScoreTracker/wwwroot/js/nav.js
+++ b/ScoreTracker/ScoreTracker/wwwroot/js/nav.js
@@ -51,7 +51,7 @@
     // which is why the chrome opens from here and not from a circuit.
     var SHEETS = [
         { sheet: '[data-more-sheet]', button: '[data-more-btn]' },
-        { sheet: '[data-search-sheet]', button: '[data-search-btn]' }
+        { sheet: '[data-search-sheet]', button: '[data-search-btn]', focus: 'input' }
     ];
 
     function sheetNode(spec) {
@@ -75,6 +75,18 @@
         if (button) button.setAttribute('aria-expanded', String(open));
         // Read back rather than trust `open`: the flag means "some sheet is up".
         document.documentElement.classList.toggle('sheet-open', !!openSheet());
+        if (open && spec.focus) focusInto(node, spec.focus);
+    }
+
+    // A sheet that exists to be typed into should be ready to type into. This has to run in
+    // the opening click's OWN call stack: iOS raises the keyboard only for a focus() it can
+    // trace back to a user gesture, so deferring it behind a timeout or the slide-in
+    // transition would open the sheet and leave the field cold.
+    // The field can legitimately be missing — it belongs to an island, and prerendering is
+    // off, so a tap landing before the circuit connects finds nothing to focus.
+    function focusInto(node, selector) {
+        var field = node.querySelector(selector);
+        if (field) field.focus();
     }
 
     function closeSheets() {

--- a/docs/design/static-shell.md
+++ b/docs/design/static-shell.md
@@ -70,6 +70,10 @@ why they are `.razor` and not cshtml partial markup** — cshtml markup would be
   time, close on outside click / Escape / link click. More sheet = fixed bottom sheet, 75vh,
   toggled class. `MudHidden` → media queries at **960px** (Mud md: desktop `min-width: 960px`,
   bottom nav + sheet `max-width: 959.98px`).
+  **Sheets are a set, not a thing** (2026-07-15): More and Search share the scrim, so at most
+  one is open and `nav.js` drives both off one `SHEETS` table. A sheet also closes on history
+  push — the search autocomplete navigates from a circuit with no link click to catch, and
+  a sheet is chrome over the page you left.
 - **D7 — Mix switching = endpoint + reload.** `GET /Mix/Set?mix=Phoenix2&redirectUrl=/TierLists`,
   modeled on [CultureController](../../ScoreTracker/ScoreTracker/Controllers/CultureController.cs).
   Mix switching already forces a full reload (MainLayout 530–534), so UX is unchanged.
@@ -148,6 +152,7 @@ why they are `.razor` and not cshtml partial markup** — cshtml markup would be
 | Live SkillRating subscription | 582, 586, 598–603 | **DELETE — dead code.** `Rating` is assigned at 582, declared at 593, reassigned at 601, and rendered nowhere. Audited: only self-references. Deleting it also removes a `GetPlayerStatsQuery` from every signed-in page load. | n/a |
 | More sheet (mobile) | `MudDrawer` 257–335 | static bottom sheet + `nav.js` toggle | no |
 | Bottom nav + active state | 341–371 | static HTML; active class server-rendered from path, re-evaluated by `nav.js` on SPA navigation | no |
+| Search sheet (mobile) | *(added 2026-07-15)* | static top sheet + `nav.js` toggle, with the **app-bar search island mounted inside it** | chrome no / filling **yes** |
 | PageDock slot + focus mode | 342–347, 445–453 | dock content stays in the Blazor root (page-supplied); `has-dock`/`focus-mode` move to `<html>` classes via a JS bridge | no |
 | `pageDock.watch()` bootstrap | 455–461 | called by `nav.js` on DOMContentLoaded. **`watch()` is idempotent** (guards on `watching`), so an overlapping MainLayout call is harmless during the transition. | no |
 | Theme vars `<style>` block | 30–32 | emitted server-side by the layout | no |


### PR DESCRIPTION
`/Chart/{id}` was unreachable from a phone.

Every route into it ran through the app bar's chart search — which is `shell-desktop-only` — or a
session highlight. `/Charts` held a bottom-nav slot the whole time, but it lists charts **without
linking to any of them**, so the one slot pointing that direction couldn't finish the trip.

## The nav

**Search takes the slot, next to More.** It opens a sheet holding the same autocomplete the app bar
has — same component, same pill, mounted twice, so the two can't drift.

**The chart list moves into More**, where desktop already files it (the Play menu). Browsing 4,400
charts is rare and deliberate; "take me to THIS chart" is the trip people actually make. Slot count
is unchanged, so the wide-only Communities slot behaves exactly as before.

## Two things that aren't arbitrary

**The sheet drops from the top**, unlike More, which rises. The phone keyboard takes the bottom half
of the screen the moment the input focuses — a bottom-anchored field opens underneath the thing
typing into it. Its input is 16px for the same family of reason: below that, iOS Safari zooms the
whole viewport on focus.

**The field is focused by the opening click itself**, not on a timeout or after the slide-in
transition. iOS raises the keyboard only for a `focus()` it can trace back to a user gesture, so
deferring it at all would open the sheet and leave the field cold.

**`nav.js` closes sheets on history push.** The click handler catches links; it can't catch the
autocomplete, which navigates from a circuit without one. Sheets are now driven from a `SHEETS`
table rather than one hardcoded pair, and share the scrim, so at most one is open.

## The bit worth a look

**This is the first time the static shell hosts an interactive child.** Every existing island is
declared in `App.razor` itself; `ShellSearchSheet` is static chrome with `<AppBarSearch
@rendermode="Interactive">` inside it. Static parent → interactive child is the documented island
pattern, but there was no precedent here, so I didn't want to argue it from the docs.

**The E2E suite settled it.** `StaticShellTests` hosts the real app on Kestrel — it proved the
nested island renders, and failed with a strict-mode violation showing *two* `.appbar-search input`
elements in the live DOM. That failure is the proof. The locator is now scoped to `header`.

A new E2E test covers the mobile path end to end at a 390×844 viewport: `nav.js` opens a sheet it
didn't render, the interactive island inside the static chrome is there to be found, and the field
is focused. Three things only a hosted run can see, in one chain.

## Known cost

Every circuit now builds **two** `ChartSelector` name dictionaries (~4,400 entries each) instead of
one — the app bar's and the sheet's, one of which is always CSS-hidden. `GetChartsQuery` is cached
repository-side so there's no second database read, but the dictionary is per-instance. This
doubles an existing waste rather than inventing one (mobile already paid for a hidden desktop
search), and the alternative is the bug. Flagging it because it's per-circuit memory, and that
scales with concurrent users.

## Noticed in passing, not fixed here

A closed sheet is hidden by `transform` alone — no `visibility`/`display` — so **its contents stay
in the tab order**. That's the shell's existing pattern (a closed More sheet's ~20 links are
tabbable today), and this sheet matches it rather than inventing a new one. It's slightly worse for
a text field than a link: tab into an invisible input, type, and an autocomplete popover opens from
a sheet you can't see. Fixing it means `visibility: hidden` on both sheets plus a forced reflow
before `focus()` — a real change, and a separate one.

## Tests

1346 unit / 60 API wire-shape / 163 bUnit / 3 static-shell E2E, all green. Solution builds clean on
Debug. Nine locales for the one new key (`Search`).

Not field-tested — the sheet has never been opened on a real phone. Open question for that pass:
focusing the field may pop the autocomplete's dropdown showing the first 15 charts alphabetically
(an empty search matches everything). Harmless if so, but it might read as noise on a small screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
