### PR TITLE
fix(catalog): add missing Yoropiku Pikuyoro ! charts + repair co-op PlayerCount on create

### DIFF
--- a/ScoreTracker/ScoreTracker.Catalog/Infrastructure/EFChartRepository.cs
+++ b/ScoreTracker/ScoreTracker.Catalog/Infrastructure/EFChartRepository.cs
@@ -348,7 +348,11 @@ internal sealed class EFChartRepository : IChartRepository
             Level = level,
             SongId = songId,
             Type = type.ToString(),
-            StepArtist = stepArtist
+            StepArtist = stepArtist,
+            // Co-ops store the player count in Level, and readers treat the persisted
+            // PlayerCount column as authoritative — it must be materialized here or the
+            // chart reports a 1-player co-op.
+            PlayerCount = type == ChartType.CoOp ? (int)level : 1
         };
         var newChartMix = new ChartMixEntity
         {

--- a/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/Apis/PiuGameApi.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/Apis/PiuGameApi.cs
@@ -100,7 +100,7 @@ internal sealed class PiuGameApi : IPiuGameApi
             else if (songName.Contains("Kasou Shinja") &&
                      !songName.Contains("SHORT", StringComparison.OrdinalIgnoreCase))
                 songName = "Kasou Shinja";
-            else if (songName.Contains("Yoropiku Pikuyoro")) songName = "Yoropiku Pikuyoro!";
+            else if (songName.Contains("Yoropiku Pikuyoro")) songName = "Yoropiku Pikuyoro !";
             result.Add(new PiuGameGetSongsResult.SongDto
             {
                 Difficulty = level,

--- a/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/OfficialSiteClient.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/OfficialSiteClient.cs
@@ -613,10 +613,10 @@ internal sealed class OfficialSiteClient : IOfficialSiteClient
             { "Kasou Shinja仮装信者", "Kasou Shinja" },
             { "Re：End of a Dream", "Re:End of a Dream" },
             { "CROSS RAY (feat. 月下Lia)", "Cross Ray" },
-            { "ヨロピク ピクヨロ！", "Yoropiku Pikuyoro!" },
+            { "ヨロピク ピクヨロ！", "Yoropiku Pikuyoro !" },
             { "甘い誘惑デインジャラス", "Amai Yuuwaku Dangerous" },
             { "甘い誘惑デインジャラス\nAmai Yuuwaku Dangerous", "Amai Yuuwaku Dangerous" },
-            { "ヨロピク ピクヨロ！\nYoropiku Pikuyoro !", "Yoropiku Pikuyoro!" }
+            { "ヨロピク ピクヨロ！\nYoropiku Pikuyoro !", "Yoropiku Pikuyoro !" }
         };
 
     public async Task<(IReadOnlyList<ChartPopularityLeaderboardEntry> Entries,

--- a/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/OfficialSiteClient.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/OfficialSiteClient.cs
@@ -613,10 +613,10 @@ internal sealed class OfficialSiteClient : IOfficialSiteClient
             { "Kasou Shinja仮装信者", "Kasou Shinja" },
             { "Re：End of a Dream", "Re:End of a Dream" },
             { "CROSS RAY (feat. 月下Lia)", "Cross Ray" },
-            { "ヨロピク ピクヨロ！", "Yoropiku Pikuyoro !" },
+            { "ヨロピク ピクヨロ！", "Yoropiku Pikuyoro!" },
             { "甘い誘惑デインジャラス", "Amai Yuuwaku Dangerous" },
             { "甘い誘惑デインジャラス\nAmai Yuuwaku Dangerous", "Amai Yuuwaku Dangerous" },
-            { "ヨロピク ピクヨロ！\nYoropiku Pikuyoro !", "Yoropiku Pikuyoro !" }
+            { "ヨロピク ピクヨロ！\nYoropiku Pikuyoro !", "Yoropiku Pikuyoro!" }
         };
 
     public async Task<(IReadOnlyList<ChartPopularityLeaderboardEntry> Entries,

--- a/ScoreTracker/ScoreTracker.Tests.Integration/EFChartRepositoryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/EFChartRepositoryTests.cs
@@ -115,6 +115,29 @@ public sealed class EFChartRepositoryTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task CreateChartStoresThePlayerCountForCoOpCharts()
+    {
+        // Co-ops store the player count in Level, and readers treat the persisted
+        // PlayerCount column as authoritative (the domain fallback never fires for
+        // DB-loaded charts) — a co-op left at the column default of 1 renders
+        // "CoOp x1" and buckets under the wrong player count.
+        await _seed.EnsurePhoenixMixAsync();
+        var writer = BuildRepository();
+        var songId = await writer.CreateSong("Team Up", "팀 업",
+            new Uri("https://piuimages.arroweclip.se/songs/TeamUp.png"), SongType.Arcade,
+            TimeSpan.FromSeconds(100), "Doin", Bpm.From(150, 150));
+        var coOpId = await writer.CreateChart(MixEnum.Phoenix, songId, ChartType.CoOp, 2,
+            "PUMP IT UP Official", new Uri("https://www.youtube.com/embed/aaaaaaaaaaa"), "SUNNY");
+        var singleId = await writer.CreateChart(MixEnum.Phoenix, songId, ChartType.Single, 22,
+            "PUMP IT UP Official", new Uri("https://www.youtube.com/embed/bbbbbbbbbbb"), "SUNNY");
+
+        var charts = (await BuildRepository().GetCharts(MixEnum.Phoenix)).ToDictionary(c => c.Id);
+
+        Assert.Equal(2, charts[coOpId].PlayerCount);
+        Assert.Equal(1, charts[singleId].PlayerCount);
+    }
+
+    [Fact]
     public async Task SetSongCultureNameThenGetEnglishLookupResolvesKoreanToEnglish()
     {
         var writer = BuildRepository();

--- a/ScoreTracker/ScoreTracker/Services/XXScoreFile.cs
+++ b/ScoreTracker/ScoreTracker/Services/XXScoreFile.cs
@@ -265,7 +265,7 @@ public sealed class XXScoreFile
         { "X-tream", "X Treme" },
         { "X-Tree", "XTree" },
         { "Yog Sothoth", "Yog-Sothoth" },
-        { "Yoropiku Pikuyoro", "Yoropiku Pikuyoro!" },
+        { "Yoropiku Pikuyoro", "Yoropiku Pikuyoro !" },
         { "What Are You Doin Remix", "What Are You Doin? Remix" },
         { "Repeatorment Remix Remix", "Repeatorment Remix" },
         { "Meteo5cience (Gadget Mix) Remix", "Meteo5cience Remix" },


### PR DESCRIPTION
## What

Two related chart-import correctness fixes, surfaced while adding the missing **Yoropiku Pikuyoro !** charts (Single 22 / Double 24 / CoOp x2 — Phoenix v1.11 content that slipped every automated import path).

### 1. Canonicalize the song name to the official-site spelling
The catalog name for this song is `Yoropiku Pikuyoro !` — the official site's romanized title, a **regular ASCII space (U+0020)** before a **regular ASCII `!` (U+0021)**, verified byte-exact against piugame.com. (The only full-width character, `！` U+FF01, is in the Japanese katakana line `ヨロピク ピクヨロ！`, which the tracker does not store.)

`main` disagreed with itself on the spelling across three name-normalization sites. All are now aligned to the spaced form so every import path resolves the same catalog row:

- **`PiuGameApi.Get20AboveSongs`** (the weekly chart-board sweep) was the load-bearing outlier — it forced the no-space form, so against a spaced catalog row it would re-flag all three charts as missing on **every** sweep.
- **`OfficialSiteClient.ManualMappings`** (×2 — feeds the popularity sweep, P2 best/recent imports, and UCS) restored to the spaced form.
- **`XXScoreFile`** XX-import mapping aligned for consistency.

### 2. `CreateChart` materializes `PlayerCount` for co-op charts
`EFChartRepository.CreateChart` left `ChartEntity.PlayerCount` at the column default of `1`. Readers treat the persisted column as authoritative (the domain's `CoOp ? Level` fallback never fires for DB-loaded charts — `GetAllCharts` always passes the column value as the override), so co-ops created through `/Admin/BulkAddCharts` rendered and bucketed as 1-player. Co-ops store the player count in `Level`; `CreateChart` now writes `PlayerCount = Level` for co-ops, `1` otherwise.

## Why it matters

Without #1, the three Yoropiku charts would relist in the missing-charts admin panel after the next leaderboard sweep even once they exist in the catalog, and Korean-session / XX / popularity imports could never match them. Without #2, every bulk-added co-op (including the three from the 2026-07-11 P2 batch — BANG BANG, Do the Dance, We Love Your Step) reports the wrong player count everywhere `Chart.PlayerCount` is trusted (`BestAttemptDto` "CoOp x{n}", By-Level stat bucketing, co-op difficulty rating validation).

## Testing

- `ScoreTracker.Tests` (fast suite): **1422/1422** green — no test or approval JSON pinned the old spelling.
- `ScoreTracker.Tests.Integration` `EFChartRepositoryTests`: **10/10** green, including the new `CreateChartStoresThePlayerCountForCoOpCharts` (creates a CoOp x2 + a Single through the repository against real SQL, asserts the read-back player counts are 2 and 1).
- Full solution builds clean in Debug.

## Reviewer notes

- The catalog rows themselves are applied by **hand-run SQL delivered out-of-band** (not committed here): `yoropiku-pikuyoro-charts.sql` (Song + 3 charts + Phoenix & Phoenix 2 mix rows + ko-KR name + 2 videos; the co-op deliberately has no video row — Andamiro never uploaded a co-op video), plus `reconcile-yoropiku-name.sql` (drives a prod Song row to the spaced name whatever spelling it currently carries) and `coop-playercount-repair.sql` (fixes the three already-mis-set batch co-ops). These are owner-run against prod; the code here is what makes future imports agree with them.
- The first commit (`align … manual mappings`) picked the wrong direction (no-space); the third commit supersedes it, so the **net change to `OfficialSiteClient` versus `main` is zero** (back to the original spaced mappings). Kept as separate commits rather than history surgery.
- Post-merge/deploy owner steps: run the SQL, `/Admin → Clear Cache` once, resolve the three missing-chart panel entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
