### PR TITLE
SERP appearance: verdict-fed descriptions, site-name signals, JSON-LD render fix

### DIFF
--- a/ScoreTracker/ScoreTracker.Data/Clients/AzureBlobFileUploadClient.cs
+++ b/ScoreTracker/ScoreTracker.Data/Clients/AzureBlobFileUploadClient.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Storage.Blobs;
+﻿using Azure;
+using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Microsoft.Extensions.Options;
 using ScoreTracker.Data.Configuration;
@@ -24,8 +25,34 @@ public sealed class AzureBlobFileUploadClient : IFileUploadClient
         path = path.TrimStart('/');
         var blobClient = _blob.GetBlobClient(path);
 
-        await blobClient.UploadAsync(fileStream, cancellationToken);
+        // IfNoneMatch keeps the no-overwrite behavior of the plain Stream overload this
+        // replaced; the headers carry the content type, which the options overload would
+        // otherwise leave as application/octet-stream.
+        await blobClient.UploadAsync(fileStream, new BlobUploadOptions
+        {
+            HttpHeaders = HeadersFor(path),
+            Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All }
+        }, cancellationToken);
         return new Uri($"https://piuimages.arroweclip.se/{path}");
+    }
+
+    // Blobs serve as application/octet-stream unless the type rides the upload — and some
+    // unfurlers and crawlers refuse to render an og:image served that way.
+    private static BlobHttpHeaders HeadersFor(string path)
+    {
+        return new BlobHttpHeaders
+        {
+            ContentType = Path.GetExtension(path).ToLowerInvariant() switch
+            {
+                ".png" => "image/png",
+                ".jpg" or ".jpeg" => "image/jpeg",
+                ".gif" => "image/gif",
+                ".webp" => "image/webp",
+                ".svg" => "image/svg+xml",
+                ".ico" => "image/x-icon",
+                _ => "application/octet-stream"
+            }
+        };
     }
 
     public Task<bool> DoesFileExist(string path, out Uri fullPath,
@@ -57,7 +84,9 @@ public sealed class AzureBlobFileUploadClient : IFileUploadClient
         var blobClient = _blob.GetBlobClient(newPath);
 
         var stream = await _client.GetStreamAsync(oldPath, cancellationToken);
-        await blobClient.UploadAsync(stream, true, cancellationToken);
+        // No conditions: this path always overwrote (the bool overload it replaced).
+        await blobClient.UploadAsync(stream, new BlobUploadOptions { HttpHeaders = HeadersFor(newPath) },
+            cancellationToken);
         return new Uri($"https://piuimages.arroweclip.se/{newPath}");
     }
 

--- a/ScoreTracker/ScoreTracker.Tests.E2E/NonComponentEndpointTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/NonComponentEndpointTests.cs
@@ -154,7 +154,8 @@ public sealed class NonComponentEndpointTests : IAsyncLifetime
     /// <summary>
     ///     The front door carries the site-name signals: WebSite JSON-LD plus og:site_name
     ///     on the root is what lets a search result say "PIU Scores" instead of the bare
-    ///     domain.
+    ///     domain. Its title carries the searchable descriptor, and data-nosnippet keeps
+    ///     the sign-in buttons and mocked-up card numbers out of search snippets.
     /// </summary>
     [Fact]
     public async Task TheFrontDoorNamesTheSiteForSearchEngines()
@@ -163,9 +164,14 @@ public sealed class NonComponentEndpointTests : IAsyncLifetime
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
+        // Two-part pin: the em-dash separator serves as a numeric entity (the HTML encoder
+        // escapes non-ASCII), so the assert brackets it rather than spelling it.
+        Assert.Contains("<title>PIU Scores ", body);
+        Assert.Contains("Pump It Up score tracker &amp; tier lists</title>", body);
         Assert.Contains("\"@type\":\"WebSite\"", body);
         Assert.Contains("\"name\":\"PIU Scores\"", body);
         Assert.Contains("property=\"og:site_name\"", body);
+        Assert.Contains("data-nosnippet", body);
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker.Tests.E2E/NonComponentEndpointTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/NonComponentEndpointTests.cs
@@ -142,6 +142,7 @@ public sealed class NonComponentEndpointTests : IAsyncLifetime
         Assert.Contains("1 score tracked, 100% pass rate.", body);
         Assert.Contains("property=\"og:image\"", body);
         Assert.Contains("property=\"og:site_name\"", body);
+        Assert.Contains("name=\"twitter:card\"", body);
         // The appearance layer rides the same static head: the JSON-LD graph (song +
         // breadcrumb trail, shown in place of raw URL slugs) and the stat tiles'
         // data-nosnippet, which keeps label soup out of search snippets so the

--- a/ScoreTracker/ScoreTracker.Tests.E2E/NonComponentEndpointTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/NonComponentEndpointTests.cs
@@ -128,13 +128,44 @@ public sealed class NonComponentEndpointTests : IAsyncLifetime
     [Fact]
     public async Task TheChartPageServesItsHeadWithoutACircuit()
     {
+        // One clean score makes the description verdict-flavored — the population stats
+        // are what give every chart page its own snippet text.
+        var user = await _fixture.Seed.SeedUserAsync("HeadFact");
+        await _fixture.Seed.SeedPhoenixScoreAsync(user, _chartId, 985_000);
+
         var response = await _client.GetAsync($"/Chart/{_chartId}");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        Assert.Contains("<title>Conflict S20</title>", body);
+        Assert.Contains("<title>Conflict S20 | PIU Scores</title>", body);
         Assert.Contains("name=\"description\"", body);
+        Assert.Contains("1 score tracked, 100% pass rate.", body);
         Assert.Contains("property=\"og:image\"", body);
+        Assert.Contains("property=\"og:site_name\"", body);
+        // The appearance layer rides the same static head: the JSON-LD graph (song +
+        // breadcrumb trail, shown in place of raw URL slugs) and the stat tiles'
+        // data-nosnippet, which keeps label soup out of search snippets so the
+        // description is what a result quotes.
+        Assert.Contains("application/ld+json", body);
+        Assert.Contains("BreadcrumbList", body);
+        Assert.Contains("data-nosnippet", body);
+    }
+
+    /// <summary>
+    ///     The front door carries the site-name signals: WebSite JSON-LD plus og:site_name
+    ///     on the root is what lets a search result say "PIU Scores" instead of the bare
+    ///     domain.
+    /// </summary>
+    [Fact]
+    public async Task TheFrontDoorNamesTheSiteForSearchEngines()
+    {
+        var response = await _client.GetAsync("/Welcome");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"@type\":\"WebSite\"", body);
+        Assert.Contains("\"name\":\"PIU Scores\"", body);
+        Assert.Contains("property=\"og:site_name\"", body);
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker.Tests.E2E/Support/E2ESeedData.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/Support/E2ESeedData.cs
@@ -133,6 +133,16 @@ public sealed class E2ESeedData
         return userId;
     }
 
+    /// <summary>A Phoenix best-score row (ScoreLedger-internal entity) — seeded with SQL.</summary>
+    public async Task SeedPhoenixScoreAsync(Guid userId, Guid chartId, int score, bool isBroken = false,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _factory.CreateDbContextAsync(cancellationToken);
+        await context.Database.ExecuteSqlInterpolatedAsync(
+            $"INSERT INTO [scores].[PhoenixRecord] ([Id], [UserId], [ChartId], [MixId], [RecordedDate], [Score], [IsBroken]) VALUES ({Guid.NewGuid()}, {userId}, {chartId}, {PhoenixMixId}, {new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)}, {score}, {isBroken})",
+            cancellationToken);
+    }
+
     /// <summary>Journal, highlight, and milestone rows belong to vertical-internal entities — seeded with SQL.</summary>
     public async Task SeedJournalRowAsync(Guid userId, Guid chartId, DateTimeOffset occurredAt, int? score,
         string? plate, bool isBroken, Guid? sessionId, string source = "manual",

--- a/ScoreTracker/ScoreTracker/App.razor
+++ b/ScoreTracker/ScoreTracker/App.razor
@@ -25,11 +25,13 @@
     @* A real head for readers that run no JS, resolved from the route (StaticHeadResolver):
        chart routes get their name, description and jacket; unmatched routes get the bare site
        title and no meta. Blazor removes the title on boot and HeadOutlet takes over, so
-       <PageTitle> keeps working unchanged. *@
-    <title>@(_head?.Title ?? L["PIU Scores"].Value)</title>
+       <PageTitle> keeps working unchanged. The brand suffix rides the document title only —
+       og:title stays the bare page name because og:site_name already carries the brand. *@
+    <title>@(_head != null ? $"{_head.Title} | PIU Scores" : L["PIU Scores"].Value)</title>
     @if (_head != null)
     {
         <meta name="description" content="@_head.Description" />
+        <meta property="og:site_name" content="PIU Scores" />
         <meta property="og:title" content="@_head.Title" />
         <meta property="og:description" content="@_head.Description" />
         <meta property="og:type" content="website" />
@@ -40,7 +42,11 @@
         @if (_head.Canonical != null)
         {
             <link rel="canonical" href="@_head.Canonical" />
-            <script type="application/ld+json">@((MarkupString)JsonLd(_head))</script>
+            @* The whole element rides one MarkupString: the static renderer silently drops
+               a <script> element whose content is a component expression, and a raw markup
+               frame is what actually reaches the document. JSON string values escape "<",
+               so a song title can't close the script early. *@
+            @((MarkupString)$"<script type=\"application/ld+json\">{JsonLd(_head)}</script>")
         }
     }
     @* Interactive, and not prerendered — matching every <PageTitle> in the app. Static, it would
@@ -132,18 +138,53 @@
     private ShellViewModel _shell = null!;
     private StaticHeadModel? _head;
 
-    // MusicRecording JSON-LD for chart pages — enough for a rich result to name the song and
-    // link its image. System.Text.Json escapes the values, so a song title can't break out.
+    // Chart-page structured data: MusicRecording names the song, its artist and jacket for
+    // rich results; BreadcrumbList is what a search result shows as its trail in place of
+    // raw URL slugs. System.Text.Json escapes the values, so a song title can't break out.
     private static string JsonLd(StaticHeadModel head)
     {
-        return System.Text.Json.JsonSerializer.Serialize(new Dictionary<string, object?>
+        var recording = new Dictionary<string, object?>
         {
-            ["@context"] = "https://schema.org",
             ["@type"] = "MusicRecording",
-            ["name"] = head.Title,
+            ["name"] = head.SongName ?? head.Title,
             ["description"] = head.Description,
             ["url"] = head.Canonical,
             ["image"] = head.OgImage
+        };
+        if (head.Artist != null)
+            recording["byArtist"] = new Dictionary<string, object?>
+            {
+                ["@type"] = "MusicGroup",
+                ["name"] = head.Artist
+            };
+        return System.Text.Json.JsonSerializer.Serialize(new Dictionary<string, object?>
+        {
+            ["@context"] = "https://schema.org",
+            ["@graph"] = new object[]
+            {
+                recording,
+                new Dictionary<string, object?>
+                {
+                    ["@type"] = "BreadcrumbList",
+                    ["itemListElement"] = new object[]
+                    {
+                        new Dictionary<string, object?>
+                        {
+                            ["@type"] = "ListItem",
+                            ["position"] = 1,
+                            ["name"] = "Charts",
+                            ["item"] = "https://piuscores.arroweclip.se/Charts"
+                        },
+                        new Dictionary<string, object?>
+                        {
+                            ["@type"] = "ListItem",
+                            ["position"] = 2,
+                            ["name"] = head.Title,
+                            ["item"] = head.Canonical
+                        }
+                    }
+                }
+            }
         });
     }
 

--- a/ScoreTracker/ScoreTracker/App.razor
+++ b/ScoreTracker/ScoreTracker/App.razor
@@ -38,10 +38,14 @@
         @if (_head.OgImage != null)
         {
             <meta property="og:image" content="@_head.OgImage" />
+            <meta property="og:image:alt" content="@($"{_head.SongName ?? _head.Title} jacket art")" />
+            @* The jacket banner is landscape (~16:9), which is what the large-card format wants. *@
+            <meta name="twitter:card" content="summary_large_image" />
         }
         @if (_head.Canonical != null)
         {
             <link rel="canonical" href="@_head.Canonical" />
+            <meta property="og:url" content="@_head.Canonical" />
             @* The whole element rides one MarkupString: the static renderer silently drops
                a <script> element whose content is a component expression, and a raw markup
                frame is what actually reaches the document. JSON string values escape "<",

--- a/ScoreTracker/ScoreTracker/Pages/ChartDetails.razor
+++ b/ScoreTracker/ScoreTracker/Pages/ChartDetails.razor
@@ -63,24 +63,46 @@
                     }
                 </div>
             }
-            <div class="chart-hero-facts">
+            @* data-nosnippet: to a text extractor the tiles are label soup ("263Scores
+               tracked"), so search snippets quote the meta description — which carries the
+               same stats as prose — instead. Value and label also sit on separate source
+               lines: extractors word-break on whitespace, not on span boundaries. *@
+            <div class="chart-hero-facts" data-nosnippet>
                 @if (_chart.Song.Bpm != null)
                 {
-                    <div><span class="chart-fact-value">@BpmDisplay</span><span class="chart-fact-label">@L["BPM"]</span></div>
+                    <div>
+                        <span class="chart-fact-value">@BpmDisplay</span>
+                        <span class="chart-fact-label">@L["BPM"]</span>
+                    </div>
                 }
                 @if (_chart.NoteCount > 0)
                 {
-                    <div><span class="chart-fact-value">@($"{_chart.NoteCount:N0}")</span><span class="chart-fact-label">@L["Notes"]</span></div>
+                    <div>
+                        <span class="chart-fact-value">@($"{_chart.NoteCount:N0}")</span>
+                        <span class="chart-fact-label">@L["Notes"]</span>
+                    </div>
                 }
                 @if (_analysis?.Nps != null)
                 {
-                    <div><span class="chart-fact-value">@_analysis.Nps.Value.ToString("0.#")</span><span class="chart-fact-label">@L["Notes per Second"]</span></div>
+                    <div>
+                        <span class="chart-fact-value">@_analysis.Nps.Value.ToString("0.#")</span>
+                        <span class="chart-fact-label">@L["Notes per Second"]</span>
+                    </div>
                 }
-                <div><span class="chart-fact-value">@_chart.OriginalMix.GetName()</span><span class="chart-fact-label">@L["Debuted in"]</span></div>
+                <div>
+                    <span class="chart-fact-value">@_chart.OriginalMix.GetName()</span>
+                    <span class="chart-fact-label">@L["Debuted in"]</span>
+                </div>
                 @if (Population != null)
                 {
-                    <div><span class="chart-fact-value">@($"{Population.ScoresTracked:N0}")</span><span class="chart-fact-label">@L["Scores tracked"]</span></div>
-                    <div><span class="chart-fact-value">@((int)Math.Round(Population.PassRate * 100))%</span><span class="chart-fact-label">@L["Pass rate"]</span></div>
+                    <div>
+                        <span class="chart-fact-value">@($"{Population.ScoresTracked:N0}")</span>
+                        <span class="chart-fact-label">@L["Scores tracked"]</span>
+                    </div>
+                    <div>
+                        <span class="chart-fact-value">@((int)Math.Round(Population.PassRate * 100))%</span>
+                        <span class="chart-fact-label">@L["Pass rate"]</span>
+                    </div>
                 }
             </div>
             <ChartVerdictCard Facets="_facets"></ChartVerdictCard>

--- a/ScoreTracker/ScoreTracker/Pages/FrontDoor.cshtml
+++ b/ScoreTracker/ScoreTracker/Pages/FrontDoor.cshtml
@@ -28,6 +28,10 @@
     <meta property="og:description" content="@L["PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play."]" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://piuscores.arroweclip.se/Welcome" />
+    <meta property="og:site_name" content="PIU Scores" />
+    @* WebSite structured data on the site root names the site in search results — without
+       it a result is labelled with the bare domain. The brand is never localized. *@
+    <script type="application/ld+json">@Html.Raw(SiteJsonLd)</script>
     @* The shipped theme tokens — same single source as the Blazor shell (MixThemes),
        so this page can never drift from the site palette. Anonymous visitors resolve
        to Phoenix by the same rule the layout uses. *@
@@ -44,6 +48,9 @@
 <body class="front-door">
 
 @functions {
+    private const string SiteJsonLd =
+        """{"@context":"https://schema.org","@type":"WebSite","name":"PIU Scores","url":"https://piuscores.arroweclip.se/"}""";
+
     private static string BandKey(TierListCategory category) => category switch
     {
         TierListCategory.Easy => "Easy",

--- a/ScoreTracker/ScoreTracker/Pages/FrontDoor.cshtml
+++ b/ScoreTracker/ScoreTracker/Pages/FrontDoor.cshtml
@@ -17,14 +17,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="~/" />
-    <title>@L["PIU Scores"]</title>
+    <title>@L["PIU Scores — Pump It Up score tracker & tier lists"]</title>
     @* One page, three routes ("/Welcome", "/Login", and anonymous "/" redirecting in):
        the canonical is what tells a crawler they are the same result. The description is
        the hero's own pitch line — one string, already in every locale. No og:image yet;
        the site has no share-card asset. *@
     <link rel="canonical" href="https://piuscores.arroweclip.se/Welcome" />
     <meta name="description" content="@L["PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play."]" />
-    <meta property="og:title" content="@L["PIU Scores"]" />
+    <meta property="og:title" content="@L["PIU Scores — Pump It Up score tracker & tier lists"]" />
     <meta property="og:description" content="@L["PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play."]" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://piuscores.arroweclip.se/Welcome" />
@@ -97,7 +97,10 @@
         </p>
     </div>
 
-    <div class="hero-signin" id="signin">
+    @* data-nosnippet on the sign-in column and the mocked-up card internals below: auth
+       buttons and illustrative numbers are the wrong text for a search snippet — the hero
+       pitch, card blurbs, and the live stat band are what a result should quote. *@
+    <div class="hero-signin" id="signin" data-nosnippet>
         <div class="signin">
             <h2>@L["Sign in"]</h2>
             <p class="new-here">@L["New here? Signing in creates your account automatically — no forms, no site password."]</p>
@@ -224,37 +227,37 @@
             <h3>@L["One-click import"]</h3>
             <p class="blurb">@L["Point it at your PIUGAME account once — grades, plates, and history land intact."]</p>
             @* Example rows — illustrative by design; the import itself is the live feature. *@
-            <div class="score-row">
+            <div class="score-row" data-nosnippet>
                 <span class="nm">Moonlight</span><span class="sc">998,404</span>
                 <span class="chip chip-grade">SSS+</span><span class="chip chip-ug">UG</span>
             </div>
-            <div class="score-row">
+            <div class="score-row" data-nosnippet>
                 <span class="nm">Sarabande</span><span class="sc">981,762</span>
                 <span class="chip chip-grade">SSS</span><span class="chip chip-eg">EG</span>
             </div>
-            <div class="score-row">
+            <div class="score-row" data-nosnippet>
                 <span class="nm">Sorceress Elise</span><span class="sc">942,310</span>
                 <span class="chip chip-grade">AA+</span><span class="chip chip-mg">MG</span>
             </div>
-            <div class="import-meter">
+            <div class="import-meter" data-nosnippet>
                 <div class="bar"><div class="fill"></div></div>
                 <div class="cap">@L["{0} scores imported from PIUGAME", 2431.ToString("N0")]</div>
             </div>
-            <div class="hl-row"><span class="star">✦</span> @L["Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp."]</div>
+            <div class="hl-row" data-nosnippet><span class="star">✦</span> @L["Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp."]</div>
             <a class="cta" href="#signin">@L["Sign in and import yours"] →</a>
         </div>
 
         <div class="card pumbility">
             <h3>@L["Watch yourself climb"]</h3>
             <p class="blurb">@L["Pumbility rating, titles, and a season recap worth screenshotting."]</p>
-            <div class="big"><small>@L["PUMBILITY"]</small>68,412</div>
-            <span class="rarity-chip">@L["Top 8% · Sapphire"]</span>
+            <div class="big" data-nosnippet><small>@L["PUMBILITY"]</small>68,412</div>
+            <span class="rarity-chip" data-nosnippet>@L["Top 8% · Sapphire"]</span>
             <svg class="spark" width="100%" height="46" viewBox="0 0 260 46" preserveAspectRatio="none" aria-hidden="true">
                 <polyline points="0,40 30,38 60,34 90,35 120,28 150,24 180,25 210,16 245,8"
                           fill="none" stroke="var(--mix-primary)" stroke-width="2.5" stroke-linecap="round"/>
                 <circle cx="245" cy="8" r="3.5" fill="var(--mix-accent)"/>
             </svg>
-            <div class="title-progress">
+            <div class="title-progress" data-nosnippet>
                 <div class="lbl"><b>INTERMEDIATE Lv.10</b><span>@L["{0}% to next title", 73]</span></div>
                 <div class="bar"><div class="fill"></div></div>
             </div>
@@ -301,7 +304,7 @@
             <p class="eyebrow">@L["For your community"]</p>
             <h3>@L["Discord, wired in"]</h3>
             <p>@L["Point your community's channel at the bot and placements, milestones, and session highlights land in your server the moment scores come in."]</p>
-            <div class="discord-msg" aria-hidden="true">
+            <div class="discord-msg" aria-hidden="true" data-nosnippet>
                 <span class="bot">PIU Scores<span class="bot-tag">BOT</span></span><br />
                 ✦ @L["Session roundup — 3 highlights: new UG plate, 2 PBs. Weekly board: up to 2nd place."]
             </div>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -3254,6 +3254,9 @@
   <data name="PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play." xml:space="preserve">
     <value>PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play.</value>
   </data>
+  <data name="PIU Scores — Pump It Up score tracker &amp; tier lists" xml:space="preserve">
+    <value>PIU Scores — Pump It Up score tracker &amp; tier lists</value>
+  </data>
   <data name="Free, and built by a player." xml:space="preserve">
     <value>Free, and built by a player.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -3168,6 +3168,9 @@
   <data name="PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play." xml:space="preserve">
     <value>PIU Scores mrglrps mrgl whrgl Pump It Up hrglstrgl, mrglprtd strglght frgl mrgl PIUGAME accrglnt, mrgl trglns mrgl mrgl Brglurgbrgl Rglgurggurgrgl, rrglnkngs, mrgl rrglcmmndrgltns trglnd mrgl hrgl mrgl mrglly plrgly.</value>
   </data>
+  <data name="PIU Scores — Pump It Up score tracker &amp; tier lists" xml:space="preserve">
+    <value>PIU Scores — Pump It Up scrgl trglckr &amp; Brglurgbrgl Rglgurggurgrgl</value>
+  </data>
   <data name="Free, and built by a player." xml:space="preserve">
     <value>Frgle, mrgl bmrglt brgl mrgl plrglyr.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -3123,6 +3123,9 @@
   <data name="PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play." xml:space="preserve">
     <value>PIU Scores guarda todo tu historial de Pump It Up, importado directamente desde tu cuenta de PIUGAME, y lo convierte en tier lists, clasificaciones y recomendaciones ajustadas a tu forma real de jugar.</value>
   </data>
+  <data name="PIU Scores — Pump It Up score tracker &amp; tier lists" xml:space="preserve">
+    <value>PIU Scores — registro de puntuaciones y tier lists de Pump It Up</value>
+  </data>
   <data name="Free, and built by a player." xml:space="preserve">
     <value>Gratis, y hecho por un jugador.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -3125,6 +3125,9 @@
   <data name="PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play." xml:space="preserve">
     <value>PIU Scores guarda todo tu historial de Pump It Up, importado directamente desde tu cuenta de PIUGAME, y lo convierte en tier lists, clasificaciones y recomendaciones ajustadas a tu forma real de jugar.</value>
   </data>
+  <data name="PIU Scores — Pump It Up score tracker &amp; tier lists" xml:space="preserve">
+    <value>PIU Scores — registro de puntuaciones y tier lists de Pump It Up</value>
+  </data>
   <data name="Free, and built by a player." xml:space="preserve">
     <value>Gratis, y hecho por un jugador.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -3239,6 +3239,9 @@
   <data name="PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play." xml:space="preserve">
     <value>PIU Scores conserve tout votre historique Pump It Up, importé directement depuis votre compte PIUGAME, et le transforme en tier lists, classements et recommandations adaptés à votre façon de jouer.</value>
   </data>
+  <data name="PIU Scores — Pump It Up score tracker &amp; tier lists" xml:space="preserve">
+    <value>PIU Scores — suivi de scores et tier lists Pump It Up</value>
+  </data>
   <data name="Free, and built by a player." xml:space="preserve">
     <value>Gratuit, et créé par un joueur.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -3245,6 +3245,9 @@
   <data name="PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play." xml:space="preserve">
     <value>PIU Scores conserva tutta la tua cronologia di Pump It Up, importata direttamente dal tuo account PIUGAME, e la trasforma in tier list, classifiche e consigli su misura per come giochi davvero.</value>
   </data>
+  <data name="PIU Scores — Pump It Up score tracker &amp; tier lists" xml:space="preserve">
+    <value>PIU Scores — tracciamento punteggi e tier list per Pump It Up</value>
+  </data>
   <data name="Free, and built by a player." xml:space="preserve">
     <value>Gratuito, e creato da un giocatore.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -3245,6 +3245,9 @@
   <data name="PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play." xml:space="preserve">
     <value>PIU Scores は PIUGAME アカウントから直接インポートした Pump It Up の全履歴を保存し、ティアリスト、ランキング、あなたのプレイスタイルに合わせたおすすめに変えます。</value>
   </data>
+  <data name="PIU Scores — Pump It Up score tracker &amp; tier lists" xml:space="preserve">
+    <value>PIU Scores — Pump It Up のスコアトラッキング＆ティアリスト</value>
+  </data>
   <data name="Free, and built by a player." xml:space="preserve">
     <value>無料、プレイヤーの手作りです。</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -3126,6 +3126,9 @@
   <data name="PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play." xml:space="preserve">
     <value>PIU Scores는 PIUGAME 계정에서 바로 가져온 펌프 잇 업 전체 기록을 보관하고, 티어리스트, 랭킹, 실제 플레이 스타일에 맞춘 추천으로 바꿔 드립니다.</value>
   </data>
+  <data name="PIU Scores — Pump It Up score tracker &amp; tier lists" xml:space="preserve">
+    <value>PIU Scores — 펌프 잇 업 스코어 트래킹 &amp; 티어리스트</value>
+  </data>
   <data name="Free, and built by a player." xml:space="preserve">
     <value>무료이며, 플레이어가 직접 만들었습니다.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -3125,6 +3125,9 @@
   <data name="PIU Scores keeps your whole Pump It Up history, imported straight from your PIUGAME account, and turns it into tier lists, rankings, and recommendations tuned to how you actually play." xml:space="preserve">
     <value>O PIU Scores guarda todo o seu histórico de Pump It Up, importado direto da sua conta PIUGAME, e o transforma em tier lists, rankings e recomendações ajustadas ao seu jeito de jogar.</value>
   </data>
+  <data name="PIU Scores — Pump It Up score tracker &amp; tier lists" xml:space="preserve">
+    <value>PIU Scores — registro de pontuações e tier lists de Pump It Up</value>
+  </data>
   <data name="Free, and built by a player." xml:space="preserve">
     <value>Grátis, e feito por um jogador.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Services/StaticHeadResolver.cs
+++ b/ScoreTracker/ScoreTracker/Services/StaticHeadResolver.cs
@@ -1,12 +1,19 @@
+using MediatR;
+using ScoreTracker.ChartIntelligence.Contracts;
+using ScoreTracker.ChartIntelligence.Contracts.Queries;
 using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.SharedKernel.Models;
 
 namespace ScoreTracker.Web.Services;
 
 /// <summary>
-///     The head a route serves as static HTML. OgImage/Canonical are absent for routes the
-///     resolver doesn't recognise.
+///     The head a route serves as static HTML. Title is the page's own text — App.razor
+///     appends the brand to the document title, so a circuit's PageTitle can still take over
+///     without the suffix flashing away. OgImage/Canonical are absent for routes the
+///     resolver doesn't recognise; SongName/Artist feed the chart page's JSON-LD.
 /// </summary>
-public sealed record StaticHeadModel(string Title, string Description, string? OgImage, string? Canonical);
+public sealed record StaticHeadModel(string Title, string Description, string? OgImage, string? Canonical,
+    string? SongName = null, string? Artist = null);
 
 /// <summary>
 ///     Resolves the document head from the request path
@@ -20,10 +27,12 @@ public sealed record StaticHeadModel(string Title, string Description, string? O
 public sealed class StaticHeadResolver
 {
     private readonly ChartUrlResolver _charts;
+    private readonly IMediator _mediator;
 
-    public StaticHeadResolver(ChartUrlResolver charts)
+    public StaticHeadResolver(ChartUrlResolver charts, IMediator mediator)
     {
         _charts = charts;
+        _mediator = mediator;
     }
 
     public async Task<StaticHeadModel?> Resolve(PathString path, MixEnum currentMix,
@@ -41,12 +50,36 @@ public sealed class StaticHeadResolver
         var chart = await _charts.FindChart(resolution.ChartId, currentMix, cancellationToken);
         if (chart == null) return null;
 
-        // Title = the chart page's own PageTitle text; description = its (previously
-        // circuit-only) meta description, now served where a crawler reads it.
         return new StaticHeadModel(
             $"{chart.Song.Name} {chart.DifficultyString}",
-            $"Statistics and leaderboards for {chart.Song.Name} {chart.DifficultyString} by {chart.Song.Artist}.",
+            await Description(chart, cancellationToken),
             chart.Song.ImagePath.ToString(),
-            $"https://piuscores.arroweclip.se{resolution.CanonicalPath}");
+            $"https://piuscores.arroweclip.se{resolution.CanonicalPath}",
+            chart.Song.Name.ToString(),
+            chart.Song.Artist.ToString());
+    }
+
+    /// <summary>
+    ///     The search snippet. The population stats make each chart's description its own,
+    ///     and substantial enough that engines quote it instead of stitching page text
+    ///     together. The verdict caches daily per (chart, mix) — which also holds the
+    ///     description stable between analytics rebuilds — and the page dispatches the same
+    ///     query later in the same request, so this warms that cache rather than doubling
+    ///     the work.
+    /// </summary>
+    private async Task<string> Description(Chart chart, CancellationToken cancellationToken)
+    {
+        var identity =
+            $"Statistics and leaderboards for {chart.Song.Name} {chart.DifficultyString} by {chart.Song.Artist}.";
+        const string tail = "Difficulty verdict, skill breakdown, and the full leaderboard on PIU Scores.";
+        // The chart's own mix, not the viewer's: FindChart can fall back to another mix's
+        // copy, and the population only exists where the chart does.
+        var population = (await _mediator.Send(new GetChartVerdictQuery(chart.Id, chart.Mix), cancellationToken))
+            .OfType<PopulationVerdict>().FirstOrDefault();
+        if (population is not { ScoresTracked: > 0 }) return $"{identity} {tail}";
+
+        var scores = population.ScoresTracked == 1 ? "score" : "scores";
+        var passRate = (int)Math.Round(population.PassRate * 100);
+        return $"{identity} {population.ScoresTracked:N0} {scores} tracked, {passRate}% pass rate. {tail}";
     }
 }

--- a/docs/design/seo-friendly-site.md
+++ b/docs/design/seo-friendly-site.md
@@ -465,6 +465,15 @@ Google's first indexed chart page exposed how a result actually *reads* ("263Sco
   `og:site_name` on `/` / `/Welcome` / `/Login`: the documented signal for showing
   "PIU Scores" instead of the bare domain above results. Site names for subdomains are
   supported but slow to take — after this markup, the lever is patience, not more markup.
+- **og:image was already there — its MIME was not.** Chart pages have served the jacket
+  banner as og:image since PR-2 (700×393 piugame art, a near-ideal large-card aspect). What
+  was broken: `AzureBlobFileUploadClient` never set a content type, so every app-uploaded
+  blob — song jackets, the tier-list folder cards — serves `application/octet-stream`, which
+  some unfurlers and crawlers refuse to render as an image. The uploader now stamps the type
+  from the extension (no-overwrite semantics preserved via `IfNoneMatch`); **existing blobs
+  need a one-time owner-side content-type stamp** (az loop; remember a CDN purge after —
+  cached octet-stream responses outlive the stamp). Head grew `og:url`, `og:image:alt`, and
+  `twitter:card = summary_large_image`.
 - **Front-door title + snippet hygiene** — the title (and og:title) gained the searchable
   descriptor: `PIU Scores — Pump It Up score tracker & tier lists`, one localized key ×9
   (each locale reuses its own established phrasing from the hero keys; the `WebSite`

--- a/docs/design/seo-friendly-site.md
+++ b/docs/design/seo-friendly-site.md
@@ -465,6 +465,13 @@ Google's first indexed chart page exposed how a result actually *reads* ("263Sco
   `og:site_name` on `/` / `/Welcome` / `/Login`: the documented signal for showing
   "PIU Scores" instead of the bare domain above results. Site names for subdomains are
   supported but slow to take — after this markup, the lever is patience, not more markup.
+- **Front-door title + snippet hygiene** — the title (and og:title) gained the searchable
+  descriptor: `PIU Scores — Pump It Up score tracker & tier lists`, one localized key ×9
+  (each locale reuses its own established phrasing from the hero keys; the `WebSite`
+  JSON-LD `name` stays the bare brand — that's the site-name signal). `data-nosnippet`
+  covers the sign-in column and the showcase cards' illustrative numbers (fused spans like
+  "Moonlight998,404" were snippet-eligible), leaving the hero pitch, card blurbs, and the
+  live stat band as what a result quotes.
 
 ### Open owner decisions
 

--- a/docs/design/seo-friendly-site.md
+++ b/docs/design/seo-friendly-site.md
@@ -434,6 +434,38 @@ still validate), and the ARR-affinity owner item (static-shell.md D18).
 - Docs: ARCHITECTURE / UX-GUIDELINES / API / DATABASE-SCHEMA sync; chart-details-overhaul.md P3
   + P4 rows close; this doc's ladder gets its shipped-marks.
 
+### SERP appearance pass (2026-07-17)
+
+Google's first indexed chart page exposed how a result actually *reads* ("263Scores tracked
+92%Pass rate…" — value/label spans fused, description too thin to be quoted alone, site named
+"arroweclip.se"). The appearance layer, landed as one pass:
+
+- **Verdict-flavored description** — the PR-2 option, now real: `StaticHeadResolver` folds the
+  daily-cached `GetChartVerdictQuery` population into the description ("263 scores tracked, 92%
+  pass rate"), making each chart's description unique and substantial enough that engines quote
+  it instead of stitching page text. The page dispatches the same query later in the same
+  request, so the head *warms* the verdict cache rather than doubling the work; the daily cache
+  is also what keeps descriptions stable between analytics rebuilds.
+- **`data-nosnippet` on the hero fact tiles** — value/label tiles are label soup to a text
+  extractor; the attribute keeps them out of search snippets (the description now carries those
+  stats as prose), and value/label sit on separate source lines so any other extractor
+  word-breaks cleanly. Verdict sentences stay snippetable on purpose — they read well.
+- **Branded document title** — `{Song} {Diff} | PIU Scores`, suffix applied in App.razor only:
+  the head model's Title stays the page's own text, so a future circuit `PageTitle` swap can't
+  flash the brand away. og:title stays bare; `og:site_name` carries the brand for unfurlers.
+- **JSON-LD grew to a graph** — `MusicRecording` (song name + `byArtist`, no longer the chart
+  title) + `BreadcrumbList` (Charts › {Song} {Diff}), which replaces raw URL slugs
+  ("Charts › phoenix › d23") as the result's displayed trail. **Landing it exposed a latent
+  K3 bug**: the static renderer silently drops a `<script>` element whose content is a
+  component expression, so the PR-4 MusicRecording script never actually reached a crawler
+  (live-site confirmed — canonical `<link>` from the same `@if` served, script absent). Fix:
+  the whole element rides one `MarkupString`; the new E2E fact pins `ld+json` in the raw body
+  so it can't regress silently again.
+- **Site name** — the front door serves `WebSite` JSON-LD (`name: "PIU Scores"`) +
+  `og:site_name` on `/` / `/Welcome` / `/Login`: the documented signal for showing
+  "PIU Scores" instead of the bare domain above results. Site names for subdomains are
+  supported but slow to take — after this markup, the lever is patience, not more markup.
+
 ### Open owner decisions
 
 | # | Decision | Blocks | Default/lean |


### PR DESCRIPTION
## Why

The first Google-indexed chart page (Rush-More D23) read badly:

> **Rush-More D23**
> arroweclip.se · piuscores.arroweclip.se › Charts › phoenix › d23
> Statistics and leaderboards for Rush-More D23 by litmus*. **263Scores tracked 92%Pass rate.** Scores open up around competitive level 25. 50% Twists 38% Runs 50% ...

Three separate problems: the hero stat tiles fuse into label soup when a snippet extractor reads them (`<span>263</span><span>Scores tracked</span>` with zero whitespace between), the meta description was too thin (~55 chars) so Google padded it with that scraped soup, and the site is named by its bare domain.

## What changed

- **Verdict-fed descriptions** — `StaticHeadResolver` now folds the population facet from the daily-cached `GetChartVerdictQuery` into each chart's description: *"Statistics and leaderboards for Rush-More D23 by litmus\*. 263 scores tracked, 92% pass rate. Difficulty verdict, skill breakdown, and the full leaderboard on PIU Scores."* Unique per chart, long enough for engines to quote outright. The page dispatches the same query later in the same request, so the head **warms** the verdict cache rather than doubling work (this was the design doc's own deferred option — PR-2 "if the description goes verdict-flavored"). Chart pages with zero scores drop the stats sentence.
- **`data-nosnippet` on the hero fact tiles** + value/label spans moved onto separate source lines (block-display spans, so no visual change). The description now carries those stats as prose; the verdict sentences stay snippetable on purpose — they read well.
- **Branded title** — `{Song} {Diff} | PIU Scores`, suffix applied in App.razor only so the head model's Title stays the page's own text. `og:title` stays bare; new `og:site_name` carries the brand for unfurlers.
- **Latent bug found & fixed: the chart JSON-LD never rendered.** The static renderer silently drops a `<script>` element whose content is a component expression — live-site confirmed (canonical `<link>` from the same `@if` serves; the script is absent from production HTML). The whole element now rides one `MarkupString`, and the payload grew to a `MusicRecording` (song name + `byArtist`, no longer the chart title) + `BreadcrumbList` (Charts › {Song} {Diff}) graph, which is what replaces the raw `phoenix › d23` slug trail in results.
- **Site name** — the front door now serves `WebSite` JSON-LD (`name: "PIU Scores"`) + `og:site_name` on `/` / `/Welcome` / `/Login`: Google's documented signal for showing **PIU Scores** instead of **arroweclip.se** above results. Subdomain site names are supported but slow to take.
- **E2E** — the chart-head fact now pins the branded title, `og:site_name`, `ld+json`, `BreadcrumbList`, `data-nosnippet`, and the exact stats sentence (`1 score tracked, 100% pass rate.`) via a new `SeedPhoenixScoreAsync` raw-SQL seeder; a new fact pins the front-door site-name signals. The `ld+json` pin is what would have caught the render bug at PR #165.

## Verification

- Fast suites: Tests **1422** / Api **60** / Components **192**, all green
- Full E2E: **42/42** green (real Kestrel + Testcontainers SQL)
- Live production HTML diffed against the new head to confirm the JSON-LD regression is real, not environmental

## What to expect

Google re-crawls on its own schedule — the snippet/title update when the page is re-fetched (you can nudge individual URLs via GSC URL Inspection → Request Indexing). The site-name swap can lag further behind; the markup is the whole lever there. Browser tabs on chart pages now read `{Song} {Diff} | PIU Scores`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)