### PR TITLE
Errlena round 1: session classification + reclears, weekly board, Pumbility titles

### DIFF
--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix2/Phoenix2TitleList.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix2/Phoenix2TitleList.cs
@@ -160,16 +160,19 @@ public static class Phoenix2TitleList
         new Phoenix2PumbilityTitle("DOUBLE MASTER", PumbilityPool.Doubles, 19500),
 
         // ---- Total PUMBILITY tiers ----
-        // Names are masked ("????") on title.php until earned. [P.B] BRONZE was observed
-        // worn on the live rankings; the rest are placeholders.
-        // TODO(P2-titles): replace placeholder names as players reveal them post-launch.
+        // Names are masked ("????") on title.php until earned, so the tier names come from
+        // players wearing them on the live PUMBILITY ranking (Phoenix2PumbilityTitleReconTests).
+        // BRONZE..ALEXANDRITE confirmed 2026-07-23 by worn titles whose lowest wearer sits just
+        // above each threshold (SILVER@12,804 .. ALEXANDRITE@19,047 for the 12500..19000 rungs).
+        // The 20000 tier exists on title.php but is still unreached (top of board ~19,640), so its
+        // name stays masked — re-run the recon to reveal it once someone earns it.
         new Phoenix2PumbilityTitle("[P.B] BRONZE", PumbilityPool.Total, 10000),
-        new Phoenix2PumbilityTitle("[P.B] ??? 12500", PumbilityPool.Total, 12500),
-        new Phoenix2PumbilityTitle("[P.B] ??? 15000", PumbilityPool.Total, 15000),
-        new Phoenix2PumbilityTitle("[P.B] ??? 16000", PumbilityPool.Total, 16000),
-        new Phoenix2PumbilityTitle("[P.B] ??? 17000", PumbilityPool.Total, 17000),
-        new Phoenix2PumbilityTitle("[P.B] ??? 18000", PumbilityPool.Total, 18000),
-        new Phoenix2PumbilityTitle("[P.B] ??? 19000", PumbilityPool.Total, 19000),
+        new Phoenix2PumbilityTitle("[P.B] SILVER", PumbilityPool.Total, 12500),
+        new Phoenix2PumbilityTitle("[P.B] GOLD", PumbilityPool.Total, 15000),
+        new Phoenix2PumbilityTitle("[P.B] PLATINUM", PumbilityPool.Total, 16000),
+        new Phoenix2PumbilityTitle("[P.B] DIAMOND", PumbilityPool.Total, 17000),
+        new Phoenix2PumbilityTitle("[P.B] RED BERYL", PumbilityPool.Total, 18000),
+        new Phoenix2PumbilityTitle("[P.B] ALEXANDRITE", PumbilityPool.Total, 19000),
         new Phoenix2PumbilityTitle("[P.B] ??? 20000", PumbilityPool.Total, 20000),
 
         // ---- Skill ladders (chart + grade) ----

--- a/ScoreTracker/ScoreTracker.ExplorationTests/LiveSite/Phoenix2PumbilityTitleReconTests.cs
+++ b/ScoreTracker/ScoreTracker.ExplorationTests/LiveSite/Phoenix2PumbilityTitleReconTests.cs
@@ -1,0 +1,95 @@
+using System.Text;
+using ScoreTracker.SharedKernel.Enums;
+using Xunit.Abstractions;
+
+namespace ScoreTracker.ExplorationTests.LiveSite;
+
+/// <summary>
+///     Reveals the names behind the masked total-PUMBILITY tiers (our <c>[P.B] ??? …</c>
+///     placeholders in <see cref="ScoreTracker.Domain.Models.Titles.Phoenix2.Phoenix2TitleList" />).
+///     title.php masks a tier the *service account* has not earned, so higher tiers stay "????"
+///     there — but the ranking board renders every top player's *worn* title verbatim, so a
+///     player who earned RED BERYL and wears it spells the name out for us. Crawls the All tab
+///     deep, then aggregates each worn <c>[P.B]</c> title to the PB range of its wearers: the
+///     minimum PB of a tier's wearers approximates that tier's threshold from above.
+///     Read-only (GETs of a login-gated ranking). Run on demand:
+///     <c>dotnet test ScoreTracker/ScoreTracker.ExplorationTests/... --filter "FullyQualifiedName~Phoenix2PumbilityTitleRecon"</c>
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class Phoenix2PumbilityTitleReconTests : IClassFixture<PiuGameSessionFixture>
+{
+    // ~50 rows/page on the board; 25 pages / 1200 rows covers the owner's "top 1000" with slack.
+    private const int MaxPages = 25;
+    private const int MaxRows = 1200;
+
+    private readonly PiuGameSessionFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public Phoenix2PumbilityTitleReconTests(PiuGameSessionFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [LiveSiteFact]
+    public async Task Worn_PB_titles_on_the_ranking_reveal_the_masked_tier_names()
+    {
+        var ct = CancellationToken.None;
+        var (client, sid) = await _fixture.Api.GetSessionId(MixEnum.Phoenix2,
+            PiuGameSessionFixture.Username!, PiuGameSessionFixture.Password!, ct);
+        Assert.False(string.IsNullOrWhiteSpace(sid), "Phoenix 2 login produced no session id.");
+
+        var rows = new List<(int Rank, string Name, string Title, double Pumbility)>();
+        for (var page = 1; page <= MaxPages && rows.Count < MaxRows; page++)
+        {
+            var result = await _fixture.Api.GetPumbilityRankings(MixEnum.Phoenix2, null, page, client, ct);
+            foreach (var e in result.Entries)
+                rows.Add((rows.Count + 1, e.ProfileName.Trim(), e.Title.Trim(), e.Pumbility));
+            if (result.IsEnd || result.Entries.Length == 0) break;
+            await Task.Delay(300, ct); // polite to the real site
+        }
+
+        Assert.NotEmpty(rows);
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Crawled {rows.Count} PUMBILITY ranking rows (All tab).");
+        sb.AppendLine($"PB range: #{rows[0].Rank} {rows[0].Name} {rows[0].Pumbility:N2}" +
+                      $"  ..  #{rows[^1].Rank} {rows[^1].Name} {rows[^1].Pumbility:N2}");
+        sb.AppendLine();
+
+        sb.AppendLine("TOP 20 ROWS (rank | PB | worn title | name):");
+        foreach (var r in rows.Take(20))
+            sb.AppendLine($"  #{r.Rank,-4} {r.Pumbility,10:N2}  {Trunc(r.Title, 30),-30}  {r.Name}");
+        sb.AppendLine();
+
+        // A player wears their highest earned tier, so the minimum PB among a tier's wearers
+        // sits just above that tier's threshold — the signal that names the ??? threshold.
+        var pb = rows.Where(r => r.Title.StartsWith("[P.B]", StringComparison.OrdinalIgnoreCase)).ToList();
+        var byTitle = pb.GroupBy(r => r.Title)
+            .Select(g => (Title: g.Key, Count: g.Count(), Min: g.Min(x => x.Pumbility), Max: g.Max(x => x.Pumbility)))
+            .OrderBy(g => g.Min).ToList();
+        sb.AppendLine($"WORN [P.B] TIERS ({pb.Count} of {rows.Count} rows wear one), sorted by min PB:");
+        foreach (var g in byTitle)
+            sb.AppendLine($"  {g.Title,-30}  n={g.Count,-4}  minPB={g.Min,10:N2}  maxPB={g.Max,10:N2}");
+        sb.AppendLine();
+
+        var highest = byTitle.Count > 0 ? byTitle[^1].Title : "(none)";
+        sb.AppendLine($"Highest worn [P.B] tier observed: {highest}");
+        sb.AppendLine($"Rows with PB >= 18000: {rows.Count(r => r.Pumbility >= 18000)}");
+        sb.AppendLine($"Rows with PB >= 19000: {rows.Count(r => r.Pumbility >= 19000)}");
+        sb.AppendLine($"Rows with PB >= 20000: {rows.Count(r => r.Pumbility >= 20000)}");
+        sb.AppendLine();
+
+        sb.AppendLine("ALL DISTINCT WORN TITLES (count):");
+        foreach (var g in rows.GroupBy(r => r.Title).OrderByDescending(g => g.Count()))
+            sb.AppendLine($"  {g.Count(),-4}  {g.Key}");
+
+        var report = sb.ToString();
+        _output.WriteLine(report);
+        var path = Path.Combine(Path.GetTempPath(), "pumbility-title-recon.txt");
+        await File.WriteAllTextAsync(path, report, ct);
+        _output.WriteLine($"(report written to {path})");
+    }
+
+    private static string Trunc(string s, int max) => s.Length <= max ? s : s[..(max - 1)] + "…";
+}

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/TitleSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/TitleSaga.cs
@@ -293,9 +293,12 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
             .ToDictionary(t => t.Title.Name);
         return BuildProgress(request.Mix, charts, current, completed)
             .Where(t => !t.IsComplete && t.Title.CompletionRequired > 0 && t.Title is not ISpecificChartTitle)
+            // Floor-aware percent (PercentComplete), so a ladder rung the player hasn't reached
+            // reads 0% instead of raw count/required — otherwise every rung above the active one
+            // shows spurious progress and the whole ladder appears to move at once.
             .Select(t => new TitleProgressDelta(t.Title.Name,
-                beforeByTitle.TryGetValue(t.Title.Name, out var b) ? Percent(b) : 0,
-                Percent(t)))
+                beforeByTitle.TryGetValue(t.Title.Name, out var b) ? b.PercentComplete : 0,
+                t.PercentComplete))
             .Where(d => (int)(d.NewPercent * 100) > (int)(d.OldPercent * 100))
             .OrderByDescending(d => d.NewPercent)
             .Take(5)
@@ -357,13 +360,6 @@ internal sealed class TitleSaga : IRequestHandler<GetTitleProgressQuery, IEnumer
         await _milestones.Append(request.Mix, request.UserId, writes, cancellationToken);
         return writes.Select(w => new PlayerMilestoneRecord(w.Kind, w.SessionId, w.OccurredAt, w.OldValue,
             w.NewValue, w.Title, w.Detail)).ToList();
-    }
-
-    private static double Percent(TitleProgress progress)
-    {
-        return progress.Title.CompletionRequired <= 0
-            ? 0
-            : Math.Min(1.0, progress.CompletionCount / progress.Title.CompletionRequired);
     }
 
     private static IEnumerable<TitleProgress> BuildProgress(MixEnum mix, IDictionary<Guid, Chart> charts,

--- a/ScoreTracker/ScoreTracker.ScoreLedger/Application/SessionFeedHandler.cs
+++ b/ScoreTracker/ScoreTracker.ScoreLedger/Application/SessionFeedHandler.cs
@@ -10,8 +10,11 @@ namespace ScoreTracker.ScoreLedger.Application;
 
 /// <summary>
 ///     The Sessions page's journal read: pages session groups and classifies every row
-///     against the chart's prior journal state. The journal is complete back to the
-///     2026-06 backfill, so "no prior row" genuinely means a first entry.
+///     against the chart's prior journal state <em>in the same mix</em>. The journal is
+///     complete back to the 2026-06 backfill, so "no prior row" genuinely means a first
+///     entry. Mix scoping matters because Phoenix and Phoenix 2 share chart ids (a
+///     returning song is one ChartId in both), so a first-ever Phoenix 2 play must read as
+///     a New Pass, not an Upscore/Clear over the player's Phoenix 1 best.
 /// </summary>
 internal sealed class SessionFeedHandler : IRequestHandler<GetRecentSessionsQuery, RecentSessionsPage>
 {
@@ -65,7 +68,9 @@ internal sealed class SessionFeedHandler : IRequestHandler<GetRecentSessionsQuer
     private static RecentSessionsPage.ScoreEventRecord Classify(ScoreJournalEntry row,
         ScoreJournalEntry[] chartHistory)
     {
-        var prior = chartHistory.Where(h => h.OccurredAt < row.OccurredAt).ToArray();
+        // Same-mix only: a returning song carries one ChartId across Phoenix and Phoenix 2,
+        // so its Phoenix 1 history must not count as prior state for a Phoenix 2 play.
+        var prior = chartHistory.Where(h => h.Mix == row.Mix && h.OccurredAt < row.OccurredAt).ToArray();
         var priorBest = prior.Where(p => p.Score != null).Select(p => (int?)(int)p.Score!.Value).Max();
         var priorPassed = prior.Any(p => !p.IsBroken);
         var priorBestPlate = prior.Where(p => !p.IsBroken && p.Plate != null).Select(p => p.Plate).Max();

--- a/ScoreTracker/ScoreTracker.ScoreLedger/Application/SessionFeedHandler.cs
+++ b/ScoreTracker/ScoreTracker.ScoreLedger/Application/SessionFeedHandler.cs
@@ -21,12 +21,15 @@ internal sealed class SessionFeedHandler : IRequestHandler<GetRecentSessionsQuer
     private readonly IScoreJournalRepository _journal;
     private readonly IUserReader _users;
     private readonly ICurrentUserAccessor _currentUser;
+    private readonly IScoreReader _scores;
 
-    public SessionFeedHandler(IScoreJournalRepository journal, IUserReader users, ICurrentUserAccessor currentUser)
+    public SessionFeedHandler(IScoreJournalRepository journal, IUserReader users, ICurrentUserAccessor currentUser,
+        IScoreReader scores)
     {
         _journal = journal;
         _users = users;
         _currentUser = currentUser;
+        _scores = scores;
     }
 
     public async Task<RecentSessionsPage> Handle(GetRecentSessionsQuery request,
@@ -47,6 +50,18 @@ internal sealed class SessionFeedHandler : IRequestHandler<GetRecentSessionsQuer
             .GroupBy(r => r.ChartId)
             .ToDictionary(g => g.Key, g => g.OrderBy(r => r.OccurredAt).ToArray());
 
+        // Cross-mix reclear (parity with the Discord session card): a New Pass on a chart
+        // already cleared non-broken in the OTHER Phoenix-family mix (free from the cross-mix
+        // history) or in legacy XX. The XX bests load only when the page actually holds a New
+        // Pass, so an upscore-only page skips the read entirely, like the card does.
+        var anyNewPass = groups.Any(g => g.Rows.Any(r => !r.IsBroken
+            && Classify(r, History(histories, r)).Classification == ScoreEventClassification.NewPass));
+        var xxCleared = anyNewPass
+            ? (await _scores.GetBestXXAttempts(request.UserId, cancellationToken))
+                .Where(a => a.BestAttempt is { IsBroken: false })
+                .Select(a => a.Chart.Id).ToHashSet()
+            : new HashSet<Guid>();
+
         return new RecentSessionsPage(total, groups.Select(g => new RecentSessionsPage.SessionGroup(
                 g.SessionId,
                 g.Day,
@@ -55,9 +70,15 @@ internal sealed class SessionFeedHandler : IRequestHandler<GetRecentSessionsQuer
                 g.Rows.Min(r => r.OccurredAt),
                 g.Rows.Max(r => r.OccurredAt),
                 g.Rows.OrderByDescending(r => r.OccurredAt)
-                    .Select(r => Classify(r, histories.GetValueOrDefault(r.ChartId, Array.Empty<ScoreJournalEntry>())))
+                    .Select(r => Classify(r, History(histories, r), xxCleared))
                     .ToArray()))
             .ToArray());
+    }
+
+    private static ScoreJournalEntry[] History(IReadOnlyDictionary<Guid, ScoreJournalEntry[]> histories,
+        ScoreJournalEntry row)
+    {
+        return histories.GetValueOrDefault(row.ChartId, Array.Empty<ScoreJournalEntry>());
     }
 
     private static string DominantSource(IReadOnlyList<ScoreJournalEntry> rows)
@@ -66,7 +87,7 @@ internal sealed class SessionFeedHandler : IRequestHandler<GetRecentSessionsQuer
     }
 
     private static RecentSessionsPage.ScoreEventRecord Classify(ScoreJournalEntry row,
-        ScoreJournalEntry[] chartHistory)
+        ScoreJournalEntry[] chartHistory, IReadOnlySet<Guid>? xxCleared = null)
     {
         // Same-mix only: a returning song carries one ChartId across Phoenix and Phoenix 2,
         // so its Phoenix 1 history must not count as prior state for a Phoenix 2 play.
@@ -76,10 +97,18 @@ internal sealed class SessionFeedHandler : IRequestHandler<GetRecentSessionsQuer
         var priorBestPlate = prior.Where(p => !p.IsBroken && p.Plate != null).Select(p => p.Plate).Max();
         var classification = ClassifyRow(row, priorPassed, priorBest, priorBestPlate);
 
+        // A New Pass on a chart cleared non-broken elsewhere is a reclear: the other
+        // Phoenix-family mix shows up in the cross-mix history, legacy XX comes in via
+        // xxCleared. Only new passes qualify — matching the Discord card's "* = reclears".
+        var isReclear = classification == ScoreEventClassification.NewPass
+                        && (chartHistory.Any(h => h.Mix != row.Mix && !h.IsBroken)
+                            || (xxCleared?.Contains(row.ChartId) ?? false));
+
         return new RecentSessionsPage.ScoreEventRecord(row.ChartId, row.OccurredAt,
             row.Score == null ? null : (int)row.Score.Value, row.Plate?.ToString(), row.IsBroken, row.Source,
             row.SessionId, classification,
-            classification == ScoreEventClassification.Upscore ? priorBest : null);
+            classification == ScoreEventClassification.Upscore ? priorBest : null,
+            isReclear);
     }
 
     private static ScoreEventClassification ClassifyRow(ScoreJournalEntry row, bool priorPassed, int? priorBest,

--- a/ScoreTracker/ScoreTracker.ScoreLedger/Contracts/RecentSessionsPage.cs
+++ b/ScoreTracker/ScoreTracker.ScoreLedger/Contracts/RecentSessionsPage.cs
@@ -30,5 +30,6 @@ public sealed record RecentSessionsPage(int TotalGroups, IReadOnlyList<RecentSes
         string Source,
         Guid? SessionId,
         ScoreEventClassification Classification,
-        int? PreviousBest);
+        int? PreviousBest,
+        bool IsReclear = false);
 }

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SessionFeedHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SessionFeedHandlerTests.cs
@@ -94,6 +94,48 @@ public sealed class SessionFeedHandlerTests
     }
 
     [Fact]
+    public async Task FirstPlayInANewMixIsANewPassDespitePriorHistoryInAnotherMix()
+    {
+        // Phoenix and Phoenix 2 share chart ids, so a returning song's Phoenix 1 journal
+        // must not bleed into its first-ever Phoenix 2 play. Errlena's report: charts show
+        // "Upscore" (or "Played") on the first Phoenix 2 play. Real case — Yog-Sothoth S23:
+        // Phoenix 1 best 961,294, first Phoenix 2 play 949,264.
+        var ctx = new HandlerContext();
+        var priorMixBest = Entry(Now.AddMonths(-2), 961000, mix: MixEnum.Phoenix);
+        var firstPhoenix2 = Entry(Now, 949000, mix: MixEnum.Phoenix2);
+        ctx.GivenGroups(new JournalSessionRows(null, DateOnly.FromDateTime(Now.Date), MixEnum.Phoenix2,
+            new[] { firstPhoenix2 }));
+        ctx.GivenHistories(new[] { priorMixBest, firstPhoenix2 });
+
+        var page = await ctx.Handler.Handle(new GetRecentSessionsQuery(UserId),
+            CancellationToken.None);
+
+        var row = page.Groups.Single().Rows.Single();
+        Assert.Equal(ScoreEventClassification.NewPass, row.Classification);
+        Assert.Null(row.PreviousBest);
+    }
+
+    [Fact]
+    public async Task FirstPlayInANewMixThatBeatsAnotherMixsBestIsStillANewPass()
+    {
+        // The headline symptom: a first Phoenix 2 play that happens to edge out the
+        // Phoenix 1 best must not read as an Upscore over that cross-mix score.
+        var ctx = new HandlerContext();
+        var priorMixBest = Entry(Now.AddMonths(-2), 981199, mix: MixEnum.Phoenix);
+        var firstPhoenix2 = Entry(Now, 981239, mix: MixEnum.Phoenix2);
+        ctx.GivenGroups(new JournalSessionRows(null, DateOnly.FromDateTime(Now.Date), MixEnum.Phoenix2,
+            new[] { firstPhoenix2 }));
+        ctx.GivenHistories(new[] { priorMixBest, firstPhoenix2 });
+
+        var page = await ctx.Handler.Handle(new GetRecentSessionsQuery(UserId),
+            CancellationToken.None);
+
+        var row = page.Groups.Single().Rows.Single();
+        Assert.Equal(ScoreEventClassification.NewPass, row.Classification);
+        Assert.Null(row.PreviousBest);
+    }
+
+    [Fact]
     public async Task PlateOnlyImprovementsClassifyAsUpscores()
     {
         var ctx = new HandlerContext();
@@ -138,9 +180,10 @@ public sealed class SessionFeedHandlerTests
     }
 
     private static ScoreJournalEntry Entry(DateTimeOffset at, int score, bool isBroken = false,
-        string source = "manual", PhoenixPlate? plate = PhoenixPlate.FairGame, Guid? sessionId = null)
+        string source = "manual", PhoenixPlate? plate = PhoenixPlate.FairGame, Guid? sessionId = null,
+        MixEnum mix = MixEnum.Phoenix)
     {
-        return new ScoreJournalEntry(at, source, UserId, ChartId, score, plate, isBroken, MixEnum.Phoenix,
+        return new ScoreJournalEntry(at, source, UserId, ChartId, score, plate, isBroken, mix,
             sessionId);
     }
 

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SessionFeedHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/SessionFeedHandlerTests.cs
@@ -136,6 +136,42 @@ public sealed class SessionFeedHandlerTests
     }
 
     [Fact]
+    public async Task AFirstPassOnAChartClearedInAnotherMixIsFlaggedAsAReclear()
+    {
+        // Yog-Sothoth: cleared in Phoenix 1, first play in Phoenix 2 -> New Pass + reclear,
+        // the same signal the Discord card carries. Seen for free in the cross-mix history.
+        var ctx = new HandlerContext();
+        var p1 = Entry(Now.AddMonths(-2), 961000, mix: MixEnum.Phoenix);
+        var p2 = Entry(Now, 949000, mix: MixEnum.Phoenix2);
+        ctx.GivenGroups(new JournalSessionRows(null, DateOnly.FromDateTime(Now.Date), MixEnum.Phoenix2,
+            new[] { p2 }));
+        ctx.GivenHistories(new[] { p1, p2 });
+
+        var page = await ctx.Handler.Handle(new GetRecentSessionsQuery(UserId), CancellationToken.None);
+
+        var row = page.Groups.Single().Rows.Single();
+        Assert.Equal(ScoreEventClassification.NewPass, row.Classification);
+        Assert.True(row.IsReclear);
+    }
+
+    [Fact]
+    public async Task AFirstEverPassWithNoHistoryElsewhereIsNotAReclear()
+    {
+        // A Phoenix 2-debut song, never cleared in any other mix -> plain New Pass, no badge.
+        var ctx = new HandlerContext();
+        var p2 = Entry(Now, 982000, mix: MixEnum.Phoenix2);
+        ctx.GivenGroups(new JournalSessionRows(null, DateOnly.FromDateTime(Now.Date), MixEnum.Phoenix2,
+            new[] { p2 }));
+        ctx.GivenHistories(new[] { p2 });
+
+        var page = await ctx.Handler.Handle(new GetRecentSessionsQuery(UserId), CancellationToken.None);
+
+        var row = page.Groups.Single().Rows.Single();
+        Assert.Equal(ScoreEventClassification.NewPass, row.Classification);
+        Assert.False(row.IsReclear);
+    }
+
+    [Fact]
     public async Task PlateOnlyImprovementsClassifyAsUpscores()
     {
         var ctx = new HandlerContext();
@@ -192,6 +228,7 @@ public sealed class SessionFeedHandlerTests
         public Mock<IScoreJournalRepository> Journal { get; } = new();
         public Mock<IUserReader> Users { get; } = new();
         public Mock<ICurrentUserAccessor> CurrentUser { get; } = new();
+        public Mock<IScoreReader> Scores { get; } = new();
         public SessionFeedHandler Handler { get; }
 
         public HandlerContext(bool isPublic = true, Guid? viewerId = null)
@@ -203,7 +240,9 @@ public sealed class SessionFeedHandlerTests
                 CurrentUser.Setup(c => c.IsLoggedIn).Returns(true);
                 CurrentUser.Setup(c => c.User).Returns(new UserBuilder().WithId(viewer).Build());
             }
-            Handler = new SessionFeedHandler(Journal.Object, Users.Object, CurrentUser.Object);
+            Scores.Setup(s => s.GetBestXXAttempts(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<BestXXChartAttempt>());
+            Handler = new SessionFeedHandler(Journal.Object, Users.Object, CurrentUser.Object, Scores.Object);
         }
 
         public void GivenGroups(params JournalSessionRows[] groups)

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TitleSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/TitleSagaTests.cs
@@ -134,6 +134,39 @@ public sealed class TitleSagaTests
         Assert.True(result.Progress.Count <= 5);
     }
 
+    [Fact]
+    public async Task ContiguousLadderFloorsKeepAllButTheActiveRungOffTheProgressList()
+    {
+        // The reported bug: one single score reported progress on EVERY [S] pumbility rung at
+        // once ("[S] INTERMEDIATE LV.1 0% → 19%, LV.2 0% → 16%, LV.3 0% → 13%") because the delta
+        // percent divided by the raw requirement, ignoring the floor. Ladder floors are
+        // contiguous (a rung floors on the rung below's requirement), so at most one rung can be
+        // mid-progress — no ladder may report two rungs moving at once.
+        var single = new ChartBuilder().WithType(ChartType.Single).WithLevel(23).Build();
+        var ctx = new SagaContext(MixEnum.Phoenix2, single);
+        ctx.GivenBestScores(Score(single.Id, 985000));
+
+        var result = await ctx.Saga.Handle(new TitleSaga.CaptureSessionTitles(ctx.UserId, MixEnum.Phoenix2, null,
+                new[]
+                {
+                    new PlayerScoresUpdatedEvent.ScoreChange(single.Id, false, 500000, 985000, "SuperbGame", false)
+                }),
+            CancellationToken.None);
+
+        Assert.Contains(result.Progress, d => d.Title.StartsWith("[S]")); // the [S] ladder is exercised
+        var doubledUp = result.Progress
+            .GroupBy(LadderBase)
+            .Where(g => g.Count() > 1)
+            .Select(g => $"{g.Key} -> {string.Join(", ", g.Select(d => d.Title))}")
+            .ToArray();
+        Assert.True(doubledUp.Length == 0,
+            "A ladder reported multiple rungs moving at once (floor ignored): " + string.Join(" | ", doubledUp));
+    }
+
+    // Strip a trailing "LV.N" / "Lv. N" rung number so sibling rungs collapse to one ladder key.
+    private static string LadderBase(TitleProgressDelta delta) =>
+        System.Text.RegularExpressions.Regex.Replace(delta.Title, @"\s*[Ll][Vv]\.?\s*\d+$", "").Trim();
+
     private sealed class SagaContext
     {
         private readonly MixEnum _mix;

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/WeeklyTournamentSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/WeeklyTournamentSagaTests.cs
@@ -578,7 +578,11 @@ public sealed class WeeklyTournamentSagaTests
         Assert.Equal(1, topSecond.InRangePlace);
 
         Assert.Equal(new[] { second, third }, summary.InRangeTopPlaces.Select(r => r.Entry.UserId).ToArray());
-        Assert.Equal(new[] { 1, 2 }, summary.InRangeTopPlaces.Select(r => r.Place).ToArray());
+        // Place stays the OVERALL rank (2, 3) even in the in-range head; the renumbered ladder lives
+        // in InRangePlace (1, 2). The grid merges both heads and orders by Place, so a row carrying
+        // its renumbered place there would interleave the two ladders (goldenmule's 1,2,2,3,3 board).
+        Assert.Equal(new[] { 2, 3 }, summary.InRangeTopPlaces.Select(r => r.Place).ToArray());
+        Assert.Equal(new int?[] { 1, 2 }, summary.InRangeTopPlaces.Select(r => r.InRangePlace).ToArray());
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/TitleLadderFloorTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/TitleLadderFloorTests.cs
@@ -59,7 +59,7 @@ public sealed class TitleLadderFloorTests
         Assert.Equal(18900, Phoenix2("SINGLE MASTER").CompletionFloor);
         // The doubles ladder is its own pool — its Lv.2 floors on the doubles Lv.1.
         Assert.Equal(5000, Phoenix2("[D] INTERMEDIATE LV.2").CompletionFloor);
-        Assert.Equal(10000, Phoenix2("[P.B] ??? 12500").CompletionFloor);
+        Assert.Equal(10000, Phoenix2("[P.B] SILVER").CompletionFloor);
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.WeeklyChallenge/Application/WeeklyTournamentSaga.cs
+++ b/ScoreTracker/ScoreTracker.WeeklyChallenge/Application/WeeklyTournamentSaga.cs
@@ -145,9 +145,15 @@ namespace ScoreTracker.WeeklyChallenge.Application
             {
                 var chartRanked = ranked[chart.ChartId];
                 var chartInRange = inRangeRanked[chart.ChartId];
+                // Place is the OVERALL place for every row, including the in-range-top rows. The grid
+                // merges the two heads and orders by Place (WeeklyBoardGrid.MergedTop); an in-range
+                // row carrying its own renumbered place would sort into the overall ladder by the
+                // wrong number — a 947k in-range #2 landing above an 989k overall #3.
+                var overallPlaces = chartRanked.ToDictionary(r => r.Item2.UserId, r => r.Item1);
                 var inRangePlaces = chartInRange.ToDictionary(r => r.Item2.UserId, r => r.Item1);
                 var catalogChart = chartDict.GetValueOrDefault(chart.ChartId);
-                WeeklyBoardRow ToRow((int, WeeklyTournamentEntry) r) => new(r.Item1,
+                WeeklyBoardRow ToRow((int, WeeklyTournamentEntry) r) => new(
+                    overallPlaces.TryGetValue(r.Item2.UserId, out var op) ? op : r.Item1,
                     userDict.GetValueOrDefault(r.Item2.UserId), r.Item2,
                     sources.TryGetValue((r.Item2.UserId, r.Item2.ChartId), out var source)
                         ? source

--- a/ScoreTracker/ScoreTracker/Components/Sessions/HighlightRow.razor
+++ b/ScoreTracker/ScoreTracker/Components/Sessions/HighlightRow.razor
@@ -63,6 +63,10 @@
             if (Flags.HasFlag(HighlightFlags.FolderDebut))
                 yield return ("🆕", Detail?.FolderDebutOrdinal is { } o ? $"#{o}" : null,
                     L["One of your first passes in this folder"].Value);
+            // A first pass this mix on a chart cleared in Phoenix 1 or XX — the same signal
+            // the Discord card and tier list carry; the card foots a legend when one renders.
+            if (Row.IsReclear)
+                yield return ("🔁", null, L["Passed in another mix"].Value);
         }
     }
 

--- a/ScoreTracker/ScoreTracker/Components/Sessions/SessionRoundupCard.razor
+++ b/ScoreTracker/ScoreTracker/Components/Sessions/SessionRoundupCard.razor
@@ -46,6 +46,16 @@
                       Flags="FlagsFor(row)" Detail="DetailFor(row)"></HighlightRow>
     }
 
+    @* Legend rides along only when a 🔁 row actually rendered — a reclear folded into the
+       hidden "+N more" tail leaves the card clean, matching the Discord footnote. *@
+    @if (InlineRows.Any(r => r.IsReclear))
+    {
+        <div class="d-flex align-center gap-1 px-3 py-1"
+             style="border-top: 1px solid var(--mud-palette-table-lines)">
+            <MudText Typo="Typo.caption">🔁 @L["Passed in another mix"]</MudText>
+        </div>
+    }
+
     <MudSpacer/>
     <div class="d-flex align-center px-2 pb-1">
         <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="() => _showAllScores = true"
@@ -70,6 +80,12 @@
             {
                 <HighlightRow Row="row" Chart="Charts.GetValueOrDefault(row.ChartId)"
                               Flags="FlagsFor(row)" Detail="DetailFor(row)"></HighlightRow>
+            }
+            @if (Ordered.Any(r => r.IsReclear))
+            {
+                <div class="d-flex align-center gap-1 px-2 py-1">
+                    <MudText Typo="Typo.caption">🔁 @L["Passed in another mix"]</MudText>
+                </div>
             }
         </div>
     </DialogContent>

--- a/docs/design/phoenix2-implementation.md
+++ b/docs/design/phoenix2-implementation.md
@@ -65,7 +65,8 @@ shipped on `claude/phoenix2-pumbility-crawl-cf2710`:
   "Recalculate Phoenix 2 Player Ratings" button (`RecalculateMixRatingsCommand` bus sweep).
 - **All 272 Phoenix 2 titles landed** (crawled authenticated from my_page/title.php 2026-07-09):
   [S]/[D] ladders + 8 hidden total tiers gate on the pool values (`Phoenix2PumbilityTitle`;
-  `[P.B] BRONZE` observed live, 7 placeholder names pending reveals); nine skill ladders
+  `[P.B] BRONZE`..`ALEXANDRITE` (10000..19000) confirmed from worn titles on the live PUMBILITY
+  ranking 2026-07-23, the 20000 tier still unreached so its name stays masked); nine skill ladders
   (chart + SSS, `Phoenix2ChartGradeTitle`) with EXPERT/SPECIALIST metas; 34 boss breakers
   (`Phoenix2ChartClearTitle`; `1948 D??` matches any level); step-artist/play-count/CO-OP/judgment
   badges site-detected only (CO-OP Rating formula unknown — TODO). **The `/Titles` page is live


### PR DESCRIPTION
Field-test feedback from Errlena (#3846) and goldenmule, plus a confirmed Pumbility-title crawl. Five independent commits.

## fix(sessions): scope classification to the play's own mix — `24aadc00`
**Errlena:** first-time Phoenix 2 plays of returning songs showed as *Upscore* / *Played* ("Jugado"), never *New Pass*.

Phoenix and Phoenix 2 are separate mixes but share chart ids, and `SessionFeedHandler` classified each row against the chart's journal history across **all** mixes — so a first P2 play was judged against the player's Phoenix 1 best. Scoped the prior-history lookup to the row's own mix.

Proof (`ErrlenaNoHj` data): Yog-Sothoth S23 — P1 961,294 (Apr 20), first P2 play 949,264 (Jul 22) → was "Played", now "New Pass".

## fix(weekly): keep overall Place on in-range-top rows — `050b30ea`
**goldenmule:** the Club Night board rendered out of order (947k above 989k) with ranks reading 1,2,2,3,3.

The weekly card ships two ladders per chart (overall + relevant-players) and the grid merges them ordered by `Place`. A shared `ToRow` stamped the *renumbered in-range* place into `Place` for the in-range head, colliding the two numbering systems. `Place` is now always the overall rank; the renumbered ladder stays in `InRangePlace`. (An existing test had encoded the bug — corrected.)

## feat(titles): name the confirmed [P.B] PUMBILITY tiers — `5a41d48a`
Crawled the live top-1000 PUMBILITY ranking and read players' worn titles. Lowest wearer of each tier sits just above its threshold:

| Threshold | Name | Lowest wearer |
|--|--|--|
| 12,500 | SILVER | 12,804 |
| 15,000 | GOLD | 15,092 |
| 16,000 | PLATINUM | 16,006 |
| 17,000 | DIAMOND | 17,060 |
| 18,000 | RED BERYL | 18,006 |
| 19,000 | **ALEXANDRITE** | 19,047 (NULL#1029) |

⚠️ **ALEXANDRITE** is the one you flagged to hold — now confirmed by a real wearer, so I set it. Revert that one line to wait. The **20,000** tier is still unreached (top of board ~19,640), so it stays `??? 20000`. Added `Phoenix2PumbilityTitleReconTests` as the re-runnable canary.

## feat(sessions): mark cross-mix reclears — `c13a315d`
After the mix-scoping fix a returning song's first P2 pass reads as a plain New Pass — but the Discord card and tier list both flag "passed in another mix". This brings the same signal in-app: a reclear glyph on the row's badge strip + a card-foot legend when one renders. Same computation as the Discord card (other Phoenix mix + XX), reusing the existing localized key.

## fix(titles): floor-rebase the Discord title-progress deltas — `49ac144f`
**Owner:** the session card showed progress on every ladder rung at once ("[S] INTERMEDIATE LV.1 → 19%, LV.2 → 16%, LV.3 → 13%").

The floor change *is* in the domain (`TitleProgress.PercentComplete` applies it, and the ladder floors are set) — but the delta path computed raw `CompletionCount / CompletionRequired`, bypassing it. Now uses `PercentComplete`: a rung below its floor rebases to 0% and drops out of the moved-percent filter, so only the rung actually in progress shows.

## Still open (not in this PR)
- Errlena's **"Jugado" → "Clear"** wording for the *Played* status — needs your call on scope (English-wide rename vs Spanish-only), since a `Clear` verb key already exists.

## Tests
Fast 1643 · Components 293 · Web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)