### PR TITLE
fix(tierlists): the URL bar is written, not navigated — NavigateTo was a reload

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.E2E/TierListTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/TierListTests.cs
@@ -90,6 +90,51 @@ public sealed class TierListTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task BareTierListsCanonicalizesInPlaceWithoutReloading()
+    {
+        // The bare route resolves a folder at the end of its init and rewrites the URL bar
+        // via history.replaceState. Navigating there instead would re-fetch and re-initialize
+        // the page it just rendered, stack junk history entries, and knock down any shell
+        // sheet the user had opened while init was still running — so the pins are on all
+        // three: one load total, an open sheet that survives the rewrite, and Back leaving
+        // the page rather than bouncing forward.
+        var tierListLoads = new List<string>();
+        _page.Request += (_, r) =>
+        {
+            if (r.Url.Contains("/TierLists", StringComparison.OrdinalIgnoreCase)
+                && r.ResourceType is "document" or "fetch")
+                lock (tierListLoads) tierListLoads.Add($"{r.ResourceType} {r.Url}");
+        };
+
+        // Below the shell's 960px breakpoint so the bottom nav (and its Search slot) exists.
+        await _page.SetViewportSizeAsync(390, 844);
+        await _page.GotoAsync("/LifeCalculator");
+        await _page.GotoAsync("/TierLists");
+
+        // Opened straight off the load: the sheet is static chrome, so this lands before the
+        // page's init resolves a folder — the tap the CI race caught being swallowed.
+        await _page.Locator("[data-search-btn]").ClickAsync();
+        await Expect(_page.Locator("[data-search-sheet]")).ToHaveClassAsync(new Regex(@"\bopen\b"));
+
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/TierLists/\w+/\d+\?TierListType="),
+            new PageAssertionsToHaveURLOptions { Timeout = 60_000 });
+
+        // The rewrite lands at the end of init, so by now any re-fetch it triggered would be
+        // in flight; a beat of settle catches it before the count is pinned.
+        await _page.WaitForTimeoutAsync(1000);
+        lock (tierListLoads)
+        {
+            Assert.True(tierListLoads.Count == 1,
+                $"Expected the single document load, saw: {string.Join(", ", tierListLoads)}");
+        }
+        await Expect(_page.Locator("[data-search-sheet]")).ToHaveClassAsync(new Regex(@"\bopen\b"));
+
+        await _page.GoBackAsync();
+        await Expect(_page).ToHaveURLAsync(new Regex("/LifeCalculator"),
+            new PageAssertionsToHaveURLOptions { Timeout = 60_000 });
+    }
+
+    [Fact]
     public async Task FolderPickerSwitchesTypeAndLevelInOneGesture()
     {
         // The headline perf fix of the overhaul: D20 → S18 is one popover interaction,

--- a/ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor
+++ b/ScoreTracker/ScoreTracker/Pages/TierLists/ChartSkills.razor
@@ -1436,14 +1436,14 @@ else
         {
             _tierListType = "Pass";
         }
-        SetQueryString();
+        await SetQueryString();
         await Recalculate();
     }
 
     private async Task ChangeLens(string lens)
     {
         _tierListType = lens;
-        SetQueryString();
+        await SetQueryString();
         await Recalculate();
     }
 
@@ -1471,12 +1471,17 @@ else
         StateHasChanged();
     }
 
-    private void SetQueryString()
+    // C3: the canonical folder URL is path-based; the lens rides as a query param. Written
+    // straight into history rather than navigated to — under the static router, NavigateTo
+    // re-fetches and re-initializes the whole page, and this component already updates itself
+    // in place. Push for a user step (Back walks folders); replace for init canonicalizing
+    // the entry URL (Back leaves the page).
+    private async Task SetQueryString(bool replace = false)
     {
-        // C3: the canonical folder URL is path-based; the lens rides as a query param.
-        NavManager.NavigateTo(NavManager.GetUriWithQueryParameters(
+        var url = NavManager.GetUriWithQueryParameters(
             $"/TierLists/{_chartType}/{_level}",
-            new Dictionary<string, object?> { { "TierListType", _tierListType } }));
+            new Dictionary<string, object?> { { "TierListType", _tierListType } });
+        await JSRuntime.InvokeVoidAsync(replace ? "history.replaceState" : "history.pushState", null, "", url);
     }
 
     private async Task ToggleTitles()
@@ -2078,7 +2083,7 @@ else
             _groupBy = "Difficulty";
         }
 
-        SetQueryString();
+        await SetQueryString(replace: true);
         await Recalculate();
     }
 }

--- a/ScoreTracker/ScoreTracker/Pages/TierLists/PersonalizedBreakdown.razor
+++ b/ScoreTracker/ScoreTracker/Pages/TierLists/PersonalizedBreakdown.razor
@@ -731,6 +731,7 @@ else
 @inject ICurrentUserAccessor CurrentUser;
 @inject IMediator Mediator;
 @inject NavigationManager NavManager;
+@inject IJSRuntime JSRuntime;
 @inject IUiSettingsAccessor UiSettings;
 @code {
 
@@ -965,14 +966,14 @@ else
 
         _chartType = folder.Type;
         _level = folder.Level;
-        SetQueryString();
+        await SetQueryString();
         await LoadFolder();
     }
 
     private async Task ChangeLens(string lens)
     {
         _lens = lens;
-        SetQueryString();
+        await SetQueryString();
         ResetMoverViewState();
         // Only the blend depends on the lens — charts, scores, chips, and rankings
         // are folder-scoped and stay.
@@ -983,11 +984,15 @@ else
         StateHasChanged();
     }
 
-    private void SetQueryString()
+    // Pushed straight into history rather than navigated to — under the static router,
+    // NavigateTo re-fetches and re-initializes the whole page, and both callers already
+    // reload exactly the slice that changed.
+    private async Task SetQueryString()
     {
-        NavManager.NavigateTo(NavManager.GetUriWithQueryParameters(
+        var url = NavManager.GetUriWithQueryParameters(
             $"/TierLists/{_chartType}/{_level}/Breakdown",
-            new Dictionary<string, object?> { { "Lens", _lens } }));
+            new Dictionary<string, object?> { { "Lens", _lens } });
+        await JSRuntime.InvokeVoidAsync("history.pushState", null, "", url);
     }
 
     // --- Load ----------------------------------------------------------------------------

--- a/ScoreTracker/ScoreTracker/wwwroot/js/nav.js
+++ b/ScoreTracker/ScoreTracker/wwwroot/js/nav.js
@@ -111,17 +111,19 @@
         }
     }
 
-    // Blazor navigates through pushState/replaceState, which fire no event of their own.
-    function wrapHistory(name) {
+    // Blazor and the pages navigate through pushState/replaceState, which fire no event of
+    // their own. A push is a step to somewhere else, so it closes any open sheet — a sheet is
+    // chrome over the page it was opened from, and the click handler cannot catch the search
+    // autocomplete, which navigates from a circuit without a link. A replace is the page
+    // rewriting its own URL in place (the tier list canonicalizing /TierLists into its folder
+    // route), so the sheet stays up.
+    function wrapHistory(name, leavesPage) {
         var original = history[name];
         if (typeof original !== 'function') return;
         history[name] = function () {
             var result = original.apply(this, arguments);
             refreshActiveNav();
-            // A sheet is chrome over the page it was opened from, so leaving that page
-            // closes it. The click handler catches links; it cannot catch the search
-            // autocomplete, which navigates from a circuit without one.
-            closeSheets();
+            if (leavesPage) closeSheets();
             return result;
         };
     }
@@ -205,8 +207,8 @@
         document.addEventListener('keydown', onKeyDown);
         window.addEventListener('resize', onResize);
         window.addEventListener('popstate', refreshActiveNav);
-        wrapHistory('pushState');
-        wrapHistory('replaceState');
+        wrapHistory('pushState', true);
+        wrapHistory('replaceState', false);
         // The dock's scroll watcher needs no circuit, so it starts with the page.
         if (window.pageDock) window.pageDock.watch();
         refreshActiveNav();

--- a/docs/design/render-modes.md
+++ b/docs/design/render-modes.md
@@ -275,6 +275,17 @@ Facts established during Stage 1 scoping that Stage 2 inherits. Re-check before 
    A narrower lever exists if we later want enhanced nav without DOM patching:
    `Blazor.start({ ssr: { disableDomPreservation: true } })`.
 
+   ⚠ **Scope correction, measured on the shipped flip (2026-07-16)**: the attribute governs
+   **link interception only**. A programmatic `NavigateTo` from an interactive island still
+   performs an *enhanced page load* — fetch + DOM patch on the same document — regardless of
+   `data-enhance-nav`. A component that calls it at the end of `OnInitializedAsync` therefore
+   re-creates itself and re-runs init (bare `/TierLists` triple-initialized and stacked two
+   history entries before the URL converged), and the patch resets any static shell chrome the
+   user had open (the mobile search sheet — the CI race behind the
+   `TheMobileSearchSheetOpensFocusedOnItsField` flake). Pages that only need the URL bar to
+   change write `history.pushState`/`replaceState` directly (the tier-list pages do);
+   `NavigateTo` is for actually leaving.
+
    ⚠ Still open when we do opt in: whether enhanced nav adds a second interception path
    alongside static-shell.md D8's `target="_top"` rule.
 2. **`HeadOutlet`'s render mode.** If static, it only collects head content from static

--- a/docs/design/seo-friendly-site.md
+++ b/docs/design/seo-friendly-site.md
@@ -310,11 +310,17 @@ QA on its own branch, exactly like Stage 1's.
 - **Verification**: the fast suites stay green through every render-mode violation (§5). E2E
   full pass + the owner FT matrix are the actual gate.
 
-**Shipped 2026-07-16, with three reality corrections found by building:**
+**Shipped 2026-07-16, with four reality corrections found by building:**
 - **The navigation model changes — this is the flip's one user-visible cost.** The §2 mechanics
   above were right; the "zero behavior change" banner was not: killing the interactive router
   ends SPA navigation, and every in-app click is a full document load now (accepted; enhanced
   nav is the chase).
+- **"Every navigation" meant link clicks.** `data-enhance-nav="false"` does not reach
+  programmatic `NavigateTo` from an interactive island, which performs an enhanced page load
+  (fetch + DOM patch, same document) — so a page that called `NavigateTo` to sync its own URL
+  re-fetched and re-initialized itself (render-modes.md §7.1 has the measurements). The
+  tier-list pages now write the URL bar through `history.pushState`/`replaceState` instead;
+  `NavigateTo` means leaving the page.
 - **Real 404s came free**: the static router answers unmatched routes itself — real 404, empty
   body — and the Router's `NotFound` fragment never renders under it. The planned status-setting
   component was dead on arrival and deleted; a branded not-found page is `NotFoundPage` polish,


### PR DESCRIPTION
## The failure

`StaticShellTests.TheMobileSearchSheetOpensFocusedOnItsField` failed on main's E2E stage, blocking the deploy gate. Not a dead feature — a boot-window race, latent since #156, that CI finally hit after the flip (#163).

## Root cause

Bare `/TierLists` ends `OnInitializedAsync` with `SetQueryString()` → `NavigateTo(/TierLists/{type}/{level}?TierListType=…)` to canonicalize the entry URL. Two post-flip facts turn that into the failure:

1. **`data-enhance-nav="false"` only reaches link clicks.** A programmatic `NavigateTo` from an interactive island still performs an *enhanced page load* — fetch + DOM patch on the same living document.
2. nav.js closes every shell sheet on any `pushState`/`replaceState` (deliberate, for real navigations).

On a slow CI box the test's tap lands while init's queries are still running: the sheet opens, init completes, the canonicalization fires — and the sheet is knocked down by the history hook and the DOM patch. On a fast machine init wins the race and the test passes. Verified both ways with an instrumented Playwright probe (history/network logging + a document-identity sentinel).

## What the probe also measured (fixed here too)

- Bare `/TierLists` re-fetched and **fully re-initialized itself twice** after rendering (NavigateTo → enhanced load → page island re-created → init re-runs → NavigateTo again → converges): ~3× the init DB work on the site's most-used page, plus two junk history entries — Back looked stuck, and backing onto bare `/TierLists` bounced you forward again.
- `/TierLists/Double/20` direct: one extra re-fetch (the query-param append on init).
- **Every folder/lens change** on tier lists and Personalized Breakdown triggered a full enhanced reload + re-init on top of the in-place update the code already performs (Breakdown's blend-only refetch was defeated).

## The fix

- Both pages' `SetQueryString` writes the URL bar straight into history via JS interop — `replaceState` for the init canonicalization (Back leaves the page, matching the C3 301 middleware's semantics for legacy URLs), `pushState` for user folder/lens steps (Back walks folders; popstate → Blazor enhanced-loads the prior URL). `NavigateTo` now means actually leaving.
- nav.js closes sheets on `pushState` only; a `replaceState` is the page cleaning up its own URL in place, so the sheet stays up. Picking a chart in the sheet's autocomplete still closes it — that navigation pushes.
- New E2E fact `BareTierListsCanonicalizesInPlaceWithoutReloading` pins the trio: one load total, a pre-circuit sheet tap that survives the rewrite (the CI race path, made deterministic), and Back landing off-page. The flaky test itself is untouched — it was right.
- render-modes.md §7.1 and seo-friendly-site.md get the scope correction: "every navigation is a full document load" holds for links; programmatic `NavigateTo` is an enhanced page load.

## Verification

- E2E: full suite green locally (Docker + Kestrel + headless Chromium), including the previously-flaky fact and the new one.
- Fast suites: Tests 1347/1347, Components 170/170.
- Post-fix, the probe's double `fetch GET /TierLists/…` pairs are gone — canonicalization is a single silent replace.

Deploy-queue note: the failed main run stopped the flip short of the deploy stage; once main is green again the gate offers it as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
