### PR TITLE
feat(scoring): mix-aware Phoenix letter grades (Phoenix 2 threshold rebalance)

### DIFF
--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix2/Phoenix2ChartGradeTitle.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix2/Phoenix2ChartGradeTitle.cs
@@ -34,7 +34,7 @@ public sealed class Phoenix2ChartGradeTitle : PhoenixTitle, ISpecificChartTitle
     public override double CompletionProgress(Chart chart, RecordedPhoenixScore attempt)
     {
         return AppliesToChart(chart) && !attempt.IsBroken && attempt.Score != null &&
-               attempt.Score.Value.LetterGrade >= _minimumGrade
+               attempt.Score.Value.LetterGradeFor(MixEnum.Phoenix2) >= _minimumGrade
             ? 1
             : 0;
     }

--- a/ScoreTracker/ScoreTracker.SharedKernel/Enums/PhoenixLetterGrade.cs
+++ b/ScoreTracker/ScoreTracker.SharedKernel/Enums/PhoenixLetterGrade.cs
@@ -87,6 +87,43 @@ public static class PhoenixLetterGradeHelperMethods
             g => typeof(PhoenixLetterGrade).GetField(g.ToString())?.GetCustomAttribute<ScoreRangeAttribute>() ??
                  throw new Exception($"Score Range not set up for {g}"));
 
+    // Phoenix 2 rebalanced the sub-AAA grade cutoffs upward — verified from live piugame.com
+    // boards 2026-07-18 (see ScoreTracker.Tests.Integration/LiveSite/Phoenix2GradeThresholdReconTests):
+    // A 800k, A+ 900k, AA 920k, AA+ 940k; AAA (950k) and everything above are identical to Phoenix.
+    // A-tier through AAA are crawl-verified; B and below are a best-guess extrapolation (C ≤690,647
+    // confirmed from one owner-supplied board row) — the low grades don't materially affect scoring
+    // and real data is being collected. Only the score→grade cutoffs differ per mix; grade identity,
+    // modifiers and names are shared, so only the floors table is overridden here.
+    private static readonly IReadOnlyDictionary<PhoenixLetterGrade, int> Phoenix2Floors =
+        new Dictionary<PhoenixLetterGrade, int>
+        {
+            [PhoenixLetterGrade.F] = 0,
+            [PhoenixLetterGrade.D] = 500000,
+            [PhoenixLetterGrade.C] = 600000,
+            [PhoenixLetterGrade.B] = 700000,
+            [PhoenixLetterGrade.A] = 800000,
+            [PhoenixLetterGrade.APlus] = 900000,
+            [PhoenixLetterGrade.AA] = 920000,
+            [PhoenixLetterGrade.AAPlus] = 940000,
+            [PhoenixLetterGrade.AAA] = 950000,
+            [PhoenixLetterGrade.AAAPlus] = 960000,
+            [PhoenixLetterGrade.S] = 970000,
+            [PhoenixLetterGrade.SPlus] = 975000,
+            [PhoenixLetterGrade.SS] = 980000,
+            [PhoenixLetterGrade.SSPlus] = 985000,
+            [PhoenixLetterGrade.SSS] = 990000,
+            [PhoenixLetterGrade.SSSPlus] = 995000
+        };
+
+    // Grades highest-floor-first, per mix, so a score resolves to the first grade it clears.
+    private static readonly IReadOnlyList<(PhoenixLetterGrade Grade, int Floor)> Phoenix1FloorsDescending =
+        Enum.GetValues<PhoenixLetterGrade>()
+            .Select(g => (g, (int)CachedRanges[g].MinimumScore))
+            .OrderByDescending(x => x.Item2).ToArray();
+
+    private static readonly IReadOnlyList<(PhoenixLetterGrade Grade, int Floor)> Phoenix2FloorsDescending =
+        Phoenix2Floors.Select(kv => (kv.Key, kv.Value)).OrderByDescending(x => x.Item2).ToArray();
+
     private static readonly IDictionary<string, PhoenixLetterGrade> Parser =
         Enum.GetValues<PhoenixLetterGrade>().ToDictionary(e => e.GetName());
 
@@ -98,6 +135,28 @@ public static class PhoenixLetterGradeHelperMethods
     public static PhoenixScore GetMaximumScore(this PhoenixLetterGrade letterGrade)
     {
         return CachedRanges[letterGrade].MaximumScore;
+    }
+
+    /// <summary>
+    ///     The minimum score that earns <paramref name="letterGrade" /> in the given mix. Phoenix 2
+    ///     shifted the sub-AAA cutoffs (see <see cref="Phoenix2Floors" />); every other mix uses the
+    ///     original Phoenix table.
+    /// </summary>
+    public static PhoenixScore GetMinimumScoreFor(this PhoenixLetterGrade letterGrade, MixEnum mix)
+    {
+        return mix == MixEnum.Phoenix2 ? Phoenix2Floors[letterGrade] : CachedRanges[letterGrade].MinimumScore;
+    }
+
+    /// <summary>
+    ///     The letter grade a raw score earns in the given mix — the single mix-aware entry point
+    ///     for score→grade resolution. Callers that know which mix a record belongs to must use this
+    ///     rather than the parameterless <see cref="PhoenixScore.LetterGrade" /> (which is the Phoenix
+    ///     default), or a Phoenix 2 score in the 800k–950k band grades one rung too high.
+    /// </summary>
+    public static PhoenixLetterGrade LetterGradeFor(this PhoenixScore score, MixEnum mix)
+    {
+        var floors = mix == MixEnum.Phoenix2 ? Phoenix2FloorsDescending : Phoenix1FloorsDescending;
+        return floors.First(f => (int)score >= f.Floor).Grade;
     }
 
     public static double GetModifier(this PhoenixLetterGrade enumValue)

--- a/ScoreTracker/ScoreTracker.SharedKernel/Models/ScoringConfiguration.cs
+++ b/ScoreTracker/ScoreTracker.SharedKernel/Models/ScoringConfiguration.cs
@@ -36,6 +36,11 @@ namespace ScoreTracker.SharedKernel.Models
             .ToDictionary(p => p, p => 1.0);
 
         public double PgLetterGradeModifier { get; set; } = PhoenixLetterGrade.SSSPlus.GetModifier();
+
+        // The mix whose grade cutoffs price score→grade in this config. Phoenix 2 shifted the
+        // sub-AAA thresholds, so a P2 config must grade against the P2 table; everything else
+        // keeps the original Phoenix table (the default).
+        public MixEnum Mix { get; set; } = MixEnum.Phoenix;
         public int MinimumScore { get; set; } = 0;
         public IDictionary<Guid, double> ChartModifiers { get; set; } = new Dictionary<Guid, double>();
         public double StageBreakModifier { get; set; } = 1.0;
@@ -103,7 +108,7 @@ namespace ScoreTracker.SharedKernel.Models
             TimeSpan duration, bool isBroken, PhoenixScore score, PhoenixPlate plate, bool includeLevelOverride)
         {
             if (score < MinimumScore) return 0;
-            var letterGrade = score.LetterGrade;
+            var letterGrade = score.LetterGradeFor(Mix);
             var letterGradeModifier = LetterGradeModifiers[letterGrade];
             if (ContinuousLetterGradeScale && score != 1000000)
             {
@@ -113,7 +118,7 @@ namespace ScoreTracker.SharedKernel.Models
                 {
                     var nextGrade = letterGrade + 1;
                     nextModifier = LetterGradeModifiers[nextGrade];
-                    nextThreshold = nextGrade.GetMinimumScore();
+                    nextThreshold = nextGrade.GetMinimumScoreFor(Mix);
                 }
                 else
                 {
@@ -121,7 +126,7 @@ namespace ScoreTracker.SharedKernel.Models
                     nextThreshold = 1000000;
                 }
 
-                var threshold = letterGrade.GetMinimumScore();
+                var threshold = letterGrade.GetMinimumScoreFor(Mix);
                 var modifier = LetterGradeModifiers[letterGrade];
                 letterGradeModifier =
                     modifier + (nextModifier - modifier) * (score - threshold) / (nextThreshold - threshold);
@@ -305,6 +310,7 @@ namespace ScoreTracker.SharedKernel.Models
         {
             var config = new ScoringConfiguration
             {
+                Mix = MixEnum.Phoenix2,
                 Formula = CalculationType.GradePlusPlate,
                 AdjustToTime = false,
                 StageBreakModifier = 0.0,

--- a/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/Phoenix2GradeThresholdReconTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/LiveSite/Phoenix2GradeThresholdReconTests.cs
@@ -1,0 +1,361 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using HtmlAgilityPack;
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.SharedKernel.ValueTypes;
+using Xunit.Abstractions;
+
+namespace ScoreTracker.Tests.Integration.LiveSite;
+
+/// <summary>
+///     Empirical recon for the Phoenix 2 letter-grade thresholds. The official pages render a
+///     grade image (<c>/l_img/grade/{stem}.png</c>) next to each raw score, so pairing the two
+///     across a busy board (which spans ~700k–1,000,000 in a single page) pins every grade
+///     boundary the site is actually using. For each observed (score, site-grade) pair this
+///     also computes our own code's grade via <see cref="PhoenixScore.LetterGrade" /> and reports
+///     the min/max site score per grade plus every disagreement — that mismatch list is the
+///     answer to "did the thresholds move, and to what". Read-only, login-gated, manual-run.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class Phoenix2GradeThresholdReconTests : IClassFixture<PiuGameSessionFixture>
+{
+    private static readonly string DumpDir =
+        Environment.GetEnvironmentVariable("PIU_RECON_DUMP_DIR")
+        ?? Path.Combine(Path.GetTempPath(), "p2-grade-recon");
+
+    // Grade-image filename stem (lowercased, "_p" = plus) -> our enum value.
+    private static readonly IReadOnlyDictionary<string, PhoenixLetterGrade> GradeByStem =
+        new Dictionary<string, PhoenixLetterGrade>
+        {
+            ["f"] = PhoenixLetterGrade.F,
+            ["d"] = PhoenixLetterGrade.D,
+            ["c"] = PhoenixLetterGrade.C,
+            ["b"] = PhoenixLetterGrade.B,
+            ["a"] = PhoenixLetterGrade.A,
+            ["a_p"] = PhoenixLetterGrade.APlus,
+            ["aa"] = PhoenixLetterGrade.AA,
+            ["aa_p"] = PhoenixLetterGrade.AAPlus,
+            ["aaa"] = PhoenixLetterGrade.AAA,
+            ["aaa_p"] = PhoenixLetterGrade.AAAPlus,
+            ["s"] = PhoenixLetterGrade.S,
+            ["s_p"] = PhoenixLetterGrade.SPlus,
+            ["ss"] = PhoenixLetterGrade.SS,
+            ["ss_p"] = PhoenixLetterGrade.SSPlus,
+            ["sss"] = PhoenixLetterGrade.SSS,
+            ["sss_p"] = PhoenixLetterGrade.SSSPlus
+        };
+
+    // Phoenix 1 serves /l_img/grade/, Phoenix 2 serves /l_img/p2/grade/ — match both.
+    private static readonly Regex GradeStemRegex =
+        new(@"/grade/([a-z_]+)\.png", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex ScoreDigitsRegex = new(@"[\d,]{4,}", RegexOptions.Compiled);
+
+    private readonly PiuGameSessionFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public Phoenix2GradeThresholdReconTests(PiuGameSessionFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    private readonly record struct Observation(int Score, string Stem, PhoenixLetterGrade SiteGrade, string Source);
+
+    /// <summary>
+    ///     The decisive comparison: Phoenix 1 (phoenix.piugame.com) serves boards anonymously,
+    ///     so we can read its grade-vs-score pairs with no login. If P1 grades still agree with
+    ///     our current thresholds, the new scheme is Phoenix-2-only (per-mix grade resolution
+    ///     needed); if P1 also disagrees, the whole game moved to the new table (edit the enum).
+    /// </summary>
+    [LiveSiteFact]
+    public async Task Phoenix1_grades_for_comparison_against_our_thresholds()
+    {
+        var ct = CancellationToken.None;
+        Directory.CreateDirectory(DumpDir);
+        using var pub = new HttpClient();
+        pub.DefaultRequestHeaders.Add("Origin", "https://phoenix.piugame.com");
+
+        var boardIds = new List<string>();
+        foreach (var listUrl in new[]
+                 {
+                     "https://phoenix.piugame.com/leaderboard/over_ranking.php?lv=20",
+                     "https://phoenix.piugame.com/leaderboard/over_ranking.php?lv=21"
+                 })
+        {
+            var (status, listHtml, finalUrl) = await FetchTolerant(pub, listUrl, ct);
+            _output.WriteLine($"P1 list {listUrl}: HTTP {status}, final={finalUrl}, {listHtml.Length} chars");
+            boardIds.AddRange(Regex.Matches(listHtml, @"over_ranking_view\.php\?no=([a-zA-Z0-9+/=%]+)")
+                .Select(m => m.Groups[1].Value).Distinct());
+            if (boardIds.Count >= 4) break;
+        }
+
+        if (boardIds.Count == 0)
+        {
+            _output.WriteLine("=> Phoenix 1 served no anonymous board ids (it now gates boards too). " +
+                              "Re-run authenticated to compare P1, or treat the P2 finding as game-wide pending that check.");
+            return;
+        }
+
+        var observations = new List<Observation>();
+        foreach (var boardId in boardIds.Distinct().Take(4))
+        {
+            var (status, html, _) = await FetchTolerant(pub,
+                $"https://phoenix.piugame.com/leaderboard/over_ranking_view.php?no={boardId}", ct);
+            await File.WriteAllTextAsync(Path.Combine(DumpDir, $"p1_board_{Sanitize(boardId)}.html"), html, ct);
+            _output.WriteLine($"P1 board {boardId}: HTTP {status}");
+            observations.AddRange(ExtractRows(html, "//div[contains(@class,'rangking_list_w')]//li", $"p1_{Sanitize(boardId)}"));
+        }
+
+        _output.WriteLine($"Phoenix 1: {observations.Count} graded rows from {boardIds.Distinct().Take(4).Count()} boards");
+        var mismatches = observations.Where(o => PhoenixScore.From(o.Score).LetterGrade != o.SiteGrade)
+            .OrderBy(o => o.Score).ToList();
+        _output.WriteLine($"Phoenix 1: {mismatches.Count} of {observations.Count} rows disagree with our thresholds");
+        foreach (var m in mismatches.Take(30))
+            _output.WriteLine(
+                $"  score {m.Score,10:N0}: site='{m.SiteGrade.GetName()}' ours='{PhoenixScore.From(m.Score).LetterGrade.GetName()}'");
+        _output.WriteLine(mismatches.Count == 0
+            ? "=> Phoenix 1 STILL MATCHES our thresholds: the new table is Phoenix-2-only (per-mix needed)."
+            : "=> Phoenix 1 ALSO disagrees: the whole game moved to the new grade table.");
+    }
+
+    /// <summary>
+    ///     Low-end probe. Hard charts (level 24/25) have players scoring well below 900k, so their
+    ///     boards expose the A / B / C floors that the crowded level-20 boards never reach. Reports
+    ///     every row the site grades below AA so the sub-900k half of the new P2 table can be pinned.
+    /// </summary>
+    [LiveSiteFact]
+    public async Task Phoenix2_low_end_grades_from_hard_charts()
+    {
+        var ct = CancellationToken.None;
+        var client = await _fixture.GetAuthenticatedPhoenix2Client(ct);
+        Directory.CreateDirectory(DumpDir);
+
+        // The sparse HARDEST boards (lv 27/28) are where crawling reaches lowest — their weakest
+        // qualifying scores sit around B (~781k). NOTE: over_ranking boards are top-heavy — popular
+        // mid-level boards stay above ~880k even 40 pages / 15k rows deep — so C/D/F are NOT
+        // reachable by crawling; the sub-B table needs the authoritative in-game/game-info source.
+        var boardIds = new List<string>();
+        foreach (var lv in new[] { 27, 26, 28, 25 })
+        {
+            var listHtml = await Fetch(client, $"https://piugame.com/leaderboard/over_ranking.php?lv={lv}", ct);
+            boardIds.AddRange(Regex.Matches(listHtml, @"over_ranking_view\.php\?no=([a-zA-Z0-9+/=%]+)")
+                .Select(m => m.Groups[1].Value).Distinct());
+        }
+
+        var observations = new List<Observation>();
+        foreach (var boardId in boardIds.Distinct().Take(16))
+        for (var page = 1; page <= 3; page++)
+        {
+            var html = await Fetch(client,
+                $"https://piugame.com/leaderboard/over_ranking_view.php?no={boardId}&page={page}", ct);
+            var rows = ExtractRows(html, "//div[contains(@class,'rangking_list_w')]//li", $"hard_{Sanitize(boardId)}_p{page}");
+            if (rows.Count == 0) break;
+            observations.AddRange(rows);
+        }
+
+        _output.WriteLine($"low-end rows: {observations.Count}, lowest score observed: {(observations.Count == 0 ? 0 : observations.Min(o => o.Score)):N0}");
+
+        _output.WriteLine("");
+        _output.WriteLine("=== Observed score range per SITE grade (low end) ===");
+        _output.WriteLine($"{"grade",-6} {"count",6} {"min",10} {"max",10}   our range");
+        foreach (var grade in Enum.GetValues<PhoenixLetterGrade>())
+        {
+            var forGrade = observations.Where(o => o.SiteGrade == grade).ToList();
+            if (forGrade.Count == 0) continue;
+            _output.WriteLine(
+                $"{grade.GetName(),-6} {forGrade.Count,6} {forGrade.Min(o => o.Score),10:N0} {forGrade.Max(o => o.Score),10:N0}   " +
+                $"[{(int)grade.GetMinimumScore():N0} .. {(int)grade.GetMaximumScore():N0}]");
+        }
+
+        _output.WriteLine("");
+        _output.WriteLine("=== Every row the SITE grades below A (B/C/D/F — score asc) ===");
+        foreach (var o in observations.Where(o => o.SiteGrade < PhoenixLetterGrade.A).OrderBy(o => o.Score))
+            _output.WriteLine(
+                $"  score {o.Score,10:N0}: site='{o.SiteGrade.GetName()}' ours='{PhoenixScore.From(o.Score).LetterGrade.GetName()}'");
+
+        Assert.NotEmpty(observations);
+    }
+
+    [LiveSiteFact]
+    public async Task Phoenix2_grade_thresholds_observed_from_live_scores()
+    {
+        var ct = CancellationToken.None;
+        var client = await _fixture.GetAuthenticatedPhoenix2Client(ct);
+        Directory.CreateDirectory(DumpDir);
+
+        var observations = new List<Observation>();
+
+        // Source A — the service account's own best scores. Guaranteed grade+score per card,
+        // but only covers whatever range this account has played.
+        for (var page = 1; page <= 3; page++)
+        {
+            var url = $"https://piugame.com/my_page/my_best_score.php?&&page={page}";
+            var html = await Fetch(client, url, ct);
+            await File.WriteAllTextAsync(Path.Combine(DumpDir, $"best_scores_p{page}.html"), html, ct);
+            var found = ExtractRows(html,
+                "//ul[contains(@class,'recently_playeList')]/li | //ul[contains(@class,'my_best_scoreList')]/li",
+                $"best_p{page}");
+            observations.AddRange(found);
+            _output.WriteLine($"best-scores page {page}: {found.Count} graded rows");
+        }
+
+        // Source B — busy per-song boards. A crowded level-20 board spans the whole grade
+        // spectrum on one page, so a handful of boards pins every boundary at once — IF the
+        // board rows carry grade images (reported below so we know either way).
+        var boardIds = await CollectBoardIds(client, ct);
+        _output.WriteLine($"collected {boardIds.Count} board ids");
+        foreach (var boardId in boardIds.Take(12))
+        {
+            var url = $"https://piugame.com/leaderboard/over_ranking_view.php?no={boardId}";
+            var html = await Fetch(client, url, ct);
+            await File.WriteAllTextAsync(Path.Combine(DumpDir, $"board_{Sanitize(boardId)}.html"), html, ct);
+            var found = ExtractRows(html, "//div[contains(@class,'rangking_list_w')]//li", $"board_{Sanitize(boardId)}");
+            observations.AddRange(found);
+            _output.WriteLine($"board {boardId}: {found.Count} graded rows");
+        }
+
+        // Source C — the authoritative grade table on the login-gated game-info page. Dump it
+        // so the exact official boundary numbers (if the page lists them) can be read straight
+        // from the source instead of inferred from observed score envelopes.
+        foreach (var infoUrl in new[]
+                 {
+                     "https://piugame.com/game_info/basic_mode.php",
+                     "https://piugame.com/game_info/rank_mode.php"
+                 })
+            try
+            {
+                var infoHtml = await Fetch(client, infoUrl, ct);
+                var file = $"gameinfo_{Sanitize(infoUrl.Split('/').Last())}.html";
+                await File.WriteAllTextAsync(Path.Combine(DumpDir, file), infoHtml, ct);
+                var gradeRefs = GradeStemRegex.Matches(infoHtml).Select(m => m.Groups[1].Value).Distinct().Count();
+                _output.WriteLine($"game-info {infoUrl}: {infoHtml.Length} chars, {gradeRefs} distinct grade images -> {file}");
+            }
+            catch (Exception e)
+            {
+                _output.WriteLine($"game-info {infoUrl}: fetch failed ({e.Message})");
+            }
+
+        _output.WriteLine("");
+        Assert.NotEmpty(observations); // No graded rows anywhere = markup drift; investigate the dumps.
+
+        // ---- Per-grade observed score envelope, ordered by grade ----
+        _output.WriteLine("=== Observed score range per SITE grade (Phoenix 2) ===");
+        _output.WriteLine($"{"grade",-6} {"count",6} {"min",10} {"max",10}   our code's range for that grade");
+        foreach (var grade in Enum.GetValues<PhoenixLetterGrade>())
+        {
+            var forGrade = observations.Where(o => o.SiteGrade == grade).ToList();
+            if (forGrade.Count == 0) continue;
+            var ourMin = (int)grade.GetMinimumScore();
+            var ourMax = (int)grade.GetMaximumScore();
+            _output.WriteLine(
+                $"{grade.GetName(),-6} {forGrade.Count,6} {forGrade.Min(o => o.Score),10:N0} {forGrade.Max(o => o.Score),10:N0}   " +
+                $"[{ourMin:N0} .. {ourMax:N0}]");
+        }
+
+        // ---- Disagreements: the site says one grade, our thresholds say another ----
+        var mismatches = observations
+            .Where(o => PhoenixScore.From(o.Score).LetterGrade != o.SiteGrade)
+            .OrderBy(o => o.Score)
+            .ToList();
+
+        _output.WriteLine("");
+        _output.WriteLine($"=== {mismatches.Count} of {observations.Count} rows disagree with our current thresholds ===");
+        foreach (var m in mismatches.Take(60))
+            _output.WriteLine(
+                $"  score {m.Score,10:N0}: site='{m.SiteGrade.GetName()}' ours='{PhoenixScore.From(m.Score).LetterGrade.GetName()}'  ({m.Source})");
+        if (mismatches.Count > 60) _output.WriteLine($"  ... and {mismatches.Count - 60} more");
+
+        // ---- Inferred boundaries: lowest score seen at each grade (the grade's floor) ----
+        _output.WriteLine("");
+        _output.WriteLine("=== Inferred grade FLOOR (lowest score observed at each grade) ===");
+        foreach (var grade in Enum.GetValues<PhoenixLetterGrade>())
+        {
+            var forGrade = observations.Where(o => o.SiteGrade == grade).ToList();
+            if (forGrade.Count == 0) continue;
+            var observedFloor = forGrade.Min(o => o.Score);
+            var ourFloor = (int)grade.GetMinimumScore();
+            var flag = observedFloor < ourFloor ? "  <-- observed BELOW our floor (floor moved down or grade shifted)" : "";
+            _output.WriteLine($"{grade.GetName(),-6} observed-floor {observedFloor,10:N0}   our-floor {ourFloor,10:N0}{flag}");
+        }
+
+        _output.WriteLine("");
+        _output.WriteLine($"Raw page dumps: {DumpDir}");
+    }
+
+    private static IReadOnlyList<Observation> ExtractRows(string html, string rowXPath, string source)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+        var rows = doc.DocumentNode.SelectNodes(rowXPath);
+        var result = new List<Observation>();
+        if (rows == null) return result;
+
+        foreach (var row in rows)
+        {
+            var inner = row.InnerHtml;
+            var gradeMatch = GradeStemRegex.Match(inner);
+            if (!gradeMatch.Success) continue;
+            var stem = gradeMatch.Groups[1].Value.ToLowerInvariant();
+            if (!GradeByStem.TryGetValue(stem, out var grade)) continue;
+
+            // The score is the largest 4+ digit number in the row's visible text (avatar urls
+            // and image dimensions are in attributes, not InnerText).
+            var text = HtmlEntity.DeEntitize(row.InnerText ?? "");
+            var best = 0;
+            foreach (Match m in ScoreDigitsRegex.Matches(text))
+                if (int.TryParse(m.Value.Replace(",", ""), out var n) && n is > 0 and <= 1_000_000 && n > best)
+                    best = n;
+            if (best == 0) continue;
+
+            result.Add(new Observation(best, stem, grade, source));
+        }
+
+        return result;
+    }
+
+    private async Task<IReadOnlyList<string>> CollectBoardIds(HttpClient client, CancellationToken ct)
+    {
+        var ids = new List<string>();
+        foreach (var listUrl in new[]
+                 {
+                     "https://piugame.com/leaderboard/over_ranking.php?lv=20",
+                     "https://piugame.com/leaderboard/over_ranking.php?lv=21",
+                     "https://piugame.com/leaderboard/over_ranking.php"
+                 })
+        {
+            var html = await Fetch(client, listUrl, ct);
+            var found = Regex
+                .Matches(html, @"over_ranking_view\.php\?no=([a-zA-Z0-9+/=%]+)")
+                .Select(m => m.Groups[1].Value)
+                .Distinct();
+            ids.AddRange(found);
+            if (ids.Count >= 6) break;
+        }
+
+        return ids.Distinct().ToList();
+    }
+
+    private static async Task<string> Fetch(HttpClient client, string url, CancellationToken ct)
+    {
+        var response = await client.GetAsync(url, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync(ct);
+    }
+
+    private static async Task<(int Status, string Body, string? FinalUrl)> FetchTolerant(
+        HttpClient client, string url, CancellationToken ct)
+    {
+        var response = await client.GetAsync(url, ct);
+        var body = await response.Content.ReadAsStringAsync(ct);
+        return ((int)response.StatusCode, body, response.RequestMessage?.RequestUri?.ToString());
+    }
+
+    private static string Sanitize(string raw)
+    {
+        var sb = new StringBuilder();
+        foreach (var c in raw)
+            sb.Append(char.IsLetterOrDigit(c) ? c : '_');
+        return sb.ToString();
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerRatingSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerRatingSagaTests.cs
@@ -455,7 +455,7 @@ public sealed class PlayerRatingSagaTests
         var s1 = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build(); // 995k SSS+ -> 230x1.508
         var s2 = new ChartBuilder().WithType(ChartType.Single).WithLevel(21).Build(); // 970k S    -> 235x1.458
         var d1 = new ChartBuilder().WithType(ChartType.Double).WithLevel(24).Build(); // 950k AAA  -> 250x1.418
-        var d2 = new ChartBuilder().WithType(ChartType.Double).WithLevel(23).Build(); // 925k AA+  -> 245x1.398
+        var d2 = new ChartBuilder().WithType(ChartType.Double).WithLevel(23).Build(); // 940k AA+  -> 245x1.398 (P2 AA+ floor)
         var stats = new Mock<IPlayerStatsRepository>();
         stats.Setup(s => s.GetStats(MixEnum.Phoenix2, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ZeroStats(userId));
@@ -464,7 +464,7 @@ public sealed class PlayerRatingSagaTests
             scores: ScoresMockReturning(userId, new[]
             {
                 Score(s1.Id, 995000), Score(s2.Id, 970000),
-                Score(d1.Id, 950000), Score(d2.Id, 925000)
+                Score(d1.Id, 950000), Score(d2.Id, 940000)
             }, MixEnum.Phoenix2),
             stats: stats);
 
@@ -527,7 +527,7 @@ public sealed class PlayerRatingSagaTests
     public async Task Phoenix2BrokenPlaysNeverEnterThePools()
     {
         // A broken 995k would top the singles pool if counted; Phoenix 2 excludes it, so
-        // the pool is only the clean 900k AA (230 x 1.378 = 316.94 -> 316).
+        // the pool is only the clean 920k AA (P2 AA floor; 230 x 1.378 = 316.94 -> 316).
         var userId = Guid.NewGuid();
         var broken = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
         var clean = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
@@ -539,7 +539,7 @@ public sealed class PlayerRatingSagaTests
             scores: ScoresMockReturning(userId, new[]
             {
                 Score(broken.Id, 995000, isBroken: true),
-                Score(clean.Id, 900000)
+                Score(clean.Id, 920000)
             }, MixEnum.Phoenix2),
             stats: stats);
 

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/Phoenix2PumbilityScoringTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/Phoenix2PumbilityScoringTests.cs
@@ -23,7 +23,10 @@ public sealed class Phoenix2PumbilityScoringTests
 
     private static double Contribution(ChartType type, int level, PhoenixLetterGrade grade, PhoenixPlate plate)
     {
-        return Scoring().GetScore(type, DifficultyLevel.From(level), grade.GetMinimumScore(), plate);
+        // Build the score from the Phoenix 2 floor for the grade — a "AA" row must be a real P2 AA
+        // (≥920k), not the P1 AA floor of 900k, which P2 now grades A+.
+        return Scoring().GetScore(type, DifficultyLevel.From(level),
+            grade.GetMinimumScoreFor(MixEnum.Phoenix2), plate);
     }
 
     [Theory]

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixLetterGradeTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/PhoenixLetterGradeTests.cs
@@ -1,0 +1,57 @@
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.SharedKernel.ValueTypes;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+/// <summary>
+///     Pins the mix-aware score→grade resolution. Phoenix 2 rebalanced the sub-AAA cutoffs upward
+///     (verified from live piugame.com boards 2026-07-18); Phoenix keeps the original table. The
+///     A-tier boundaries below are the crawl-verified ones — a score sitting on a moved boundary
+///     must grade one rung lower under Phoenix 2 than under Phoenix.
+/// </summary>
+public sealed class PhoenixLetterGradeTests
+{
+    [Theory]
+    // Scores in the rebalanced band grade one rung lower on Phoenix 2 (P1 grade, P2 grade).
+    [InlineData(899999, PhoenixLetterGrade.APlus, PhoenixLetterGrade.A)]
+    [InlineData(900000, PhoenixLetterGrade.AA, PhoenixLetterGrade.APlus)]
+    [InlineData(919999, PhoenixLetterGrade.AA, PhoenixLetterGrade.APlus)]
+    [InlineData(925000, PhoenixLetterGrade.AAPlus, PhoenixLetterGrade.AA)]
+    [InlineData(939999, PhoenixLetterGrade.AAPlus, PhoenixLetterGrade.AA)]
+    public void ATierBoundariesGradeOneRungLowerOnPhoenix2(int score, PhoenixLetterGrade phoenix,
+        PhoenixLetterGrade phoenix2)
+    {
+        Assert.Equal(phoenix, PhoenixScore.From(score).LetterGradeFor(MixEnum.Phoenix));
+        Assert.Equal(phoenix2, PhoenixScore.From(score).LetterGradeFor(MixEnum.Phoenix2));
+    }
+
+    [Theory]
+    // AAA and up are identical across mixes — the rebalance stopped at 950k.
+    [InlineData(950000, PhoenixLetterGrade.AAA)]
+    [InlineData(960000, PhoenixLetterGrade.AAAPlus)]
+    [InlineData(970000, PhoenixLetterGrade.S)]
+    [InlineData(990000, PhoenixLetterGrade.SSS)]
+    [InlineData(1000000, PhoenixLetterGrade.SSSPlus)]
+    public void AaaAndAboveAreIdenticalAcrossMixes(int score, PhoenixLetterGrade expected)
+    {
+        Assert.Equal(expected, PhoenixScore.From(score).LetterGradeFor(MixEnum.Phoenix));
+        Assert.Equal(expected, PhoenixScore.From(score).LetterGradeFor(MixEnum.Phoenix2));
+    }
+
+    [Fact]
+    public void ParameterlessLetterGradeStaysThePhoenixTable()
+    {
+        // The default property is Phoenix — a 900k is AA there, A+ only when asked for Phoenix 2.
+        Assert.Equal(PhoenixLetterGrade.AA, PhoenixScore.From(900000).LetterGrade);
+        Assert.Equal(PhoenixScore.From(900000).LetterGrade,
+            PhoenixScore.From(900000).LetterGradeFor(MixEnum.Phoenix));
+    }
+
+    [Fact]
+    public void Phoenix2FloorForAGradeResolvesBackToThatGrade()
+    {
+        foreach (var grade in System.Enum.GetValues<PhoenixLetterGrade>())
+            Assert.Equal(grade, grade.GetMinimumScoreFor(MixEnum.Phoenix2).LetterGradeFor(MixEnum.Phoenix2));
+    }
+}

--- a/ScoreTracker/ScoreTracker/Controllers/Api/PhoenixScoresController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/PhoenixScoresController.cs
@@ -176,7 +176,7 @@ public sealed class PhoenixScoresController : Controller
         if (maxLevel != null) rows = rows.Where(x => (int)x.Chart.Level <= maxLevel.Value);
         if (typeFilter != null) rows = rows.Where(x => x.Chart.Type == typeFilter.Value);
         if (minGrade != null)
-            rows = rows.Where(x => x.Record.Score != null && x.Record.Score.Value.LetterGrade >= minGrade.Value);
+            rows = rows.Where(x => x.Record.Score != null && x.Record.Score.Value.LetterGradeFor(mix) >= minGrade.Value);
         if (minPlateFilter != null)
             rows = rows.Where(x => x.Record.Plate != null && x.Record.Plate.Value >= minPlateFilter.Value);
         if (isBroken != null) rows = rows.Where(x => x.Record.IsBroken == isBroken.Value);
@@ -188,7 +188,7 @@ public sealed class PhoenixScoresController : Controller
             return sortKey switch
             {
                 "Score" => x.Record.Score == null ? null : (int)x.Record.Score.Value,
-                "LetterGrade" => x.Record.Score == null ? null : (int)x.Record.Score.Value.LetterGrade,
+                "LetterGrade" => x.Record.Score == null ? null : (int)x.Record.Score.Value.LetterGradeFor(mix),
                 "Plate" => x.Record.Plate == null ? null : (int)x.Record.Plate.Value,
                 "Level" => (int)x.Chart.Level,
                 "Pumbility" => x.Pumbility,
@@ -214,7 +214,7 @@ public sealed class PhoenixScoresController : Controller
             Results = next.Select(x => new PhoenixRecordDto
             {
                 IsBroken = x.Record.IsBroken,
-                LetterGrade = x.Record.Score?.LetterGrade.GetName(),
+                LetterGrade = x.Record.Score?.LetterGradeFor(mix).GetName(),
                 Plate = x.Record.Plate?.GetName(),
                 RecordedDate = x.Record.RecordedDate,
                 Score = x.Record.Score,

--- a/ScoreTracker/ScoreTracker/Controllers/Api/WeeklyChartsController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/Api/WeeklyChartsController.cs
@@ -58,7 +58,7 @@ public sealed class WeeklyChartsController : Controller
         {
             ChartId = e.ChartId,
             Player = new PlayerDto(users[e.UserId]),
-            Score = new ScoreDto(e.Score, e.Plate, e.IsBroken)
+            Score = new ScoreDto(e.Score, e.Plate, e.IsBroken, mix)
         }));
     }
 

--- a/ScoreTracker/ScoreTracker/Dtos/Api/ScoreDto.cs
+++ b/ScoreTracker/ScoreTracker/Dtos/Api/ScoreDto.cs
@@ -5,11 +5,11 @@ namespace ScoreTracker.Web.Dtos.Api
 {
     public sealed class ScoreDto
     {
-        public ScoreDto(PhoenixScore score, PhoenixPlate plate, bool isBroken)
+        public ScoreDto(PhoenixScore score, PhoenixPlate plate, bool isBroken, MixEnum mix = MixEnum.Phoenix)
         {
             Score = score;
             Plate = plate.ToString();
-            LetterGrade = score.LetterGrade.GetName();
+            LetterGrade = score.LetterGradeFor(mix).GetName();
             IsBroken = isBroken;
         }
 

--- a/ScoreTracker/ScoreTracker/Services/HomeDashboard/ByLevelDataSource.cs
+++ b/ScoreTracker/ScoreTracker/Services/HomeDashboard/ByLevelDataSource.cs
@@ -49,12 +49,13 @@ public sealed class ByLevelDataSource
             ? BuildLegacy(charts,
                 await _mediator.Send(new GetXXBestChartAttemptsQuery(userId, mix), cancellationToken), now)
             : BuildPhoenix(charts,
-                await _mediator.Send(new GetPhoenixRecordsQuery(userId, mix), cancellationToken), now);
+                await _mediator.Send(new GetPhoenixRecordsQuery(userId, mix), cancellationToken), now, mix);
         return (records, ScalesFor(mix));
     }
 
     private static IReadOnlyList<BreakdownRecord> BuildPhoenix(
-        IReadOnlyDictionary<Guid, Chart> charts, IEnumerable<RecordedPhoenixScore> scores, DateTimeOffset now)
+        IReadOnlyDictionary<Guid, Chart> charts, IEnumerable<RecordedPhoenixScore> scores, DateTimeOffset now,
+        MixEnum mix)
     {
         var byChart = scores.GroupBy(s => s.ChartId).ToDictionary(g => g.Key, g => g.First());
         var records = new List<BreakdownRecord>(charts.Count);
@@ -69,7 +70,7 @@ public sealed class ByLevelDataSource
             // Metric values are clear-achievements: a fail contributes only its played flag.
             var passed = !score.IsBroken;
             int? scoreValue = passed && score.Score != null ? (int)score.Score.Value : null;
-            int? gradeRank = passed && score.Score != null ? (int)score.Score.Value.LetterGrade : null;
+            int? gradeRank = passed && score.Score != null ? (int)score.Score.Value.LetterGradeFor(mix) : null;
             int? plateRank = passed && score.Plate != null ? (int)score.Plate.Value : null;
             var age = Math.Max(0, (int)(now - score.RecordedDate).TotalDays);
             records.Add(new BreakdownRecord(Normalize(chart.Type), Bucket(chart), true, passed,


### PR DESCRIPTION
## What & why

Phoenix 2 rebalanced the sub-AAA letter-grade cutoffs **upward**. Verified from live piugame.com boards on 2026-07-18 (pairing each board row's raw score with its `/l_img/p2/grade/*.png` image):

| Grade | Phoenix 1 (unchanged) | **Phoenix 2** |
|---|---|---|
| A | 750,000 | **800,000** |
| A+ | 825,000 | **900,000** |
| AA | 900,000 | **920,000** |
| AA+ | 925,000 | **940,000** |
| AAA → SSS+ | — | **unchanged** |

Phoenix 1 boards still match the original table (412 rows, 0 disagreements), so this is a **Phoenix-2-only** change — the shared `PhoenixLetterGrade` enum can no longer bake in one set of thresholds.

## Changes

- **Core**: `PhoenixLetterGradeHelperMethods.LetterGradeFor(score, mix)` + `GetMinimumScoreFor(grade, mix)` with a `Phoenix2Floors` table. Only the cutoffs are per-mix; grade identity, modifiers, and names stay shared. The parameterless `PhoenixScore.LetterGrade` stays the **Phoenix (P1) default** — no regression; mix-aware callers opt in.
- **Routed** the correctness-critical consumers through the mix: `ScoringConfiguration` (new `Mix`; Pumbility grade + continuous-scale thresholds), Phoenix 2 chart-grade titles, `PhoenixScoresController`, `ScoreDto` + `WeeklyChartsController`, the By-Level widget, and the weekly Discord card.
- **Hardcoded-threshold hunt**: no production code compares scores to grade magic-numbers; the plate/Fung constant tables are legitimately not grade-based, and the cutline/highlights calculators only use AAA+ grades (unchanged).

## Confidence / gaps

- A-tier through AAA are crawl-verified. **B and below are a best-guess extrapolation** (C floor confirmed ≤690,647 from one owner-supplied board row) — clearly commented as unverified; the low grades don't materially affect scoring and real data is being collected.
- Added `Phoenix2GradeThresholdReconTests` (manual `[LiveSiteFact]` recon that pins the thresholds live) as the canary.

## Tests

`PhoenixLetterGradeTests` pins the boundary pairs (e.g. 900,000 → AA on Phoenix, A+ on Phoenix 2). Two existing suites had scores sitting exactly on moved boundaries; bumped to the P2 floor so labels stay true. All fast suites green: **Tests 1457, Api 60, Components 204**.

## Not in this PR / post-deploy

- **Display-layer sweep**: ~30 Razor grade badges still render P2 record grades via the P1 default (a P2 930k shows AA+ not AA). Mechanical follow-up, owner field-tests UI.
- **Post-deploy**: run **Admin → Recalculate Phoenix 2 Player Ratings** once (after this deploys) to reprice band scores in P2 Pumbility/ratings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
