### PR TITLE
fix(l10n): quality pass over the non-English locales - every doc-tracked known bug

### DIFF
--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -121,10 +121,10 @@
     <value>(Opcional) Borrar también los datos históricos</value>
   </data>
   <data name="1+ Level Easier" xml:space="preserve">
-    <value>1+ Nivel más fácil</value>
+    <value>1+ nivel más fácil</value>
   </data>
   <data name="1+ Level Harder" xml:space="preserve">
-    <value>1+ Nivel más difícil</value>
+    <value>1+ nivel más difícil</value>
   </data>
   <data name="100% (or everyone with a PG)" xml:space="preserve">
     <value>100% (o todos con un PG)</value>
@@ -163,7 +163,7 @@
     <value>Agregar jugador</value>
   </data>
   <data name="Add to Favorites" xml:space="preserve">
-    <value>Agregar a Favoritos</value>
+    <value>Agregar a favoritos</value>
   </data>
   <data name="Add to ToDo" xml:space="preserve">
     <value>Agregar a Cosas que hacer</value>
@@ -271,7 +271,7 @@
     <value>BPM</value>
   </data>
   <data name="Broken" xml:space="preserve">
-    <value>Rota</value>
+    <value>Roto</value>
   </data>
   <data name="Broken scores get a multiplier of X" xml:space="preserve">
     <value>Los puntajes rotos reciben un multiplicador de {0}</value>
@@ -343,7 +343,7 @@
     <value>Estadísticas del chart</value>
   </data>
   <data name="Chart Type" xml:space="preserve">
-    <value>Tipo de Charts</value>
+    <value>Tipo de charts</value>
   </data>
   <data name="Chart Update" xml:space="preserve">
     <value>Actualización de chart</value>
@@ -634,7 +634,7 @@
     <value>Ocultar chart para esta categoría</value>
   </data>
   <data name="Hide Completed Charts" xml:space="preserve">
-    <value>Esconder charts completos</value>
+    <value>Ocultar charts completos</value>
   </data>
   <data name="Hide Record-less Charts" xml:space="preserve">
     <value>Ocultar charts sin record</value>
@@ -775,13 +775,13 @@
     <value>Bloquear establecerá el nombre de usuario de este usuario en su GameTag.</value>
   </data>
   <data name="Log In With" xml:space="preserve">
-    <value>Entrar con {0}</value>
+    <value>Iniciar sesión con {0}</value>
   </data>
   <data name="Login" xml:space="preserve">
-    <value>Entrar sesión</value>
+    <value>Iniciar sesión</value>
   </data>
   <data name="Logout" xml:space="preserve">
-    <value>Salir sesión</value>
+    <value>Cerrar sesión</value>
   </data>
   <data name="Machine Name" xml:space="preserve">
     <value>Nombre de la máquina</value>
@@ -901,7 +901,7 @@
     <value>Nuevo nombre de usuario</value>
   </data>
   <data name="Next Letter" xml:space="preserve">
-    <value>Siguiente Letra</value>
+    <value>Siguiente letra</value>
   </data>
   <data name="No one has passed this CoOp yet so no level is assigned." xml:space="preserve">
     <value>Nadie ha pasado este CoOp aún, así que no se le asigna nivel.</value>
@@ -916,7 +916,7 @@
     <value>No clasificado</value>
   </data>
   <data name="Not Passed Count" xml:space="preserve">
-    <value>Conteo de No Pasados</value>
+    <value>Conteo de no pasados</value>
   </data>
   <data name="Not Relevant to Category" xml:space="preserve">
     <value>No relevante para la categoría</value>
@@ -991,7 +991,7 @@
     <value>Pasado</value>
   </data>
   <data name="Passed Count" xml:space="preserve">
-    <value>Conteo de Pasados</value>
+    <value>Conteo de pasados</value>
   </data>
   <data name="Passes" xml:space="preserve">
     <value>Pases</value>
@@ -1264,7 +1264,7 @@
     <value>Guardar puntajes</value>
   </data>
   <data name="Saved Charts" xml:space="preserve">
-    <value>Guardar Charts</value>
+    <value>Charts guardados</value>
   </data>
   <data name="Saved!" xml:space="preserve">
     <value>¡Guardado!</value>
@@ -1441,7 +1441,7 @@
     <value>Duración de canción</value>
   </data>
   <data name="Song Image" xml:space="preserve">
-    <value>Imágen de canción</value>
+    <value>Imagen de canción</value>
   </data>
   <data name="Song Name" xml:space="preserve">
     <value>Nombre de canción</value>
@@ -1741,7 +1741,7 @@
     <value>Subir imagen</value>
   </data>
   <data name="Upload Scores" xml:space="preserve">
-    <value>Subir Puntajes</value>
+    <value>Subir puntajes</value>
   </data>
   <data name="Upload XX Scores" xml:space="preserve">
     <value>Subir puntajes de XX</value>
@@ -1750,13 +1750,13 @@
     <value>Uploader</value>
   </data>
   <data name="Use Password 1" xml:space="preserve">
-    <value>Esto hará que PIUScores haga login en su cuenta e importe sus scores:</value>
+    <value>Esto hará que PIUScores haga login en su cuenta e importe sus puntajes:</value>
   </data>
   <data name="Use Password 2" xml:space="preserve">
     <value>Por defecto no guardo tu usuario ni tu contraseña: los escribes cada vez. O usa la opción de recordar contraseña de abajo para guardarla, cifrada y solo en este dispositivo.</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>Para minimizar las llamadas para https://phoenix.piugame.com/, solo importaremos scores nuevos o mejorados. Cada usuario recibirá importación completa usando usuario/contraseña solo una vez. Use el importador dev-tools si quiere reimportar puntajes más antiguas.</value>
+    <value>Para minimizar las llamadas para https://phoenix.piugame.com/, solo importaremos scores nuevos o mejorados. Cada usuario recibirá importación completa usando usuario/contraseña solo una vez. Use el importador dev-tools si quiere reimportar puntajes más antiguos.</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
     <value>Una vez iniciado, puedes salir de esta página: la importación termina en segundo plano.</value>
@@ -1804,7 +1804,7 @@
     <value>Vida visible</value>
   </data>
   <data name="Vote Count" xml:space="preserve">
-    <value>{0} Conteo de votos</value>
+    <value>{0} votos</value>
   </data>
   <data name="Website" xml:space="preserve">
     <value>Sitio web</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -189,7 +189,7 @@
     <value>CoOp</value>
   </data>
   <data name="CoOp Aggregation" xml:space="preserve">
-    <value>Aggregation des CoOps</value>
+    <value>Agrégation des CoOp</value>
   </data>
   <data name="Copy Script" xml:space="preserve">
     <value>Copier le Script</value>
@@ -204,7 +204,7 @@
     <value>Doubles</value>
   </data>
   <data name="Download Failures" xml:space="preserve">
-    <value>Echecs de téléchargement</value>
+    <value>Échecs de téléchargement</value>
   </data>
   <data name="Download Scores" xml:space="preserve">
     <value>Télécharger les scores</value>
@@ -222,7 +222,7 @@
     <value>Favoris</value>
   </data>
   <data name="Full Privacy Policy" xml:space="preserve">
-    <value>Politique de Confidentialité Complète</value>
+    <value>Politique de confidentialité complète</value>
   </data>
   <data name="Hard" xml:space="preserve">
     <value>Difficile</value>
@@ -268,10 +268,10 @@
     <value>Rendre public</value>
   </data>
   <data name="Make Public Disclaimer 1" xml:space="preserve">
-    <value>Rendre votre compte public rendra vos scores et progression accessibles au public. Vous serez également ajouté de la communauté Monde.</value>
+    <value>Rendre votre compte public rendra vos scores et progression accessibles au public. Vous serez également ajouté à la communauté Monde.</value>
   </data>
   <data name="Make Public Disclaimer 2" xml:space="preserve">
-    <value>Si votre compte était prédcédemment public et que vous l'avez passé en privé, le passer à nouveau en public permettra à nouveau à vos followers de consulter votre progression.</value>
+    <value>Si votre compte était précédemment public et que vous l'avez passé en privé, le passer à nouveau en public permettra à nouveau à vos followers de consulter votre progression.</value>
   </data>
   <data name="Medium" xml:space="preserve">
     <value>Moyen</value>
@@ -280,10 +280,10 @@
     <value>Mix</value>
   </data>
   <data name="My Score" xml:space="preserve">
-    <value>Mon Score</value>
+    <value>Mon score</value>
   </data>
   <data name="Next Letter" xml:space="preserve">
-    <value>Prochaine Lettre</value>
+    <value>Prochaine lettre</value>
   </data>
   <data name="Not Graded Count" xml:space="preserve">
     <value>Non Gradé</value>
@@ -301,7 +301,7 @@
     <value>Ouvrir Vidéo</value>
   </data>
   <data name="Parse Failures" xml:space="preserve">
-    <value>Echecs d'analyse des données</value>
+    <value>Échecs d'analyse des données</value>
   </data>
   <data name="Passed Count" xml:space="preserve">
     <value>Passed</value>
@@ -319,10 +319,10 @@
     <value>Vous pourrez par la suite uploader ce CSV sur le site pour que vos scores y apparaissent.</value>
   </data>
   <data name="Phoenix Import Info 4" xml:space="preserve">
-    <value>NB: cet outil est expérimental et demandera surement un peu de debugging de votre côté pour fonctionner. Vérifiez bien que vos bloqueurs de publicité sont désactivés.</value>
+    <value>NB: cet outil est expérimental et demandera sûrement un peu de debugging de votre côté pour fonctionner. Vérifiez bien que vos bloqueurs de publicité sont désactivés.</value>
   </data>
   <data name="Phoenix Import Saving" xml:space="preserve">
-    <value>Si vous quittez la page ou annulez, l'upload s'arrêtera mais vous conserverez les scores qui ont déja sauvegardés pendant cet upload.</value>
+    <value>Si vous quittez la page ou annulez, l'upload s'arrêtera mais vous conserverez les scores qui ont déjà été sauvegardés pendant cet upload.</value>
   </data>
   <data name="Phoenix Import Saving Failures" xml:space="preserve">
     <value>Certains charts n'ont pas pu être téléchargés. Vous pouvez télécharger un CSV récapitulant les échecs pour faire des corrections et tenter à nouveau.</value>
@@ -364,16 +364,16 @@
     <value>Date d'enregistrement</value>
   </data>
   <data name="Recorded On" xml:space="preserve">
-    <value>Enregistré Le {0}</value>
-    <comment>par exemple, Enregistré Le 12/6/2023 (pas de support de format locaux pour le moment)</comment>
+    <value>Enregistré le {0}</value>
+    <comment>par exemple, Enregistré le 12/6/2023 (pas de support de format locaux pour le moment)</comment>
   </data>
   <data name="Remaining Charts" xml:space="preserve">
-    <value>{0} (SSS+) - {1} (AA) Charts Restants</value>
-    <comment>par exemple : 6 (SSS+) - 10 (AA) Charts Restants</comment>
+    <value>{0} (SSS+) - {1} (AA) Charts Restantes</value>
+    <comment>par exemple : 6 (SSS+) - 10 (AA) Charts Restantes</comment>
   </data>
   <data name="Remaining Charts For You" xml:space="preserve">
-    <value>{0} Charts Restants pour Vous</value>
-    <comment>par exemple : 8 Charts Restants pour Vousu</comment>
+    <value>{0} Charts Restantes pour Vous</value>
+    <comment>par exemple : 8 Charts Restantes pour Vous</comment>
   </data>
   <data name="Remove from ToDo" xml:space="preserve">
     <value>Enlever de la ToDo List</value>
@@ -391,7 +391,7 @@
     <value>Sauvegarder les Scores</value>
   </data>
   <data name="Saved Charts" xml:space="preserve">
-    <value>Charts Sauvegardées</value>
+    <value>Charts sauvegardées</value>
   </data>
   <data name="Score" xml:space="preserve">
     <value>Score</value>
@@ -404,23 +404,23 @@
     <comment>par exemple : Perte de Score liée aux Goods</comment>
   </data>
   <data name="Score Loss Note" xml:space="preserve">
-    <value>NB : la perte de scopre peut être incorrecte de 1 à 4 points à cause de l'arrondi</value>
+    <value>NB : la perte de score peut être incorrecte de 1 à 4 points à cause de l'arrondi</value>
   </data>
   <data name="Score Range Shoutout" xml:space="preserve">
     <value>Shout out à daryen pour la collecte de données et la finalisation des intervalles de scores pour les lettres de Rang !</value>
   </data>
   <data name="Score State" xml:space="preserve">
-    <value>Statut du Score</value>
+    <value>Statut du score</value>
     <comment>Statuts du Score = Passed, Unpassed, Unscored</comment>
   </data>
   <data name="Scores Parsed" xml:space="preserve">
     <value>Scores Analysés</value>
   </data>
   <data name="Show Only ToDo Charts" xml:space="preserve">
-    <value>Afficher Seulement les Charts ToDo</value>
+    <value>Montrer seulement les Charts ToDo</value>
   </data>
   <data name="Show Score Distribution" xml:space="preserve">
-    <value>Afficher la Distribution des Scores</value>
+    <value>Montrer la distribution des scores</value>
   </data>
   <data name="Singles" xml:space="preserve">
     <value>Singles</value>
@@ -435,7 +435,7 @@
     <value>Nom de la chanson</value>
   </data>
   <data name="Song Type" xml:space="preserve">
-    <value>Type de Chanson</value>
+    <value>Type de chanson</value>
     <comment>Types de Chanson = Arcade, Full Song, etc.</comment>
   </data>
   <data name="Starting Page" xml:space="preserve">
@@ -467,10 +467,10 @@
     <comment>par exemple, voius avez 19 charts de niveau 24 dans votre ToDo list que vous n'avez pas Pass</comment>
   </data>
   <data name="Upload Scores" xml:space="preserve">
-    <value>Télécharger Scores</value>
+    <value>Téléverser les scores</value>
   </data>
   <data name="Upload XX Scores" xml:space="preserve">
-    <value>Télécharger Scores XX</value>
+    <value>Téléverser les scores XX</value>
   </data>
   <data name="Use Password 1" xml:space="preserve">
     <value>Ceci permet à PIUScores de se connecter à votre compte et d'importer les scores pour vous.</value>
@@ -479,7 +479,7 @@
     <value>Par défaut, je ne garde ni votre nom d'utilisateur ni votre mot de passe — vous les saisissez à chaque fois. Ou utilisez l'option « se souvenir du mot de passe » ci-dessous pour l'enregistrer, chiffré et uniquement sur cet appareil.</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>Pour limiter les requètes vers https://phoenix.piugame.com, je n'importe que les scores nouveaux ou améliorés. Chaque utilisateur a un import entier avec son nom d'utilisateur et mot de passe. Utilisez l'importateur outils developpeur si vous souhaitez réimporter des scores plus anciens.</value>
+    <value>Pour limiter les requêtes vers https://phoenix.piugame.com, je n'importe que les scores nouveaux ou améliorés. Chaque utilisateur a un import entier avec son nom d'utilisateur et mot de passe. Utilisez l'importateur outils développeur si vous souhaitez réimporter des scores plus anciens.</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
     <value>Une fois démarré, vous pouvez quitter cette page — l'importation se termine en arrière-plan.</value>
@@ -507,8 +507,8 @@
     <comment>Photos</comment>
   </data>
   <data name="Qualifiers Leaderboard" xml:space="preserve">
-    <value>{0} Leaderboard de Qualification</value>
-    <comment>Leaderboard de Qualification</comment>
+    <value>{0} Leaderboard de qualifications</value>
+    <comment>Leaderboard de qualifications</comment>
   </data>
   <data name="Place" xml:space="preserve">
     <value>Place</value>
@@ -550,10 +550,10 @@
     <value>Rating Max</value>
   </data>
   <data name="Qualifier Submit Phrase 1" xml:space="preserve">
-    <value>Vous n'avez pas besoin d'être identifié pour utilsier cet outil. Entrez un nom d'utilisateur pour commencer à envoyer</value>
+    <value>Vous n'avez pas besoin d'être identifié pour utiliser cet outil. Entrez un nom d'utilisateur pour commencer à envoyer</value>
   </data>
   <data name="Qualifier Submit Phrase 2" xml:space="preserve">
-    <value>C'est votre premier envoi !  Assurez vous que votre nom d'utilisateur est identifiable depuis Discord ou Start.GG</value>
+    <value>C'est votre premier envoi ! Assurez-vous que votre nom d'utilisateur est identifiable depuis Discord ou Start.GG</value>
   </data>
   <data name="Qualifiers Submission" xml:space="preserve">
     <value>{0} envois pour qualifications</value>
@@ -565,7 +565,7 @@
     <value>Chanson</value>
   </data>
   <data name="Song Artist" xml:space="preserve">
-    <value>Song Artist</value>
+    <value>Artiste de la chanson</value>
   </data>
   <data name="Submission Page" xml:space="preserve">
     <value>Page d'envoi</value>
@@ -663,10 +663,6 @@
 	  <value>Nombre de Notes</value>
 	  <comment>Nombre de Notes</comment>
   </data>
-  <data name="Pass (Avec Données)" xml:space="preserve">
-	  <value>Pass (Avec Données)</value>
-	  <comment>Pass (Avec Données)</comment>
-  </data>
   <data name="Score (Data Backed)" xml:space="preserve">
 	  <value>Score (Avec Données)</value>
 	  <comment>Score (Avec Données)</comment>
@@ -680,8 +676,8 @@
 	  <comment>Nombre de Joueurs</comment>
   </data>
   <data name="Difficulty Categorization" xml:space="preserve">
-	  <value>Catégorisation par Difficulté</value>
-	  <comment>Catégorisation par Difficulté</comment>
+	  <value>Catégorisation par difficulté</value>
+	  <comment>Catégorisation par difficulté</comment>
   </data>
   <data name="Scoring Level" xml:space="preserve">
 	  <value>Niveau de Score</value>
@@ -1515,7 +1511,7 @@
     <comment>Titre de page sur /Tournament/{id}/Admin. {0} = nom du tournoi.</comment>
   </data>
   <data name="Sync Qualifier Leaderboard" xml:space="preserve">
-    <value>Synchroniser le Leaderboard de qualification</value>
+    <value>Synchroniser le Leaderboard de qualifications</value>
   </data>
   <data name="New Player Name" xml:space="preserve">
     <value>Nom du nouveau joueur</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -149,7 +149,7 @@
     <value>お気に入りを追加</value>
   </data>
   <data name="Add to ToDo" xml:space="preserve">
-    <value>やりことリストを追加</value>
+    <value>やることリストを追加</value>
   </data>
   <data name="Average" xml:space="preserve">
     <value>平均</value>
@@ -161,7 +161,7 @@
     <value>キャンセル</value>
   </data>
   <data name="Chart List Share Description" xml:space="preserve">
-    <value>この譜面リストをシェアー</value>
+    <value>この譜面リストをシェア</value>
   </data>
   <data name="Chart Randomizer" xml:space="preserve">
     <value>譜面くじ引き（抽選機）</value>
@@ -189,7 +189,7 @@
     <value>CoOp</value>
   </data>
   <data name="CoOp Aggregation" xml:space="preserve">
-    <value>CoOp集合</value>
+    <value>CoOp集計</value>
   </data>
   <data name="Copy Script" xml:space="preserve">
     <value>コピー</value>
@@ -271,13 +271,13 @@
     <value>公開すれば自分のスコアと進化が誰度も見えるようになります。世界ランキングを追加されます。</value>
   </data>
   <data name="Make Public Disclaimer 2" xml:space="preserve">
-    <value>公開すれば、まえのフォローしてる友達も見えるようになります。</value>
+    <value>公開すれば、以前のフォローしてる友達も見えるようになります。</value>
   </data>
   <data name="Medium" xml:space="preserve">
     <value>中</value>
   </data>
   <data name="Mix" xml:space="preserve">
-    <value>ベーション</value>
+    <value>バージョン</value>
   </data>
   <data name="My Score" xml:space="preserve">
     <value>自己スコア</value>
@@ -292,7 +292,7 @@
     <value>未クリア数</value>
   </data>
   <data name="Official Leaderboard Search" xml:space="preserve">
-    <value>公開ランキング捜索</value>
+    <value>公開ランキング検索</value>
   </data>
   <data name="Official Scores" xml:space="preserve">
     <value>公開スコア</value>
@@ -325,7 +325,7 @@
     <value>このページを離れたら、アップロードしたスコアは失わないです。</value>
   </data>
   <data name="Phoenix Import Saving Failures" xml:space="preserve">
-    <value>一部のスコアダウンロードが失敗しまいました。失敗なCSVファイルはダウンロードして編集しても一回アップロード可能です。</value>
+    <value>一部のスコアダウンロードが失敗しました。失敗したCSVファイルはダウンロードして編集して、もう一回アップロード可能です。</value>
   </data>
   <data name="Phoenix Import Saving Progress" xml:space="preserve">
     <value>{0}/{1} 成功. {2} 残り. {3}登録失敗</value>
@@ -364,7 +364,7 @@
     <value>記録日</value>
   </data>
   <data name="Recorded On" xml:space="preserve">
-    <value>{0}にき記録した</value>
+    <value>{0}に記録した</value>
     
   <comment>例：12/6/2023に記録した。日本の日付の局在化は未完成です。🙇</comment></data>
   <data name="Remaining Charts" xml:space="preserve">
@@ -376,7 +376,7 @@
     
   <comment>例：８譜面残り（推測）</comment></data>
   <data name="Remove from ToDo" xml:space="preserve">
-    <value>やりことリストから解除</value>
+    <value>やることリストから解除</value>
   </data>
   <data name="Report Video" xml:space="preserve">
     <value>ビデオを報告</value>
@@ -451,10 +451,10 @@
     <value>タイトル</value>
   </data>
   <data name="To Do" xml:space="preserve">
-    <value>やりこと</value>
+    <value>やること</value>
   </data>
   <data name="Tools" xml:space="preserve">
-    <value>ツルー</value>
+    <value>ツール</value>
   </data>
   <data name="Total Count" xml:space="preserve">
     <value>総計</value>
@@ -463,9 +463,9 @@
     <value>大会</value>
   </data>
   <data name="Unpassed ToDos" xml:space="preserve">
-    <value>やりことリストの中のレベレ{1}で譜面まだ{0}曲が残してる（クリアしてない）</value>
+    <value>やることリストの中のレベル{1}で譜面まだ{0}曲が残してる（クリアしてない）</value>
     
-  <comment>例：レベレ２４の中でまだ９譜面が残してる</comment></data>
+  <comment>例：レベル２４の中でまだ９譜面が残してる</comment></data>
   <data name="Upload Scores" xml:space="preserve">
     <value>スコア更新</value>
   </data>
@@ -473,14 +473,13 @@
     <value>XXスコア更新</value>
   </data>
   <data name="Use Password 1" xml:space="preserve">
-    <value>このツルーはpiugame.comにログインして、自動でスコアアップロードすます。</value>
+    <value>このツールはpiugame.comにログインして、自動でスコアアップロードします。</value>
   </data>
   <data name="Use Password 2" xml:space="preserve">
     <value>通常はユーザー名やパスワードを保存しないので、毎回入力してください。下のパスワードを記憶するオプションを使うと、暗号化してこのデバイスにのみ保存できます。</value>
   </data>
   <data name="Use Password 3" xml:space="preserve">
-    <value>https://phoenix.piugame.comのAPI呼び出すのを減らすなめに、新しいとか改良スコアどけインポートする。各ユーザーは完全インポート（ユーザーとパスワード）一回だけのサービスを上げます。古いスコアが
-          も一回インポート場合、dev-toolsのスクリプト使ってください。</value>
+    <value>https://phoenix.piugame.comのAPI呼び出すのを減らすために、新しいとか改良スコアだけインポートする。各ユーザーは完全インポート（ユーザーとパスワード）一回だけのサービスを上げます。古いスコアをもう一回インポートする場合、dev-toolsのスクリプト使ってください。</value>
   </data>
   <data name="Use Password 4" xml:space="preserve">
     <value>開始後はこのページを離れても大丈夫です。インポートはバックグラウンドで完了します。</value>
@@ -489,7 +488,7 @@
     <value>デバッグ用</value>
   </data>
   <data name="Username" xml:space="preserve">
-    <value>ユーザ名</value>
+    <value>ユーザー名</value>
   </data>
   <data name="Very Easy" xml:space="preserve">
     <value>とても簡単</value>
@@ -551,10 +550,10 @@
     <value>最高評定</value>
   </data>
   <data name="Qualifier Submit Phrase 1" xml:space="preserve">
-    <value>このツルーはログイン必要ありません。登録前、ユーザ名を入力お願いします。</value>
+    <value>このツールはログイン必要ありません。登録前、ユーザー名を入力お願いします。</value>
   </data>
   <data name="Qualifier Submit Phrase 2" xml:space="preserve">
-    <value>初めての登録！ユーザ名はdiscordとかstart.ggで同じく確認してください</value>
+    <value>初めての登録！ユーザー名はdiscordとかstart.ggで同じく確認してください</value>
   </data>
   <data name="Qualifiers Submission" xml:space="preserve">
     <value>{0}資格の登録</value>
@@ -597,11 +596,11 @@
     
   <comment>文字示す</comment></data>
   <data name="Open" xml:space="preserve">
-	  <value>Open</value>
+	  <value>開く</value>
 	  
   <comment>開く</comment></data>
   <data name="Country" xml:space="preserve">
-	  <value>Country</value>
+	  <value>国</value>
 	  
   <comment>国</comment></data>
   <data name="Avatar" xml:space="preserve">
@@ -669,7 +668,7 @@
 	  
   <comment>Pass (Data Backed)</comment></data>
   <data name="Score (Data Backed)" xml:space="preserve">
-	  <value>スコア(データあり)</value>
+	  <value>スコア（データあり）</value>
 	  
   <comment>Score (Data Backed)</comment></data>
   <data name="Popularity (PIU Game Leaderboard)" xml:space="preserve">
@@ -1046,7 +1045,7 @@
 	  
   </data>
   <data name="You had a few charts that were not able to be downloaded. You can download a CSV of the failures to make adjustments and try again." xml:space="preserve">
-	  <value>一部のスコアダウンロードが失敗しまいました。失敗なCSVファイルはダウンロードして編集しても一回アップロード可能です。</value>
+	  <value>一部のスコアダウンロードが失敗しました。失敗したCSVファイルはダウンロードして編集して、もう一回アップロード可能です。</value>
   </data>
   <data name="All charts you uploaded were successfully updated!" xml:space="preserve">
 	  <value>アップロードした譜面全部更新出来ました！</value>
@@ -1893,10 +1892,10 @@
 	  <value>このカテゴリーで譜面を隠す</value>
   </data>
   <data name="Added to ToDo List!" xml:space="preserve">
-	  <value>やりことリストに追加しました！</value>
+	  <value>やることリストに追加しました！</value>
   </data>
   <data name="Removed from ToDo List!" xml:space="preserve">
-	  <value>やりことリストから削除しました！</value>
+	  <value>やることリストから削除しました！</value>
   </data>
   <data name="Chart Details" xml:space="preserve">
 	  <value>譜面詳細</value>
@@ -1940,7 +1939,7 @@
 	  <value>ユーザー検索（名前またはユーザーID）</value>
   </data>
   <data name="Current Username" xml:space="preserve">
-	  <value>現在のユーザ名</value>
+	  <value>現在のユーザー名</value>
   </data>
   <data name="Lock Status" xml:space="preserve">
 	  <value>ロック状態</value>
@@ -1952,10 +1951,10 @@
 	  <value>ロック解除済</value>
   </data>
   <data name="Lock User" xml:space="preserve">
-	  <value>ユーザロック</value>
+	  <value>ユーザーロック</value>
   </data>
   <data name="Unlock User" xml:space="preserve">
-	  <value>ユーザロック解除</value>
+	  <value>ユーザーロック解除</value>
   </data>
   <data name="User locked" xml:space="preserve">
 	  <value>ユーザーをロックしました</value>
@@ -1970,7 +1969,7 @@
 	  <value>このユーザーにはGameTagがありません。ロック前にユーザー名を割り当ててください。</value>
   </data>
   <data name="New Username" xml:space="preserve">
-	  <value>新ユーザ名</value>
+	  <value>新ユーザー名</value>
   </data>
   <data name="Your account is content-locked. Message an admin if you have questions." xml:space="preserve">
 	  <value>アカウントはコンテンツロック中です。質問があれば管理者へご連絡ください。</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -160,7 +160,7 @@
     <value>취소</value>
   </data>
   <data name="Chart List Share Description" xml:space="preserve">
-    <value>이 링크를 사용하여 차트 목록을 다른 유저와 공유해보세요.</value>
+    <value>이 링크를 사용하여 채보 목록을 다른 유저와 공유해보세요.</value>
   </data>
   <data name="Chart Randomizer" xml:space="preserve">
     <value>채보 무작위 생성기</value>
@@ -202,7 +202,7 @@
     <value>다운로드 실패</value>
   </data>
   <data name="Download Scores" xml:space="preserve">
-    <value>스코어 다운로드</value>
+    <value>점수 다운로드</value>
   </data>
   <data name="Easiest Player" xml:space="preserve">
     <value>하급</value>
@@ -226,7 +226,7 @@
     <value>상급</value>
   </data>
   <data name="Hide Completed Charts" xml:space="preserve">
-    <value>클리어한 차트 숨기기</value>
+    <value>클리어한 채보 숨기기</value>
   </data>
   <data name="Import Phoenix Scores" xml:space="preserve">
     <value>Phoenix 점수 불러오기</value>
@@ -241,7 +241,7 @@
     <value>랭크</value>
   </data>
   <data name="Log In With" xml:space="preserve">
-    <value>로 로그인 {0}</value>
+    <value>{0} 계정으로 로그인</value>
   </data>
   <data name="Login" xml:space="preserve">
     <value>로그인</value>
@@ -304,13 +304,13 @@
     <value>CSV 파일을 이곳에 업로드하시면 점수가 표시됩니다.</value>
   </data>
   <data name="Phoenix Import Info 4" xml:space="preserve">
-    <value>참고: 이 과정은 상당히 불안정할 수 있으며 작동을 위해 일부 디버깅이 필요할 수 있습니다. 광고 차단기를 비활성화 하셔야 합니다. </value>
+    <value>참고: 이 과정은 상당히 불안정할 수 있으며 작동을 위해 일부 디버깅이 필요할 수 있습니다. 광고 차단기를 비활성화 하셔야 합니다.</value>
   </data>
   <data name="Phoenix Import Saving" xml:space="preserve">
     <value>이 페이지를 떠나시거나 취소하시면 업로드는 중단됩니다. 하지만 이미 업로드된 기록 중에서는 어떠한 점수도 손실되지 않습니다.</value>
   </data>
   <data name="Phoenix Import Saving Failures" xml:space="preserve">
-    <value>특정 채보를 다운로드 할 수 없었습니다. 조정을 위해 실패한 채보의 CSV를 다운로드하고 다시 시도할 수 있습니다. </value>
+    <value>특정 채보를 다운로드 할 수 없었습니다. 조정을 위해 실패한 채보의 CSV를 다운로드하고 다시 시도할 수 있습니다.</value>
   </data>
   <data name="Phoenix Import Saving Progress" xml:space="preserve">
     <value>{0}/{1} 업로드됨 {2} 남음 {3} 기록 실패</value>
@@ -346,7 +346,7 @@
     <value>기록된 날짜</value>
   </data>
   <data name="Recorded On" xml:space="preserve">
-    <value>기록됨 {0}</value>
+    <value>{0}에 기록됨</value>
   </data>
   <data name="Remaining Charts" xml:space="preserve">
     <value>{0} (SSS+) - {1} (AA) 남은 채보</value>
@@ -376,7 +376,7 @@
     <value>점수</value>
   </data>
   <data name="Score Formula Shoutout" xml:space="preserve">
-    <value>이 점수공식을 제작해주신 Mr_WEQ 님에게 감사드립니다</value>
+    <value>이 점수공식을 제작해주신 Mr_WEQ님에게 감사드립니다</value>
   </data>
   <data name="Score Loss" xml:space="preserve">
     <value>{0} 점수 감소</value>
@@ -535,7 +535,7 @@
     <value>레이팅 계산기</value>
   </data>
   <data name="Song" xml:space="preserve">
-    <value>음악</value>
+    <value>노래</value>
   </data>
   <data name="Song Artist" xml:space="preserve">
     <value>작곡자</value>
@@ -2057,7 +2057,7 @@
     <value>점수 가져오기</value>
   </data>
   <data name="Find a chart" xml:space="preserve">
-    <value>차트 찾기</value>
+    <value>채보 찾기</value>
   </data>
   <data name="Coming Soon" xml:space="preserve">
     <value>곧 제공 예정</value>
@@ -3571,7 +3571,7 @@
     <value>데일리 스텝</value>
   </data>
   <data name="Today's shared chart, plus a weekly Limbo Day." xml:space="preserve">
-    <value>오늘의 공유 차트, 그리고 주 1회 림보 데이.</value>
+    <value>오늘의 공유 채보, 그리고 주 1회 림보 데이.</value>
   </data>
   <data name="Today's Step posts at midnight." xml:space="preserve">
     <value>오늘의 스텝은 자정에 공개됩니다.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -504,9 +504,6 @@
   <data name="BPM" xml:space="preserve">
     <value>BPM</value>
   </data>
-  <data name="Days Old" xml:space="preserve">
-    <value>dias de idade</value>
-  </data>
   <data name="Difficulty Categorization" xml:space="preserve">
     <value>Categorização de dificuldade</value>
   </data>
@@ -660,12 +657,6 @@
   <data name="My Relative Difficulty" xml:space="preserve">
     <value>Minha dificuldade relativa</value>
   </data>
-  <data name="New Letter Grade" xml:space="preserve">
-    <value>Letra de nota nova</value>
-  </data>
-  <data name="Old Letter Grade" xml:space="preserve">
-    <value>Letra de nota antiga</value>
-  </data>
   <data name="Overall Letters" xml:space="preserve">
     <value>Letras gerais</value>
   </data>
@@ -789,17 +780,8 @@
   <data name="Last Updated" xml:space="preserve">
     <value>Última atualização</value>
   </data>
-  <data name="Leaderboard Name" xml:space="preserve">
-    <value>Nome da classificação</value>
-  </data>
   <data name="Level/Players" xml:space="preserve">
     <value>Nível/Jogadores</value>
-  </data>
-  <data name="Maximum Level" xml:space="preserve">
-    <value>Nível máximo</value>
-  </data>
-  <data name="Minimum Level" xml:space="preserve">
-    <value>Nível mínimo</value>
   </data>
   <data name="Minutes" xml:space="preserve">
     <value>Minutos</value>
@@ -822,9 +804,6 @@
   <data name="Seconds" xml:space="preserve">
     <value>Segundos</value>
   </data>
-  <data name="Show Regional Guests" xml:space="preserve">
-    <value>Mostrar convidados regionais</value>
-  </data>
   <data name="Update Chart" xml:space="preserve">
     <value>Atualizar chart</value>
   </data>
@@ -845,9 +824,6 @@
   </data>
   <data name="Added" xml:space="preserve">
     <value>Adicionado</value>
-  </data>
-  <data name="Arrows Pressed" xml:space="preserve">
-    <value>Setas pressionadas</value>
   </data>
   <data name="Bads vs Misses Observations" xml:space="preserve">
     <value>Observações: Bads vs Misses</value>
@@ -923,12 +899,6 @@
   </data>
   <data name="Removed" xml:space="preserve">
     <value>Removido</value>
-  </data>
-  <data name="Saved Settings" xml:space="preserve">
-    <value>Configurações salvas</value>
-  </data>
-  <data name="Settings Name" xml:space="preserve">
-    <value>Nome das configurações</value>
   </data>
   <data name="Source" xml:space="preserve">
     <value>Fonte</value>
@@ -1215,9 +1185,6 @@
   <data name="Bad Suggestion" xml:space="preserve">
     <value>Sugestão ruim</value>
   </data>
-  <data name="Change Card" xml:space="preserve">
-    <value>Trocar cartão</value>
-  </data>
   <data name="Chart Details" xml:space="preserve">
     <value>Detalhes do chart</value>
   </data>
@@ -1254,9 +1221,6 @@
   <data name="From" xml:space="preserve">
     <value>De</value>
   </data>
-  <data name="Game Card" xml:space="preserve">
-    <value>Cartão do jogo</value>
-  </data>
   <data name="Good Suggestion" xml:space="preserve">
     <value>Boa sugestão</value>
   </data>
@@ -1271,9 +1235,6 @@
   </data>
   <data name="I Just Want to Hide The Chart" xml:space="preserve">
     <value>Só quero ocultar este chart</value>
-  </data>
-  <data name="Include Broken Scores" xml:space="preserve">
-    <value>Incluir pontuações quebradas</value>
   </data>
   <data name="IsBroken" xml:space="preserve">
     <value>Quebrada</value>
@@ -1371,9 +1332,6 @@
   <data name="Type" xml:space="preserve">
     <value>Tipo</value>
   </data>
-  <data name="Use Password" xml:space="preserve">
-    <value>Usar senha</value>
-  </data>
   <data name="Use Script" xml:space="preserve">
     <value>Usar script</value>
   </data>
@@ -1443,9 +1401,6 @@
   <data name="Add Player" xml:space="preserve">
     <value>Adicionar jogador</value>
   </data>
-  <data name="Add Scores" xml:space="preserve">
-    <value>Adicionar pontuações</value>
-  </data>
   <data name="Always" xml:space="preserve">
     <value>Sempre</value>
   </data>
@@ -1460,12 +1415,6 @@
   </data>
   <data name="Broken scores get a multiplier of X" xml:space="preserve">
     <value>Pontuações quebradas recebem um multiplicador de {0}</value>
-  </data>
-  <data name="Chart Types" xml:space="preserve">
-    <value>Tipos de chart</value>
-  </data>
-  <data name="Check Your Best Pumbility Charts" xml:space="preserve">
-    <value>Verifique seus melhores charts de Pumbility</value>
   </data>
   <data name="Discord Id" xml:space="preserve">
     <value>ID do Discord</value>
@@ -1488,9 +1437,6 @@
   <data name="Is Warmup" xml:space="preserve">
     <value>Aquecimento</value>
   </data>
-  <data name="Letter Grades" xml:space="preserve">
-    <value>Letras de nota</value>
-  </data>
   <data name="Link" xml:space="preserve">
     <value>Link</value>
   </data>
@@ -1511,9 +1457,6 @@
   </data>
   <data name="Notes" xml:space="preserve">
     <value>Notas</value>
-  </data>
-  <data name="Password" xml:space="preserve">
-    <value>Senha</value>
   </data>
   <data name="Pending" xml:space="preserve">
     <value>Pendente</value>
@@ -1558,10 +1501,10 @@
     <value>Este é seu primeiro envio! Certifique-se de que seu nome de usuário seja identificável via Discord ou Start.GG.</value>
   </data>
   <data name="Qualifiers Leaderboard" xml:space="preserve">
-    <value>Classificação dos qualifiers</value>
+    <value>Classificação dos qualifiers de {0}</value>
   </data>
   <data name="Qualifiers Submission" xml:space="preserve">
-    <value>Envio dos qualifiers</value>
+    <value>Envio dos qualifiers de {0}</value>
   </data>
   <data name="Repeated charts X allowed." xml:space="preserve">
     <value>Charts repetidos {0} permitidos.</value>
@@ -1571,9 +1514,6 @@
   </data>
   <data name="Seed" xml:space="preserve">
     <value>Seed</value>
-  </data>
-  <data name="Song Types" xml:space="preserve">
-    <value>Tipos de música</value>
   </data>
   <data name="Songs will have score adjusted based on song length (treating 2 minutes as baseline)" xml:space="preserve">
     <value>As músicas terão a pontuação ajustada com base na duração da música (considerando 2 minutos como base)</value>
@@ -1628,9 +1568,6 @@
   </data>
   <data name="Average PPS" xml:space="preserve">
     <value>PPS médio</value>
-  </data>
-  <data name="Average Score" xml:space="preserve">
-    <value>Pontuação média</value>
   </data>
   <data name="Best Score" xml:space="preserve">
     <value>Melhor pontuação</value>

--- a/docs/LOCALIZATION-es-MX.md
+++ b/docs/LOCALIZATION-es-MX.md
@@ -8,8 +8,8 @@ The bulk batch made structural decisions for the entries it added; those decisio
 
 ## Style conventions
 
-- **Address the user with formal `usted`.** The existing prose voice leans `usted` (`Use el importador dev-tools si quiere reimportar`, `no salga de esta página`, `de lo contrario sus puntajes no serán guardadas`), with one mixed string that drops into informal `tú` mid-sentence (`tendrá que introducirlos siempre que uses esa opción` — see Known issues). Mexico web UIs use both `tú` and `usted`; this file already chose `usted`. Match that for new entries — `usted` / `su` / `sus`, imperative `Use`, `Salga`, `Importe`, etc. Don't introduce `tú` / `tu` / `tus` outside the existing inconsistencies.
-- **Sentence case in values, even when the English key is Title Case.** Example: `"Difficulty Level"` → `"Nivel de dificultad"`, `"Phoenix Score Calculator"` → `"Calculadora de puntajes de Phoenix"`, `"Full Privacy Policy"` → `"Política de privacidad completa"`. The existing file mixes sentence case with English-influenced Title Case in several entries (`Conteo de Pasados`, `Tipo de Charts`, `Siguiente Letra`, `Subir Puntajes`, `Agregar a Favoritos`); standard Spanish orthography uses sentence case, so favor that for new entries and leave the older Title Case entries for a separate cleanup sweep — see Known issues.
+- **Address the user with formal `usted`.** The original prose voice chose `usted` (`Use el importador dev-tools si quiere reimportar`, `no salga de esta página`, `de lo contrario sus puntajes no serán guardadas`), and the 2026-04-26 bulk batch applied it sweepingly. **However**, the feature batches from mid-2026 (front door, home-page widgets, import widget, tier-list breakdown) landed in informal `tú` — the file is now register-forked (~96 tú-marked keys vs ~56 usted-marked). See Known issues: the fork needs an owner/native decision on direction before any sweep. Until that decision, match the register of the strings *around* the feature you're translating rather than adding to the imbalance.
+- **Sentence case in values, even when the English key is Title Case.** Example: `"Difficulty Level"` → `"Nivel de dificultad"`, `"Phoenix Score Calculator"` → `"Calculadora de puntajes de Phoenix"`, `"Full Privacy Policy"` → `"Política de privacidad completa"`. The older Title Case stragglers (`Conteo de Pasados`, `Tipo de Charts`, `Siguiente Letra`, `Subir Puntajes`, `Agregar a Favoritos`, `1+ Nivel más fácil/difícil`) were swept to sentence case in the 2026-07 QC pass; the file is uniform now.
 - **Brand and proper-noun casing is preserved verbatim.** `Score Tracker`, `Phoenix`, `XX`, `PIU`, `PIUScores`, `Discord`, `https://piugame.com` — keep their original casing inside Spanish sentences.
 - **Preserve positional placeholders verbatim.** `{0}`, `{1}`, `{2}` go into the value untouched, in whatever order Spanish grammar wants. Examples: `"Log In With"` (English value `"Log In With {0}"`) → `"Entrar con {0}"`; `"Vote Count"` → `"{0} Conteo de votos"`. (The latter is awkward — see Known issues.)
 - **Skip prose with inline markup.** Per CLAUDE.md, `<MudText>` bodies with embedded `<MudLink>`/other elements stay hardcoded English. Don't extract them, don't translate them.
@@ -20,7 +20,7 @@ The bulk batch made structural decisions for the entries it added; those decisio
   - `descargar` for download (established, `Descargar puntajes`).
   - `subir` for upload (established, `Subir Puntajes`).
   - `borrar` for delete (established, `Borrar de la lista de Cosas que hacer`); `eliminar` is also acceptable.
-  - `iniciar sesión` / `cerrar sesión` for login/logout (existing `Entrar sesión` / `Salir sesión` is awkward — see Known issues; new entries should use the standard forms when extending the login family).
+  - `iniciar sesión` / `cerrar sesión` for login/logout (the awkward `Entrar sesión` / `Salir sesión` forms were swept in the 2026-07 QC pass; the whole login family now uses the standard forms).
 
 ## Established term mappings
 
@@ -35,10 +35,10 @@ These have at least one existing translation in `App.es-MX.resx`. New translatio
 | Account | Cuenta | |
 | Account Creation? | ¿Crear cuenta? | Opening `¿` per Spanish punctuation. |
 | Actions | Acciones | |
-| Add to Favorites | Agregar a Favoritos | Title Case on `Favoritos` — older entry. New "Add to X" should use sentence case (`Agregar a favoritos`). Mexico uses `Agregar` over Spain's `Añadir`. |
+| Add to Favorites | Agregar a favoritos | Mexico uses `Agregar` over Spain's `Añadir`. |
 | Add to ToDo | Agregar a Cosas que hacer | "ToDo" rendered as `Cosas que hacer` (see To Do). |
 | Average | Promedio | |
-| Broken | Rota | Past participle, feminine default — likely modifying an implicit `chart` (treated as feminine here, see Charts gender note in Known issues). |
+| Broken | Roto | Past participle, masculine — agrees with `[el chart]` per the committed Charts-masculine decision. |
 | Cancel | Cancelar | |
 | Close | Cerrar | |
 | Completed | Completado | Masculine default. |
@@ -50,14 +50,14 @@ These have at least one existing translation in `App.es-MX.resx`. New translatio
 | Favorites | Favoritos | |
 | Full Privacy Policy | Política de privacidad completa | Sentence case. |
 | Hardest Player | Jugador más difícil | |
-| Hide Completed Charts | Esconder charts completos | `Esconder` rather than the more standard `Ocultar`; both are valid in Mexico — `Esconder` reads slightly more colloquial. Lean toward `Ocultar` for new "Hide" entries to match what other locales do consistently. |
+| Hide Completed Charts | Ocultar charts completos | The lone `Esconder` outlier was swept to `Ocultar` — every `Hide X` is `Ocultar X` now. |
 | Language | (untranslated stub) | Existing entry is the English string `Language`. Translate as `Idioma` when next touched. |
-| Log In With | Entrar con {0} | Verb form; placeholder takes the provider name (Discord, Google, Facebook). `Entrar` reads natural in Mexico, though `Iniciar sesión con {0}` is the more standard form — see Known issues for the login-family inconsistency. |
-| Login | Entrar sesión | **Awkward** — should be `Iniciar sesión` (standard) or `Inicio de sesión` (noun). See Known issues. |
-| Logout | Salir sesión | **Awkward** — should be `Cerrar sesión`. See Known issues. |
+| Log In With | Iniciar sesión con {0} | Verb form; placeholder takes the provider name (Discord, Google, Facebook). |
+| Login | Iniciar sesión | |
+| Logout | Cerrar sesión | |
 | Make Public / Private | Hacerla pública / Hacerla privada | Feminine `la` — implicit antecedent is `[la cuenta]`. Verb construction. |
 | Medium | Medio | Masculine default. |
-| Next Letter | Siguiente Letra | Title Case on `Letra` — older entry. Sentence case (`Siguiente letra`) for new entries. |
+| Next Letter | Siguiente letra | |
 | Not Graded Count | No clasificado | `Count` left implicit. |
 | Open Video | Abrir video | |
 | Place (rank) | (untranslated stub) | Existing entry is the English string `Place`. Translate as `Posición` (matches pt-BR; more idiomatic than literal `Lugar` for a leaderboard column). |
@@ -74,22 +74,22 @@ These have at least one existing translation in `App.es-MX.resx`. New translatio
 | Total Count | Total | `Count` left implicit. |
 | Tournaments | Torneos | |
 | Upload Image | (untranslated stub) | Existing entry is the English string `Upload Image`. Translate as `Subir imagen` when next touched. |
-| Upload Scores | Subir Puntajes | Title Case on `Puntajes` — older entry. Sentence case (`Subir puntajes`) for new uploads. |
-| Upload XX Scores | Subir puntajes de XX | Sentence case here (inconsistent with Upload Scores above). |
+| Upload Scores | Subir puntajes | |
+| Upload XX Scores | Subir puntajes de XX | |
 | Used Primarily for debugging | Se usa principalmente para debugging | `debugging` left as English loanword. |
 | Username | Usuario | |
 | Very Easy / Very Hard | Muy fácil / Muy difícil | |
 | Video | Video | Identical to English. (Spain uses `Vídeo` with accent; Mexico uses `Video`.) |
-| Vote Count | {0} Conteo de votos | **Awkward placeholder + label compound.** Should be `{0} votos` or `Conteo de votos: {0}`. See Known issues. |
-| 1+ Level Easier / Harder | 1+ Nivel más fácil / 1+ Nivel más difícil | Title Case on `Nivel` — older entries. Sentence case (`1+ nivel más fácil/difícil`) for new entries if possible. |
+| Vote Count | {0} votos | Matches the fr-FR `{0} votes` form. |
+| 1+ Level Easier / Harder | 1+ nivel más fácil / 1+ nivel más difícil | |
 
 ### PIU domain
 
 | English | es-MX | Notes |
 |---|---|---|
-| Chart(s) | Charts | **Untranslated**, kept English (matches pt-BR `chart` policy). Used compositionally with Spanish articles: `Aleatorizador de charts`, `Tipo de Charts`, `Esconder charts completos`. Capitalization is inconsistent (`Charts` vs `charts` mid-sentence — see Known issues). |
+| Chart(s) | Charts | **Untranslated**, kept English (matches pt-BR `chart` policy). Used compositionally with Spanish articles: `Aleatorizador de charts`, `Tipo de charts`, `Ocultar charts completos`. Lowercase `charts` mid-sentence; capitalized only standalone. |
 | Chart Randomizer | Aleatorizador de charts | `Aleatorizador` is technically correct but unusual; pt-BR uses `Sorteador`. Either is acceptable. |
-| Chart Type | Tipo de Charts | Title Case on `Charts`. Plural form here even though the English key is singular `Chart Type`. |
+| Chart Type | Tipo de charts | Plural form here even though the English key is singular `Chart Type`. |
 | CoOp | CoOp | Untranslated. |
 | Singles / Doubles | Simples / Dobles | **Translated** — `Simples` for Singles, `Dobles` for Doubles. Distinct from pt-BR / fr-FR / ja-JP / ko-KR which all keep these English (or use loanwords). Mexican PIU community usage may vary; the choice is in force, but worth confirming with native players if a sweep happens. |
 | Difficulty Level | Nivel de dificultad | Sentence case. |
@@ -97,15 +97,15 @@ These have at least one existing translation in `App.es-MX.resx`. New translatio
 | Mix | Versión | Translated, matches pt-BR `Versão`. (Compare ja-JP `バージョン`/`ベーション`, ko-KR `시리즈`, fr-FR `Mix` untranslated.) |
 | Phoenix / XX | Phoenix / XX | Game versions, untranslated proper nouns. "Phoenix Score Calculator" → `Calculadora de puntajes de Phoenix`; "Upload XX Scores" → `Subir puntajes de XX`; "Import Phoenix Scores" → `Importar puntajes de Phoenix`. |
 | Plate | Placa | **Translated** — same choice as fr-FR (`Plaque`). (Compare ja-JP `プレート` loanword, pt-BR `Plate` untranslated, ko-KR `플레이트` loanword.) |
-| Pass / Passed / Not Passed | Pasados / No Pasados | "Passed Count" → `Conteo de Pasados`; "Not Passed Count" → `Conteo de No Pasados`. Title Case on the past participles — older entries. Sentence case (`Conteo de pasados` / `Conteo de no pasados`) for new entries. Note: this codebase translates `Pass` (unlike pt-BR / fr-FR which keep English `pass`). |
+| Pass / Passed / Not Passed | Pasados / No pasados | "Passed Count" → `Conteo de pasados`; "Not Passed Count" → `Conteo de no pasados`. Note: this codebase translates `Pass` (unlike pt-BR / fr-FR which keep English `pass`). |
 | Score (singular) | Puntaje | "Score" → `Puntaje`. Mexican/LatAm form (Spain uses `Puntuación`). |
 | Scores (plural / collection) | Puntajes | "Save Scores" → `Guardar puntajes`; "Download Scores" → `Descargar puntajes`. |
-| score / scores (lowercase, mid-sentence loanword) | scores | One legacy entry mixes English `scores` mid-sentence (`importe sus scores`). Don't propagate — translate to `puntajes` for new entries. See Known issues. |
+| score / scores (lowercase, mid-sentence loanword) | ~~scores~~ | The legacy `importe sus scores` outlier was swept to `puntajes`. **Do not** use English `score(s)` mid-sentence in es-MX — that's the es-ES convention, and es-ES strings must never be copied here (see Known issues). |
 | Phoenix Score Calculator | Calculadora de puntajes de Phoenix | Sentence case. |
-| Saved Charts | Guardar Charts | **Wrong** — translates the past participle `Saved` as the infinitive verb `Guardar` ("to save"). Should be `Charts guardados`. See Known issues. |
+| Saved Charts | Charts guardados | Masculine plural agreement. |
 | Song | (untranslated stub) | Existing entry is the English string `Song`. Translate as `Canción` (matches the Song-compound translations below). |
 | Song Name | Nombre de canción | |
-| Song Image | Imágen de canción | **Typo** — should be `Imagen de canción` (no accent on `i`). See Known issues. |
+| Song Image | Imagen de canción | |
 | Song Duration | Duración de canción | |
 | Song Type | Tipo de canción | |
 | Song Artist | (untranslated stub) | Existing entry is the English string `Song Artist`. Translate as `Artista de la canción` (matches the Song-compound family). |
@@ -120,7 +120,7 @@ These have at least one existing translation in `App.es-MX.resx`. New translatio
 
 | English | es-MX | Notes |
 |---|---|---|
-| Broken | Rota | Past participle, feminine — implicit antecedent treated as feminine (`[la chart] rota`). |
+| Broken | Roto | Past participle, masculine — agrees with `[el chart]`. |
 | debugging | debugging | Untranslated loanword. (`Se usa principalmente para debugging`.) |
 | dev-tools | dev-tools | Untranslated loanword. (`Use el importador dev-tools`.) |
 
@@ -134,65 +134,23 @@ These have at least one existing translation in `App.es-MX.resx`. New translatio
 
 ## Known issues / native review needed
 
-These were carried over from the existing translations and should be reviewed by a native speaker. Keep structural and quality changes separate diffs.
+The mechanical items originally tracked here were fixed in the 2026-07 QC pass: the login family swept to the standard forms (`Iniciar sesión` / `Cerrar sesión` / `Iniciar sesión con {0}`), `Saved Charts` corrected to `Charts guardados`, `Vote Count` to `{0} votos`, the `Imágen` accent typo, the `antiguas`→`antiguos` gender disagreement in Use Password 3, `importe sus scores`→`puntajes` in Use Password 1, the seven Title Case stragglers swept to sentence case, `Rota`→`Roto` (Charts gender committed masculine), and the lone `Esconder`→`Ocultar` outlier. (The old `Use Password 2` register-mix string was replaced wholesale by the 2026-07 remember-password feature — its replacement is part of the register fork below.)
 
-### Critical / awkward translations
+### es-ES cross-contamination + register fork (NEEDS OWNER DECISION)
 
-- **`Login` → `Entrar sesión` / `Logout` → `Salir sesión`.** Both are non-idiomatic — Spanish requires a preposition (`Entrar a sesión` is also wrong because `entrar a` doesn't take `sesión`). Standard renderings:
-  - `Login` (noun) → `Inicio de sesión` or `Iniciar sesión`.
-  - `Logout` (verb / noun) → `Cerrar sesión`.
-  - The verb-form `Log In With` should likewise be `Iniciar sesión con {0}` rather than `Entrar con {0}`.
-  - **Fix as a single login-family sweep**, not piecemeal.
-- **`Saved Charts` → `Guardar Charts`.** Wrong — translates the past participle `Saved` as the infinitive verb `Guardar` ("to save"). Should be `Charts guardados` (masculine plural agreeing with `Charts` as masculine — see gender note below).
-- **`Vote Count` → `{0} Conteo de votos`.** The placeholder is unintegrated; reads as "{N} count of votes" rather than the intended "{N} votes" or "Vote count: {N}". Recommend `{0} votos` (matches the fr-FR `{0} votes` form) or `Conteo de votos: {0}`.
+The feature batches from mid-2026 (front door, home-page widgets, import widget / remember-password, tier-list breakdown, community highlights) landed es-MX values that read as **es-ES**, violating both this glossary and the es-ES glossary's "do not copy strings between the two Spanish files" rule. Measured 2026-07-16:
 
-### Spelling typos
+- **~248 non-trivial keys have values byte-identical to `App.es-ES.resx`** (some legitimately coincide — shared-Spanish labels with no register/vocabulary markers — but the overlap includes long prose that should diverge).
+- **54 keys use Spain-form `puntuación/puntuaciones`** where es-MX's established term is `puntaje(s)`; scattered strings also use `notas` for grades (es-ES's term — es-MX uses `Grado de letra`) and English `plates` (es-MX translates `Placa`).
+- **Register census: ~96 keys carry informal `tú` markers vs ~56 formal `usted`** — the file's established register is `usted`, so the majority of second-person strings now contradict the convention.
 
-- **`Imágen` → `Imagen`.** In `Song Image` → `Imágen de canción`. The acute accent on `í` is wrong — `imagen` is a paroxytone ending in `n` preceded by a vowel, but it doesn't take a written accent in the singular. Plural `imágenes` does.
-- **`puntajes más antiguas` → `puntajes más antiguos`.** In `Use Password 3`. Gender disagreement — `puntajes` is masculine, so the adjective must be `antiguos`, not `antiguas`.
-
-### Register inconsistency
-
-- **Mixed `usted` / `tú` in the same string.** `Use Password 2`: `No almacenamos un registro de tu usuario o contraseña, tendrá que introducirlos siempre que uses esa opción.` mixes informal `tu` (possessive) and `uses` (subjunctive) with formal `tendrá` (future). Pick one register and sweep:
-  - **Recommended:** all `usted` — `No almacenamos un registro de su usuario o contraseña, tendrá que introducirlos siempre que use esa opción.`
-  - Or all `tú` — `No almacenamos un registro de tu usuario o contraseña, tendrás que introducirlos siempre que uses esa opción.`
-  - The other Use Password strings use `usted`, so the `usted` sweep is the lower-churn fix.
-- **`importe sus scores`** (Use Password 1) — uses formal `Importe` and possessive `sus`, but mid-sentence English `scores` instead of `puntajes`. Convert to `puntajes` for consistency with the rest of the file.
-
-### Capitalization inconsistencies
-
-- **Mixed sentence case vs Title Case in values.** The file freely mixes sentence case (`Nivel de dificultad`, `Política de privacidad completa`, `Calculadora de puntajes de Phoenix`) with English-influenced Title Case (`Conteo de Pasados`, `Conteo de No Pasados`, `Tipo de Charts`, `Siguiente Letra`, `Subir Puntajes`, `Agregar a Favoritos`, `1+ Nivel más fácil`). Standard Spanish is **sentence case**. Recommend a one-shot sweep to lowercase non-initial, non-proper-noun words. Examples to fix:
-  - `Conteo de Pasados` → `Conteo de pasados`
-  - `Conteo de No Pasados` → `Conteo de no pasados`
-  - `Tipo de Charts` → `Tipo de charts` (keep `Charts` capitalized only if treated as proper noun; otherwise lowercase mid-sentence)
-  - `Siguiente Letra` → `Siguiente letra`
-  - `Subir Puntajes` → `Subir puntajes` (matches the sibling `Subir puntajes de XX`)
-  - `Agregar a Favoritos` → `Agregar a favoritos`
-  - `1+ Nivel más fácil` → `1+ nivel más fácil`
-
-### Charts capitalization and gender
-
-The English loanword `Charts` is treated inconsistently:
-
-- **Capitalized:** `Charts` (bare), `Tipo de Charts`, `Saved Charts → Guardar Charts`.
-- **Lowercase:** `Aleatorizador de charts`, `Esconder charts completos`.
-
-Gender: the past-participle adjectives in the file imply mixed gender:
-- **Masculine plural** (implicit): `charts completos` ("hidden completed charts").
-- **Feminine singular** (implicit): `Rota` for `Broken` (assumes `[la chart] rota`).
-- **Should-be:** `Charts guardados` (masculine plural) for the wrongly-translated `Saved Charts`.
-
-Pick one gender. Brazilian PIU community treats `chart` as **masculine** (per pt-BR glossary); recommend the same for es-MX since most of the existing implicit-agreement entries are already masculine (`completos`). Sweep `Rota` → `Roto` if `Broken` modifies a chart. Or if the implicit antecedent is `[la canción]` (feminine), the gender becomes feminine — disambiguate by context.
-
-For lowercase vs capitalized: recommend **lowercase `charts`** mid-sentence (matches pt-BR), capitalized only when standalone.
+Fix direction is an owner/native call, because the two consistent end-states pull opposite ways: (a) re-localize the contaminated batch into `usted` + `puntaje` es-MX (honors this glossary, ~100+ strings to rewrite), or (b) flip the register convention to `tú` (modern Mexican web UI is drifting that way) and still fix the vocabulary (`puntuación`→`puntaje` etc.), sweeping the older `usted` core instead. Either way the vocabulary fixes are mandatory; only the register direction is a choice. **Do it as one dedicated sweep, not piecemeal.**
 
 ### Questionable word choices
 
-- **`Esconder` vs `Ocultar` for "Hide".** `Hide Completed Charts` → `Esconder charts completos`. `Esconder` reads more colloquial / "hide a physical object"; `Ocultar` is the more standard UI verb. Mexican usage accepts both, but `Ocultar` is cleaner for UI labels.
 - **`Cosas que hacer` for "To Do".** Literal but verbose. `Pendientes` (matches pt-BR) is shorter and more idiomatic for a task-list label. Compounds would shrink: `Agregar a pendientes`, `Borrar de pendientes`. Consider switching in a future cleanup.
 - **`Aleatorizador de charts` for "Chart Randomizer".** Technically correct but `Aleatorizador` is uncommon as a noun. Alternatives: `Sorteador de charts` (matches pt-BR `Sorteador de charts`), or `Generador aleatorio de charts`. Either reads more naturally.
 - **`Grado de letra` for "Letter Grade".** Literal translation. Mexican PIU community usage isn't established; the term works but `Letra de calificación` or `Calificación` (just "grade") might fit better depending on context.
-- **`Place` left untranslated as English.** Should be `Posición` (matches pt-BR `Posição`). `Lugar` is the literal translation but reads less naturally for a leaderboard column.
 
 ## Open decisions (terms upcoming batches will need)
 
@@ -258,12 +216,12 @@ The conventions below were committed by this batch. Future entries should reuse 
 
 ### Conventions committed by the bulk batch
 
-- **Sentence case throughout for new entries.** All ~500 new entries use sentence case (`Nivel competitivo`, `Distribución de puntajes`, `Calculadora de vida de PIU`, `Detalles del chart`). The older Title Case entries (`Conteo de Pasados`, `Tipo de Charts`, `Siguiente Letra`, `Subir Puntajes`, `Agregar a Favoritos`, `1+ Nivel más fácil`) are not retrofitted in this batch — fix in a separate sweep.
-- **Formal `usted` register, sweepingly applied.** Every prose entry uses `usted` voice — `Su cuenta`, `sus puntajes`, `Use el botón`, `Asegúrese de`, `Tenga en cuenta`, `Vuelva a revisar`, `Si abandona esta página`. No `tú` / `tus` introduced. The pre-existing `Use Password 2` register-mix (`tu` + `tendrá` + `uses`) remains a known issue to sweep.
-- **`Charts` lowercase mid-sentence.** New entries treat `charts` as a lowercase common-noun loanword in prose (`Lista de charts`, `Comparación de charts`, `Mostrar solo charts sugeridos`, `Tener {0} charts`). Capitalized `Charts` reserved for standalone labels and proper-noun-feeling positions (`Charts semanales`, `Top 50 {0} Charts` style). The older `Tipo de Charts` Title-Case form is left for the separate sweep.
-- **`Charts` is masculine.** New agreement-bearing entries use masculine plural (`charts repetidos`, `charts sugeridos`, `charts completos`, `Chart guardado`, `Chart sugerido`, `Chart seleccionado`). The older feminine `Rota` (for `Broken`) remains a known issue — should become `Roto` if antecedent is `[el chart]`. Sweep alongside the Charts gender pass.
+- **Sentence case throughout for new entries.** All ~500 new entries use sentence case (`Nivel competitivo`, `Distribución de puntajes`, `Calculadora de vida de PIU`, `Detalles del chart`). The older Title Case entries were retrofitted in the 2026-07 QC pass — the file is uniform.
+- **Formal `usted` register, sweepingly applied.** Every prose entry in this batch uses `usted` voice — `Su cuenta`, `sus puntajes`, `Use el botón`, `Asegúrese de`, `Tenga en cuenta`, `Vuelva a revisar`, `Si abandona esta página`. No `tú` / `tus` introduced. (The mid-2026 feature batches later broke this — see the register-fork known issue.)
+- **`Charts` lowercase mid-sentence.** New entries treat `charts` as a lowercase common-noun loanword in prose (`Lista de charts`, `Comparación de charts`, `Mostrar solo charts sugeridos`, `Tener {0} charts`). Capitalized `Charts` reserved for standalone labels and proper-noun-feeling positions (`Charts semanales`, `Top 50 {0} Charts` style).
+- **`Charts` is masculine.** Agreement-bearing entries use masculine (`charts repetidos`, `charts sugeridos`, `charts completos`, `Chart guardado`, `Chart sugerido`, `Chart seleccionado`, `Roto` for `Broken`).
 - **`Show` → `Mostrar` consistently.** All `Show X` entries use `Mostrar X` (matches pt-BR `Mostrar` and fr-FR `Montrer` patterns). No `Enseñar` / `Ver` variants introduced.
-- **`Hide` → `Ocultar` consistently for new entries.** The older `Esconder charts completos` (using `Esconder`) remains as the lone pre-batch outlier; sweep when convenient. New `Hide X` entries are `Ocultar X` (`Ocultar chart para esta categoría`, `Ocultar charts sin record`, `Ocultar charts con cero de puntaje`).
+- **`Hide` → `Ocultar` consistently.** All `Hide X` entries are `Ocultar X` (`Ocultar chart para esta categoría`, `Ocultar charts sin record`, `Ocultar charts con cero de puntaje`, `Ocultar charts completos`).
 - **PIU jargon stays English mid-sentence.** Confirmed for: `Pass`, `Pase`, `Step Artist`, `Spreadsheet`, `Stage Break`, `lifebar`, `Lifebar` (capitalized at start of label), `bad`, `miss`, `perfect`, `great`, `good`, `combo`, `run`, `play(s)`, `Rainbow Life`, `Stage Break`, `Stamina`, `Bounty`/`Bounties`, `Seed`, `folder`, `JSON`, `CSV`, `Spreadsheet`, `Phoenix`, `XX`, `PIU`, `PIUGame`, `dev tools`, `debugging`, `hacky`, `data-mine`, `JSON`, `TLDR`, `TRUE`/`FALSE`, judgment plurals (`bads`, `misses`, `perfects`, `greats`, `goods`). Lowercase when used as a generic noun in prose; capitalized when standalone label or proper-noun-feeling.
 - **`Combo X / X Break` compound headers.** "Perfect Combo, Miss Break" → `Combo Perfect, Miss Break` (Spanish word order, English judgment + break terms verbatim).
 - **`lifebar` lowercase loanword.** `lifebar` mid-prose (`la lifebar`, `su lifebar`, `desborde de la lifebar`); `Lifebar` capitalized only at start of a label (`Lifebar por nivel`, `Calculadora de lifebar`, `Descripción de la lifebar`, `Estadísticas de lifebar`).
@@ -598,6 +556,6 @@ Short labels (column headers, button text) are likely fine.
 2. List its English keys (`grep -oP '(?<=L\[")[^"]+' ScoreTracker/ScoreTracker/Pages/<Folder>/**/*.razor` or similar).
 3. Cross-reference against `App.es-MX.resx` to find which are missing.
 4. Translate using this glossary. **If a new term needs a decision, add a row to "Established term mappings" before translating.**
-5. For inconsistency fixes (login family, sentence-case sweep on the older Title-Case entries, `Imágen` → `Imagen`, `Esconder` → `Ocultar` for the one outlier, `Cosas que hacer` → `Pendientes`, `Rota` → `Roto` for the Charts gender sweep, register normalization in `Use Password 2`, the `Simples`/`Dobles` vs `Singles`/`Doubles` split-treatment), do **one batch per category** so the diff is reviewable.
+5. For the remaining inconsistency fixes (the es-ES contamination / register-fork sweep once the owner picks a direction, `Cosas que hacer` → `Pendientes` if adopted, the `Simples`/`Dobles` vs `Singles`/`Doubles` split-treatment), do **one batch per category** so the diff is reviewable.
 6. `dotnet build ScoreTracker/ScoreTracker.sln -c Release` to confirm resx well-formedness.
 7. PR titled like `Translate <Folder> to es-MX` or `Fix es-MX <inconsistency>`.

--- a/docs/LOCALIZATION-fr-FR.md
+++ b/docs/LOCALIZATION-fr-FR.md
@@ -7,9 +7,9 @@ For the localization mechanism itself (resx layout, `L["..."]` usage, key conven
 ## Style conventions
 
 - **Address the user with formal `vous`.** Every existing prose string uses `vous` / `votre` / `vos`, never `tu`. Examples: `Si vous n'avez pas de compte`, `Vous serez retiré de la communauté Monde`, `Vérifiez bien que vos bloqueurs de publicité sont désactivés`. Match that — French web UI default is `vous` and the existing voice is consistent on this one point.
-- **Capitalization in values is inconsistent.** The existing file mixes sentence case (`Niveau de difficulté`, `Joueur le plus facile`, `Recherche sur le classement officiel`) with English-influenced Title Case (`Statut du Score`, `Mon Score`, `Prochaine Lettre`, `Charts Sauvegardées`, `Catégorisation par Difficulté`). Native French orthography uses **sentence case** (only the first word capitalized, plus proper nouns). Lean toward sentence case for new entries; the Title Case forms are an inherited inconsistency to fix in a separate sweep, not perpetuate. See Known issues.
+- **Capitalization in values is inconsistent.** Native French orthography uses **sentence case** (only the first word capitalized, plus proper nouns). The worst Title Case offenders (`Statut du Score`, `Mon Score`, `Prochaine Lettre`, `Charts Sauvegardées`, `Catégorisation par Difficulté`, `Politique de Confidentialité Complète`, `Type de Chanson`, `Enregistré Le`) were swept to sentence case in the 2026-07 QC pass, but plenty of Title Case remains (`Sauvegarder les Scores`, `Nombre de Charts`, `Très Facile`, …). Use sentence case for new entries; the full-file sweep is still an open item — see Known issues.
 - **Brand and proper-noun casing is preserved verbatim.** `Score Tracker`, `Phoenix`, `XX`, `PIU`, `PIUScores`, `Discord`, `Start.GG`, `https://piugame.com` — keep their original casing inside French sentences.
-- **Preserve positional placeholders verbatim.** `{0}`, `{1}`, `{2}` go into the value untouched, in whatever order French grammar wants. Examples: `Se connecter avec {0}`; `{0}/{1} Uploadés. {2} Restants. {3} Problèmes d'enregistrement`; `{0} Charts Restants pour Vous`; `Vous avez {0} charts de niveau {1} dans votre ToDo list que vous n'avez pas Pass`.
+- **Preserve positional placeholders verbatim.** `{0}`, `{1}`, `{2}` go into the value untouched, in whatever order French grammar wants. Examples: `Se connecter avec {0}`; `{0}/{1} Uploadés. {2} Restants. {3} Problèmes d'enregistrement`; `{0} Charts Restantes pour Vous`; `Vous avez {0} charts de niveau {1} dans votre ToDo list que vous n'avez pas Pass`.
 - **Skip prose with inline markup.** Per CLAUDE.md, `<MudText>` bodies with embedded `<MudLink>`/other elements stay hardcoded English. Don't extract them, don't translate them.
 - **Use proper French orthography.** Acute, grave, circumflex, cedilla, diaeresis — `àâäéèêëîïôöùûüç`. Don't ASCII-fold. The existing file already uses `À`, `é`, `è`, `ê`, `ç`, `î`, `ô`, `û` correctly in most places (see Known issues for a few stripped-accent typos).
 - **French typographic spacing is not currently enforced.** Standard French typography requires a non-breaking space (`U+00A0`) before `?`, `!`, `:`, `;`, and inside `« »`. The existing file is inconsistent: `Création de compte?` (no space), `succès !` (regular space), `envoi !  Assurez vous` (regular space + double space). Do not introduce new violations; preferably normalize to NBSP before high punctuation, but flag rather than churn the whole file in one pass — see Known issues.
@@ -44,8 +44,8 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Copy to Clipboard | Copier dans le presse-papiers | |
 | Country | Pays | |
 | Difficulty Level | Niveau de difficulté | Sentence case. |
-| Download Failures | Echecs de téléchargement | Should be `Échecs` with capital É — see Known issues. |
-| Download Scores | Télécharger les scores | Note: `Télécharger` is also (incorrectly) used for `Upload Scores` — see Known issues. |
+| Download Failures | Échecs de téléchargement | Capital É at sentence start (`Échecs d'analyse des données` likewise). |
+| Download Scores | Télécharger les scores | `Télécharger` = download only; upload is `Téléverser` (see Upload Scores). |
 | Easiest Player | Joueur le plus facile | Comparative. Feminine form would be `Joueuse la plus facile` if needed. |
 | Easy / Hard | Facile / Difficile | Plain adjectives, masculine default. |
 | Ending Page | Page de fin | "Starting Page" → "Page de début". |
@@ -53,7 +53,7 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Event Links | Liens Évènements | Note: `Liens Évènements` lacks `des`/`d'` — `Liens d'évènements` would be more standard. Acceptable as a label. |
 | Favorites | Favoris | |
 | Filters | Filtres | |
-| Full Privacy Policy | Politique de Confidentialité Complète | Title Case throughout — sentence case (`Politique de confidentialité complète`) would be more standard. |
+| Full Privacy Policy | Politique de confidentialité complète | |
 | Home | Accueil | Sidebar nav label. |
 | Language | Langue | |
 | Last Updated | Dernière mise à jour | |
@@ -68,9 +68,9 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Min/Max BPM | BPM Min / BPM Max | Postfixed abbreviation. |
 | Min/Max Letter Grade | Rang Min (lettres) / Rang Max (lettres) | Postfixed `Min`/`Max`; the `(lettres)` parenthetical disambiguates `Rang` (which alone could mean a numeric rank). |
 | Min/Max Note Count | Nombre de Notes Min / Nombre de Notes Max | Postfixed. |
-| My Score | Mon Score | Title Case on `Score`. |
+| My Score | Mon score | |
 | Name | Nom | |
-| Next Letter | Prochaine Lettre | "Next" rendered as `Prochaine` (feminine, agreeing with `Lettre`). Title Case. |
+| Next Letter | Prochaine lettre | "Next" rendered as `Prochaine` (feminine, agreeing with `lettre`). |
 | Not Graded Count | Non Gradé | "Not Graded" with `Count` left implicit. Masculine default. |
 | Open | Ouvert | Masculine default. |
 | Pending | En attente | |
@@ -81,24 +81,24 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Progress | Progression | |
 | Public | Publique | Note: written as `Publique` (feminine) even though referenced as a generic on/off label. Standard masculine would be `Public` — `Publique` is the feminine form. The label likely refers to "[ta] visibilité publique" but as a bare adjective it should agree with whatever it modifies. See Known issues. |
 | Recorded Date | Date d'enregistrement | |
-| Recorded On X | Enregistré Le {0} | Note: `Le` is capitalized mid-sentence — should be `Enregistré le {0}`. See Known issues. |
+| Recorded On X | Enregistré le {0} | |
 | Remove from ToDo | Enlever de la ToDo List | Matches "Add to ToDo" → "Ajouter à la ToDo List". |
 | Report Video | Signaler vidéo | |
 | Report Video Tooltip | Signaler lien endommagé, ou vidéo incorrecte | |
 | Restart | Recommencer | |
 | Rules | Règles | |
-| Save Scores | Sauvegarder les Scores | Title Case on `Scores`. |
-| Saved Charts | Charts Sauvegardées | Feminine plural agreement (`Charts` → feminine here). Compare `Charts Restants` (masculine in another entry) — gender treatment is inconsistent. See Known issues. |
+| Save Scores | Sauvegarder les Scores | Title Case on `Scores` — still un-swept (full sentence-case sweep is an open item). |
+| Saved Charts | Charts sauvegardées | Feminine plural agreement — `Charts` is committed feminine file-wide (the old masculine `Restants` outliers were swept to `Restantes`). |
 | Score | Score | Identical, loanword. |
-| Score (Data Backed) | Score (Avec Données) | The English key suffix `(Data Backed)` is rendered as `(Avec Données)`. **Note:** the Pass equivalent has its key incorrectly translated (`Pass (Avec Données)` as the resx key, not `Pass (Data Backed)`) — see Known issues. |
+| Score (Data Backed) | Score (Avec Données) | The English key suffix `(Data Backed)` is rendered as `(Avec Données)`. The orphan entry keyed by its own French value (`Pass (Avec Données)`) was deleted in the 2026-07 QC pass. |
 | Score Loss | Perte de Score liée aux {0} | Note: adds `liée aux` before placeholder (assumes feminine plural — `liée` agrees with `Perte`, `aux` with judgment-term plural). For singular or masculine placeholders the agreement may be wrong. See Known issues. |
 | Score Ranking | Classement par Score | Compare `Leaderboard` → `Leaderboard` (loanword); `World Rankings` → `Classements mondiaux`. Three different renderings for the ranking family. |
-| Score State | Statut du Score | Title Case on `Score`. |
+| Score State | Statut du score | |
 | Scores Parsed | Scores Analysés | |
 | Settings | Réglages | |
 | Show X | Montrer X | Suffix pattern: `Show Skills` → `Montrer les Compétences`, `Show Difficulty` → `Montrer la Difficulté`, `Show Song Name` → `Montrer le Nom de la Chanson`, `Show Step Artist` → `Montrer le Step Artist`, `Show Age` → `Montrer l'ancienneté`. Article (`les`/`la`/`le`/`l'`) per gender of the modified noun. |
-| Show Score Distribution | Afficher la Distribution des Scores | Outlier — uses `Afficher` instead of `Montrer`. The other Show entries use `Montrer`. See Known issues. |
-| Show Only ToDo Charts | Afficher Seulement les Charts ToDo | Also uses `Afficher`. `ToDo` kept English as the chart-state qualifier. |
+| Show Score Distribution | Montrer la distribution des scores | Converged on `Montrer` (was the `Afficher` outlier). |
+| Show Only ToDo Charts | Montrer seulement les Charts ToDo | `ToDo` kept English as the chart-state qualifier. |
 | Site | Site | (Implicit in "Site web".) |
 | Skill | Compétence | Chart trait/skill (runs, drills, twists, etc.). |
 | Submission Page | Page d'envoi | |
@@ -116,8 +116,8 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Tournaments | Tournois | |
 | UCS Leaderboard | Leaderboard UCS | Postfixed UCS. |
 | Upload Image | Uploader l'image | Loanword verb `uploader`. |
-| Upload Scores | Télécharger Scores | **Wrong direction:** `Télécharger` means *download*, not upload. See Known issues. |
-| Upload XX Scores | Télécharger Scores XX | Same wrong-direction issue. |
+| Upload Scores | Téléverser les scores | `Téléverser` = upload (the old `Télécharger` wrong-direction values were fixed in the 2026-07 QC pass). |
+| Upload XX Scores | Téléverser les scores XX | |
 | Uploader | Uploadeur | Role/agent noun derived from `uploader`. |
 | Use Script | Utiliser le script | |
 | Used Primarily for debugging | Utilisé principalement pour déboguer | |
@@ -134,14 +134,14 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 
 | English | fr-FR | Notes |
 |---|---|---|
-| Chart(s) | Chart / Charts | **Untranslated**, kept English. Used compositionally with French articles: `Type de Chart`, `Liste des Charts`, `Charts Sauvegardées`, `Charts Restants`, `Masquer les Charts`. Gender treatment is inconsistent — see Known issues. |
+| Chart(s) | Chart / Charts | **Untranslated**, kept English. Used compositionally with French articles: `Type de Chart`, `Liste des Charts`, `Charts sauvegardées`, `Charts Restantes`, `Masquer les Charts`. Feminine file-wide. |
 | Chart List | Liste des Charts | |
 | Chart Randomizer | Randomizer de Chart | `Randomizer` kept English (no native French equivalent in use). |
 | Chart Type | Type de Chart | |
-| CoOp | CoOp | Untranslated. "CoOp Aggregation" → "Aggregation des CoOps". |
+| CoOp | CoOp | Untranslated. "CoOp Aggregation" → "Agrégation des CoOp". |
 | Singles / Doubles | Singles / Doubles | Untranslated. |
 | Difficulty Level | Niveau de difficulté | Sentence case. |
-| Difficulty Categorization | Catégorisation par Difficulté | Title Case on `Difficulté`. |
+| Difficulty Categorization | Catégorisation par difficulté | |
 | Letter Grade | Rang (lettres) | Translated as `Rang` with parenthetical `(lettres)` to disambiguate from numeric rank. Min/Max forms keep the parenthetical. |
 | Mix | Mix | Untranslated. (Compare ja-JP `バージョン`/`ベーション`, ko-KR `시리즈`, pt-BR `Versão`.) |
 | Phoenix / XX | Phoenix / XX | Game versions, untranslated proper nouns. "Phoenix Score Calculator" → "Calculateur de score Phoenix" (Phoenix postfixed). "Import Phoenix Scores" → "Importer les Scores Phoenix"; "Upload XX Scores" → "Télécharger Scores XX". |
@@ -163,7 +163,7 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Players | Joueurs | Masculine plural default. |
 | Player Count | Nombre de Joueurs | |
 | Tournaments | Tournois | |
-| Qualifiers | Qualification(s) | "Qualifiers Leaderboard" → "{0} Leaderboard de Qualification" (singular); "Qualifiers Submission" → "{0} envois pour qualifications" (plural lowercase). Number/case inconsistency — see Known issues. |
+| Qualifiers | qualifications | Converged plural lowercase: "Qualifiers Leaderboard" → "{0} Leaderboard de qualifications"; "Qualifiers Submission" → "{0} envois pour qualifications"; "Sync Qualifier Leaderboard" → "Synchroniser le Leaderboard de qualifications". |
 | Rating | Rating | **Untranslated**. Loanword. "Max Rating" → "Rating Max"; "Rating Calculator" → "Calculateur de Rating". |
 | Rating Calculator | Calculateur de Rating | |
 | Pumbility | (none yet) | Not yet translated. Recommend leaving as `Pumbility` (proper-noun loanword) per the Phoenix/XX/Rating policy. |
@@ -171,8 +171,8 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Song Name | Nom de la chanson | |
 | Song Image | Image de la chanson | |
 | Song Duration | Durée de la chanson | |
-| Song Type | Type de Chanson | Title Case here, sentence case in the other Song compounds. Inconsistent — see Known issues. |
-| Song Artist | Song Artist | **Untranslated**. Inconsistent with other Song compounds which translate. See Known issues. |
+| Song Type | Type de chanson | |
+| Song Artist | Artiste de la chanson | Matches the other Song compounds. |
 | Personalized Difficulty | Difficulté Personnalisée | |
 | Scoring Level | Niveau de Score | |
 | Skill | Compétence | |
@@ -196,7 +196,7 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 - **Formal `vous` register.** Every prose string uses `vous` / `votre` / `vos`. Don't introduce `tu`. Example: `Si vous n'avez pas de compte avec Score Tracker, un compte sera créé lorsque vous sélectionnez une des méthodes d'authentification.`
 - **`NB :` or `NB:` prefix for warnings/disclaimers.** Used for technical notes: `NB : la perte de score peut être incorrecte de 1 à 4 points à cause de l'arrondi`, `NB: cet outil est expérimental...`. Place at sentence start. Spacing inconsistent (`NB :` vs `NB:`) — pick one and standardize. French typography wants `NB :` with NBSP.
 - **`Shout out à X pour Y` for credit lines.** `Shout out à MR_WEQ pour le reverse-engineering de la formule !`, `Shout out à daryen pour la collecte de données et la finalisation des intervalles de scores pour les lettres de Rang !`. Loanword `Shout out` kept English; `à` introduces the credited person.
-- **Show / Hide as verb-prefix `Montrer X` / `Masquer X`.** `Show Skills` → `Montrer les Compétences`, `Hide Completed Charts` → `Masquer les Charts terminées`. Article (`les`/`la`/`le`/`l'`) per gender of the modified noun. The `Afficher` variant exists in two entries (`Afficher la Distribution des Scores`, `Afficher Seulement les Charts ToDo`) — converge on `Montrer` for new entries.
+- **Show / Hide as verb-prefix `Montrer X` / `Masquer X`.** `Show Skills` → `Montrer les Compétences`, `Hide Completed Charts` → `Masquer les Charts terminées`. Article (`les`/`la`/`le`/`l'`) per gender of the modified noun. The old `Afficher` variants were converged to `Montrer` in the 2026-07 QC pass — `Montrer` only for new entries.
 - **`Min` / `Max` postfixed with space.** `BPM Min`, `BPM Max`, `Rating Max`, `Nombre de Notes Min`, `Rang Min (lettres)`. Don't switch to `Min. BPM` or prefix forms.
 - **Possessives**: `votre compte`, `vos scores`, `votre progression`, `vos followers`. Possessive precedes noun, agrees in gender/number.
 - **English brand and PIU jargon stay verbatim mid-sentence.** `Score Tracker`, `Phoenix`, `XX`, `PIU`, `PIUScores`, `Discord`, `Start.GG`, `Pass`, `ToDo`, `Charts`, `CoOp`, `Singles`, `Doubles`, `Mix`, `Tier Lists`, `Leaderboard`, `Rating`, `Step Artist`, `Stage Pass`, `BPM`, `UCS`, `Avatar`, `Tag`, `Tags`, judgment terms (`Bad`, `Miss`, `Perfect`, `Great`, `Good`, plural `Goods`).
@@ -204,68 +204,29 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 
 ## Known issues / native review needed
 
-These were carried over from the existing translations and should be reviewed by a native speaker. Keep structural and quality changes separate diffs.
+The mechanical items originally tracked here were fixed in the 2026-07 QC pass:
 
-### Critical bugs
+- **Critical**: the orphan `<data name="Pass (Avec Données)">` entry (keyed by its own French value, resolvable by no `L["..."]` call) was deleted.
+- **Wrong-direction**: `Upload Scores` / `Upload XX Scores` now use `Téléverser les scores` / `Téléverser les scores XX`; `Télécharger` remains download-only. (`Upload Image` had always been correct with `Uploader l'image`.)
+- **Spelling**: `Agrégation des CoOp` (was `Aggregation des CoOps`), `précédemment`, `sûrement`, `déjà été sauvegardés` (accent + the missing `été`), `score` (was `scopre`), `requêtes` and `développeur` (both in Use Password 3), `Échecs` ×2, `utiliser` (was `utilsier`), `Assurez-vous` (hyphen + the double space before it), `ajouté à la communauté Monde` (was `de`), and the `Vousu` typo in the Remaining Charts For You comment.
+- **Capitalization**: the worst offenders swept to sentence case (`Politique de confidentialité complète`, `Statut du score`, `Mon score`, `Prochaine lettre`, `Catégorisation par difficulté`, `Charts sauvegardées`, `Type de chanson`, `Enregistré le {0}`).
+- **Charts gender**: committed **feminine**; the masculine `Charts Restants` outliers swept to `Charts Restantes` (both Remaining-Charts keys and their comments).
+- **Show verb**: converged on `Montrer` (the two `Afficher` entries rewritten).
+- **Qualifiers number**: converged on plural lowercase `qualifications` (Leaderboard, Submission, and Sync entries).
+- **`Song Artist`**: translated to `Artiste de la chanson`.
 
-- **`Pass (Data Backed)` correct entry now exists; broken legacy entry still in file.** The 2026-04-26 batch added a correct `Pass (Data Backed)` entry with value `Pass (Avec Données)`. The pre-existing broken entry whose `name` attribute is the *translated* string `Pass (Avec Données)` is still in the file as an orphan that no `L["..."]` call resolves to. **Cleanup task:** delete the orphan `<data name="Pass (Avec Données)">` entry. Compare to `Score (Data Backed)` which has always been keyed correctly (English key, French value).
+Still open for a native/owner pass:
 
-### Wrong-direction translations
+### Full sentence-case sweep
 
-- **`Upload Scores` / `Upload XX Scores` → `Télécharger Scores` / `Télécharger Scores XX`.** `Télécharger` means *download*, not upload. The same word `Télécharger` is also used for `Download Scores` → `Télécharger les scores`, so the file says "download" for both directions of transfer. **Fix:** use `Téléverser` (the standard French for upload) or the loanword `Uploader` (already established for `Upload Image` → `Uploader l'image`). Recommend `Téléverser les scores` / `Téléverser les scores XX` for consistency with formal French; alternative is `Uploader les scores` to match the verb already in the prose.
-- **`Upload Image` correctly uses `Uploader l'image`.** Consistent with the `uploader` verb in `Vous pourrez par la suite uploader ce CSV` prose. The Score upload entries are the outliers.
-
-### Spelling typos
-
-- **`Aggregation` → `Agrégation`.** Current: `CoOp Aggregation` → `Aggregation des CoOps`. `Aggregation` is the English spelling; French is `Agrégation` (acute on first `e`, single `g`).
-- **`prédcédemment` → `précédemment`.** In Make Public Disclaimer 2.
-- **`surement` → `sûrement`.** In Phoenix Import Info 4.
-- **`déja` → `déjà`.** In Phoenix Import Saving (`les scores qui ont déja sauvegardés` — also missing `été`: should be `qui ont déjà été sauvegardés`).
-- **`scopre` → `score`.** In Score Loss Note (`la perte de scopre`).
-- **`requètes` → `requêtes`.** In Use Password 3 (`Pour limiter les requètes`).
-- **`Echecs` → `Échecs`.** In `Download Failures` and `Parse Failures`. Capital É required at sentence start.
-- **`utilsier` → `utiliser`.** In Qualifier Submit Phrase 1.
-- **`Vousu` → `Vous`.** In the comment for `Remaining Charts For You` (`8 Charts Restants pour Vousu`).
-- **`Assurez vous` → `Assurez-vous`.** In Qualifier Submit Phrase 2 — imperative + reflexive pronoun takes a hyphen.
-- **`ajouté de la communauté Monde` → `ajouté à la communauté Monde`.** In Make Public Disclaimer 1. Wrong preposition — `ajouté` takes `à`, not `de`. Likely a copy-paste from the parallel `retiré de la communauté` in the Make Not Public Disclaimer.
-
-### Capitalization inconsistencies
-
-- **Mixed sentence case vs Title Case in values.** The file freely mixes `Niveau de difficulté` (sentence) with `Statut du Score` (Title), `Recherche sur le classement officiel` (sentence) with `Catégorisation par Difficulté` (Title), `Joueur le plus facile` (sentence) with `Charts Sauvegardées` (Title). Standard French is **sentence case**. Recommend a one-shot sweep to lowercase non-initial, non-proper-noun words. Examples to fix:
-  - `Politique de Confidentialité Complète` → `Politique de confidentialité complète`
-  - `Statut du Score` → `Statut du score`
-  - `Mon Score` → `Mon score`
-  - `Prochaine Lettre` → `Prochaine lettre`
-  - `Catégorisation par Difficulté` → `Catégorisation par difficulté`
-  - `Charts Sauvegardées` → `Charts sauvegardées` (keep `Charts` capitalized as proper-noun loanword)
-- **`Recorded On` → `Enregistré Le {0}`.** `Le` should be lowercase — French preposition mid-sentence: `Enregistré le {0}`.
-
-### Gender treatment of `Charts`
-
-The English loanword `Charts` is treated inconsistently as masculine and feminine across entries:
-
-- **Feminine:** `Charts terminées`, `Charts Sauvegardées`, `Chart Suggérée`.
-- **Masculine:** `Charts Restants`, `Charts ToDo`.
-
-Pick one. Brazilian PIU community treats `chart` as masculine; French community usage isn't established in this file. Recommend **feminine** (`la chart`, `les charts`) to match the most-recent entries (`Sauvegardées`, `Suggérée`), and sweep `Restants` → `Restantes`. Or pick masculine and sweep the others. Either way, do it in one batch.
-
-### Show / Hide verb inconsistency
-
-- **`Show X` mostly uses `Montrer`** (`Montrer les Compétences`, `Montrer la Difficulté`, `Montrer le Nom de la Chanson`, `Montrer le Step Artist`, `Montrer l'ancienneté`).
-- **Two entries use `Afficher`** (`Afficher la Distribution des Scores`, `Afficher Seulement les Charts ToDo`).
-
-Both verbs are valid French; converge on one. Recommend **`Montrer`** since it has 5 entries vs 2.
+Only the worst Title Case offenders were fixed. Plenty remains (`Sauvegarder les Scores`, `Nombre de Charts`, `Nombre de Notes Min/Max`, `Très Facile / Très Difficile`, `Ouvrir Vidéo`, `Chart Suggérée`, `Statistiques Joueur`, `Vue Textuelle`, `Classement par Score`, …). Standard French is **sentence case**; a one-shot sweep to lowercase non-initial, non-proper-noun words is still recommended — separate diff, not mixed into a feature batch.
 
 ### Questionable word choices
 
 - **`Public` → `Publique`.** `Publique` is the feminine singular form. As a generic on/off label whose grammatical antecedent isn't in the key, the masculine `Public` would be safer. The comment (`(on/off, si le compte est configuré en tant que publique)`) implies the antecedent is `[la visibilité]`, justifying feminine — but as a bare label this is fragile. Compare `Make Public` → `Rendre public` (masculine), so the file is internally split.
 - **`Score Loss` → `Perte de Score liée aux {0}`.** Adds `liée` (feminine, agrees with `Perte`) and `aux` (plural). Works for plural masculine judgment terms (`Goods`, `Greats`, `Bads`, `Misses`). For singular or ambiguous placeholders the agreement may be wrong. The English source is `{0} Score Loss` (e.g. "Goods Score Loss") — known to be plural in current usage, so this is currently safe but fragile.
 - **`Progress Charts` → `Statistiques Joueur`.** "Player statistics" rather than literal "progress charts" — interpretive, like nabulator's ja-JP `進捗中の譜面` for `Player Stats`. May or may not be the right call depending on the page-context label.
-- **`Plate` → `Plaque`.** Literal French translation. Other locales (ja-JP, ko-KR, pt-BR) keep `Plate` or use a phonetic loanword. The PIU community in France probably uses `Plate` in conversation; `Plaque` reads as an over-translation. Consider switching to `Plate`. The comment lists `MG, PG, UG` (in-game tier names) which stay untranslated regardless.
-- **`Song Artist` → `Song Artist` (untranslated).** All other Song compounds translate (`Nom de la chanson`, `Image de la chanson`, etc.). Should likely be `Artiste de la chanson` (or `Compositeur` if treated as composer like ko-KR's 작곡자). Currently the only Song compound left in English.
-- **`Song Type` → `Type de Chanson`** uses Title Case while sibling Song compounds (`Nom de la chanson`, `Image de la chanson`, `Durée de la chanson`) use sentence case. Should be `Type de chanson`.
-- **`Qualifiers Leaderboard` → `{0} Leaderboard de Qualification`** uses singular `Qualification`; **`Qualifiers Submission` → `{0} envois pour qualifications`** uses plural `qualifications`. English is plural in both. Pick one (recommend `qualifications` plural) and sweep.
-- **`CoOp Aggregation` → `Aggregation des CoOps`.** `Aggregation` is the English spelling — French is `Agrégation`. Also the plural `CoOps` is unusual; English-source writers usually treat `CoOp` as a non-count noun. Recommend `Agrégation des CoOp` (no plural `s`).
+- **`Plate` → `Plaque`.** Literal French translation. Other locales (ja-JP, ko-KR, pt-BR, it-IT) keep `Plate` or use a phonetic loanword. The PIU community in France probably uses `Plate` in conversation; `Plaque` reads as an over-translation. Consider switching to `Plate`. The comment lists `MG, PG, UG` (in-game tier names) which stay untranslated regardless.
 
 ### Typographic spacing
 
@@ -273,7 +234,7 @@ French typography requires a non-breaking space (`U+00A0`, `&#160;` in resx) bef
 
 - `Création de compte?` — no space (should be `Création de compte ?`)
 - `succès !` — regular ASCII space (should be `succès !`)
-- `C'est votre premier envoi !  Assurez vous` — regular space + double space (should be `envoi ! Assurez-vous` with single trailing space)
+- `C'est votre premier envoi ! Assurez-vous` — regular ASCII space (should be `envoi ! Assurez-vous` with NBSP)
 - `NB : la perte` — regular space (should be `NB :`)
 - `NB:` — no space (inconsistent with `NB :`)
 
@@ -285,7 +246,7 @@ The 405 entries added on 2026-04-26 made structural choices that should be honor
 
 ### Conventions committed by the bulk batch
 
-- **`Charts` is feminine.** All new agreement-bearing entries treat `Chart`/`Charts` as feminine (`Chart sauvegardée`, `Chart sélectionnée`, `Charts répétées`). This aligns with the most-recent older entries (`Charts Sauvegardées`, `Chart Suggérée`, `Charts terminées`). The two older masculine outliers (`Charts Restants`, `Charts ToDo`) remain to fix in a future sweep.
+- **`Charts` is feminine.** All new agreement-bearing entries treat `Chart`/`Charts` as feminine (`Chart sauvegardée`, `Chart sélectionnée`, `Charts répétées`). This aligns with the older entries (`Charts sauvegardées`, `Chart Suggérée`, `Charts terminées`); the last masculine outliers (`Charts Restants`) were swept to `Charts Restantes` in the 2026-07 QC pass.
 - **Sentence case is the new default.** New entries use sentence case throughout (`Niveau Min`, `Score moyen`, `Détails du chart`, `Distribution des plaques`). The older Title Case entries are not retro-fixed in this batch.
 - **`Show` → `Montrer` only.** `Afficher` was not used in any new entry.
 - **`Hide` → `Masquer`.**
@@ -300,7 +261,7 @@ The 405 entries added on 2026-04-26 made structural choices that should be honor
 - **`PUMBILITY` (uppercase) preserved.** When the source has `PUMBILITY` in caps, the value mirrors that. Lowercase `Pumbility` would be used elsewhere (none yet).
 - **`Leaderboard` reserved for the `Leaderboard` keyword.** New compound forms: `Leaderboard mensuel`, `Leaderboard du chart`, `Leaderboard des Bounties`, `Leaderboards officiels`, `Leaderboards de complétion`, `Leaderboards UCS`. `Classement(s)` is reserved for `Score Ranking(s)` / `World Rankings`.
 - **Decimal separator: comma.** `0,5`, `9,6` in prose. Half-width Arabic numerals.
-- **Critical-bug fix shipped.** Added correct `Pass (Data Backed)` resx entry. The orphan broken-key entry from the previous file remains and should be deleted in a follow-up.
+- **Critical-bug fix shipped.** Added correct `Pass (Data Backed)` resx entry. (The orphan broken-key entry it replaced was deleted in the 2026-07 QC pass.)
 
 ### Established term mappings added 2026-04-26
 
@@ -591,6 +552,6 @@ Short labels (column headers, button text) are likely fine.
 2. List its English keys (`grep -oP '(?<=L\[")[^"]+' ScoreTracker/ScoreTracker/Pages/<Folder>/**/*.razor` or similar).
 3. Cross-reference against `App.fr-FR.resx` to find which are missing.
 4. Translate using this glossary. **If a new term needs a decision, add a row to "Established term mappings" before translating.**
-5. For inconsistency fixes (e.g. converging `Montrer`/`Afficher`, fixing the wrong-direction `Télécharger`/`Téléverser`, fixing the broken `Pass (Avec Données)` key, sweeping Title Case to sentence case, normalizing French typographic spacing), do **one batch per category** so the diff is reviewable.
+5. For the remaining inconsistency fixes (the full Title Case → sentence case sweep, French typographic NBSP normalization, the `Plaque`→`Plate` question if adopted), do **one batch per category** so the diff is reviewable.
 6. `dotnet build ScoreTracker/ScoreTracker.sln -c Release` to confirm resx well-formedness.
 7. PR titled like `Translate <Folder> to fr-FR` or `Fix fr-FR <inconsistency>`.

--- a/docs/LOCALIZATION-it-IT.md
+++ b/docs/LOCALIZATION-it-IT.md
@@ -1,10 +1,10 @@
 # it-IT localization glossary
 
-Working reference for translating `App.en-US.resx` into `App.it-IT.resx`. Unlike the other locale glossaries — which captured conventions inferred from existing translations — this one is **prescriptive**: there are no Italian entries in the resx yet, so this file establishes the conventions ahead of the first translation batch. Decisions here become "established" the moment they're applied to the resx.
+Working reference for translating `App.en-US.resx` into `App.it-IT.resx`. This glossary was written **prescriptively** before any Italian entries existed; the first full-coverage batch has since landed following it, so its mappings are now established conventions, not proposals.
 
 For the localization mechanism itself (resx layout, `L["..."]` usage, key conventions), see [ARCHITECTURE.md](ARCHITECTURE.md). For PIU domain terms in English, see [DOMAIN.md](DOMAIN.md). For the parallel ja-JP, ko-KR, pt-BR, fr-FR, and es-MX conventions, see [LOCALIZATION-ja-JP.md](LOCALIZATION-ja-JP.md), [LOCALIZATION-ko-KR.md](LOCALIZATION-ko-KR.md), [LOCALIZATION-pt-BR.md](LOCALIZATION-pt-BR.md), [LOCALIZATION-fr-FR.md](LOCALIZATION-fr-FR.md), and [LOCALIZATION-es-MX.md](LOCALIZATION-es-MX.md).
 
-> **Status (2026-04-26):** Glossary only. No `App.it-IT.resx` exists yet, and `it-IT` is not yet listed in the supported-cultures array in [Program.cs](../ScoreTracker/ScoreTracker/Program.cs). Both will be wired up when the first translation batch lands.
+> **Status (2026-07-16):** Live. `App.it-IT.resx` exists at full key parity with en-US, and `it-IT` is listed in the supported-cultures array in [Program.cs](../ScoreTracker/ScoreTracker/Program.cs). The 2026-07 QC pass verified the file against this glossary (Mix/Plate/Singles/Doubles untranslated, `Classifica`, invariable loanword plurals — all conforming).
 
 ## Style conventions
 
@@ -18,9 +18,9 @@ For the localization mechanism itself (resx layout, `L["..."]` usage, key conven
 - **Decimal separator: comma.** Italian uses `0,5` not `0.5` in prose. Half-width Arabic numerals throughout (matches fr-FR / es-MX / pt-BR conventions).
 - **Apostrophe contractions.** Italian elides the article before vowel-initial nouns: `l'utente`, `l'immagine`, `un'opzione` (feminine `un'`), `un account` (masculine, no apostrophe — be careful with the gender rule), `dell'utente`, `nell'app`, `all'account`. Always use a straight ASCII apostrophe `'`, never a curly `'`.
 
-## Recommended term mappings
+## Established term mappings
 
-These are the prescriptive defaults for the first translation batch. Once an entry is in `App.it-IT.resx`, this section becomes "Established term mappings" and future batches must reuse the form. **If a term needs a different rendering in a particular context, document the divergence here before translating.**
+Prescribed ahead of the first batch and applied by it — these are now in force in `App.it-IT.resx`, and future batches must reuse the forms. **If a term needs a different rendering in a particular context, document the divergence here before translating.**
 
 ### App / generic UI
 
@@ -366,7 +366,7 @@ These are the prescriptive defaults for the first translation batch. Once an ent
 
 ## Open decisions (terms upcoming batches will need)
 
-These are terms the en-US source contains that don't yet have an obvious recommendation above. Decide once per term, then add the row to **Recommended term mappings** and use it consistently.
+These are terms the en-US source contains that don't yet have an obvious recommendation above. Decide once per term, then add the row to **Established term mappings** and use it consistently.
 
 - **`Korean Name`** → `Nome coreano` (matches the pattern of other locales).
 - **`Channel Name`** → `Nome del canale`.
@@ -388,23 +388,14 @@ These are terms the en-US source contains that don't yet have an obvious recomme
 - **`Original Concept (excel score tracking) Constructed by KyleTT`** → `Concetto originale (tracciamento punteggi su Excel) realizzato da KyleTT`.
 - **`Updated X Y` snackbar** → `{0} {1} aggiornato` (masculine default for the chart-save case).
 
-## Process for the first batch
+## Process for future batches
 
-The first batch is structurally different from the per-locale ongoing batches because the resx and the supported-cultures wiring don't exist yet:
-
-1. **Wire up the supported culture.** In [Program.cs](../ScoreTracker/ScoreTracker/Program.cs), add `"it-IT"` to the supported-cultures array used by `AddRequestLocalization`. (Search for the existing `"fr-FR"` registration as the template.) Update the `Cross-cutting concerns` section in [ARCHITECTURE.md](ARCHITECTURE.md) to list `it-IT` alongside the others.
-2. **Create `App.it-IT.resx`** as a copy of `App.en-US.resx` with values cleared (or with English fallback values that this glossary will overwrite). Don't delete keys — the file must mirror the en-US key set exactly. Italian-localized values fill in over time; missing keys fall back to the English source per CLAUDE.md.
-3. **Pick a feature folder** (Tournaments, Tier Lists, Progress, Admin, Tools, etc.) for the first content batch.
-4. **Translate using this glossary.** If a new term needs a decision, add a row to `Recommended term mappings` **before translating** so the convention is captured.
-5. `dotnet build ScoreTracker/ScoreTracker.sln -c Release` to confirm resx well-formedness.
-6. PR titled `Add it-IT localization scaffold + first batch (<Folder>)` for the first PR; subsequent PRs `Translate <Folder> to it-IT`.
-
-## Process for ongoing batches (after the scaffold lands)
+(The scaffold — resx creation and Program.cs culture wiring — landed with the first full-coverage batch; new keys now land in it-IT in the same pass as every other locale.)
 
 1. Pick a feature folder or a category from the recommendations.
 2. List its English keys (`grep -oP '(?<=L\[")[^"]+' ScoreTracker/ScoreTracker/Pages/<Folder>/**/*.razor` or similar).
 3. Cross-reference against `App.it-IT.resx` to find which are missing.
-4. Translate using this glossary. **If a new term needs a decision, add a row to "Recommended term mappings" (or rename it to "Established term mappings" once the first content batch lands) before translating.**
+4. Translate using this glossary. **If a new term needs a decision, add a row to "Established term mappings" before translating.**
 5. `dotnet build ScoreTracker/ScoreTracker.sln -c Release` to confirm resx well-formedness.
 6. PR titled like `Translate <Folder> to it-IT`.
 

--- a/docs/LOCALIZATION-ja-JP.md
+++ b/docs/LOCALIZATION-ja-JP.md
@@ -8,7 +8,7 @@ For the localization mechanism itself (resx layout, `L["..."]` usage, key conven
 
 - **Polite register (です／ます).** ~60 entries use `〜ます／〜ません／〜です／〜ください`; only a handful of older nabulator strings drop into plain form (`変更できる`, `ロールバック出来ません` — see Known issues). New translations should be polite throughout. Avoid keigo (尊敬語/謙譲語) except in the few stock phrases that already use it (`ご連絡ください`).
 - **Sentence case is not a thing in Japanese.** Ignore the en-US Title Case in keys; values just use natural Japanese without capitalization rules. (English brand names embedded mid-sentence — `Phoenix`, `PIU`, `Score Tracker`, `XX`, `Discord` — keep their original casing.)
-- **Punctuation is full-width.** Established split: `（）` not `()`, `：` not `:`, `。` not `.` for sentence-final periods, `、` not `,` for in-sentence commas. Counts in the current resx: 31 full-width parens vs 3 half-width; 22 full-width `：` vs 2 half-width. Stay consistent.
+- **Punctuation is full-width.** Established split: `（）` not `()`, `：` not `:`, `。` not `.` for sentence-final periods, `、` not `,` for in-sentence commas. Full-width dominates the current resx. Stay consistent.
 - **Numerals are half-width** except in three legacy nabulator strings (`１レベル`, `１－４ポイント`). New translations use `1`, `2`, `10`, etc. Don't introduce more full-width numerals.
 - **Preserve positional placeholders verbatim.** `{0}`, `{1}` go into the value untouched, in whatever order Japanese grammar wants. Example: key `Welcome to Score Tracker, X!` → value `Score Trackerへようこそ、{0}さん！`. The `さん` honorific suffix is appended after `{0}` because the placeholder is a name.
 - **Skip prose with inline markup.** Per CLAUDE.md, `<MudText>` bodies with embedded `<MudLink>`/other elements stay hardcoded English. Don't extract them, don't translate them.
@@ -33,7 +33,7 @@ These have at least one existing translation in `App.ja-JP.resx`. New translatio
 | Confirm | 確認 | Also used for "Verification". |
 | Completed | 完了 | Used for "Done" too. |
 | Copy | コピー | "Copy Script" / "Copy to Clipboard" both → コピー. |
-| Country | Country | **Untranslated** in nabulator's seed. See Known issues. |
+| Country | 国 | |
 | Create | 作成 | |
 | Default | デフォルト | |
 | Delete | 削除 | |
@@ -57,7 +57,7 @@ These have at least one existing translation in `App.ja-JP.resx`. New translatio
 | Medium | 中 | |
 | Name | 名前 | |
 | Next | 次の | "Next Letter" → 次のランク. |
-| Open | Open | **Untranslated** in nabulator's seed. See Known issues. |
+| Open | 開く | Verb sense — the season-recap popup button. |
 | Page | ページ | "Starting Page" → 再開のページ, "Ending Page" → 最後のページ. |
 | Pending | 未決定 | |
 | Permissions | 権限 | |
@@ -65,11 +65,11 @@ These have at least one existing translation in `App.ja-JP.resx`. New translatio
 | Public / Private | 公開 / 非公開 | |
 | Reason | 理由 | |
 | Recorded Date | 記録日 | |
-| Recorded On X | {0}にき記録した | nabulator. Note "き" appears to be a typo before 記録した. |
+| Recorded On X | {0}に記録した | |
 | Restart | 再起動 | |
 | Rules | 規則 | |
 | Save | 保存 | |
-| Search | 捜索 / 検索 | nabulator uses 捜索 ("Official Leaderboard Search" → 公開ランキング捜索); newer entries use 検索 ("Search User" → ユーザー検索). Pick one going forward — 検索 is the more common UI word. |
+| Search | 検索 | Converged on 検索 ("Official Leaderboard Search" → 公開ランキング検索, "Search User" → ユーザー検索). |
 | Settings | 設定 | "Admin Settings" → 管理設定, "Extra Settings" → 追加設定. |
 | Show | 表示 | "Show Age" → 歳表示, "Show Difficulty" → 難度表示. Suffix pattern. |
 | Source | 出典 | |
@@ -79,15 +79,15 @@ These have at least one existing translation in `App.ja-JP.resx`. New translatio
 | Submit | 登録 | Also used for "Submission". |
 | Tag(s) | タグ | |
 | Title (in-game title award) | タイトル | "Title Progress" → タイトル進捗, "Titles" → タイトル. |
-| To Do | やりこと | **Typo** of やること. See Known issues. |
-| Tools | ツルー | **Typo** of ツール. See Known issues. |
+| To Do | やること | Compounds use やることリスト. |
+| Tools | ツール | Also "this tool" mid-prose: このツール. |
 | Total | 総計 | |
 | Type | 種類 | "Chart Type" → 譜面タイプ (Type rendered as タイプ here, but as 種類 elsewhere — context-dependent). |
 | Ungraded / Not Graded | 未ランク / 未ランク数 | |
 | Unknown | 不明 | |
 | Update | 更新 | "Upload Scores" → スコア更新 (so 更新 doubles for "upload" in some contexts — see Upload below). |
 | Upload | アップロード or 更新 | Inconsistent. "Upload Image" → 画像アップロード; "Upload Scores" → スコア更新; "アップロード" appears in disclaimers. Lean on context, prefer アップロード for new entries. |
-| Username | ユーザ名 / ユーザー名 | nabulator uses ユーザ (no 長音); newer entries use ユーザー (with 長音). Inconsistent — see Known issues. |
+| Username | ユーザー名 | Converged on the 長音 form ユーザー (ユーザーロック, 新ユーザー名, etc.). |
 | Validation | 確認 | |
 | Very Easy / Very Hard | とても簡単 / とても難しい | |
 | Video | ビデオ | "Video URL" → ビデオURL, "Open Video" → ビデオリンク開く. |
@@ -98,19 +98,19 @@ These have at least one existing translation in `App.ja-JP.resx`. New translatio
 | English | ja-JP | Notes |
 |---|---|---|
 | Chart(s) | 譜面 | nabulator's choice — translated, not loanword. Used compositionally: 譜面リスト, 譜面タイプ, 譜面作者, 譜面くじ引き, 譜面残り, 譜面比較. **Don't switch to チャート mid-file.** |
-| CoOp | CoOp | Untranslated. "CoOp Aggregation" → CoOp集合 (see Known issues — 集合 is "set", not "aggregate"). |
+| CoOp | CoOp | Untranslated. "CoOp Aggregation" → CoOp集計. |
 | Co-Op | Co-Op | Distinct from "CoOp" — used as a select-item label on /WeeklyCharts. Both spellings appear in source verbatim. |
 | Singles / Doubles | Singles / Doubles | Untranslated. "Singles Level" → Singlesレベル, "Doubles Level" → Doublesレベル. |
 | Difficulty Level | 難しさレベル | |
 | Letter Grade | ランク | Loanword, katakana. "Min/Max Letter Grade" → 最低/最高ランク. "Next Letter" → 次のランク. |
 | Letter Difficulty | ランク難度 | |
-| Mix | ベーション | **Typo** of バージョン. See Known issues. |
+| Mix | バージョン | Matches the CLAUDE.md glossary line. |
 | Phoenix / XX | Phoenix / XX | Game versions, untranslated proper nouns. "Phoenix Score Calculator" → Phoenixスコア計算; "Upload XX Scores" → XXスコア更新. |
 | Plate | プレート | Loanword, katakana. (Compare pt-BR which keeps it English.) |
 | Pass (verb / noun for clearing a chart) | クリア | Semantic translation. "Hide Completed Charts" → 完了譜面隠す (uses 完了 for "completed"); "Passed Count" → クリア数; "Not Passed" → 未クリア数; "Stage Pass" → Stageクリア (Stage left English mid-word). |
 | Score (singular) | スコア | "Score" → スコア, "Score State" → スコア状態, "My Score" → 自己スコア. |
 | Scores (plural / collection) | スコア | Same word — Japanese doesn't grammatically distinguish. |
-| Score (Data Backed) | スコア(データあり) | Half-width parens here are nabulator's choice — note inconsistency with the full-width-parens convention. |
+| Score (Data Backed) | スコア（データあり） | Full-width parens per the punctuation convention. |
 | Note Count | ノーツ数 | "Min/Max Note Count" → 最低/最高ノーツ数. "Notes" → ノーツ. |
 | Step Artist | 譜面作者 | "Step Artist: X" → 譜面作者：{0}. |
 | BPM | BPM | Untranslated. "Min/Max BPM" → 最低/最高BPM. |
@@ -157,34 +157,13 @@ These have at least one existing translation in `App.ja-JP.resx`. New translatio
 
 ## Known issues / native review needed
 
-These were carried over from nabulator's seed translations (PR #44) and intentionally **not** corrected during the machine-translation sweep, to keep structural and quality changes separate. A native-speaker pass should fold these in.
+The mechanical items originally tracked here (nabulator-seed typos and inconsistencies) were fixed in the 2026-07 QC pass: `ベーション`→`バージョン`, `ツルー`→`ツール` (×3 entries), `やりこと`→`やること` (all six ToDo strings, plus the `レベレ`→`レベル` typo in Unpassed ToDos), the stray `き` in Recorded On, `失敗しまいました`→`失敗しました` (+ `失敗な`→`失敗した`, both entries), `まえ`→`以前` (Make Public Disclaimer 2), `Country`→`国`, `Open`→`開く`, `CoOp集合`→`CoOp集計`, `シェアー`→`シェア`, `捜索`→`検索`, the `ユーザ`→`ユーザー` sweep, full-width parens in `スコア（データあり）`, and typo repairs inside Use Password 1/3 (`すます`→`します`, `なめに`→`ために`, `どけ`→`だけ`, plus a stray mid-sentence line break). What remains is judgment territory for a native-speaker pass:
 
-### Typos
-
-- **`Mix` → `ベーション`** (line ≈ resx). Should be `バージョン` or — more accurately for this game — `ミックス` since "Mix" in PIU refers to game versions/iterations rather than a generic version number.
-- **`Filters` → `フィアルた`**. Should be `フィルター`. The reordered characters are clearly a typo.
-- **`Tools` → `ツルー`**. Should be `ツール`.
-- **`To Do` → `やりこと`** (and downstream `やりことリスト`). Should be `やること` (and `やることリスト`). The typo propagates through "Add to ToDo", "Remove from To Do List", "Show Only ToDo Charts", "Toggle ToDo".
-- **`Recorded On X` → `{0}にき記録した`**. Stray `き` — should be `{0}に記録した` or `{0}に記録されました` (polite-passive).
-- **`一部のスコアダウンロードが失敗しまいました`** (Phoenix Import Saving Failures). `失敗しまいました` is non-standard — should be `失敗してしまいました` or just `失敗しました`.
-- **`まえ` (Make Public Disclaimer 2)** — should be `前` (kanji) or `以前` for register consistency.
-
-### Untranslated where translation is expected
-
-- **`Country` → `Country`**. Should be `国`. nabulator left the dropdown label English; everywhere else the file uses Japanese for similar labels.
-- **`Open` → `Open`**. Should be `オープン` or context-appropriate.
-- **`Broken` → `Break Off`**. Left as English (and a different English phrase from the source). Should likely be `失敗` to match the rest of the break/fail vocabulary, or `Stage Break` to match the original PIU term.
-
-### Questionable word choices
-
-- **`CoOp Aggregation` → `CoOp集合`**. `集合` means "set/gathering", not "aggregation". Should be `集計` (which is what the new translation pass uses for similar concepts).
-- **`Communities` → `地域ランキング`** ("regional rankings"). Loses the social-community connotation; the feature is about player groups, not just regions. Reasonable candidate: `コミュニティ`.
+- **`Broken` → `Break Off`**. Left as English (and a different English phrase from the source). Candidates: `失敗` to match the break/fail vocabulary, or keep `Break Off` — ko-KR deliberately uses the equivalent loanword 브레이크 오프, so the current value is defensible.
+- **`Communities` → `地域ランキング`** ("regional rankings"). Loses the social-community connotation; the feature is about player groups, not just regions. Reasonable candidate: `コミュニティ` (which is what ko-KR does with 커뮤니티).
 - **`Players` → `プレーヤー達`**. The `達` plural marker is grammatically valid but unusual in game UI, where bare `プレーヤー` is the norm. Compounds drop it correctly (`プレーヤー数`, `プレーヤーレベル`).
 - **`Player Stats` → `進捗中の譜面`** ("in-progress charts"). nabulator interpreted "Stats" as the in-progress chart list this label is associated with on the page; not a literal translation. May or may not be the right call — depends on how the label reads in context.
-- **`スコア(データあり)`** uses half-width parens, breaking the full-width convention. nabulator's choice; consistency-wise should be `スコア（データあり）`.
-- **`シェアー`** (Chart List Share Description) — `シェアー` is non-standard katakana; standard would be `シェア`.
-- **`捜索` vs `検索`** for "Search". Two forms in use; pick one (recommend `検索`).
-- **`ユーザ` vs `ユーザー` / `プレーヤー`** — long-vowel mark inconsistency. nabulator uses `ユーザ`; the new batch uses `ユーザー`. Pick one and sweep.
+- **Rough nabulator prose that survives the typo fixes**: `残してる` (plain form + questionable transitivity) in Unpassed ToDos, `サービスを上げます` ("raise a service") in Use Password 3, `公開ランキング` ("public rankings") where the English says "Official". Grammatical now, but a native pass should rephrase.
 
 ### Machine-translation review priority
 

--- a/docs/LOCALIZATION-ko-KR.md
+++ b/docs/LOCALIZATION-ko-KR.md
@@ -13,7 +13,7 @@ For the localization mechanism itself (resx layout, `L["..."]` usage, key conven
 - **Spacing around English brand names mid-sentence.** Korean inserts a space between Hangul and embedded Latin tokens: `Phoenix 점수 계산기`, `Score Tracker 소개`, `Score Tracker에는 암호가...` (the particle `에는` attaches directly with no space, but the word boundary before the brand name has a space). Match the existing examples; particles attach to whichever side is grammatically attached.
 - **Preserve positional placeholders verbatim.** `{0}`, `{1}`, `{2}` go into the value untouched, in whatever order Korean grammar wants. Example: key `Remaining Charts` (English value `{0} (SSS+) - {1} (AA) Charts Remaining`) → ko-KR value `{0} (SSS+) - {1} (AA) 남은 채보`. Example: key `Remaining Charts For You` → `{0}개의 채보가 남았습니다` (counter `개` follows the placeholder, then particle).
 - **Skip prose with inline markup.** Per CLAUDE.md, `<MudText>` bodies with embedded `<MudLink>`/other elements stay hardcoded English. Don't extract them, don't translate them.
-- **Honorific `님` for proper names in credits.** Same role as Japanese `さん`. Examples: `Mr_WEQ 님에게 감사드립니다`, `daryen님에게 감사드립니다`. Note: existing entries are inconsistent on the space before `님` (`Mr_WEQ 님` vs `daryen님`). Recommend **no space** before `님` — that's the more standard form. See Known issues.
+- **Honorific `님` for proper names in credits.** Same role as Japanese `さん`. Examples: `Mr_WEQ님에게 감사드립니다`, `daryen님에게 감사드립니다`. **No space** before `님` — the file is converged on that form.
 
 ## Established term mappings
 
@@ -83,8 +83,8 @@ These have at least one existing translation in `App.ko-KR.resx`. New translatio
 
 | English | ko-KR | Notes |
 |---|---|---|
-| Chart(s) | 채보 | Translated, not loanword. Plural "Charts" → 채보들 (with 들 marker). Used compositionally: `채보 목록`, `채보 종류`, `채보 갯수`, `저장된 채보`, `남은 채보`, `진행중인 채보`, `목표 채보`, `채보 무작위 생성기`. **Don't switch to 차트 mid-file** (one legacy entry uses 차트 — see Known issues). |
-| Chart List Share | 차트 목록 공유 | One legacy `Chart List Share Description` uses 차트; everywhere else is 채보. See Known issues. |
+| Chart(s) | 채보 | Translated, not loanword. Plural "Charts" → 채보들 (with 들 marker). Used compositionally: `채보 목록`, `채보 종류`, `채보 갯수`, `저장된 채보`, `남은 채보`, `진행중인 채보`, `목표 채보`, `채보 무작위 생성기`, `채보 찾기`. **Don't switch to 차트 mid-file** — new batches keep drifting to 차트 and getting swept back (three entries fixed in the 2026-07 QC pass). |
+| Chart List Share | 채보 목록 공유 | The Description prose uses 채보 목록 too. |
 | CoOp | 코옵 | **Translated** (loanword in Hangul), unlike ja-JP/pt-BR which keep "CoOp" English. "CoOp Aggregation" → 코옵 난이도 (rendered as "CoOp difficulty" — see Known issues). |
 | Singles / Doubles | 싱글 / 더블 | Loanwords in Hangul, not 단식/복식. |
 | Difficulty Level | 난이도 | (Repeated from generic UI for cross-reference.) |
@@ -94,7 +94,7 @@ These have at least one existing translation in `App.ko-KR.resx`. New translatio
 | Plate | 플레이트 | Loanword (Hangul). |
 | Pass (verb / noun for clearing a chart) | 클리어 / 성공 | Mixed. "Hide Completed Charts" → 클리어한 차트 숨기기 (uses Konglish 클리어한 = "cleared"); "Passed Count" → 성공; "Not Passed Count" → 실패; "Stage Pass" — not yet present. The pass/fail dyad is 성공/실패 for counts; 클리어 for the verb sense. |
 | Score | 점수 | Translated (not loanword). "Score" → 점수, "Score State" → 기록 상태 (note: 기록 = "record"), "My Score" → 내 점수, "Score Loss" → "{0} 점수 감소", "Save Scores" → 점수 저장, "Official Scores" → 공식 점수, "Score Range" → score-range (in shoutout: 점수 등급의 범위). |
-| Score (occasionally) | 스코어 | "Download Scores" → 스코어 다운로드 — one entry uses Konglish 스코어 instead of 점수. Inconsistency — see Known issues. |
+| Score (occasionally) | ~~스코어~~ | The lone Konglish outlier (`Download Scores` → 스코어 다운로드) was swept to 점수 다운로드; the file is uniformly 점수 now. |
 | Phoenix Score Calculator | Phoenix 점수 계산기 | |
 | Score Loss | 점수 감소 | "{0} Score Loss" → "{0} 점수 감소" (placeholder is the magnitude). |
 | Note Count | (none yet) | Not yet present in ko-KR. |
@@ -107,7 +107,7 @@ These have at least one existing translation in `App.ko-KR.resx`. New translatio
 | Qualifiers | 예선과제 | Rendered as "preliminary task." "Qualifiers Leaderboard" → "{0} 예선과제 등수", "Qualifiers Submission" → "{0} 예선과제 제출". |
 | Rating | 레이팅 | Loanword (Hangul). "Max Rating" → 최고 레이팅, "Rating Calculator" → 레이팅 계산기. |
 | Pumbility | (none yet) | Not yet translated. Recommend leaving as `Pumbility` (proper-noun loanword) per the Phoenix/XX pattern. |
-| Song | 음악 / 노래 | **Inconsistent.** Bare "Song" → 음악 ("music"); compounds use 노래 ("song"): `Song Name` → 노래 이름, `Song Image` → 노래 이미지, `Song Type` → 노래 종류, `Song Duration` → 노래 길이. See Known issues — should converge on one. |
+| Song | 노래 | Converged on 노래 (bare "Song" had been 음악): `Song Name` → 노래 이름, `Song Image` → 노래 이미지, `Song Type` → 노래 종류, `Song Duration` → 노래 길이. |
 | Song Artist | 작곡자 | Rendered as "composer." |
 | Suggested Chart | 추천 채보 | |
 | Title (in-game title award) | 칭호 | (Cross-reference: same as generic UI Title.) |
@@ -136,20 +136,9 @@ These have at least one existing translation in `App.ko-KR.resx`. New translatio
 
 ## Known issues / native review needed
 
-These were carried over from the existing translations and should be reviewed by a native speaker. Keep structural and quality changes separate diffs.
+The mechanical items originally tracked here were fixed in the 2026-07 QC pass: bare `Song` converged on 노래; the Konglish 차트 outliers swept to 채보 (`Hide Completed Charts`, `Chart List Share Description`, plus two newer drifts `Find a chart` and the Daily Step caption); `Download Scores` swept to 점수 다운로드; `님` spacing converged on no-space (`Mr_WEQ님에게`); the broken placeholder order in `Log In With X` fixed to `{0} 계정으로 로그인` (the 계정으로 form sidesteps the 로/으로 particle alternation on English brand names); `Recorded On X` fixed to `{0}에 기록됨`; and the trailing spaces in Phoenix Import Info 4 / Phoenix Import Saving Failures trimmed. What remains is judgment territory:
 
-### Inconsistencies
-
-- **`Song` → 음악 vs 노래.** Bare `Song` → 음악, but every `Song X` compound (`Song Name`, `Song Image`, `Song Type`, `Song Duration`) → 노래 X. Pick one: 노래 is the more colloquial fit; 음악 is more formal/musical. Recommend **converging on 노래** since the compounds outnumber the bare entry 4:1.
-- **`Charts` → 채보 (consistent) except `Hide Completed Charts` → 클리어한 차트 숨기기.** That one entry uses Konglish 차트 instead of the file-wide 채보. Should be 클리어한 채보 숨기기.
-- **`Score` → 점수 (consistent) except `Download Scores` → 스코어 다운로드.** That one entry uses Konglish 스코어. Should be 점수 다운로드 to match the rest of the file (`Save Scores` → 점수 저장, `Official Scores` → 공식 점수).
-- **Honorific `님` spacing.** `Mr_WEQ 님에게` (with space) vs `daryen님에게` (no space). Korean style guide recommends **no space before `님`** — converge on `Mr_WEQ님에게`.
 - **Loanword vs translation policy is not uniform.** `Charts` translated (채보) but `Plate` loanworded (플레이트); `Letter Grade` loanworded (랭크) but `Tier List` translated (서열표); `Leaderboard` loanworded (리더보드) but `World Rankings` partly-translated (세계 랭킹). The choices are individually defensible but the mix can feel arbitrary. No action recommended — document and continue, but note the pattern when adding new terms (default toward the choice the most-similar existing term made).
-
-### Placeholder-order issues
-
-- **`Log In With X` → "로 로그인 {0}".** Korean grammar wants `{0}로 로그인` (placeholder before the particle `로`). The current value is grammatically broken — placeholder comes after the particle that's supposed to attach to it. Should be `{0}로 로그인` or `{0} 계정으로 로그인`.
-- **`Recorded On X` → "기록됨 {0}".** Korean wants `{0}에 기록됨` (placeholder + temporal particle `에` + verb). Current rendering puts the verb before the date, which reads awkwardly.
 - **`Phoenix Import Saving Progress` → "{0}/{1} 업로드됨 {2} 남음 {3} 기록 실패".** Four-placeholder string with no connecting punctuation; reads as a terse status line. Acceptable but spartan; a native pass might add commas (`{0}/{1} 업로드됨, {2} 남음, {3} 기록 실패`).
 
 ### Questionable word choices
@@ -161,7 +150,7 @@ These were carried over from the existing translations and should be reviewed by
 - **`CoOp Aggregation` → 코옵 난이도.** `난이도` means "difficulty," not "aggregation." The aggregation in question is the calculated CoOp difficulty score, so the rendering is contextually correct but lexically off — equivalent to ja-JP's `集合` / `集計` confusion. Better candidate: 코옵 집계.
 - **`Username` → 아이디.** Standard Korean web UI but a loanword for a noun that has native Korean equivalents (사용자 이름, 사용자명, 닉네임). 아이디 reads natural for login forms; if `Username` ever appears as a generic profile-display label, 닉네임 might fit better.
 - **`Starting Page` → 홈페이지.** Rendered as "homepage" rather than "starting page" — context-dependent (was used for the Phoenix-import script's start-from-page param). If `Starting Page` ever appears in a different context, this rendering will mislead.
-- **`Score Range Shoutout` mixes 점수 (translated) and 스코어 (loanword).** "데이터 수집과 점수 등급의 범위" uses 점수, consistent with the file. No issue here — flagging only as a contrast to the `Download Scores` entry that uses 스코어 instead.
+- **`Score Range Shoutout`** — "데이터 수집과 점수 등급의 범위" uses 점수, consistent with the file-wide convention. No issue; kept here as the reference example for the 점수-everywhere rule.
 
 ## Open decisions (terms upcoming batches will need)
 

--- a/docs/LOCALIZATION-pt-BR.md
+++ b/docs/LOCALIZATION-pt-BR.md
@@ -54,7 +54,6 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Very Easy / Very Hard | Muito fácil / Muito difícil | |
 | Video | Vídeo | |
 | Age | Idade | |
-| Days Old | dias de idade | lowercase — used as suffix to a number ("42 dias de idade"). |
 | Filters | Filtros | |
 | Settings | Configurações | |
 | All | Todos | Plural masculine. (When the underlying noun is feminine, use `Todas`; pick per key context.) |
@@ -84,7 +83,7 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | CoOp | CoOp | Untranslated. "CoOp Aggregation" → "Agregação de CoOp". |
 | Singles / Doubles | Singles / Doubles | Untranslated. |
 | Difficulty Level | Nível de dificuldade | |
-| Letter Grade | Letras de nota | Min/Max forms use singular: "Min Letter Grade" → "Letra de nota mín.", "Max Letter Grade" → "Letra de nota máx." Old/New variants: "Old Letter Grade" → "Letra de nota antiga", "New Letter Grade" → "Letra de nota nova". |
+| Letter Grade | Letras de nota | Min/Max forms use singular: "Min Letter Grade" → "Letra de nota mín.", "Max Letter Grade" → "Letra de nota máx." Old/New pairs gender-agree: `antiga` / `nova` with `Letra`. |
 | Letter-grade tier names (As, Ss, SSs, SSSs) | As, Ss, SSs, SSSs | **Untranslated**. Column-header labels for letter-grade counts ("how many A grades, how many S grades, …"). PIU jargon. |
 | Mix | Versão | "Mix" → "Versão". XX, Phoenix proper names stay untranslated. |
 | Phoenix | Phoenix | Game version proper name. Untranslated. |
@@ -141,7 +140,7 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Plates (plural) | Plates | **Untranslated**, plural form. "Plate Breakdown" → "Detalhamento de plates"; "Plate Distribution" → "Distribuição de plates". |
 | Welcome (greeting) | Bem-vindo | Masculine default for the bare greeting. |
 | Tournament / Campeonato (singular) | Campeonato | "Active Tournaments" → "Campeonatos ativos"; "Previous/Upcoming Tournaments" → "Campeonatos anteriores/próximos". |
-| Qualifiers | qualifiers | **Untranslated**, lowercase. Brazilian tournament community uses both `qualifiers` and `qualificatórias`; we keep the loanword. E.g. "Qualifiers Leaderboard" → "Classificação dos qualifiers". |
+| Qualifiers | qualifiers | **Untranslated**, lowercase. Brazilian tournament community uses both `qualifiers` and `qualificatórias`; we keep the loanword. E.g. "{0} Qualifiers Leaderboard" → "Classificação dos qualifiers de {0}" (`{0}` = tournament name — don't drop the placeholder). |
 | Brackets (tournament) | Chaves | **Translated**. Standard pt-BR for tournament brackets. "{0} Brackets" → "{0} Chaves". |
 | Seed (tournament seeding) | Seed | **Untranslated**. Tournament jargon, common loanword. |
 | Stamina | stamina | **Untranslated**. Brazilian PIU community usage. E.g. "Stamina Session Builder" → "Construtor de sessão de stamina". |


### PR DESCRIPTION
Full quality pass over the six non-English, non-Murloc resx files (es-ES, es-MX, fr-FR, it-IT, ja-JP, ko-KR, pt-BR), fixing every mechanical item the locale glossaries' **Known issues** sections had been tracking, plus the defects a scripted resx comparison surfaced. Docs updated in the same pass. One commit per locale so each category diff reviews independently.

## Structural state (verified by scripted QC)

Every locale now sits at **exact key parity with en-US (1,392 keys)** — no missing keys, no stale extras, no duplicate names, no `{0}` placeholder mismatches, no whitespace defects. it-IT needed zero value changes: the whole file conforms to its prescriptive glossary.

## What changed, per commit

- **ja-JP** — the nabulator-era typo list: `ベーション`→`バージョン` (Mix now matches the CLAUDE.md glossary), `ツルー`→`ツール` (×3 — the doc only knew about one), `やりこと`→`やること` (×6 ToDo strings), stray `き` in Recorded On, `失敗しまいました`/`失敗な`, `まえ`→`以前`, plus undocumented riders (`レベレ`→`レベル`, `すます`→`します`, `なめに`→`ために`, `どけ`→`だけ`, a raw line break mid-sentence in Use Password 3). Untranslated `Country`/`Open` get `国`/`開く` (Open is the recap-popup button → verb form). `CoOp集合`→`集計`, `シェアー`→`シェア`, and the doc-recommended `捜索`→`検索` / `ユーザ`→`ユーザー` sweeps. Full-width parens in `スコア（データあり）`.
- **ko-KR** — the grammatically broken `로 로그인 {0}` becomes `{0} 계정으로 로그인` (the `계정으로` form sidesteps the 로/으로 particle alternation on English brand names); `기록됨 {0}`→`{0}에 기록됨`; bare Song converges on `노래`; Konglish outliers sweep back to convention (`차트`→`채보` ×3, including two post-glossary drifts in `Find a chart` and the Daily Step caption; `스코어 다운로드`→`점수 다운로드`); `Mr_WEQ님` spacing; two trailing spaces trimmed.
- **es-MX** — login family standardized (`Iniciar sesión` / `Cerrar sesión` / `Iniciar sesión con {0}`); `Guardar Charts` (infinitive-for-participle bug) → `Charts guardados`; `{0} Conteo de votos`→`{0} votos`; `Imágen`→`Imagen`; `antiguas`→`antiguos`; `importe sus scores`→`puntajes`; the seven Title Case stragglers → sentence case; `Rota`→`Roto` (chart committed masculine); the lone `Esconder`→`Ocultar`.
- **fr-FR** — deletes the orphan `Pass (Avec Données)` entry (keyed by its own French value — resolvable by no `L[...]` call); fixes the wrong-direction upload (`Télécharger Scores` → `Téléverser les scores`, ×2); eleven documented spelling typos plus a bonus `développeur`; the doc's Title-Case examples → sentence case; Charts gender committed feminine (`Restants`→`Restantes`); `Afficher`→`Montrer`; qualifiers converge on the plural; `Song Artist`→`Artiste de la chanson`.
- **pt-BR** — deletes **21 dead entries** whose keys no longer exist in en-US (`Password`, `Game Card`, `Days Old`, `Old/New Letter Grade`, `Maximum/Minimum Level`, …) — lookups key on the English source text, so these could never resolve; restores the `{0}` tournament-name placeholder both Qualifiers strings had dropped.
- **it-IT (docs only)** — the glossary's status note still claimed no resx existed and the culture was unwired; both long false. Recommended mappings become Established; the first-batch process section retires.

## Deliberately not fixed (flagged, not churned)

- Native-review judgment calls stay flagged in each doc: ja `Break Off`/`地域ランキング`/`プレーヤー達`, ko `코옵 난이도`/`시리즈`/`유저`, fr `Plaque`/`Publique` + the NBSP typographic sweep + the full sentence-case sweep, es-ES's `¡`-omission (awaiting Errlena).
- **es-MX is contaminated with es-ES** — the mid-2026 feature batches landed es-ES-flavored values: 248 non-trivial strings byte-identical across the two Spanish files, 54 keys using Spain-form `puntuación` (es-MX = `puntaje`), register forked ~96 `tú` vs ~56 `usted`. Documented as the top Known issue in the es-MX glossary with both sweep directions laid out — the direction (re-localize to `usted`+`puntaje`, or flip the convention to `tú` and fix vocabulary only) is an owner call, so no strings were rewritten here.
- Two untranslated clusters violate the new-keys-in-all-locales rule: the By-Level-Breakdown captions (~10 strings, English in **all seven** locales including es-ES) and the recap/title archetype names (~14 strings, English everywhere except es-ES). Left as-is pending a call on whether the flavor names are English-by-design.

## Verification

`dotnet build` Debug clean (0 errors — resx well-formedness) and the three fast suites green: **Tests 1,346 / Api 60 / Components 163**, zero failures. Scripted QC re-run post-fix reports zero mechanical defects across all seven locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
