### PR TITLE
fix: public users missing from World, and the three ways it happened

### DIFF
--- a/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
@@ -993,7 +993,6 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         switch (community.PrivacyType)
         {
             case CommunityPrivacyType.Public:
-                community.MemberIds.Add(userId);
                 break;
             case CommunityPrivacyType.Private:
             case CommunityPrivacyType.PublicWithCode:
@@ -1007,13 +1006,14 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
                     new DateOnly(_dateTime.Now.Year, _dateTime.Now.Month, _dateTime.Now.Day))
                     throw new DeniedFromCommunityException("This invite code is expired");
 
-                community.MemberIds.Add(userId);
                 break;
             default:
                 throw new DeniedFromCommunityException("Community privacy type could not be determined");
         }
 
-        await _communities.SaveCommunity(community, cancellationToken);
+        // One row, not the whole aggregate: saving the community would write back the member set
+        // as it looked when this handler loaded it, deleting anyone who joined in between.
+        await _communities.AddMembership(community.Name, userId, cancellationToken);
     }
 
     public async Task Handle(LeaveCommunityCommand request, CancellationToken cancellationToken)
@@ -1022,8 +1022,7 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         var community = await GetCommunity(request.CommunityName, cancellationToken);
         if (!community.MemberIds.Contains(userId)) return;
 
-        community.MemberIds.Remove(userId);
-        await _communities.SaveCommunity(community, cancellationToken);
+        await _communities.RemoveMembership(community.Name, userId, cancellationToken);
     }
 
     public async Task Handle(RemoveDiscordChannelFromCommunityCommand request, CancellationToken cancellationToken)

--- a/ScoreTracker/ScoreTracker.Communities/Domain/ICommunityRepository.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Domain/ICommunityRepository.cs
@@ -10,7 +10,27 @@ namespace ScoreTracker.Communities.Domain
     internal interface ICommunityRepository
     {
         Task<Name?> GetCommunityByInviteCode(Guid inviteCode, CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Persist the whole community: settings, the full member projection, invite codes and
+        ///     channels. Rows missing from the projection are deleted, so callers must hold a
+        ///     current aggregate — use <see cref="AddMembership" />/<see cref="RemoveMembership" />
+        ///     for a plain join or leave, which touch one row and cannot clobber a concurrent one.
+        /// </summary>
         Task SaveCommunity(Community community, CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Add one plain membership row, leaving every other member untouched. A no-op when the
+        ///     user already holds a row of any kind (including a retained ban), so joining twice —
+        ///     or concurrently — is safe. False means no row was written.
+        /// </summary>
+        Task<bool> AddMembership(Name communityName, Guid userId, CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Delete one user's membership row. Retained bans and the creator seat stay, matching
+        ///     what saving the aggregate does with them.
+        /// </summary>
+        Task RemoveMembership(Name communityName, Guid userId, CancellationToken cancellationToken);
 
         /// <summary>Delete a community and all of its member/invite/channel/highlight rows.</summary>
         Task DeleteCommunity(Name communityName, CancellationToken cancellationToken);

--- a/ScoreTracker/ScoreTracker.Communities/Infrastructure/EFCommunitiesRepository.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Infrastructure/EFCommunitiesRepository.cs
@@ -156,6 +156,74 @@ namespace ScoreTracker.Communities.Infrastructure
             await database.SaveChangesAsync(cancellationToken);
         }
 
+        public async Task<bool> AddMembership(Name communityName, Guid userId, CancellationToken cancellationToken)
+        {
+            await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+            var communityId = await FindCommunityId(database, communityName, cancellationToken);
+            if (communityId == null) return false;
+
+            if (await HoldsARow(database, communityId.Value, userId, cancellationToken)) return false;
+
+            await database.Set<CommunityMembershipEntity>().AddAsync(new CommunityMembershipEntity
+            {
+                Id = Guid.NewGuid(),
+                CommunityId = communityId.Value,
+                UserId = userId,
+                Role = nameof(CommunityRole.Member),
+                Permissions = (int)CommunityPermission.None,
+                GrantedByUserId = null,
+                JoinedAt = _dateTime.Now
+            }, cancellationToken);
+
+            try
+            {
+                await database.SaveChangesAsync(cancellationToken);
+                return true;
+            }
+            catch (DbUpdateException)
+            {
+                // The unique index turns a lost concurrent insert into a failure here. If the row
+                // that beat us is the one we wanted, the join already happened; anything else is a
+                // real fault and still surfaces.
+                database.ChangeTracker.Clear();
+                if (await HoldsARow(database, communityId.Value, userId, cancellationToken)) return false;
+                throw;
+            }
+        }
+
+        public async Task RemoveMembership(Name communityName, Guid userId, CancellationToken cancellationToken)
+        {
+            await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+            var communityId = await FindCommunityId(database, communityName, cancellationToken);
+            if (communityId == null) return;
+
+            var banned = nameof(CommunityRole.Banned);
+            var creator = nameof(CommunityRole.Creator);
+            var rows = await database.Set<CommunityMembershipEntity>()
+                .Where(m => m.CommunityId == communityId.Value && m.UserId == userId
+                                                              && m.Role != banned && m.Role != creator)
+                .ToArrayAsync(cancellationToken);
+            if (rows.Length == 0) return;
+
+            database.Set<CommunityMembershipEntity>().RemoveRange(rows);
+            await database.SaveChangesAsync(cancellationToken);
+        }
+
+        private static async Task<Guid?> FindCommunityId(ChartAttemptDbContext database, Name communityName,
+            CancellationToken cancellationToken)
+        {
+            var name = communityName.ToString();
+            return await database.Set<CommunityEntity>().Where(c => c.Name == name)
+                .Select(c => (Guid?)c.Id).FirstOrDefaultAsync(cancellationToken);
+        }
+
+        private static async Task<bool> HoldsARow(ChartAttemptDbContext database, Guid communityId, Guid userId,
+            CancellationToken cancellationToken)
+        {
+            return await database.Set<CommunityMembershipEntity>().AsNoTracking()
+                .AnyAsync(m => m.CommunityId == communityId && m.UserId == userId, cancellationToken);
+        }
+
         public async Task<IReadOnlyList<ChannelCommunityInfo>> GetChannelCommunities(ulong channelId,
             CancellationToken cancellationToken)
         {

--- a/ScoreTracker/ScoreTracker.Communities/Infrastructure/Entities/CommunityMembershipEntity.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Infrastructure/Entities/CommunityMembershipEntity.cs
@@ -3,7 +3,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ScoreTracker.Communities.Infrastructure.Entities
 {
-    [Index(nameof(CommunityId), nameof(UserId))]
+    // A user holds at most one row per community — member, admin, creator or ban are all the
+    // same seat. Unique so a concurrent join cannot double-insert.
+    [Index(nameof(CommunityId), nameof(UserId), IsUnique = true)]
     [Index(nameof(CommunityId), nameof(Role))]
     internal sealed class CommunityMembershipEntity
     {

--- a/ScoreTracker/ScoreTracker.Data/Migrations/20260724213934_UniqueCommunityMembership.Designer.cs
+++ b/ScoreTracker/ScoreTracker.Data/Migrations/20260724213934_UniqueCommunityMembership.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScoreTracker.Data.Persistence;
 
@@ -11,9 +12,11 @@ using ScoreTracker.Data.Persistence;
 namespace ScoreTracker.Data.Migrations
 {
     [DbContext(typeof(ChartAttemptDbContext))]
-    partial class ChartAttemptDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724213934_UniqueCommunityMembership")]
+    partial class UniqueCommunityMembership
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ScoreTracker/ScoreTracker.Data/Migrations/20260724213934_UniqueCommunityMembership.cs
+++ b/ScoreTracker/ScoreTracker.Data/Migrations/20260724213934_UniqueCommunityMembership.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScoreTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class UniqueCommunityMembership : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CommunityMembership_CommunityId_UserId",
+                schema: "scores",
+                table: "CommunityMembership");
+
+            // The index cannot be created while a duplicate seat exists, and a migration that
+            // throws blocks the whole deploy. Collapse any duplicate to the row carrying the most
+            // standing: a ban has to survive because it is what blocks rejoin, then the creator
+            // seat, then an admin's permissions, then a plain member.
+            migrationBuilder.Sql(@"
+                WITH ranked AS (
+                    SELECT Id, ROW_NUMBER() OVER (
+                        PARTITION BY CommunityId, UserId
+                        ORDER BY CASE Role WHEN 'Banned'  THEN 0
+                                           WHEN 'Creator' THEN 1
+                                           WHEN 'Admin'   THEN 2
+                                           ELSE 3 END, JoinedAt, Id) AS Seat
+                    FROM scores.CommunityMembership)
+                DELETE FROM scores.CommunityMembership
+                WHERE Id IN (SELECT Id FROM ranked WHERE Seat > 1);");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommunityMembership_CommunityId_UserId",
+                schema: "scores",
+                table: "CommunityMembership",
+                columns: new[] { "CommunityId", "UserId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CommunityMembership_CommunityId_UserId",
+                schema: "scores",
+                table: "CommunityMembership");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommunityMembership_CommunityId_UserId",
+                schema: "scores",
+                table: "CommunityMembership",
+                columns: new[] { "CommunityId", "UserId" });
+        }
+    }
+}

--- a/ScoreTracker/ScoreTracker.Identity/Application/AccountMergeSaga.cs
+++ b/ScoreTracker/ScoreTracker.Identity/Application/AccountMergeSaga.cs
@@ -68,8 +68,11 @@ internal sealed class AccountMergeSaga :
 
         var now = _dateTime.Now;
         var snapshot = new RetiredUserSnapshot(retired.IsPublic, retired.GameTag?.ToString());
-        await _users.SaveUser(retired with { IsPublic = false, GameTag = null, ClaimsInvalidatedAt = now },
-            cancellationToken);
+        var hidden = retired with { IsPublic = false, GameTag = null, ClaimsInvalidatedAt = now };
+        await _users.SaveUser(hidden, cancellationToken);
+        // Retiring an account makes it private, which is a profile change like any other:
+        // without this the account keeps its World membership and stays on public boards.
+        await _bus.Publish(UserUpdatedEvent.From(hidden), cancellationToken);
 
         var merge = new MergeRequest(Guid.NewGuid(), survivor.Id, retired.Id, movedLogins, snapshot,
             MergeState.Active, now, now + GraceWindow, null);
@@ -100,9 +103,11 @@ internal sealed class AccountMergeSaga :
 
         var retired = await _users.GetUser(merge.RetiredUserId, cancellationToken)
                       ?? throw new UserNotFoundException(merge.RetiredUserId);
-        await _users.SaveUser(
-            retired with { IsPublic = merge.Snapshot.IsPublic, GameTag = merge.Snapshot.GameTag },
-            cancellationToken);
+        var restored = retired with { IsPublic = merge.Snapshot.IsPublic, GameTag = merge.Snapshot.GameTag };
+        await _users.SaveUser(restored, cancellationToken);
+        // Restoring the snapshot can make the account public again, which has to put it back
+        // into the communities the retire took it out of.
+        await _bus.Publish(UserUpdatedEvent.From(restored), cancellationToken);
 
         await _merges.Save(merge with { State = MergeState.Undone }, cancellationToken);
     }

--- a/ScoreTracker/ScoreTracker.Identity/Application/SetUserContentLockHandler.cs
+++ b/ScoreTracker/ScoreTracker.Identity/Application/SetUserContentLockHandler.cs
@@ -44,6 +44,6 @@ internal sealed class SetUserContentLockHandler : IRequestHandler<SetUserContent
             existing.Country, request.IsLocked, _clock.Now);
 
         await _users.SaveUser(locked, cancellationToken);
-        await _bus.Publish(new UserUpdatedEvent(existing.Id, existing.Country, existing.IsPublic), cancellationToken);
+        await _bus.Publish(UserUpdatedEvent.From(locked), cancellationToken);
     }
 }

--- a/ScoreTracker/ScoreTracker.Identity/Application/UpdateUserHandler.cs
+++ b/ScoreTracker/ScoreTracker.Identity/Application/UpdateUserHandler.cs
@@ -40,6 +40,6 @@ internal sealed class UpdateUserHandler : IRequestHandler<UpdateUserCommand>
             existing?.IsContentLocked ?? false,
             existing?.ClaimsInvalidatedAt ?? default);
         await _users.SaveUser(newUser, cancellationToken);
-        await _bus.Publish(new UserUpdatedEvent(user.Id, user.Country, user.IsPublic), cancellationToken);
+        await _bus.Publish(UserUpdatedEvent.From(newUser), cancellationToken);
     }
 }

--- a/ScoreTracker/ScoreTracker.Identity/Contracts/Events/UserUpdatedEvent.cs
+++ b/ScoreTracker/ScoreTracker.Identity/Contracts/Events/UserUpdatedEvent.cs
@@ -1,7 +1,20 @@
-﻿namespace ScoreTracker.Identity.Contracts.Events
+using ScoreTracker.Domain.Models;
+
+namespace ScoreTracker.Identity.Contracts.Events
 {
     [ExcludeFromCodeCoverage]
     public sealed record UserUpdatedEvent(Guid UserId, string? Country, bool IsPublic)
     {
+        /// <summary>
+        ///     Builds the event from the user record that was just persisted. Publishers use this
+        ///     instead of the constructor so the flags can only come from a saved <see cref="User" />:
+        ///     the signed-in user carried by ICurrentUserAccessor is a claims snapshot that refreshes
+        ///     only after the update completes, so reading the flags off it announces the state from
+        ///     before the save — which subscribers act on as if it were the new state.
+        /// </summary>
+        public static UserUpdatedEvent From(User user)
+        {
+            return new UserUpdatedEvent(user.Id, user.Country, user.IsPublic);
+        }
     }
 }

--- a/ScoreTracker/ScoreTracker.Tests.Integration/EFCommunitiesRepositoryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/EFCommunitiesRepositoryTests.cs
@@ -193,4 +193,68 @@ public sealed class EFCommunitiesRepositoryTests : IAsyncLifetime
         Assert.Contains(publicCommunities, c => (string)c.CommunityName == "PublicWithCodeOne");
         Assert.DoesNotContain(publicCommunities, c => (string)c.CommunityName == "PrivateOne");
     }
+
+    // SaveCommunity writes the member projection the caller is holding, so two joins that load
+    // the community at the same time each save a set missing the other's row. World is the
+    // busiest community on the site and the most exposed to it.
+    [Fact]
+    public async Task ConcurrentJoinsAllSurvive()
+    {
+        var owner = Guid.NewGuid();
+        await BuildRepository().SaveCommunity(new Community("World", owner, CommunityPrivacyType.Public,
+            new[] { owner }, Array.Empty<Community.ChannelConfiguration>(),
+            new Dictionary<Guid, DateOnly?>(), false), CancellationToken.None);
+
+        var joiners = Enumerable.Range(0, 12).Select(_ => Guid.NewGuid()).ToArray();
+        await Task.WhenAll(joiners.Select(id =>
+            BuildRepository().AddMembership("World", id, CancellationToken.None)));
+
+        var world = await BuildRepository().GetCommunityByName("World", CancellationToken.None);
+        Assert.NotNull(world);
+        foreach (var joiner in joiners) Assert.Contains(joiner, world!.MemberIds);
+        Assert.Contains(owner, world!.MemberIds);
+    }
+
+    [Fact]
+    public async Task AddMembershipIsANoOpForAnExistingMemberOrABannedUser()
+    {
+        var owner = Guid.NewGuid();
+        var member = Guid.NewGuid();
+        var banned = Guid.NewGuid();
+        var community = new Community("Guarded", owner, CommunityPrivacyType.Public,
+            new[] { owner, member, banned }, Array.Empty<Community.ChannelConfiguration>(),
+            new Dictionary<Guid, DateOnly?>(), false);
+        community.Ban(owner, banned);
+        await BuildRepository().SaveCommunity(community, CancellationToken.None);
+
+        Assert.False(await BuildRepository().AddMembership("Guarded", member, CancellationToken.None));
+        Assert.False(await BuildRepository().AddMembership("Guarded", banned, CancellationToken.None));
+
+        var retrieved = await BuildRepository().GetCommunityByName("Guarded", CancellationToken.None);
+        Assert.True(retrieved!.IsBanned(banned));
+        Assert.DoesNotContain(banned, retrieved.MemberIds);
+        Assert.Equal(CommunityRole.Member, retrieved.RoleOf(member));
+    }
+
+    [Fact]
+    public async Task RemoveMembershipDropsTheMemberButKeepsBansAndTheCreatorSeat()
+    {
+        var owner = Guid.NewGuid();
+        var member = Guid.NewGuid();
+        var banned = Guid.NewGuid();
+        var community = new Community("Leavers", owner, CommunityPrivacyType.Public,
+            new[] { owner, member, banned }, Array.Empty<Community.ChannelConfiguration>(),
+            new Dictionary<Guid, DateOnly?>(), false);
+        community.Ban(owner, banned);
+        await BuildRepository().SaveCommunity(community, CancellationToken.None);
+
+        await BuildRepository().RemoveMembership("Leavers", member, CancellationToken.None);
+        await BuildRepository().RemoveMembership("Leavers", banned, CancellationToken.None);
+        await BuildRepository().RemoveMembership("Leavers", owner, CancellationToken.None);
+
+        var retrieved = await BuildRepository().GetCommunityByName("Leavers", CancellationToken.None);
+        Assert.DoesNotContain(member, retrieved!.MemberIds);
+        Assert.True(retrieved.IsBanned(banned));
+        Assert.Equal(CommunityRole.Creator, retrieved.RoleOf(owner));
+    }
 }

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/AccountMergeSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/AccountMergeSagaTests.cs
@@ -73,6 +73,32 @@ public sealed class AccountMergeSagaTests
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    // Hiding the retired account is a visibility change, and the subscribers that act on
+    // visibility only hear about it through UserUpdatedEvent — AccountsMergedEvent means
+    // something else. Without it the retired account keeps its World membership.
+    [Fact]
+    public async Task MergeAnnouncesTheRetiredAccountIsNoLongerPublic()
+    {
+        await _saga.Handle(new ExecuteAccountMergeCommand(_survivor.Id, _retired.Id), CancellationToken.None);
+
+        _bus.Verify(b => b.Publish(It.Is<UserUpdatedEvent>(e => e.UserId == _retired.Id && !e.IsPublic),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UndoAnnouncesTheRestoredVisibility()
+    {
+        var merge = ExistingMerge();
+        _merges.Setup(m => m.Get(merge.Id, It.IsAny<CancellationToken>())).ReturnsAsync(merge);
+        _users.Setup(u => u.GetUser(_retired.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_retired with { IsPublic = false, GameTag = null });
+
+        await _saga.Handle(new UndoAccountMergeCommand(merge.Id), CancellationToken.None);
+
+        _bus.Verify(b => b.Publish(It.Is<UserUpdatedEvent>(e => e.UserId == _retired.Id && e.IsPublic),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     [Fact]
     public async Task MergeRequiresTheCurrentUserToBeAParticipant()
     {

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -95,9 +95,12 @@ public sealed class CommunitySagaTests
 
         await ctx.Saga.Handle(new JoinCommunityCommand(Name.From("Acme"), null), CancellationToken.None);
 
-        ctx.Communities.Verify(c => c.SaveCommunity(
-            It.Is<Community>(comm => comm.MemberIds.Contains(userId)),
-            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Communities.Verify(c => c.AddMembership(Name.From("Acme"), userId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        // Writing the aggregate back would persist the member set as it looked when the handler
+        // loaded it, dropping anyone who joined while this join was in flight.
+        ctx.Communities.Verify(c => c.SaveCommunity(It.IsAny<Community>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -241,9 +244,10 @@ public sealed class CommunitySagaTests
 
         await ctx.Saga.Handle(new LeaveCommunityCommand(Name.From("Acme")), CancellationToken.None);
 
-        ctx.Communities.Verify(c => c.SaveCommunity(
-            It.Is<Community>(comm => !comm.MemberIds.Contains(userId)),
-            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.Communities.Verify(c => c.RemoveMembership(Name.From("Acme"), userId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        ctx.Communities.Verify(c => c.SaveCommunity(It.IsAny<Community>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdateUserHandlerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/UpdateUserHandlerTests.cs
@@ -51,6 +51,47 @@ public sealed class UpdateUserHandlerTests
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    // The signed-in user is a claims snapshot that only refreshes after this handler returns, so
+    // it still reports the pre-update flags. Subscribers treat the event as the new state:
+    // CommunitySaga reads IsPublic to decide whether to join or leave World, and reads Country to
+    // pick the regional community. Publishing the snapshot means turning your profile public
+    // announces IsPublic=false and removes you from World instead of adding you.
+    [Fact]
+    public async Task PublishesTheSavedFlagsRatherThanTheStaleClaimsSnapshot()
+    {
+        var signedIn = new UserBuilder().WithIsPublic(false).WithCountry("US").Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(signedIn.Id, It.IsAny<CancellationToken>())).ReturnsAsync(signedIn);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(signedIn);
+        var bus = new Mock<IBus>();
+
+        var handler = new UpdateUserHandler(users.Object, currentUser.Object, bus.Object);
+        await handler.Handle(new UpdateUserCommand(signedIn.Name, true, Name.From("CA")), CancellationToken.None);
+
+        bus.Verify(b => b.Publish(
+            It.Is<UserUpdatedEvent>(e => e.UserId == signedIn.Id && e.IsPublic && e.Country == "CA"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishesClearedCountryWhenTheProfileDropsIt()
+    {
+        var signedIn = new UserBuilder().WithIsPublic(true).WithCountry("US").Build();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetUser(signedIn.Id, It.IsAny<CancellationToken>())).ReturnsAsync(signedIn);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(c => c.User).Returns(signedIn);
+        var bus = new Mock<IBus>();
+
+        var handler = new UpdateUserHandler(users.Object, currentUser.Object, bus.Object);
+        await handler.Handle(new UpdateUserCommand(signedIn.Name, false, null), CancellationToken.None);
+
+        bus.Verify(b => b.Publish(
+            It.Is<UserUpdatedEvent>(e => !e.IsPublic && e.Country == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     [Fact]
     public async Task UsesDefaultProfileImageWhenExistingUserHasNone()
     {

--- a/docs/DATABASE-SCHEMA.md
+++ b/docs/DATABASE-SCHEMA.md
@@ -152,7 +152,7 @@ One SQL Server database, one EF Core `DbContext` ([`ChartAttemptDbContext`](../S
 | Table | Purpose |
 |---|---|
 | `scores.Community` | Communities with privacy type and regional flag; `DefaultAdminPermissions` (CommunityPermission flags applied to newly promoted admins) and `DefaultLanguage` (Discord-notification fallback culture) |
-| `scores.CommunityMembership` | Community membership + role overlay: `Role` (CommunityRole — Creator/Admin/Member/Banned; a Banned row is retained to block rejoin), `Permissions` (CommunityPermission flags, admins only), `GrantedByUserId`, `JoinedAt` |
+| `scores.CommunityMembership` | Community membership + role overlay: `Role` (CommunityRole — Creator/Admin/Member/Banned; a Banned row is retained to block rejoin), `Permissions` (CommunityPermission flags, admins only), `GrantedByUserId`, `JoinedAt`. One row per (community, user) — the index is unique, so a plain join/leave writes a single row rather than rewriting the roster |
 | `scores.CommunityInviteCode` | Invite codes, optionally expiring |
 | `scores.CommunityChannel` | Discord channels wired to a community's event feed. Every registered channel receives every community notification — the old per-type opt-in columns (`SendNewScores`/`SendTitles`/`SendNewMembers`) were never honored and were dropped. `Culture` (nullable, null = English) is the language the channel's cards render in |
 | `scores.CommunityHighlight` | Community big-wins feed: one summary row per (score-event × community the winner belongs to), `Payload` a JSON list of `SignificantWin`, `EventId` dedupes across shared communities. Written by the highlight saga off `ScoreHighlightsCapturedEvent`, purged weekly after 30 days ([home-page-widgets §7](design/home-page-widgets.md)) |


### PR DESCRIPTION
222 of 779 public users — 28% — were not in the World community. Investigating that turned up three separate mechanisms.

## What was wrong

**1. The profile update announced the state from before the save.** `UpdateUserHandler` built `UserUpdatedEvent` from `ICurrentUserAccessor.User`, which is a claims snapshot that only refreshes *after* the update completes (`ProfilePanel` calls the refresh endpoint once the command returns). `CommunitySaga` reads exactly those two fields, so:

- the save that turns your profile public announced `IsPublic=false` and sent `LeaveCommunityCommand("World")` instead of joining you
- the save that first set your country announced no country, so the regional join never happened; a country *change* announced the old country, rejoining the one you left

You only landed in World on a *subsequent* profile save. This has been there since `3ac96e4d` (2024-08-31), the commit that introduced the event.

The data matches the mechanism exactly: 125 of the 222 are in their country community but not World — country set on an earlier save, public flipped on a later one. 297 of 863 users with a country set aren't in it, and 133 sit in a community for a country they no longer claim.

**2. Account merge never told anyone.** `AccountMergeSaga` sets `IsPublic=false` on the retired account (and restores it on undo) but published only `AccountsMergedEvent`, which no visibility subscriber listens for. 3 of the 10 private-users-inside-World are merge-retired accounts.

**3. A join could delete another join.** `SaveCommunity` persists the whole member projection and deletes rows missing from it. Two joins that load the community concurrently each write back a roster without the other. World is the busiest community on the site and the most exposed. `IX_CommunityMembership_CommunityId_UserId` was not unique, so nothing caught it.

## The fix, one commit each

| Commit | What |
|---|---|
| `fix(identity): publish profile updates from the saved user…` | `UserUpdatedEvent.From(User)` becomes the construction path, so the flags can only come from a persisted record. `SetUserContentLockHandler` moves to it too. |
| `fix(identity): announce visibility changes made by an account merge` | Retire and undo both publish from the record they saved. |
| `feat(communities): write one membership row for a join or leave` | `AddMembership`/`RemoveMembership` touch a single row; `SaveCommunity` keeps role/permission/channel/invite changes. The index becomes unique; the migration collapses any pre-existing duplicate first (keeping the row with the most standing) so it can't block the deploy. |

Bans and the creator seat are preserved everywhere: a retained ban is still a row, so it keeps blocking rejoin, and removals skip `Banned`/`Creator`.

## Verification

Both regression tests fail against the old `UpdateUserHandler` and pass after. `ConcurrentJoinsAllSurvive` fails when `AddMembership` is reimplemented as read-modify-write — I checked, rather than assuming.

Suites: **1647** unit/component · **60** API · **293** bUnit · **140** integration · **45** E2E — all green. EF snapshot clean.

## Deploy notes

The existing 222 users are repaired by a three-statement SQL script (`reconcile-system-communities.sql`), verified against the prod-synced local DB inside a rolled-back transaction: **222 World adds, 10 World removes, 297 country adds**, all drift checks to 0.

**Run it after this deploys**, not before — until the handler fix is live, a public user's next profile save kicks them straight back out.

One open question, not addressed here: **should a private user stay in their country community?** Today they do — the saga joins on country regardless of `IsPublic` and never leaves. If you'd rather they were absent from regional boards, that's a saga change, not a backfill change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
