### PR TITLE
fix(import): P2 best-score walk stops on the up-score window, not the card date

### DIFF
--- a/ScoreTracker/ScoreTracker.OfficialMirror/Application/OfficialLeaderboardSaga.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Application/OfficialLeaderboardSaga.cs
@@ -4,7 +4,6 @@ using ScoreTracker.OfficialMirror.Contracts.Messages;
 using ScoreTracker.OfficialMirror.Contracts.Queries;
 using ScoreTracker.OfficialMirror.Contracts.Commands;
 using ScoreTracker.OfficialMirror.Domain;
-using System.Globalization;
 using System.Text.RegularExpressions;
 using MassTransit;
 using MediatR;
@@ -199,15 +198,8 @@ namespace ScoreTracker.OfficialMirror.Application
                     : null;
             }
 
-            var watermarkSetting = $"BestScoreWatermark__{mix}__{cardId}";
-            DateTimeOffset? since = settings.TryGetValue(watermarkSetting, out var storedWatermark) &&
-                                    DateTimeOffset.TryParse(storedWatermark, CultureInfo.InvariantCulture,
-                                        DateTimeStyles.RoundtripKind, out var parsedWatermark)
-                ? parsedWatermark
-                : null;
-
             var scores =
-                (await _officialSite.GetRecordedScores(mix, userId, sid, cardId, includeBroken, limit, since,
+                (await _officialSite.GetRecordedScores(mix, userId, sid, cardId, includeBroken, limit,
                     cancellationToken))
                 .ToArray();
             var count = 0;
@@ -261,14 +253,6 @@ namespace ScoreTracker.OfficialMirror.Application
             if (maxPages != null)
                 await _mediator.Send(new SaveUserUiSettingCommand(pageCountSetting, maxPages.Value.ToString()),
                     cancellationToken);
-
-            // The next dated import stops paging at already-imported territory: remember the
-            // newest saved date this run observed for this card.
-            var newestSeen = scores.Where(s => s.RecordedAt != null).Select(s => s.RecordedAt!.Value)
-                .DefaultIfEmpty().Max();
-            if (newestSeen != default)
-                await _mediator.Send(new SaveUserUiSettingCommand(watermarkSetting,
-                    newestSeen.ToString("O", CultureInfo.InvariantCulture)), cancellationToken);
         }
 
         /// <summary>

--- a/ScoreTracker/ScoreTracker.OfficialMirror/Domain/IOfficialSiteClient.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Domain/IOfficialSiteClient.cs
@@ -29,14 +29,12 @@ internal interface IOfficialSiteClient
     Task<int> GetScorePageCount(MixEnum mix, string sid, CancellationToken cancellationToken);
 
     /// <summary>
-    ///     <paramref name="maxPages" /> drives the classic (undated) page walk;
-    ///     <paramref name="since" /> is the saved-date watermark that cuts the dated walk
-    ///     short. Each strategy ignores the other's parameter.
+    ///     <paramref name="maxPages" /> drives the classic (undated) page walk; the dated
+    ///     (redesigned) walk ignores it and instead stops on its up-score window.
     /// </summary>
     Task<IEnumerable<OfficialRecordedScore>> GetRecordedScores(MixEnum mix, Guid userId, string sid, string id,
         bool includeBroken,
         int? maxPages,
-        DateTimeOffset? since,
         CancellationToken cancellationToken);
 
 

--- a/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/OfficialSiteClient.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/OfficialSiteClient.cs
@@ -403,15 +403,15 @@ internal sealed class OfficialSiteClient : IOfficialSiteClient
         return results.Values;
     }
 
-    // Four consecutive best pages holding nothing new-or-improved end the dated walk — the
-    // port of the classic up-score window (~12 cards a page, so a ~48-chart look-back). Any
-    // page with even one savable card resets the count.
-    private const int MaxDatedPagesWithoutNewBest = 3;
+    // Five consecutive best pages holding nothing new-or-improved end the dated walk — the
+    // port of the classic "five folders back" up-score window (~12 cards a page, so a
+    // ~60-chart look-back). Any page with even one savable card resets the count.
+    private const int MaxDatedPagesWithoutNewBest = 5;
 
     /// <summary>
     ///     Walks the redesigned (newest-played-first) best list, collecting every card for the
     ///     caller to best-filter. Stops on the up-score window — <see cref="MaxDatedPagesWithoutNewBest" />
-    ///     + 1 consecutive pages holding nothing we don't already have at an equal-or-better
+    ///     consecutive pages holding nothing we don't already have at an equal-or-better
     ///     result — never on the card's displayed date. On the redesign that date is the
     ///     chart's FIRST play, unrelated to the newest-played sort order, so trusting it as a
     ///     cutoff ended the walk a page in whenever a replayed old chart sat near the top (the
@@ -452,7 +452,7 @@ internal sealed class OfficialSiteClient : IOfficialSiteClient
             if (added == 0 || page.Scores.Length == 0) break;
 
             pagesWithoutNewBest = newBests == 0 ? pagesWithoutNewBest + 1 : 0;
-            if (pagesWithoutNewBest > MaxDatedPagesWithoutNewBest) break;
+            if (pagesWithoutNewBest >= MaxDatedPagesWithoutNewBest) break;
 
             page = await _piuGame.GetBestScores(mix, sessionId, pageNumber + 1, cancellationToken);
         }

--- a/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/OfficialSiteClient.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Infrastructure/OfficialSiteClient.cs
@@ -290,7 +290,7 @@ internal sealed class OfficialSiteClient : IOfficialSiteClient
     public async Task<IEnumerable<OfficialRecordedScore>> GetRecordedScores(MixEnum mix, Guid userId,
         string sid, string id,
         bool includeBroken,
-        int? maxPages, DateTimeOffset? since, CancellationToken cancellationToken)
+        int? maxPages, CancellationToken cancellationToken)
     {
         await _mediator.Publish(
             new ImportStatusUpdatedEvent(userId, "Logging In",
@@ -308,7 +308,7 @@ internal sealed class OfficialSiteClient : IOfficialSiteClient
         // incremental cutoff; the classic list has no dates and keeps the page-count delta +
         // up-score-window walk. Strategy follows the page shape, never the mix.
         var responses = firstPage.Scores.Any(s => s.RecordedAt != null)
-            ? await WalkDatedBestScores(mix, userId, sessionId, firstPage, since, cancellationToken)
+            ? await WalkDatedBestScores(mix, userId, sessionId, firstPage, cancellationToken)
             : await WalkClassicBestScores(mix, userId, sessionId, firstPage, maxPages, cancellationToken);
 
         var results = new Dictionary<Guid, OfficialRecordedScore>();
@@ -403,19 +403,31 @@ internal sealed class OfficialSiteClient : IOfficialSiteClient
         return results.Values;
     }
 
+    // Four consecutive best pages holding nothing new-or-improved end the dated walk — the
+    // port of the classic up-score window (~12 cards a page, so a ~48-chart look-back). Any
+    // page with even one savable card resets the count.
+    private const int MaxDatedPagesWithoutNewBest = 3;
+
     /// <summary>
-    ///     Walks the redesigned (dated, newest-first) best list. Stops after the page that
-    ///     crosses the watermark — that page still processes whole, so equal-timestamp saves
-    ///     re-import harmlessly — or when a page adds nothing new. The site clamps
-    ///     out-of-range page numbers to the last page, so repetition is the reliable end
-    ///     signal and the pager markup is never trusted.
+    ///     Walks the redesigned (newest-played-first) best list, collecting every card for the
+    ///     caller to best-filter. Stops on the up-score window — <see cref="MaxDatedPagesWithoutNewBest" />
+    ///     + 1 consecutive pages holding nothing we don't already have at an equal-or-better
+    ///     result — never on the card's displayed date. On the redesign that date is the
+    ///     chart's FIRST play, unrelated to the newest-played sort order, so trusting it as a
+    ///     cutoff ended the walk a page in whenever a replayed old chart sat near the top (the
+    ///     bug that truncated every incremental import after the first). A page that adds
+    ///     nothing is also the reliable end-of-list signal, since the site clamps out-of-range
+    ///     page numbers to the last page and its pager markup is never trusted.
     /// </summary>
     private async Task<List<PiuGameGetBestScoresResult.ScoreDto>> WalkDatedBestScores(MixEnum mix, Guid userId,
-        HttpClient sessionId, PiuGameGetBestScoresResult firstPage, DateTimeOffset? since,
+        HttpClient sessionId, PiuGameGetBestScoresResult firstPage,
         CancellationToken cancellationToken)
     {
         var responses = new List<PiuGameGetBestScoresResult.ScoreDto>();
         var seen = new HashSet<(string, ChartType, int, int, DateTimeOffset?)>();
+        var storedBests = (await _phoenixRecords.GetBestScores(mix, userId, cancellationToken))
+            .ToDictionary(r => r.ChartId);
+        var pagesWithoutNewBest = 0;
         var page = firstPage;
         for (var pageNumber = 1; pageNumber <= 1000; pageNumber++)
         {
@@ -424,6 +436,7 @@ internal sealed class OfficialSiteClient : IOfficialSiteClient
                     Array.Empty<RecordedPhoenixScore>(), mix),
                 cancellationToken);
             var added = 0;
+            var newBests = 0;
             foreach (var score in page.Scores)
             {
                 if (!seen.Add((score.SongName.ToString(), score.ChartType, (int)score.Level, (int)score.Score,
@@ -431,16 +444,39 @@ internal sealed class OfficialSiteClient : IOfficialSiteClient
 
                 responses.Add(score);
                 added++;
+                if (await IsNewOrImprovedBest(mix, score, storedBests, cancellationToken)) newBests++;
             }
 
-            var crossedWatermark = since != null &&
-                                   page.Scores.Any(s => s.RecordedAt != null && s.RecordedAt < since);
-            if (crossedWatermark || added == 0 || page.Scores.Length == 0) break;
+            // A page that adds nothing is the end of the list (or the clamp re-serving a page
+            // we've already read): stop regardless of the window.
+            if (added == 0 || page.Scores.Length == 0) break;
+
+            pagesWithoutNewBest = newBests == 0 ? pagesWithoutNewBest + 1 : 0;
+            if (pagesWithoutNewBest > MaxDatedPagesWithoutNewBest) break;
 
             page = await _piuGame.GetBestScores(mix, sessionId, pageNumber + 1, cancellationToken);
         }
 
         return responses;
+    }
+
+    /// <summary>
+    ///     Whether a best card would change what we store — a chart we don't hold yet, a
+    ///     stage break we've since cleared, or a better plate/score at the same broken-ness.
+    ///     Mirrors the saga's save filter so the dated walk pages exactly as far as there is
+    ///     new work to save, and no farther. An unmappable card is never "work".
+    /// </summary>
+    private async Task<bool> IsNewOrImprovedBest(MixEnum mix, PiuGameGetBestScoresResult.ScoreDto card,
+        IReadOnlyDictionary<Guid, RecordedPhoenixScore> storedBests, CancellationToken cancellationToken)
+    {
+        var song = await GetMappedName(card.SongName, cancellationToken);
+        var chart = (await _charts.GetChartsForSong(mix, song, cancellationToken))
+            .FirstOrDefault(c => c.Type == card.ChartType && c.Level == card.Level);
+        if (chart == null) return false;
+        if (!storedBests.TryGetValue(chart.Id, out var stored)) return true;
+        if (stored.IsBroken && !card.IsBroken) return true;
+        if (stored.IsBroken != card.IsBroken) return false;
+        return stored.Plate < card.Plate || (stored.Score ?? 0) < card.Score;
     }
 
     private async Task<List<PiuGameGetBestScoresResult.ScoreDto>> WalkClassicBestScores(MixEnum mix, Guid userId,

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/OfficialLeaderboardSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/OfficialLeaderboardSagaTests.cs
@@ -103,7 +103,7 @@ public sealed class OfficialLeaderboardSagaTests
         site.Setup(s => s.GetScorePageCount(mix, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(maxPages);
         site.Setup(s => s.GetRecordedScores(mix, ImportUserId, It.IsAny<string>(), "card1", It.IsAny<bool>(),
-                It.IsAny<int?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(officialScores ?? Array.Empty<OfficialRecordedScore>());
         site.Setup(s => s.GetGameCards(mix, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<GameCardRecord>());
@@ -295,7 +295,7 @@ public sealed class OfficialLeaderboardSagaTests
 
         // limit = maxPages - previous + 1 = 5 - 3 + 1
         f.Site.Verify(s => s.GetRecordedScores(MixEnum.Phoenix, ImportUserId, It.IsAny<string>(), "card1", false, 3,
-            It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()), Times.Once);
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -324,7 +324,7 @@ public sealed class OfficialLeaderboardSagaTests
             It.IsAny<CancellationToken>()), Times.Once);
         // A session that can't resolve to an account is terminal — no scrape follows.
         f.Site.Verify(s => s.GetRecordedScores(It.IsAny<MixEnum>(), It.IsAny<Guid>(), It.IsAny<string>(),
-            It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<DateTimeOffset?>(),
+            It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<int?>(),
             It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -347,7 +347,7 @@ public sealed class OfficialLeaderboardSagaTests
         f.Site.Verify(s => s.GetAccountData(MixEnum.Phoenix2, It.IsAny<string>(), "card1",
             It.IsAny<CancellationToken>()), Times.Once);
         f.Site.Verify(s => s.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, It.IsAny<string>(), "card1",
-            It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()),
+            It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // Existing-score comparison reads the Phoenix 2 rows, not Phoenix 1's.
@@ -372,39 +372,34 @@ public sealed class OfficialLeaderboardSagaTests
     }
 
     [Fact]
-    public async Task Phoenix2ImportUsesTheSavedDateWatermarkInsteadOfPageCounts()
+    public async Task Phoenix2ImportIgnoresPageCountsEntirely()
     {
-        // The dated (redesigned) best list imports by saved-date watermark, keyed per card:
-        // the P2 import never reads the page count, ignores the retired page-count keys, and
-        // remembers the newest saved date it returned for the next run's cutoff.
-        var storedWatermark = new DateTimeOffset(2026, 7, 16, 10, 0, 0, TimeSpan.FromHours(9));
-        var newestSave = new DateTimeOffset(2026, 7, 17, 23, 16, 30, TimeSpan.FromHours(9));
+        // The dated (redesigned) best list paginates by its own up-score window inside the
+        // site client — passing maxPages null. The P2 import never reads the score page count
+        // and never reads or writes the retired page-count keys.
         var chart = new ChartBuilder().Build();
         var f = ArrangeImport(mix: MixEnum.Phoenix2,
             uiSettings: new Dictionary<string, string>
             {
-                ["PreviousPageCount"] = "2", // legacy keys — never read by a dated import
-                ["PreviousPageCount__Phoenix2"] = "4",
-                ["BestScoreWatermark__Phoenix2__card1"] = storedWatermark.ToString("O")
+                ["PreviousPageCount"] = "2", // legacy keys — never read or written by a dated import
+                ["PreviousPageCount__Phoenix2"] = "4"
             },
             officialScores: new[]
             {
                 new OfficialRecordedScore(chart, 920000, PhoenixPlate.FairGame, false,
-                    newestSave.AddMinutes(-5)),
+                    new DateTimeOffset(2026, 7, 17, 23, 11, 30, TimeSpan.FromHours(9))),
                 new OfficialRecordedScore(new ChartBuilder().Build(), 930000, PhoenixPlate.FairGame, false,
-                    newestSave)
+                    new DateTimeOffset(2026, 7, 17, 23, 16, 30, TimeSpan.FromHours(9)))
             });
         var saga = BuildImportSaga(f);
 
         await saga.Handle(ImportCommand(mix: MixEnum.Phoenix2), CancellationToken.None);
 
+        // maxPages null — the classic page-count delta never drives a dated import.
         f.Site.Verify(s => s.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, It.IsAny<string>(), "card1", false,
-            null, storedWatermark, It.IsAny<CancellationToken>()), Times.Once);
+            null, It.IsAny<CancellationToken>()), Times.Once);
         f.Site.Verify(s => s.GetScorePageCount(MixEnum.Phoenix2, It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
-        f.Mediator.Verify(m => m.Send(It.Is<SaveUserUiSettingCommand>(c =>
-                c.SettingName == "BestScoreWatermark__Phoenix2__card1" && c.NewValue == newestSave.ToString("O")),
-            It.IsAny<CancellationToken>()), Times.Once);
         f.Mediator.Verify(m => m.Send(It.Is<SaveUserUiSettingCommand>(c =>
                 c.SettingName.StartsWith("PreviousPageCount")),
             It.IsAny<CancellationToken>()), Times.Never);

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/OfficialSiteClientTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/OfficialSiteClientTests.cs
@@ -278,38 +278,8 @@ public sealed class OfficialSiteClientTests
         // The redesign sorts by last-played and dates each card by FIRST play, so a replayed
         // upscore can sit pages behind freshly-replayed charts we already hold at the same
         // result. The walk must page through those no-work cards to reach it — the exact case
-        // the old date cutoff truncated. Three held pages fit inside the window; page 4's
-        // upscore is found.
-        var h = new ImportHarness();
-        var held = new List<Chart>();
-        for (var i = 1; i <= 3; i++)
-        {
-            var chart = h.GivenChart(new ChartBuilder().WithSongName($"Held{i}").WithNoteCount(100).Build());
-            h.GivenStoredBest(chart, 950000);
-            h.GivenBestScorePage(i, Card(chart, 950000, T0.AddMinutes(-i)));
-            held.Add(chart);
-        }
-
-        var upscored = h.GivenChart(new ChartBuilder().WithSongName("Upscored").WithNoteCount(100).Build());
-        h.GivenStoredBest(upscored, 900000);
-        h.GivenBestScorePage(4, Card(upscored, 990000, T0.AddHours(-99)));
-        h.GivenBestScorePage(5); // empty → end of list
-
-        var results = (await h.Client.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, "sid", "card1",
-            includeBroken: false, maxPages: null, CancellationToken.None)).ToArray();
-
-        Assert.Contains(results, r => r.Chart.Id == upscored.Id && (int)r.Score == 990000);
-        h.Api.Verify(a => a.GetBestScores(MixEnum.Phoenix2, It.IsAny<HttpClient>(), 4, It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task DatedWalkStopsAfterAWindowOfPagesWithNoNewBest()
-    {
-        // Every card on these pages is already held at an equal result: after the window of
-        // no-work pages the walk stops without reading the whole list. A real upscore sits on
-        // page 5, past the window — the walk must never reach it (the accepted look-back
-        // limit, matching the classic up-score window).
+        // the old date cutoff truncated. Four held pages fit inside the five-page window; page
+        // 5's upscore is found.
         var h = new ImportHarness();
         for (var i = 1; i <= 4; i++)
         {
@@ -318,15 +288,43 @@ public sealed class OfficialSiteClientTests
             h.GivenBestScorePage(i, Card(chart, 950000, T0.AddMinutes(-i)));
         }
 
+        var upscored = h.GivenChart(new ChartBuilder().WithSongName("Upscored").WithNoteCount(100).Build());
+        h.GivenStoredBest(upscored, 900000);
+        h.GivenBestScorePage(5, Card(upscored, 990000, T0.AddHours(-99)));
+        h.GivenBestScorePage(6); // empty → end of list
+
+        var results = (await h.Client.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, "sid", "card1",
+            includeBroken: false, maxPages: null, CancellationToken.None)).ToArray();
+
+        Assert.Contains(results, r => r.Chart.Id == upscored.Id && (int)r.Score == 990000);
+        h.Api.Verify(a => a.GetBestScores(MixEnum.Phoenix2, It.IsAny<HttpClient>(), 5, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DatedWalkStopsAfterAWindowOfPagesWithNoNewBest()
+    {
+        // Every card on these pages is already held at an equal result: after five no-work
+        // pages the walk stops without reading the whole list. A real upscore sits on page 6,
+        // past the window — the walk must never reach it (the accepted look-back limit,
+        // matching the classic "five folders back" up-score window).
+        var h = new ImportHarness();
+        for (var i = 1; i <= 5; i++)
+        {
+            var chart = h.GivenChart(new ChartBuilder().WithSongName($"Held{i}").WithNoteCount(100).Build());
+            h.GivenStoredBest(chart, 950000);
+            h.GivenBestScorePage(i, Card(chart, 950000, T0.AddMinutes(-i)));
+        }
+
         var beyond = h.GivenChart(new ChartBuilder().WithSongName("Beyond").WithNoteCount(100).Build());
         h.GivenStoredBest(beyond, 900000);
-        h.GivenBestScorePage(5, Card(beyond, 999000, T0.AddHours(-99)));
+        h.GivenBestScorePage(6, Card(beyond, 999000, T0.AddHours(-99)));
 
         var results = (await h.Client.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, "sid", "card1",
             includeBroken: false, maxPages: null, CancellationToken.None)).ToArray();
 
         Assert.DoesNotContain(results, r => r.Chart.Id == beyond.Id);
-        h.Api.Verify(a => a.GetBestScores(MixEnum.Phoenix2, It.IsAny<HttpClient>(), 5, It.IsAny<CancellationToken>()),
+        h.Api.Verify(a => a.GetBestScores(MixEnum.Phoenix2, It.IsAny<HttpClient>(), 6, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/OfficialSiteClientTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/OfficialSiteClientTests.cs
@@ -265,33 +265,68 @@ public sealed class OfficialSiteClientTests
 
     // ───────────────────────────────────────────────────────────────────────────
     // The import walk over the best-scores pages: the dated (redesigned) list stops
-    // on the saved-date watermark or on page repetition — never trusting the pager —
-    // and recent plays attribute their judgement breakdowns onto the bests they
-    // produced.
+    // on the up-score window — a run of pages holding nothing new-or-improved — or on
+    // page repetition, never on the card's displayed (first-play) date, and recent
+    // plays attribute their judgement breakdowns onto the bests they produced.
 
     private static readonly Guid ImportUserId = Guid.NewGuid();
     private static readonly DateTimeOffset T0 = new(2026, 7, 17, 23, 0, 0, TimeSpan.FromHours(9));
 
     [Fact]
-    public async Task DatedWalkStopsAfterThePageThatCrossesTheWatermark()
+    public async Task DatedWalkPagesPastAlreadyHeldChartsToReachABuriedUpscore()
     {
+        // The redesign sorts by last-played and dates each card by FIRST play, so a replayed
+        // upscore can sit pages behind freshly-replayed charts we already hold at the same
+        // result. The walk must page through those no-work cards to reach it — the exact case
+        // the old date cutoff truncated. Three held pages fit inside the window; page 4's
+        // upscore is found.
         var h = new ImportHarness();
-        var newest = h.GivenChart(new ChartBuilder().WithSongName("Newest").WithNoteCount(100).Build());
-        var newer = h.GivenChart(new ChartBuilder().WithSongName("Newer").WithNoteCount(100).Build());
-        var older = h.GivenChart(new ChartBuilder().WithSongName("Older").WithNoteCount(100).Build());
-        var watermark = T0.AddHours(-12);
-        h.GivenBestScorePage(1, Card(newest, 950000, T0), Card(newer, 940000, T0.AddMinutes(-5)));
-        // Page 2 crosses the watermark: it is still processed whole, but no page 3 is read.
-        h.GivenBestScorePage(2, Card(older, 930000, watermark.AddHours(-1)));
+        var held = new List<Chart>();
+        for (var i = 1; i <= 3; i++)
+        {
+            var chart = h.GivenChart(new ChartBuilder().WithSongName($"Held{i}").WithNoteCount(100).Build());
+            h.GivenStoredBest(chart, 950000);
+            h.GivenBestScorePage(i, Card(chart, 950000, T0.AddMinutes(-i)));
+            held.Add(chart);
+        }
+
+        var upscored = h.GivenChart(new ChartBuilder().WithSongName("Upscored").WithNoteCount(100).Build());
+        h.GivenStoredBest(upscored, 900000);
+        h.GivenBestScorePage(4, Card(upscored, 990000, T0.AddHours(-99)));
+        h.GivenBestScorePage(5); // empty → end of list
 
         var results = (await h.Client.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, "sid", "card1",
-            includeBroken: false, maxPages: null, since: watermark, CancellationToken.None)).ToArray();
+            includeBroken: false, maxPages: null, CancellationToken.None)).ToArray();
 
-        Assert.Equal(3, results.Length);
-        Assert.Contains(results, r => r.Chart.Id == older.Id);
-        h.Api.Verify(a => a.GetBestScores(MixEnum.Phoenix2, It.IsAny<HttpClient>(), 2, It.IsAny<CancellationToken>()),
+        Assert.Contains(results, r => r.Chart.Id == upscored.Id && (int)r.Score == 990000);
+        h.Api.Verify(a => a.GetBestScores(MixEnum.Phoenix2, It.IsAny<HttpClient>(), 4, It.IsAny<CancellationToken>()),
             Times.Once);
-        h.Api.Verify(a => a.GetBestScores(MixEnum.Phoenix2, It.IsAny<HttpClient>(), 3, It.IsAny<CancellationToken>()),
+    }
+
+    [Fact]
+    public async Task DatedWalkStopsAfterAWindowOfPagesWithNoNewBest()
+    {
+        // Every card on these pages is already held at an equal result: after the window of
+        // no-work pages the walk stops without reading the whole list. A real upscore sits on
+        // page 5, past the window — the walk must never reach it (the accepted look-back
+        // limit, matching the classic up-score window).
+        var h = new ImportHarness();
+        for (var i = 1; i <= 4; i++)
+        {
+            var chart = h.GivenChart(new ChartBuilder().WithSongName($"Held{i}").WithNoteCount(100).Build());
+            h.GivenStoredBest(chart, 950000);
+            h.GivenBestScorePage(i, Card(chart, 950000, T0.AddMinutes(-i)));
+        }
+
+        var beyond = h.GivenChart(new ChartBuilder().WithSongName("Beyond").WithNoteCount(100).Build());
+        h.GivenStoredBest(beyond, 900000);
+        h.GivenBestScorePage(5, Card(beyond, 999000, T0.AddHours(-99)));
+
+        var results = (await h.Client.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, "sid", "card1",
+            includeBroken: false, maxPages: null, CancellationToken.None)).ToArray();
+
+        Assert.DoesNotContain(results, r => r.Chart.Id == beyond.Id);
+        h.Api.Verify(a => a.GetBestScores(MixEnum.Phoenix2, It.IsAny<HttpClient>(), 5, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -307,7 +342,7 @@ public sealed class OfficialSiteClientTests
         h.GivenBestScorePage(2, card);
 
         var results = (await h.Client.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, "sid", "card1",
-            includeBroken: false, maxPages: null, since: null, CancellationToken.None)).ToArray();
+            includeBroken: false, maxPages: null, CancellationToken.None)).ToArray();
 
         Assert.Single(results);
         h.Api.Verify(a => a.GetBestScores(MixEnum.Phoenix2, It.IsAny<HttpClient>(), 3, It.IsAny<CancellationToken>()),
@@ -325,9 +360,9 @@ public sealed class OfficialSiteClientTests
         h.GivenBestScorePage(2, brokenCard); // the clamp: out-of-range pages repeat the last page
 
         var without = (await h.Client.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, "sid", "card1",
-            includeBroken: false, maxPages: null, since: null, CancellationToken.None)).ToArray();
+            includeBroken: false, maxPages: null, CancellationToken.None)).ToArray();
         var withBroken = (await h.Client.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, "sid", "card1",
-            includeBroken: true, maxPages: null, since: null, CancellationToken.None)).ToArray();
+            includeBroken: true, maxPages: null, CancellationToken.None)).ToArray();
 
         Assert.Empty(without);
         var saved = Assert.Single(withBroken);
@@ -352,7 +387,7 @@ public sealed class OfficialSiteClientTests
             Play(chart, 960000, T0.AddMinutes(-10), perfects: 1000, greats: 60, goods: 30, bads: 20, misses: 20));
 
         var results = (await h.Client.GetRecordedScores(MixEnum.Phoenix2, ImportUserId, "sid", "card1",
-            includeBroken: false, maxPages: null, since: null, CancellationToken.None)).ToArray();
+            includeBroken: false, maxPages: null, CancellationToken.None)).ToArray();
 
         var saved = Assert.Single(results);
         Assert.Equal(new JudgementCounts(1100, 14, 1, 1, 14), saved.Judgements);
@@ -371,7 +406,7 @@ public sealed class OfficialSiteClientTests
         h.GivenBestScorePage(4, maxPage: 4);
 
         var results = (await h.Client.GetRecordedScores(MixEnum.Phoenix, ImportUserId, "sid", "card1",
-            includeBroken: false, maxPages: 2, since: null, CancellationToken.None)).ToArray();
+            includeBroken: false, maxPages: 2, CancellationToken.None)).ToArray();
 
         Assert.Equal(2, results.Length);
         Assert.All(results, r => Assert.Null(r.RecordedAt));
@@ -422,6 +457,7 @@ public sealed class OfficialSiteClientTests
     private sealed class ImportHarness
     {
         private readonly List<Chart> _charts = new();
+        private readonly List<ScoreTracker.Domain.Models.RecordedPhoenixScore> _storedBests = new();
 
         public Mock<IPiuGameApi> Api { get; } = new();
         public Mock<IChartRepository> Charts { get; } = new();
@@ -449,7 +485,7 @@ public sealed class OfficialSiteClientTests
                     _charts.Where(c => c.Song.Name == name).ToArray());
             var scores = new Mock<IScoreReader>();
             scores.Setup(s => s.GetBestScores(It.IsAny<MixEnum>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Array.Empty<ScoreTracker.Domain.Models.RecordedPhoenixScore>());
+                .ReturnsAsync(() => _storedBests.ToArray());
             Client = new OfficialSiteClient(Api.Object, Charts.Object, NullLogger<OfficialSiteClient>.Instance,
                 Mock.Of<IMediator>(), Mock.Of<ICurrentUserAccessor>(), scores.Object, Mock.Of<IFileUploadClient>(),
                 Mock.Of<IOfficialLeaderboardRepository>(), Mock.Of<IBus>(), FakeDateTime.At(T0).Object,
@@ -459,6 +495,14 @@ public sealed class OfficialSiteClientTests
         public Chart GivenChart(Chart chart)
         {
             _charts.Add(chart);
+            return chart;
+        }
+
+        /// <summary>Seeds a stored best the dated walk reads to decide whether a card is work.</summary>
+        public Chart GivenStoredBest(Chart chart, int score, PhoenixPlate plate = PhoenixPlate.FairGame,
+            bool isBroken = false)
+        {
+            _storedBests.Add(new ScoreTracker.Domain.Models.RecordedPhoenixScore(chart.Id, score, plate, isBroken, T0));
             return chart;
         }
 


### PR DESCRIPTION
## The bug

User **ERRLENA #3846** reported 43 songs in their PUMBILITY on piuscores vs 50 on piugame.

The PUMBILITY formula is **not** at fault — recomputing from their 43 stored records reproduces the site's chips to the decimal (Total 14,658.94 / Singles 9,576.96 / Doubles 5,081.98 vs displayed 14,658 / 9,576 / 5,081). The pool was just short.

Root cause is in the Phoenix 2 import. The redesigned `my_best_score.php`:
- **sorts by last-played**, descending;
- **displays each card's FIRST play date** (`recently_date_tt`), which is unrelated to the sort order;
- pages **12 cards** at a time.

`WalkDatedBestScores` broke paging on the first card older than the stored date watermark. Because the displayed dates are scrambled relative to the sort, one replayed old chart near the top tripped the break immediately — so every incremental import after a user's first read only ~12 cards. ERRLENA's second import saved 6 of a ~21-chart session and never fetched pages 2–4.

Proof from the captured pages: `ALiVE` D21 was played 07-17, stage-broken 07-19, then upscored 07-19 23:12 — its best card shows the 988,596 score but the **07-17** first-play date, positioned by its 07-19 last play. Deduping `recently_played.php` to newest-play-per-chart reproduces the best-list order exactly.

## The fix

Replace the date cutoff with the **classic up-score window**: page until four consecutive pages (`MaxDatedPagesWithoutNewBest = 3`, ~48-chart look-back) hold nothing new-or-improved versus our stored bests. `IsNewOrImprovedBest` mirrors the saga's save filter, so the walk pages exactly as far as there's work to save.

This fits the last-played sort well: doing any work — an upscore *or* a first-ever play — updates last-played and floats it to the top, so the first sustained run of already-held charts reliably means we're past everything new.

The now-dead `since`/watermark mechanism is removed entirely — the `GetRecordedScores` parameter, the saga's `BestScoreWatermark` read/write, and the unused `System.Globalization` import — since it only fed the deleted date break.

## Tests

- Replaced the watermark test with two window tests: a buried upscore behind already-held pages is still reached (the ERRLENA regression), and the window stops before reading the whole list.
- The saga test now asserts the still-true contract: a dated import ignores page counts (never reads `GetScorePageCount`, never touches the `PreviousPageCount` keys).
- Fast suite green: **1620 passed**. E2E is unaffected (its fixture is the classic list, which this doesn't touch).

## Operational note — existing accounts don't self-heal

This prevents *future* truncation. A chart already lost to the bug sits deep in the list (untouched since, so pushed down) and a normal re-import stops before reaching it. Recovering an already-truncated account (like ERRLENA) needs a full walk: clear their Phoenix 2 `PhoenixRecord` rows, then re-import — empty stored bests make every card "new work" so the walk runs to the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
