### PR TITLE
fix(seo): namespace-valid sitemap, robots.txt, one canonical front door

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.E2E/FrontDoorDispatcherTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/FrontDoorDispatcherTests.cs
@@ -75,6 +75,22 @@ public sealed class FrontDoorDispatcherTests : IAsyncLifetime
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 60_000 });
     }
 
+    /// <summary>
+    ///     "/Welcome" and "/Login" serve the same HTML; the canonical link is what tells a
+    ///     crawler they are one page — and that "/Welcome" is the URL that owns the result.
+    /// </summary>
+    [Fact]
+    public async Task BothFrontDoorRoutesCanonicalizeToWelcome()
+    {
+        foreach (var route in new[] { "/Welcome", "/Login" })
+        {
+            await _page.GotoAsync(route);
+            await Expect(_page.Locator("link[rel='canonical']"))
+                .ToHaveAttributeAsync("href", "https://piuscores.arroweclip.se/Welcome",
+                    new LocatorAssertionsToHaveAttributeOptions { Timeout = 60_000 });
+        }
+    }
+
     [Fact]
     public async Task SignedInRootServesTheHomeDashboard()
     {

--- a/ScoreTracker/ScoreTracker.Tests.E2E/NonComponentEndpointTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/NonComponentEndpointTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Xml.Linq;
 using ScoreTracker.Tests.E2E.Support;
 
 namespace ScoreTracker.Tests.E2E;
@@ -63,14 +64,42 @@ public sealed class NonComponentEndpointTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
+    /// <summary>
+    ///     Google rejects a sitemap whose elements sit outside the sitemap namespace.
+    ///     LINQ-to-XML children do not inherit their parent's namespace, so the regression
+    ///     serializes every url element with an empty xmlns and the whole file reads as
+    ///     invalid — this parses the document and holds each element to the namespace.
+    /// </summary>
     [Fact]
-    public async Task TheSitemapStillServesXml()
+    public async Task TheSitemapIsNamespaceValidXml()
     {
         var response = await _client.GetAsync("/sitemap.xml");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.StartsWith("application/xml", response.Content.Headers.ContentType?.ToString());
+
         var body = await response.Content.ReadAsStringAsync();
-        Assert.Contains("<urlset", body);
+        Assert.StartsWith("<?xml", body);
+
+        var document = XDocument.Parse(body);
+        XNamespace ns = "http://www.sitemaps.org/schemas/sitemap/0.9";
+        Assert.Equal(ns + "urlset", document.Root!.Name);
+        Assert.All(document.Descendants(), element => Assert.Equal(ns, element.Name.Namespace));
+
+        var urls = document.Descendants(ns + "loc").Select(loc => loc.Value).ToArray();
+        Assert.Contains("https://piuscores.arroweclip.se/Welcome", urls);
+        Assert.Contains(urls, url => url.StartsWith("https://piuscores.arroweclip.se/Chart/"));
+    }
+
+    /// <summary>Crawlers discover the sitemap through robots.txt, not Search Console alone.</summary>
+    [Fact]
+    public async Task RobotsTxtPointsCrawlersAtTheSitemap()
+    {
+        var response = await _client.GetAsync("/robots.txt");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Sitemap: https://piuscores.arroweclip.se/sitemap.xml", body);
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker/Controllers/SitemapController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/SitemapController.cs
@@ -1,20 +1,35 @@
-﻿using System.Net.Mime;
+using System.Text;
 using System.Xml.Linq;
+using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using ScoreTracker.Catalog.Contracts.Queries;
 using ScoreTracker.SharedKernel.Enums;
-using ScoreTracker.Domain.SecondaryPorts;
 
 namespace ScoreTracker.Web.Controllers
 {
     [Route("")]
     public sealed class SitemapController : Controller
     {
+        // Children never inherit an XML namespace: every element must carry it explicitly,
+        // or it serializes as <url xmlns=""> and validators reject the whole file.
+        private static readonly XNamespace Ns = "http://www.sitemaps.org/schemas/sitemap/0.9";
+
+        private readonly IMediator _mediator;
+
+        public SitemapController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
         [ApiExplorerSettings(IgnoreApi = true)]
         [Route("sitemap.xml")]
-        public async Task<IActionResult> GetSitemap([FromServices] IChartRepository _charts)
+        public async Task<IActionResult> GetSitemap(CancellationToken cancellationToken)
         {
-            var charts = (await _charts.GetCharts(MixEnum.Phoenix)).ToArray();
-            var pages = charts.Select(chart => $"https://piuscores.arroweclip.se/Chart/{chart.Id}").ToList();
+            var charts = (await _mediator.Send(new GetChartsQuery(MixEnum.Phoenix), cancellationToken)).ToArray();
+            // The front door: anonymous "/" and "/Login" both resolve to the same page,
+            // which canonicalizes itself to /Welcome — only the canonical is listed.
+            var pages = new List<string> { "https://piuscores.arroweclip.se/Welcome" };
+            pages.AddRange(charts.Select(chart => $"https://piuscores.arroweclip.se/Chart/{chart.Id}"));
             pages.Add("https://piuscores.arroweclip.se/TierLists");
             // Tier-lists overhaul C3: one canonical URL per Singles/Doubles folder that
             // actually has charts — each is an indexable community tier list.
@@ -29,15 +44,31 @@ namespace ScoreTracker.Web.Controllers
             pages.Add("https://piuscores.arroweclip.se/LifeCalculator");
             pages.Add("https://piuscores.arroweclip.se/PhoenixToXXCalculator");
 
+            var urlset = new XElement(Ns + "urlset",
+                pages.Select(page => new XElement(Ns + "url", new XElement(Ns + "loc", page))));
+            var document = new XDocument(new XDeclaration("1.0", "utf-8", null), urlset);
 
-            var ns = "{http://www.sitemaps.org/schemas/sitemap/0.9}";
-            var urlset = new XElement(ns + "urlset");
+            // ToString() drops the XML declaration; Save through a writer is what emits it.
+            var xml = new StringBuilder();
+            using (var writer = new Utf8StringWriter(xml))
+            {
+                document.Save(writer);
+            }
 
-            foreach (var t in pages)
-                urlset.Add(new XElement("url",
-                    new XElement("loc", t)
-                ));
-            return Content(urlset.ToString(), MediaTypeNames.Application.Xml);
+            return Content(xml.ToString(), "application/xml; charset=utf-8");
+        }
+
+        /// <summary>
+        ///     StringWriter reports UTF-16, and XDocument.Save writes the writer's encoding
+        ///     into the declaration — this pins it to the UTF-8 the response actually ships.
+        /// </summary>
+        private sealed class Utf8StringWriter : StringWriter
+        {
+            public Utf8StringWriter(StringBuilder builder) : base(builder)
+            {
+            }
+
+            public override Encoding Encoding => Encoding.UTF8;
         }
     }
 }

--- a/ScoreTracker/ScoreTracker/Pages/FrontDoor.cshtml
+++ b/ScoreTracker/ScoreTracker/Pages/FrontDoor.cshtml
@@ -18,6 +18,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="~/" />
     <title>@L["PIU Scores"]</title>
+    @* One page, three routes ("/Welcome", "/Login", and anonymous "/" redirecting in):
+       the canonical is what tells a crawler they are the same result. The description is
+       the hero's own pitch line — one string, already in every locale. No og:image yet;
+       the site has no share-card asset. *@
+    <link rel="canonical" href="https://piuscores.arroweclip.se/Welcome" />
+    <meta name="description" content="@L["PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play."]" />
+    <meta property="og:title" content="@L["PIU Scores"]" />
+    <meta property="og:description" content="@L["PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play."]" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://piuscores.arroweclip.se/Welcome" />
     @* The shipped theme tokens — same single source as the Blazor shell (MixThemes),
        so this page can never drift from the site palette. Anonymous visitors resolve
        to Phoenix by the same rule the layout uses. *@

--- a/ScoreTracker/ScoreTracker/Program.cs
+++ b/ScoreTracker/ScoreTracker/Program.cs
@@ -46,8 +46,8 @@ builder.Services.Configure<JsonSerializerOptions>(o =>
 });
 
 // Add services to the container.
-// The front door owns "/" via its @page directive; a Razor Page can declare only one
-// route, so "/Login" is attached as a second route to the same page here.
+// The front door owns "/Welcome" via its @page directive; a Razor Page can declare only
+// one route, so "/Login" is attached as a second route to the same page here.
 builder.Services.AddRazorPages(options => options.Conventions.AddPageRoute("/FrontDoor", "Login"));
 // Render modes: components render as static HTML by default, and only what asks for it gets a
 // circuit (docs/design/render-modes.md). Prerendering stays off — see App.razor.

--- a/ScoreTracker/ScoreTracker/wwwroot/robots.txt
+++ b/ScoreTracker/ScoreTracker/wwwroot/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow: /hangfire
+Disallow: /api/
+Disallow: /Dev/
+Disallow: /Admin
+
+Sitemap: https://piuscores.arroweclip.se/sitemap.xml

--- a/docs/design/front-door.md
+++ b/docs/design/front-door.md
@@ -180,7 +180,7 @@ Checkpoint commits, suites green at each. FT = owner field-test checkpoint.
 | C8 | Retire `Login.razor` | Blazor login page deleted; its `UiColorTokenTests` allowlist entries burned; "Account Creation?" strings retired into card microcopy |
 | C9 | Sign-in dialog | Blazor `SignInCard` component + app-bar hookup: opens in place on public pages, bottom sheet at phone widths (static twin documented) |
 | C10 | returnUrl | all eight gated-page redirects, OAuth state + PIUGAME flow carry-through, post-auth resume — **FT2: flows** |
-| C11 | Head + crawl surface | front-door meta/OG/JSON-LD/canonical, site-wide OG defaults in `_Layout`, `robots.txt`, sitemap additions — **FT3: view-source is real HTML; Discord unfurl works** |
+| C11 | Head + crawl surface | front-door meta/OG/JSON-LD/canonical, site-wide OG defaults in `_Layout`, `robots.txt`, sitemap additions — **FT3: view-source is real HTML; Discord unfurl works**. *Partially landed 2026-07-16 by the SSR ladder's PR-1 ([seo-friendly-site.md](seo-friendly-site.md) §7): canonical → `/Welcome` + meta/OG on the front door, `robots.txt`, sitemap namespace fix + `/Welcome` entry. Still open: JSON-LD, site-wide OG defaults (now the route-aware head, ladder PR-2), extra public-page sitemap entries.* |
 | C12 | E2E | update PIUGAME-login selectors; new facts: anonymous `/` serves the front door, authenticated `/` serves the app, dialog sign-in path |
 | C13 | Docs | ARCHITECTURE.md (pages table + login-flow paragraph + front-door link), UX-GUIDELINES if the dialog pattern earns a rule, this doc synced |
 

--- a/docs/design/seo-friendly-site.md
+++ b/docs/design/seo-friendly-site.md
@@ -1,13 +1,14 @@
 # An SEO-friendly site — what static rendering actually costs
 
-> **STATUS: INCOMPLETE. This is a findings dump, not a plan.**
-> Everything below was established by reading shipped source on 2026-07-15, after Stage 2
-> (`20c6b41e`) merged. What it does **not** contain is a per-page audit — 38 routable pages have
-> to be looked at individually, and the owner is doing that scoping. Treat the mechanics here as
-> load-bearing and the effort estimates as absent on purpose.
+> **STATUS: SCOPED — §7 is the PR ladder.** §1–§6 were established by reading shipped source on
+> 2026-07-15, after Stage 2 (`20c6b41e`) merged; the ladder was scoped 2026-07-16 against this
+> tree, and each PR gets its full scoping as it comes up. What this doc still does **not**
+> contain is the per-page audit — which of the **58** routable pages converts, and in what
+> order, is the owner's scoping. Treat the mechanics here as load-bearing.
 
 Companion to [render-modes.md](render-modes.md) (Stage 2, shipped) and
-[static-shell.md](static-shell.md) (Stage 1, shipped). This doc is Stage 3's problem statement.
+[static-shell.md](static-shell.md) (Stage 1, shipped). This doc is Stage 3's problem statement
+and its plan (§7).
 
 ---
 
@@ -51,11 +52,24 @@ so a crawler that lands anywhere sees a site and can follow it. The *page* is wh
 A render mode propagates **down** and a child cannot opt back out. So:
 
 1. **Nothing under `<Routes>` can be static** while that attribute is there.
-2. **No page carries a mode of its own** — verified, zero hits across all 38 routable pages. They
-   all inherit.
+2. **No page carries a mode of its own** — verified, zero hits across all routable pages. They
+   all inherit. (Count corrected 2026-07-16: **58 page files, 66 `@page` routes** — the "38"
+   this doc first recorded was wrong.)
 3. Therefore the first step is: **drop the attribute from `Routes`, add
    `@rendermode RenderModes.Interactive` to every page.** Zero behaviour change; every page still
    a circuit. Pages then convert one at a time by deleting their own line.
+
+⚠ **Plus one seed the flip silently breaks — the mix.** `UiSettingsAccessor.GetSelectedMix`
+short-circuits on a `ShellContext` that only `Routes.razor` seeds *into the circuit* today
+(`Routes.razor:32`, an interactive root). Once `Routes` is static, its `OnInitialized` runs in
+the request scope instead — harmlessly, `ShellModelFactory` already seeded that scope — and
+**every interactive page's circuit is left unseeded**: anonymous users on interactive pages
+silently fall back to Phoenix, signed-in users fall back to the per-page settings query that
+static-shell.md D10 killed. Static pages are unaffected. The fix rides §7 PR-3: a tiny
+interactive root (`ShellMixSeed`) rendered ahead of `<Routes>`, seeding the circuit-scoped
+`ShellContext` exactly as `Routes` does now — interactive roots share the circuit's DI scope
+(the shell islands prove it daily) and activate in document order by the framework's sequence
+contract (render-modes.md §7 Q4).
 
 ⚠ **And that step is not mechanical, because of the layout.**
 
@@ -95,7 +109,7 @@ the server path. Islands in the same circuit share a DI scope, so the `PageDockS
 
 ---
 
-## 4. ⚠ The head problem — unsolved, and it is the entire point
+## 4. The head problem — decided: a route-aware static head (§7 PR-2)
 
 **Making the chart page static does not, by itself, give a crawler its `<HeadContent>`. It takes
 it away.**
@@ -116,18 +130,24 @@ Read it backwards and that is the trap: **an *interactive* outlet collects nothi
 | **static** | **interactive** | `PIU Scores`, no OG — **head content goes nowhere at all** |
 | static | static | correct — but every still-interactive page loses its `<PageTitle>` |
 
-There is no configuration of one outlet that serves a mixed world. Candidate answers, none
-verified:
+There is no configuration of one outlet that serves a mixed world — so the outlet is not the
+mechanism. **Decided 2026-07-16: a route-aware static head, and no outlet changes, ever.**
 
-- **Two outlets**, one per render mode. Only one is ever populated, because a page lives in
-  exactly one mode. Plausible and cheap *if* the section registries are per-renderer as expected —
-  **needs a spike, do not assume.**
-- **A route-aware static head.** `ShellModelFactory` already resolves per-request state for
-  `App.razor`; it could resolve title/description/OG from the route. Bespoke, but it is the one
-  option that **works without any page going static** — i.e. it would fix Discord unfurls and
-  search titles on their own, while the body stays a circuit. Half a loaf, available now.
-- **Finish Stage 3 first**, then flip the outlet to static once no interactive pages remain.
-  Correct end state; useless in the interim.
+- A resolver in the `ShellModelFactory` mold maps the request path → title / meta description /
+  OG image (later: canonical `<link>` + JSON-LD), and `App.razor` renders it statically in
+  `<head>`. Unknown routes fall back to today's literal.
+- **Interactive pages**: the static head serves crawlers; `<PageTitle>` takes over when the
+  circuit connects — that is the shipped title-swap pattern already working on every page
+  (static-shell.md §9: boot removes the marker-less title and uses its text as the fallback),
+  zero new machinery. A page whose circuit also emits `HeadContent` meta duplicates it in the
+  live DOM post-boot — the known-harmless case (static-shell.md §9); each duplicate retires when
+  its page converts.
+- **Static pages**: the route-aware head is the *only* head. The page's `<PageTitle>` /
+  `<HeadContent>` become dead code, deleted at conversion.
+- `HeadOutlet` stays `Interactive` permanently. The two-outlet idea dies un-spiked: one
+  deterministic mechanism covers both worlds, and this one **works before any page goes
+  static** — real chart titles, descriptions and Discord unfurls ship at §7 PR-2 while every
+  body is still a circuit.
 
 ---
 
@@ -149,16 +169,175 @@ QA covers one risk, and so a second pass on the layout does not strand unrelated
 
 ## 6. What this doc does NOT know
 
-- **The 38 pages.** Which are genuinely static-able, which are personalized end-to-end (`/Account`,
+- **The 58 pages.** Which are genuinely static-able, which are personalized end-to-end (`/Account`,
   the upload pages, `/Dev/Populate`) and should simply stay interactive forever, and which are
   worth the conversion at all. **Owner is scoping this.** SEO value is not uniform — `/Chart/{id}`,
-  `/Charts`, `/TierLists` are the crawl targets; `/Dev/Populate` is not.
-- **Output caching.** The chart page is the first meaningfully cacheable page, but nothing personal
-  may enter the cached HTML — the record panel and every "you" marker must be islands, and the
-  signed-in path must bypass. Not designed.
-- **Whether the 301 lattice/sitemap ship before or after the body is real.** The chart-details doc
-  says P3 ships as ONE unit precisely to avoid pointing crawlers at empty shells; that constraint
-  should be re-read once the head fix lands, because a correct head with an empty body may already
-  be worth advertising.
+  `/Charts`, `/TierLists` are the crawl targets; `/Dev/Populate` is not. One audit criterion
+  already found: a page that reads UiSettings for *anonymous* users goes through
+  `ProtectedLocalStorage` — circuit-only JS interop — so its anon path must stay in an island or
+  change stores (the per-page density prefs are the known case).
+- **Output caching** — now scoped into §7 PR-4: the policy shape (anonymous GETs only; vary by
+  path + resolved culture + mix cookie; bypass on auth cookie; TTL from config) plus two spikes
+  (does `@attribute [OutputCache]` flow into component endpoint metadata; what writes the
+  observed `Cache-Control: no-cache, no-store` — prime suspect is antiforgery on the component
+  endpoints) and the ARR-affinity owner item (static-shell.md D18).
+- **Whether the 301 lattice/sitemap ship before or after the body is real** — now owner decision
+  ③ in §7: the default stays the chart-details doc's ONE-unit rule (the vanity sitemap waits for
+  PR-4); the PR-2 head makes "correct head over an empty body" possible earlier if wanted.
 - **Enhanced navigation.** Still off. Turning it on is its own change with its own field test
   (render-modes.md §7.1) — and static pages plus enhanced nav is the combination nobody has tried.
+
+---
+
+## 7. The PR ladder
+
+Scoped 2026-07-16 against this tree. **Ship order is the numbering**; the true dependency graph
+is looser — PR-1, PR-2 and PR-3 are mutually independent, PR-4 needs 2+3, PR-5 needs 4. Each PR
+gets a full scoping pass when it comes up; the entries below are everything known now, written
+so a cold session can pick one up. Sizes: S/M/L.
+
+### PR-1 — sitemap validity, robots.txt, front-door canonical [S]
+
+The sitemap Google flags as invalid is one bug: `SitemapController.cs:33–39` creates `urlset`
+in the sitemap namespace but its children with `new XElement("url", …)` — LINQ-to-XML children
+do **not** inherit the parent's namespace, so every entry serializes as `<url xmlns="">`,
+escaping the namespace. That is Google's "needs a namespace" complaint, verbatim. Also true
+today: no XML declaration (`XElement.ToString()` never emits one), no `robots.txt` anywhere, and
+the front door's two routes (`/Welcome`, `/Login` — same page, `Program.cs:51`) serve identical
+HTML with no `rel=canonical` between them while anonymous `/` 302s into them (`Program.cs:347`).
+
+| File | Change |
+|---|---|
+| `Controllers/SitemapController.cs` | `XNamespace` on **every** element; emit `<?xml version="1.0" encoding="UTF-8"?>` (`XDocument` + UTF-8 `StringWriter`); `application/xml; charset=utf-8`; add the front-door canonical `/Welcome`; swap the direct `IChartRepository` injection to constructor `IMediator` + Catalog's `GetChartsQuery` (the direct port injection is a pre-existing Web-convention violation, and PR-4 rewrites this controller anyway) |
+| `wwwroot/robots.txt` — **new** | `Sitemap:` pointer (discovery today is Search-Console-only) + `Disallow` for `/hangfire`, `/api/`, `/Dev/`, `/Admin` crawl waste; served by `UseStaticFiles` as-is |
+| `Pages/FrontDoor.cshtml` | `<link rel="canonical">` to `/Welcome`; meta description + OG title/description/type/url — the description reuses the hero pitch-line key, already localized ×9, so zero new resx entries. No `og:image`: wwwroot's only image is the favicon; a share-card asset is a later nicety |
+| `Tests.E2E/NonComponentEndpointTests.cs` | strengthen the sitemap pin (today only `Contains("<urlset")`): parse the body, assert every element is in the sitemap namespace (no `xmlns=""`), declaration present, front-door URL listed; add a robots.txt fact |
+| `Tests.E2E/FrontDoorDispatcherTests.cs` | pin the canonical tag on `/Login` and `/Welcome` |
+| `Program.cs:49` | comment correction only — "the front door owns /" is stale (it owns `/Welcome`) |
+
+Chart pages **stay GUID URLs** here; the vanity swap is PR-4's, welded to real HTML. Entirely
+presentation-layer; no contracts, no migrations, no new resx keys. **Decision ① (owner,
+2026-07-16): `/Welcome` is canonical — it describes the page better.** `/Login` keeps serving
+the same HTML and canonicalizes to it; the sitemap lists only `/Welcome`. **Owner post-deploy:**
+resubmit the sitemap in Search Console.
+
+### PR-2 — the route-aware static head [M]
+
+The §4 decision, built. Ships real crawler heads for the whole site while every body is still a
+circuit — this is the PR that fixes Discord unfurls and search titles on its own.
+
+- **New** `Services/StaticHeadResolver.cs` (name at impl): request path → head model (title,
+  description, OG title/image; canonical + JSON-LD deliberately deferred to PR-4, where the
+  canonical namespace settles). Scoped service beside `ShellModelFactory`; `App.razor` renders
+  the result in `<head>` in place of the literal `<title>` (which becomes the fallback for
+  unmatched routes).
+- **First resolver: chart routes** (`/Chart/{guid}` now; the vanity shape joins at PR-4). Data
+  through existing cached reads — `ChartUrlResolver`'s 1h `GetChartsQuery` cache for identity,
+  `GetChartVerdictQuery` (daily-cached) if the description goes verdict-flavored; otherwise the
+  page's current `MetaDescription` shape. Nothing new below Web.
+- Candidate cheap follow-ons, same mechanism: `/TierLists/{type}/{level}` folder titles, the
+  calculators. Each is a resolver case, not a design question.
+- **Verification is E2E-only by nature** (the head is `App.razor`'s document — bUnit renders
+  components, not the document): anon `GET /Chart/{guid}` body contains the chart-named
+  `<title>` and `og:image` **before any circuit**, StaticShellTests-style.
+- Files: the new service + record, `App.razor` head edit, one `Program.cs` DI line, E2E facts.
+  Presentation-only.
+
+### PR-3 — the flip: every page opts in, MainLayout goes static [M–L, the risky one]
+
+§2's mechanics plus everything §3 catalogued. **Zero intended behavior change**; one site-wide
+QA on its own branch, exactly like Stage 1's.
+
+- Drop `@rendermode` from `<Routes>` (`App.razor:79`); new shared `RenderModes` class holding
+  the single `new InteractiveServerRenderMode(prerender: false)` instance (today a private
+  static in `App.razor`); add `@rendermode RenderModes.Interactive` to **all 58 pages**.
+- **`ShellMixSeed`** interactive root ahead of `<Routes>` — the §2 mix-seed fix. `Routes.razor`
+  loses its `CurrentMix` parameter/seeding role.
+- **MainLayout static** (§3): `ChartVideoDisplay` → island (7 pages fire its service event);
+  recap pointer dialog → island (signed-in only — its UiSettings reads/writes take the DB path,
+  static-safe, but the dialog itself needs a circuit); PageDock content host → island (a page's
+  `RenderFragment` crossing into it stays legal because both ends are islands on one circuit);
+  `MudLayout` relocates into the 3 drawer pages (HomeDashboard, TierLists/ChartSkills,
+  Tools/ChartRandomizer); the legacy-mix gate's `NavigateTo` becomes a real server redirect
+  (static SSR turns `NavigationManager.NavigateTo` into an HTTP redirect — strictly better than
+  today's bounce-after-paint); `LocationChanged` + the `OnAfterRenderAsync` dock re-sync die
+  (enhanced nav is off; every navigation is a full page load).
+  - MainLayout's `<PageTitle>` (line 13) dies harmlessly: pages without their own title fall to
+    the boot fallback, which **is** the static title's text.
+  - `MudContainer` is presentational and static-safe; it stays.
+- **Real 404s**: the static router's `NotFound` branch sets `Response.StatusCode = 404` — today
+  every garbage URL 200s an empty shell (soft-404 crawl waste).
+- **Ratchet**: new architecture test — every `@page` file in `Pages/` declares a `@rendermode`,
+  shrink-only allowlist for pages that have converted to static. bUnit cannot see render modes
+  (§5), so "a new page forgot to opt in" must fail as a file scan, not a rendering test.
+- **Verification**: the fast suites stay green through every render-mode violation (§5). E2E
+  full pass + the owner FT matrix are the actual gate.
+
+### PR-4 — ChartDetails static + output caching + the URL cutover [L — ships as ONE unit]
+
+The chart-details doc's P3, sharpened against this tree. The page is already rebuilt with every
+circuit-needing section its own child, so the conversion is mostly render-mode lines — the real
+work is caching and the lattice.
+
+- **Page**: delete its `@rendermode` line. Islands: `ChartVideoPlayer`, `ChartRecordPanel`,
+  `ChartEvidenceSection` (Apex), `ChartLeaderboardSection`, `SimilarChartsShelf`'s controls
+  (cards are already real `<a href>`s). The finder empty-state (`ChartSelector`) dies with the
+  bare `/Chart` + `/Record` routes. Unresolvable chart → 404 status via PR-3's mechanism.
+- **Skeletons**: the settled `data-island-ready` pattern (one wrapper CSS rule,
+  `:has([data-island-ready])`). ⚠ Verified wrinkle: `ChartRecordPanel` renders **nothing** for
+  anonymous users (`ChartRecordPanel.razor:23`), and an island that never renders never signals
+  ready — so its wrapper + skeleton must sit inside a server-side `@if` on request auth (the
+  static page reads `HttpContext`). **Owner decision ②:** v1 keeps the whole panel as the island
+  (the shipped comment's intent — everything in it is personal and cache-excluded anyway) vs.
+  the design doc's static-your-best-for-signed-in split. Default: whole-panel island.
+- **Token audit** (verified): `SkillCoverageBars` carries 1 `--mud-*` var and renders in a
+  static section — fix; then a pass over the `.chart-*` CSS rules. `DifficultyBubble`,
+  `ScoreBreakdown`, `UserLabel`, `SongImage` came up clean.
+- **The URL cutover** (machinery built dark at B4 — `ChartSlugs`, `ChartUrlResolver`):
+  - Vanity `@page "/{MixSlug}/{SongSlug}/{DifficultySlug}"` on the page; `/Chart/{guid}`,
+    `/Chart`, `/Record` leave it. ⚠ Component routes take no custom constraints, so the vanity
+    route is the site's **three-segment catch-all**: every existing 3-segment route out-ranks it
+    on literal segments (verified across the route table), and **any future 3-segment route must
+    too** — recorded hazard.
+  - ⚠ **Historical triples share the canonical shape**, so they cannot live in an MVC
+    controller — the same pattern registered twice is an `AmbiguousMatchException`. The **page
+    itself** compares the requested triple to the resolved chart's canonical and issues the 301
+    through `HttpContext.Response` — possible only under static SSR, which is *why* the cutover
+    is welded to this PR.
+  - **New `ChartPermalinkController`** (MVC): `/Chart/{guid}` → 301 canonical, forever;
+    `/Record` + bare `/Chart` → 301 `/Charts`.
+  - **In-app links → `ChartSlugs.CanonicalPath(chart)`** — full verified inventory, 5 sites:
+    `ChartDetails.razor:76` (siblings), `:245` (`GoToChart`), `AppBarSearch.razor:26`,
+    `SimilarChartCard.razor:101`, `Sessions/HighlightRow.razor:15`. All hold a full `Chart`.
+    Caveat: a non-default-mix record yields that mix's historical URL → one 301 hop; accepted.
+  - **Sitemap swap** to vanity (one line, post-PR-1 shape) + the PR-2 head resolver gains the
+    vanity route, self-canonical `<link>`, and JSON-LD.
+- **Output caching — this page ships it**: anonymous GETs only; vary by path + resolved culture
+  + mix cookie; bypass on auth cookie; TTL from config. Spike ①: does
+  `@attribute [OutputCache(...)]` on a component page flow into endpoint metadata (fallback:
+  path-keyed policy/middleware). Spike ②: find the live `Cache-Control: no-cache, no-store`
+  writer — prime suspect is antiforgery on the component endpoints (`UseAntiforgery`,
+  `Program.cs:340`) — and neutralize it for cacheable anonymous GETs. Owner/Azure item
+  (static-shell.md D18): ARR affinity cookies make first-hit responses edge-uncacheable — if the
+  plan runs a single instance, disable ARR affinity.
+- **Corrections to carry into chart-details-overhaul.md when syncing**: `ChartOverview` is NOT
+  dead — `Charts.razor:426` still opens it; its retirement belongs to `/Charts`' own conversion.
+- **FT**: view-source is real HTML; Discord unfurl shows the jacket; a GUID URL 301s.
+- **Owner decision ③:** hold the vanity sitemap swap for this PR (default, the ONE-unit rule) or
+  advertise correct-head-over-empty-body earlier once PR-2 lands.
+
+### PR-5 — E2E facts + doc sync [S–M]
+
+- E2E: anon vanity URL serves content **pre-circuit**; GUID / historical / stale-slug 301
+  chains; glow + your-best render only when signed in; 404 status for unknown charts and garbage
+  three-segment paths; cached-anon-HTML actually contains content.
+- Docs: ARCHITECTURE / UX-GUIDELINES / API / DATABASE-SCHEMA sync; chart-details-overhaul.md P3
+  + P4 rows close; this doc's ladder gets its shipped-marks.
+
+### Open owner decisions
+
+| # | Decision | Blocks | Default/lean |
+|---|---|---|---|
+| ① | Front-door canonical: `/Login` or `/Welcome` | PR-1 | **decided 2026-07-16: `/Welcome`** |
+| ② | `ChartRecordPanel`: whole-panel island vs static-your-best split | PR-4 | whole-panel island |
+| ③ | Vanity sitemap: wait for PR-4 (ONE unit) vs advertise after PR-2 | PR-4 timing | wait for PR-4 |


### PR DESCRIPTION
**SSR ladder PR-1** — the first of five PRs planned in `docs/design/seo-friendly-site.md` §7 (the plan lands in this PR too: the doc graduates from findings dump to the PR ladder, with the head decision, the 58-page count correction, and the mix-seed hazard PR-3 must carry).

## The sitemap bug

Google's "invalid, needs a namespace" error was real: only `urlset` carried the sitemap namespace — LINQ-to-XML children never inherit it, so every entry serialized as `<url xmlns="">`. Now:

- every element is created in the namespace explicitly
- the response ships a real `<?xml version="1.0" encoding="UTF-8"?>` declaration (`XDocument.Save` through a UTF-8 writer — `ToString()` silently drops declarations)
- `application/xml; charset=utf-8`
- the controller dispatches through `IMediator` (Catalog's `GetChartsQuery`) instead of injecting `IChartRepository` directly — same records, byte-identical URL output, and Web stops touching a repository port

Chart pages stay GUID URLs here; the vanity swap is welded to real page HTML (ladder PR-4).

## Crawl surface

- **`robots.txt` (new)** — sitemap pointer (discovery was Search-Console-only) + `Disallow` for `/hangfire`, `/api/`, `/Dev/`, `/Admin`
- **`/Welcome` is the canonical front door** (owner decision ①): it enters the sitemap, `/Login` serves the same HTML with `rel=canonical` pointing at it, and the page gains a meta description + OG title/description/type/url. The description reuses the hero pitch line — one string, already localized in all nine locales, zero new resx keys. No `og:image` yet (the only wwwroot image is the favicon; a share-card asset is a later nicety).

## Tests

- `TheSitemapStillServesXml` grew teeth → `TheSitemapIsNamespaceValidXml`: parses the document, holds **every** element to the sitemap namespace, asserts the declaration, the content type, `/Welcome`, and a chart URL
- New facts: `RobotsTxtPointsCrawlersAtTheSitemap`, `BothFrontDoorRoutesCanonicalizeToWelcome`

Suites: Tests **1346** / Api **60** / Components **163** green; the two touched E2E classes (**10** facts) green against the real Kestrel host.

## Owner post-deploy

Resubmit the sitemap in Google Search Console and watch the namespace error clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)