### PR TITLE
fix(l10n): restore the skill-coverage caption's translations

### DIFF
--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -4412,4 +4412,7 @@
   <data name="Search" xml:space="preserve">
     <value>Search</value>
   </data>
+  <data name="Share of chart sections featuring each skill" xml:space="preserve">
+    <value>Share of chart sections featuring each skill</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -4335,4 +4335,7 @@
   <data name="Search" xml:space="preserve">
     <value>Srgl</value>
   </data>
+  <data name="Share of chart sections featuring each skill" xml:space="preserve">
+    <value>Shrgre of chart sectrgns featrgring each skrgll</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -4290,4 +4290,7 @@
   <data name="Search" xml:space="preserve">
     <value>Buscar</value>
   </data>
+  <data name="Share of chart sections featuring each skill" xml:space="preserve">
+    <value>Proporción de secciones del chart con cada skill</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -4292,4 +4292,7 @@
   <data name="Search" xml:space="preserve">
     <value>Buscar</value>
   </data>
+  <data name="Share of chart sections featuring each skill" xml:space="preserve">
+    <value>Proporción de secciones del chart con cada habilidad</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -4410,4 +4410,7 @@
   <data name="Search" xml:space="preserve">
     <value>Chercher</value>
   </data>
+  <data name="Share of chart sections featuring each skill" xml:space="preserve">
+    <value>Part des sections du chart présentant chaque compétence</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -4412,4 +4412,7 @@
   <data name="Search" xml:space="preserve">
     <value>Cerca</value>
   </data>
+  <data name="Share of chart sections featuring each skill" xml:space="preserve">
+    <value>Quota di sezioni del chart con ogni abilità</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -4413,4 +4413,7 @@
   <data name="Search" xml:space="preserve">
     <value>検索</value>
   </data>
+  <data name="Share of chart sections featuring each skill" xml:space="preserve">
+    <value>各スキルが登場するチャートセクションの割合</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -4293,4 +4293,7 @@
   <data name="Search" xml:space="preserve">
     <value>검색</value>
   </data>
+  <data name="Share of chart sections featuring each skill" xml:space="preserve">
+    <value>각 스킬이 나오는 채보 구간 비율</value>
+  </data>
 </root>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -2628,9 +2628,6 @@
   <data name="More" xml:space="preserve">
     <value>Mais</value>
   </data>
-  <data name="Import" xml:space="preserve">
-    <value>Importar</value>
-  </data>
   <data name="Tiers" xml:space="preserve">
     <value>Tiers</value>
   </data>
@@ -4357,5 +4354,8 @@
   </data>
   <data name="Search" xml:space="preserve">
     <value>Buscar</value>
+  </data>
+  <data name="Share of chart sections featuring each skill" xml:space="preserve">
+    <value>Proporção de seções do chart com cada habilidade</value>
   </data>
 </root>


### PR DESCRIPTION
## What

PR #155's UX pass (`2f62a588`) deleted the resx key `"Share of chart sections featuring each skill"` from all nine locales, but `SkillCoverageBars.razor` still renders `@L["Share of chart sections featuring each skill"]`. Since keys are English verbatim, en-US looked fine — the other eight locales silently lost the caption's translation.

- Restores the key in all nine `App.*.resx` files, with each locale's original translation recovered from history (`2f62a588~1`) — no new translations invented.
- Drops `App.pt-BR.resx`'s duplicate `"Import"` entry (two identical `Importar` blocks; the later one wins silently today).

The other two keys deleted in the same pass (`Sustain Time`, `Time Under Tension`) are genuinely unreferenced and stay deleted.

## Verification

- All nine files XML-well-formed, key present exactly once per locale.
- `dotnet build` Debug: 0 errors; fast suites green (Tests 1346, Api 60, Components 163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)