### PR TITLE
fix(test): the rankings board is rows, not a table

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.E2E/OfficialLeaderboardsHubTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/OfficialLeaderboardsHubTests.cs
@@ -68,7 +68,10 @@ public sealed class OfficialLeaderboardsHubTests : IAsyncLifetime
             .ToBeVisibleAsync(timeout);
         await Expect(_page.GetByText("E2ECHAMP").First).ToBeVisibleAsync();
         await Expect(_page.GetByText("E2ERUNNER").First).ToBeVisibleAsync();
-        var rows = _page.Locator("tr", new PageLocatorOptions { HasTextString = "E2E" });
-        Assert.True(await rows.CountAsync() >= 2, "Expected both seeded players in the rankings table.");
+        // The board is compact rows, not a table: the rankings board is the leaderboard
+        // golden standard (UX rule 5), so a row is .olb-rank-card and never a <tr>. The
+        // count is exact — one row per player, so a re-introduced twin fails here.
+        var rows = _page.Locator(".olb-rank-card", new PageLocatorOptions { HasTextString = "E2E" });
+        await Expect(rows).ToHaveCountAsync(2);
     }
 }


### PR DESCRIPTION
Fixes the red E2E stage on `main` after #177.

`RankingsDeepLinkOpensTheComputedBoardWithTheSeededPlayers` counted `<tr>` elements to prove both seeded players reached the rankings board. #177 made the rankings board **compact card rows instead of a table** — the leaderboard golden standard from that round's field test — so the count went to zero and the assert fired. The page itself is fine: the two `GetByText` assertions immediately above it passed, which is why the failure is a stale locator and not a regression.

The fact now counts `.olb-rank-card`, and counts **exactly two** rather than "at least two". The seed is fixed at two players, and an exact count means a re-introduced duplicate-player row — the twin-tag bug #177 also fixed — fails here instead of sliding through.

**Verification**: the E2E suite needs Docker, which isn't running on my machine right now, so this is verified by compile plus the CI stage on this PR — the same stage and environment that caught it. The bUnit fact `RankingsAreCompactCardsWithTheArchetypeAndNoBoardCount` already pins `.olb-rank-card` as the row class, so the selector is not a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
