### PR TITLE
Those aren't first passes, they're passes

### DIFF
--- a/ScoreTracker/ScoreTracker.ChartIntelligence/Contracts/ChartVerdictFacet.cs
+++ b/ScoreTracker/ScoreTracker.ChartIntelligence/Contracts/ChartVerdictFacet.cs
@@ -19,7 +19,7 @@ public sealed record PassVsScoreVerdict(TierListCategory PassTier, TierListCateg
 
 /// <summary>The interquartile competitive-level band of the players who pass it.</summary>
 [ExcludeFromCodeCoverage]
-public sealed record FirstPassBandVerdict(int LowerLevel, int UpperLevel) : ChartVerdictFacet;
+public sealed record PassBandVerdict(int LowerLevel, int UpperLevel) : ChartVerdictFacet;
 
 /// <summary>The competitive level where the population's average score crosses SS+ (975k).</summary>
 [ExcludeFromCodeCoverage]

--- a/ScoreTracker/ScoreTracker.ChartIntelligence/Domain/ChartVerdictService.cs
+++ b/ScoreTracker/ScoreTracker.ChartIntelligence/Domain/ChartVerdictService.cs
@@ -12,8 +12,8 @@ namespace ScoreTracker.ChartIntelligence.Domain;
 /// </summary>
 internal static class ChartVerdictService
 {
-    /// <summary>Passes needed before the first-pass band means anything.</summary>
-    internal const int FirstPassBandMinimumPasses = 20;
+    /// <summary>Passes needed before the pass band means anything.</summary>
+    internal const int PassBandMinimumPasses = 20;
 
     /// <summary>The yield knee: where the population's average crosses SS+ (975k).</summary>
     internal const int YieldKneeScore = 975_000;
@@ -56,7 +56,7 @@ internal static class ChartVerdictService
         if (LetterWall(inputs) is { } wall) facets.Add(wall);
         if (YieldKnee(inputs) is { } knee) facets.Add(knee);
         if (StyleFingerprint(inputs) is { } style) facets.Add(style);
-        if (FirstPassBand(inputs) is { } band) facets.Add(band);
+        if (PassBand(inputs) is { } band) facets.Add(band);
         if (PlateResidual(inputs) is { } plates) facets.Add(plates);
         if (History(inputs) is { } history) facets.Add(history);
         facets.Add(new PopulationVerdict(inputs.ScoresTracked,
@@ -129,17 +129,17 @@ internal static class ChartVerdictService
             inputs.TensionFraction is { } tension && tension >= SustainedTensionFraction);
     }
 
-    private static FirstPassBandVerdict? FirstPassBand(ChartVerdictInputs inputs)
+    private static PassBandVerdict? PassBand(ChartVerdictInputs inputs)
     {
         var totalPasses = inputs.PassCountByLevel.Sum(l => l.Passes);
-        if (totalPasses < FirstPassBandMinimumPasses) return null;
+        if (totalPasses < PassBandMinimumPasses) return null;
         var passerLevels = inputs.PassCountByLevel
             .OrderBy(l => l.Level)
             .SelectMany(l => Enumerable.Repeat(l.Level, l.Passes))
             .ToArray();
         var lower = passerLevels[(passerLevels.Length - 1) / 4];
         var upper = passerLevels[(passerLevels.Length - 1) * 3 / 4];
-        return new FirstPassBandVerdict(lower, upper);
+        return new PassBandVerdict(lower, upper);
     }
 
     private static PlateResidualVerdict? PlateResidual(ChartVerdictInputs inputs)

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/ChartVerdictServiceTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/ChartVerdictServiceTests.cs
@@ -165,7 +165,7 @@ public sealed class ChartVerdictServiceTests
     }
 
     [Fact]
-    public void FirstPassBandReportsTheInterquartileLevels()
+    public void PassBandReportsTheInterquartileLevels()
     {
         var facets = ChartVerdictService.ComputeFacets(Inputs(passes: new[]
         {
@@ -174,17 +174,17 @@ public sealed class ChartVerdictServiceTests
             new LevelPasses(22, 5)
         }));
 
-        var band = facets.OfType<FirstPassBandVerdict>().Single();
+        var band = facets.OfType<PassBandVerdict>().Single();
         Assert.Equal(20, band.LowerLevel);
         Assert.Equal(21, band.UpperLevel);
     }
 
     [Fact]
-    public void FirstPassBandStaysSilentUnderTwentyPasses()
+    public void PassBandStaysSilentUnderTwentyPasses()
     {
         var facets = ChartVerdictService.ComputeFacets(Inputs(passes: new[] { new LevelPasses(20, 19) }));
 
-        Assert.Empty(facets.OfType<FirstPassBandVerdict>());
+        Assert.Empty(facets.OfType<PassBandVerdict>());
     }
 
     [Fact]
@@ -290,7 +290,7 @@ public sealed class ChartVerdictServiceTests
         Assert.Equal(new[]
         {
             typeof(PassVsScoreVerdict), typeof(LetterWallVerdict), typeof(YieldKneeVerdict),
-            typeof(StyleFingerprintVerdict), typeof(FirstPassBandVerdict), typeof(PlateResidualVerdict),
+            typeof(StyleFingerprintVerdict), typeof(PassBandVerdict), typeof(PlateResidualVerdict),
             typeof(HistoryVerdict), typeof(PopulationVerdict)
         }, facets.Select(f => f.GetType()).ToArray());
     }

--- a/ScoreTracker/ScoreTracker/Components/ChartEvidenceSection.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartEvidenceSection.razor
@@ -29,7 +29,7 @@
             <div class="chart-evidence-card">
                 <span class="chart-overline">@L["Passes by competitive level"]</span>
                 <p class="chart-evidence-caption">
-                    @if (Facet<FirstPassBandVerdict>() is { } band)
+                    @if (Facet<PassBandVerdict>() is { } band)
                     {
                         <VerdictSentence Facet="band"></VerdictSentence>
                     }

--- a/ScoreTracker/ScoreTracker/Components/VerdictSentence.razor
+++ b/ScoreTracker/ScoreTracker/Components/VerdictSentence.razor
@@ -27,9 +27,9 @@ else if (Facet is StyleFingerprintVerdict style)
         <text> </text>@L["Sustained — it holds you under tension for most of its runtime."]
     }
 }
-else if (Facet is FirstPassBandVerdict band)
+else if (Facet is PassBandVerdict band)
 {
-    @L["First passes cluster between competitive levels {0} and {1}.", band.LowerLevel, band.UpperLevel]
+    @L["Passes cluster between competitive levels {0} and {1}.", band.LowerLevel, band.UpperLevel]
 }
 @* PlateResidualVerdict deliberately has no sentence. It used to claim "a kill-spot
    signature" / "smooth attrition"; plates mostly restate scores, so neither is something

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -4148,8 +4148,8 @@
   <data name="Sustained — it holds you under tension for most of its runtime." xml:space="preserve">
     <value>Sustained — it holds you under tension for most of its runtime.</value>
   </data>
-  <data name="First passes cluster between competitive levels {0} and {1}." xml:space="preserve">
-    <value>First passes cluster between competitive levels {0} and {1}.</value>
+  <data name="Passes cluster between competitive levels {0} and {1}." xml:space="preserve">
+    <value>Passes cluster between competitive levels {0} and {1}.</value>
   </data>
   <data name="Debuted in {0}." xml:space="preserve">
     <value>Debuted in {0}.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -4071,8 +4071,8 @@
   <data name="Sustained — it holds you under tension for most of its runtime." xml:space="preserve">
     <value>Mrglllll grlgl tensionrlgl mrgl!</value>
   </data>
-  <data name="First passes cluster between competitive levels {0} and {1}." xml:space="preserve">
-    <value>Mrgl pass mrglrgl {0} rgl {1}!</value>
+  <data name="Passes cluster between competitive levels {0} and {1}." xml:space="preserve">
+    <value>Mrgl passes cluster mrglrgl {0} rgl {1}!</value>
   </data>
   <data name="Debuted in {0}." xml:space="preserve">
     <value>Mrgl debut {0}!</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -4026,8 +4026,8 @@
   <data name="Sustained — it holds you under tension for most of its runtime." xml:space="preserve">
     <value>Sostenido — te mantiene bajo tensión durante casi todo el tema.</value>
   </data>
-  <data name="First passes cluster between competitive levels {0} and {1}." xml:space="preserve">
-    <value>Los primeros passes se concentran entre los niveles competitivos {0} y {1}.</value>
+  <data name="Passes cluster between competitive levels {0} and {1}." xml:space="preserve">
+    <value>Los passes se concentran entre los niveles competitivos {0} y {1}.</value>
   </data>
   <data name="Debuted in {0}." xml:space="preserve">
     <value>Debutó en {0}.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -4028,8 +4028,8 @@
   <data name="Sustained — it holds you under tension for most of its runtime." xml:space="preserve">
     <value>Sostenido — te mantiene bajo tensión durante casi todo el tema.</value>
   </data>
-  <data name="First passes cluster between competitive levels {0} and {1}." xml:space="preserve">
-    <value>Los primeros passes se concentran entre los niveles competitivos {0} y {1}.</value>
+  <data name="Passes cluster between competitive levels {0} and {1}." xml:space="preserve">
+    <value>Los passes se concentran entre los niveles competitivos {0} y {1}.</value>
   </data>
   <data name="Debuted in {0}." xml:space="preserve">
     <value>Debutó en {0}.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -4146,8 +4146,8 @@
   <data name="Sustained — it holds you under tension for most of its runtime." xml:space="preserve">
     <value>Soutenu — vous reste sous tension presque toute la chanson.</value>
   </data>
-  <data name="First passes cluster between competitive levels {0} and {1}." xml:space="preserve">
-    <value>Les premiers passes se concentrent entre les niveaux compétitifs {0} et {1}.</value>
+  <data name="Passes cluster between competitive levels {0} and {1}." xml:space="preserve">
+    <value>Les passes se concentrent entre les niveaux compétitifs {0} et {1}.</value>
   </data>
   <data name="Debuted in {0}." xml:space="preserve">
     <value>Apparu dans {0}.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -4148,8 +4148,8 @@
   <data name="Sustained — it holds you under tension for most of its runtime." xml:space="preserve">
     <value>Sostenuto — ti tiene sotto tensione per quasi tutto il brano.</value>
   </data>
-  <data name="First passes cluster between competitive levels {0} and {1}." xml:space="preserve">
-    <value>I primi pass si concentrano tra i livelli competitivi {0} e {1}.</value>
+  <data name="Passes cluster between competitive levels {0} and {1}." xml:space="preserve">
+    <value>I pass si concentrano tra i livelli competitivi {0} e {1}.</value>
   </data>
   <data name="Debuted in {0}." xml:space="preserve">
     <value>Debuttato in {0}.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -4149,8 +4149,8 @@
   <data name="Sustained — it holds you under tension for most of its runtime." xml:space="preserve">
     <value>サステイン型——曲のほとんどの間、緊張が続きます。</value>
   </data>
-  <data name="First passes cluster between competitive levels {0} and {1}." xml:space="preserve">
-    <value>初クリアは競技レベル{0}〜{1}に集中しています。</value>
+  <data name="Passes cluster between competitive levels {0} and {1}." xml:space="preserve">
+    <value>クリアは競技レベル{0}〜{1}に集中しています。</value>
   </data>
   <data name="Debuted in {0}." xml:space="preserve">
     <value>{0}で初登場。</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -4029,8 +4029,8 @@
   <data name="Sustained — it holds you under tension for most of its runtime." xml:space="preserve">
     <value>지속형 — 곡 대부분 동안 긴장을 유지시킵니다.</value>
   </data>
-  <data name="First passes cluster between competitive levels {0} and {1}." xml:space="preserve">
-    <value>첫 클리어는 경쟁 레벨 {0}~{1} 사이에 몰려 있습니다.</value>
+  <data name="Passes cluster between competitive levels {0} and {1}." xml:space="preserve">
+    <value>클리어는 경쟁 레벨 {0}~{1} 사이에 몰려 있습니다.</value>
   </data>
   <data name="Debuted in {0}." xml:space="preserve">
     <value>{0}에서 데뷔했습니다.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -4094,8 +4094,8 @@
   <data name="Sustained — it holds you under tension for most of its runtime." xml:space="preserve">
     <value>Sustentado — mantém você sob tensão durante quase toda a música.</value>
   </data>
-  <data name="First passes cluster between competitive levels {0} and {1}." xml:space="preserve">
-    <value>Os primeiros passes se concentram entre os níveis competitivos {0} e {1}.</value>
+  <data name="Passes cluster between competitive levels {0} and {1}." xml:space="preserve">
+    <value>Os passes se concentram entre os níveis competitivos {0} e {1}.</value>
   </data>
   <data name="Debuted in {0}." xml:space="preserve">
     <value>Estreou em {0}.</value>

--- a/docs/design/chart-verdicts.md
+++ b/docs/design/chart-verdicts.md
@@ -25,7 +25,7 @@ page's **meta description and JSON-LD description**: unique, data-derived, quota
 | Facet | Source | Fires when | Example rendering |
 |---|---|---|---|
 | **PassVsScore** | Pass tier category × Scores tier category (`GetTierListWithFallbackQuery`) | either ≠ Medium | "Hard to pass for its level — generous to score once passed." |
-| **FirstPassBand** | pass counts by competitive level | ≥ 20 passes | "First passes cluster around level 21." |
+| **PassBand** | pass counts by competitive level | ≥ 20 passes | "Passes cluster between competitive levels 19 and 21." (the interquartile band of everyone who passed — nothing about *first* passes; the name said so and the copy repeated it into nine locales) |
 | **YieldKnee** | avg-score-by-level curve | avg crosses SS+ (975k) inside the observed range | "Opens up around level 22; below 21, expect low 900s." |
 | **LetterWall** | letter-grade percentile curve | max adjacent percentile drop ≥ 25 pts | "SS is routine here — SSS is top-decile." |
 | **PlateResidual** | median plate vs `ScoringConfiguration.ExpectedPlateForScore(median score)`, within a (level, song-type) cohort | ≥ 50 scores AND \|residual\| ≥ 1 plate step | "Plates run worse than scores predict — a kill-spot signature." / "…better than predicted — smooth attrition." |


### PR DESCRIPTION
The caption over **Passes by competitive level** read:

> *First passes cluster between competitive levels 19 and 21.*

You're right that it's just passes — and the name was hiding that it's worse than a copy slip.

## It never computed anything about first passes

```csharp
var lower = passerLevels[(passerLevels.Length - 1) / 4];      // 25th percentile
var upper = passerLevels[(passerLevels.Length - 1) * 3 / 4];  // 75th percentile
```

That's the **interquartile band of the competitive levels of everyone who passed** — the middle half
of passers. There's no notion of a player's first pass in it, and none of the earliest passes
either. The contract's own docstring has said so the whole time: *"The interquartile
competitive-level band of the players who pass it."* Only the type name and the sentence claimed
otherwise.

## So the type goes too

`FirstPassBandVerdict` → `PassBandVerdict` (and `FirstPassBandMinimumPasses` → `PassBandMinimumPasses`).
Renaming only the string would leave the word sitting in the type the string is generated from, and
it'd drift back the next time someone wrote copy from the code.

New sentence: **"Passes cluster between competitive levels {0} and {1}."**

## Nine locales, nine fixes

Every locale had inherited the error, so this wasn't a find-and-replace on the English:

| | was | now |
|---|---|---|
| ja | 初クリア ("first clear") | クリア |
| ko | 첫 클리어 ("first clear") | 클리어 |
| es / pt | "los/os primeiros passes" | "los/os passes" |
| fr | "les premiers passes" | "les passes" |
| it | "i primi pass" | "i pass" |

## Tests

1346 unit / 60 API / 163 bUnit green; solution builds clean on Debug. The two `ChartVerdictService`
tests that cover this facet were renamed with it — the math is untouched, and they still pass, which
is the point: nothing about the behaviour was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)