### PR TITLE
refactor(l10n): collapse 28 case-differing resx key pairs onto one spelling

### DIFF
--- a/ScoreTracker/ScoreTracker.Communities/Application/BotCommandSaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/BotCommandSaga.cs
@@ -429,7 +429,7 @@ namespace ScoreTracker.Communities.Application
             var typeName = _localizer.Get(culture, type switch
             {
                 ChartType.Double => "Doubles",
-                ChartType.CoOp => "Co-op",
+                ChartType.CoOp => "Co-Op",
                 _ => "Singles"
             });
             return type == ChartType.CoOp

--- a/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
@@ -367,7 +367,7 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         AddNotableRows(blocks, inputs, culture, ref remaining, shown);
         AddCompactBucket(blocks, inputs.MoreScores, inputs, _localizer.Get(culture, "More scores"),
             ref remaining, shown);
-        AddCompactBucket(blocks, inputs.CoOpScores, inputs, _localizer.Get(culture, "Co-op"),
+        AddCompactBucket(blocks, inputs.CoOpScores, inputs, _localizer.Get(culture, "Co-Op"),
             ref remaining, shown);
         AddOverflowLine(blocks, inputs, culture, shown);
 

--- a/ScoreTracker/ScoreTracker.Communities/Contracts/PiuCommandCatalog.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Contracts/PiuCommandCatalog.cs
@@ -110,7 +110,7 @@ namespace ScoreTracker.Communities.Contracts
         {
             new BotOptionChoice("Singles", "Single"),
             new BotOptionChoice("Doubles", "Double"),
-            new BotOptionChoice("Co-op", "CoOp")
+            new BotOptionChoice("Co-Op", "CoOp")
         };
 
         private static BotSubCommand Random =>
@@ -140,7 +140,7 @@ namespace ScoreTracker.Communities.Contracts
             new("chart", "Find a chart and its pages",
                 new[]
                 {
-                    new BotCommandOption("song", "Song name", BotCommandOptionType.String, Required: true,
+                    new BotCommandOption("song", "Song Name", BotCommandOptionType.String, Required: true,
                         Autocomplete: true),
                     OptionalMix
                 });
@@ -161,7 +161,7 @@ namespace ScoreTracker.Communities.Contracts
                     new BotSubCommand("community", "Community score and title notifications",
                         new[]
                         {
-                            new BotCommandOption("name", "Community name", BotCommandOptionType.String,
+                            new BotCommandOption("name", "Community Name", BotCommandOptionType.String,
                                 Autocomplete: true),
                             new BotCommandOption("invite-code", "Invite code (private communities only)"),
                             Language

--- a/ScoreTracker/ScoreTracker.OfficialMirror/Application/OfficialDigestFeedSaga.cs
+++ b/ScoreTracker/ScoreTracker.OfficialMirror/Application/OfficialDigestFeedSaga.cs
@@ -156,9 +156,9 @@ namespace ScoreTracker.OfficialMirror.Application
                 mix.GetAccentColor(),
                 new[]
                 {
-                    new RichBotLink(_localizer.Get(culture, "This week"),
+                    new RichBotLink(_localizer.Get(culture, "This Week"),
                         new Uri($"{SiteBase}/OfficialLeaderboards")),
-                    new RichBotLink(_localizer.Get(culture, "What it takes"),
+                    new RichBotLink(_localizer.Get(culture, "What It Takes"),
                         new Uri($"{SiteBase}/OfficialLeaderboards/WhatItTakes"))
                 });
         }

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -896,7 +896,7 @@ public sealed class CommunitySagaTests
         // labelled bucket, the remainder compressing with a CO-OP count; header still marks CO-OP.
         ctx.Bot.Verify(b => b.SendRichMessages(
             It.Is<IEnumerable<RichBotMessage>>(msgs => !msgs.Single().Blocks.OfType<RichBotSection>().Any()
-                && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("-# Co-op")
+                && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("-# Co-Op")
                     && t.Markdown.Split('\n').Count(l => l.Contains("#DIFFICULTY|")) == 5)
                 && msgs.Single().Blocks.OfType<RichBotText>().Any(t => t.Markdown.Contains("+2 more: CO-OP ×2"))
                 && msgs.Single().Header!.Markdown.Contains("CO-OP")),

--- a/ScoreTracker/ScoreTracker/Components/Challenges/WeeklyBoardGrid.razor
+++ b/ScoreTracker/ScoreTracker/Components/Challenges/WeeklyBoardGrid.razor
@@ -22,7 +22,7 @@
     {
         @* Both states ship; :has() on the grid's class decides which shows (M13). *@
         <span class="challenge-filter-note">
-            <span class="when-filtered">@L["showing suggested"] <a data-challenge-showall="">@L["show all {0}", Summaries.Count]</a></span>
+            <span class="when-filtered">@L["showing suggested"] <a data-challenge-showall="">@L["Show all {0}", Summaries.Count]</a></span>
             <span class="when-all"><a data-challenge-showall="">@L["show suggested only"]</a></span>
         </span>
     }
@@ -80,7 +80,7 @@ else
                             <span class="who">
                                 @if (IsMine(row))
                                 {
-                                    @L["you"]
+                                    @L["You"]
                                 }
                                 else if (row.Player != null)
                                 {
@@ -121,7 +121,7 @@ else
     </div>
 }
 
-<p class="challenge-poollink"><a href="@PoolHref">@L["Charts not yet featured"]</a></p>
+<p class="challenge-poollink"><a href="@PoolHref">@L["Charts Not Yet Featured"]</a></p>
 
 @code {
     [Parameter] public IReadOnlyList<WeeklyBoardChartSummary> Summaries { get; set; } = Array.Empty<WeeklyBoardChartSummary>();

--- a/ScoreTracker/ScoreTracker/Components/ChartLeaderboardSection.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartLeaderboardSection.razor
@@ -51,8 +51,8 @@
             </table>
             <div class="chart-lb-foot">
                 <span class="chart-lb-legend">
-                    <i class="chart-lb-dot chart-lb-dot-community"></i>@L["your communities"]
-                    <i class="chart-lb-dot chart-lb-dot-me"></i>@L["you"]
+                    <i class="chart-lb-dot chart-lb-dot-community"></i>@L["Your Communities"]
+                    <i class="chart-lb-dot chart-lb-dot-me"></i>@L["You"]
                 </span>
                 @if (_visible < _scores.Count)
                 {

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CommunityHighlightsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CommunityHighlightsWidget.razor
@@ -224,7 +224,7 @@ else
 
     private string TitleSuffix(SignificantWin win) => win.Kind == WinKind.RareTitle && win.RarityShare != null
         ? $"· {L["only {0} hold it", Pct(win.RarityShare)]}"
-        : L["completed"];
+        : L["Completed"];
 
     private static string Pct(double? share) =>
         share == null ? "" : (share.Value * 100).ToString("0.#", CultureInfo.InvariantCulture) + "%";

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/ImportScoresWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/ImportScoresWidget.razor
@@ -62,7 +62,7 @@ else
                         <MudText Typo="Typo.caption" Class="mt-1">@L["Game tag"]: @_gameTag</MudText>
                     }
                     <MudButton Class="mt-3" FullWidth="true" Variant="Variant.Filled" Color="Color.Primary"
-                               Disabled="EditMode" OnClick="ImportFromStored">@L["Import scores"]</MudButton>
+                               Disabled="EditMode" OnClick="ImportFromStored">@L["Import Scores"]</MudButton>
                     @if (_error != null)
                     {
                         <MudText Typo="Typo.caption" Color="Color.Error" Align="MudBlazor.Align.Center" Class="mt-1">@_error</MudText>
@@ -86,7 +86,7 @@ else
                                       Margin="Margin.Dense" Variant="Variant.Outlined" Disabled="EditMode"/>
                     </div>
                     <MudButton Class="import-typed-go" Variant="Variant.Filled" Color="Color.Primary"
-                               title="@L["Import scores"].Value"
+                               title="@L["Import Scores"].Value"
                                Disabled="EditMode || string.IsNullOrWhiteSpace(_username) || string.IsNullOrWhiteSpace(_password)"
                                OnClick="ImportFromTyped">
                         <MudIcon Icon="@Icons.Material.Filled.CloudDownload"/>

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
@@ -34,7 +34,7 @@ else
 {
     <div class="dash-acct">
         <div class="dash-acct-stats">
-            <div class="dash-acct-eyebrow">@L["Pumbility"]</div>
+            <div class="dash-acct-eyebrow">@L["PUMBILITY"]</div>
             <div class="dash-acct-hero">
                 <span class="dash-acct-total">
                     <span class="dash-stat-num rarity-glow-1">@(((int)_stats.SkillRating).ToString("N0"))</span>

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsConfigPanel.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsConfigPanel.razor
@@ -58,7 +58,7 @@
                 @L["Chart level"]
             </MudSelectItem>
             <MudSelectItem T="RecommendationLevelBasis" Value="RecommendationLevelBasis.ScoringLevel">
-                @L["Scoring level"]
+                @L["Scoring Level"]
             </MudSelectItem>
         </MudSelect>
         <MudText Typo="Typo.caption" Class="dash-muted">

--- a/ScoreTracker/ScoreTracker/Components/SimilarChartsShelf.razor
+++ b/ScoreTracker/ScoreTracker/Components/SimilarChartsShelf.razor
@@ -517,7 +517,7 @@
     private static readonly Dimension[] Dimensions =
     {
         new(FilterDimension.Folder, "Folder", 1, 2),
-        new(FilterDimension.ScoringLevel, "Scoring level", 10, 20),
+        new(FilterDimension.ScoringLevel, "Scoring Level", 10, 20),
         new(FilterDimension.Bpm, "BPM", 1, 10),
         new(FilterDimension.Nps, "NPS", 10, 10)
     };

--- a/ScoreTracker/ScoreTracker/Pages/Admin/OfficialLeaderboardsAdmin.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Admin/OfficialLeaderboardsAdmin.razor
@@ -133,7 +133,7 @@ else
         <MudTd>@context.Stage</MudTd>
         <MudTd Style="text-align:right">
             @context.BoardsWritten@(context.BoardsExpected > 0 ? $"/{context.BoardsExpected}" : "")
-            @(context.BoardsSkipped > 0 ? $" (+{context.BoardsSkipped} {L["skipped"]})" : "")
+            @(context.BoardsSkipped > 0 ? $" (+{context.BoardsSkipped} {L["Skipped"]})" : "")
         </MudTd>
         <MudTd Style="text-align:right">
             @(context.CompletedAt != null

--- a/ScoreTracker/ScoreTracker/Pages/ChartDetails.razor
+++ b/ScoreTracker/ScoreTracker/Pages/ChartDetails.razor
@@ -101,7 +101,7 @@
                     </div>
                     <div>
                         <span class="chart-fact-value">@((int)Math.Round(Population.PassRate * 100))%</span>
-                        <span class="chart-fact-label">@L["Pass rate"]</span>
+                        <span class="chart-fact-label">@L["Pass Rate"]</span>
                     </div>
                 }
             </div>

--- a/ScoreTracker/ScoreTracker/Pages/Communities/Communities.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Communities/Communities.razor
@@ -267,7 +267,7 @@
             <div class="bot-dialog-ico"><MudIcon Icon="@Icons.Material.Filled.Calculate" Size="Size.Small"/></div>
             <div>
                 <span class="bot-dialog-cmd">/piu calc</span>
-                <div class="bot-dialog-desc">@L["calculate a Phoenix score from a result screen"]</div>
+                <div class="bot-dialog-desc">@L["Calculate a Phoenix score from a result screen"]</div>
             </div>
         </div>
         <div class="bot-dialog-row">

--- a/ScoreTracker/ScoreTracker/Pages/Communities/CommunityInvite.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Communities/CommunityInvite.razor
@@ -46,7 +46,7 @@
             else if (!CurrentUser.IsLoggedIn)
             {
                 <MudText Typo="Typo.body1" Class="mb-3">@L["Sign in to accept this invite."]</MudText>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="/Login">@L["Sign In"]</MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="/Login">@L["Sign in"]</MudButton>
             }
             else
             {

--- a/ScoreTracker/ScoreTracker/Pages/Competition/WeeklyCharts.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Competition/WeeklyCharts.razor
@@ -53,7 +53,7 @@ else
         }
         <div class="challenge-controls">
             <details class="challenge-picker">
-                <summary>@L["Week"]: @(_weekStart == null ? L["current"] : WeekLabel(_weekStart.Value))</summary>
+                <summary>@L["Week"]: @(_weekStart == null ? L["Current"] : WeekLabel(_weekStart.Value))</summary>
                 <div class="challenge-picker-menu">
                     <a href="/WeeklyCharts" class="@(_weekStart == null ? "on" : "")">@L["Current"]</a>
                     @foreach (var date in _pastDates)

--- a/ScoreTracker/ScoreTracker/Pages/FrontDoor.cshtml
+++ b/ScoreTracker/ScoreTracker/Pages/FrontDoor.cshtml
@@ -325,7 +325,7 @@
             {
                 <span class="mix-chip" style="@MixChipStyle(mix)">@mix.GetName()</span>
             }
-            <span class="mix-era">— @L["today"]</span>
+            <span class="mix-era">— @L["Today"]</span>
         </div>
     </div>
     <div class="steward-grid">

--- a/ScoreTracker/ScoreTracker/Pages/OfficialLeaderboards/HubPlayers.razor
+++ b/ScoreTracker/ScoreTracker/Pages/OfficialLeaderboards/HubPlayers.razor
@@ -50,7 +50,7 @@ else
                     @if (_profile.PumbilityRank != null)
                     {
                         <MudText Typo="Typo.caption">
-                            @L["rank"] #@_profile.PumbilityRank
+                            @L["Rank"] #@_profile.PumbilityRank
                             @if (_profile.PumbilityRankDelta is > 0)
                             {
                                 <span class="olb-delta-up"> ▲@_profile.PumbilityRankDelta</span>
@@ -65,7 +65,7 @@ else
             </MudItem>
             <MudItem xs="6" sm="3">
                 <MudPaper Class="pa-2" Outlined="true">
-                    <MudText Typo="Typo.overline">@L["Chart Boards"]</MudText>
+                    <MudText Typo="Typo.overline">@L["chart boards"]</MudText>
                     <MudText Typo="Typo.h5"><b>@_profile.BoardsInTop</b></MudText>
                 </MudPaper>
             </MudItem>

--- a/ScoreTracker/ScoreTracker/Pages/OfficialLeaderboards/OfficialChartBoardDialog.razor
+++ b/ScoreTracker/ScoreTracker/Pages/OfficialLeaderboards/OfficialChartBoardDialog.razor
@@ -53,8 +53,8 @@
             </div>
             <MudStack Row="true" AlignItems="AlignItems.Center" Class="mt-2 flex-wrap" Spacing="2">
                 <span class="chart-lb-legend">
-                    <i class="chart-lb-dot chart-lb-dot-community"></i>@L["your communities"]
-                    <i class="chart-lb-dot chart-lb-dot-me"></i>@L["you"]
+                    <i class="chart-lb-dot chart-lb-dot-community"></i>@L["Your Communities"]
+                    <i class="chart-lb-dot chart-lb-dot-me"></i>@L["You"]
                 </span>
                 <MudSpacer/>
                 @if (_visible < _board.Entries.Count)

--- a/ScoreTracker/ScoreTracker/Pages/Progress/PhoenixRecap.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/PhoenixRecap.razor
@@ -254,7 +254,7 @@ else if (_user != null && _recap != null)
         {
             <section class="precap-slide" style="--gx:20%;--gy:100%">
                 <div class="precap-inner">
-                    <div class="precap-eyebrow">@L["Weekly charts"]</div>
+                    <div class="precap-eyebrow">@L["Weekly Charts"]</div>
                     <h2 class="precap-h2"><span class="precap-hl" data-count="@weekly.LongestStreak">@weekly.LongestStreak</span> @L["weeks. No misses."]</h2>
                     <div class="precap-weekstats">
                         <div class="precap-weekstat"><div class="precap-num">@weekly.WeeksEntered</div><div class="precap-cap">@L["weeks entered"]</div></div>

--- a/ScoreTracker/ScoreTracker/Pages/TierLists/PersonalizedBreakdown.razor
+++ b/ScoreTracker/ScoreTracker/Pages/TierLists/PersonalizedBreakdown.razor
@@ -278,7 +278,7 @@ else
                                        flows inline instead of floating right. *@
                                     <div class="bd-source-strip">
                                         @SourceSegment(L["Community"], _breakdown.CommunityWeight, mover.CommunityCategory)
-                                        @SourceSegment(L["Players like you"], _breakdown.SimilarPlayersWeight, mover.SimilarPlayersCategory)
+                                        @SourceSegment(L["Players Like You"], _breakdown.SimilarPlayersWeight, mover.SimilarPlayersCategory)
                                         @SourceSegment(L["Your skills"], _breakdown.SkillWeight, mover.SkillCategory)
                                         <span class="bd-src-final">= <span style="color:@ThemeScales.DifficultyColor(mover.PersonalizedCategory)">@L[TierNameFor(mover.PersonalizedCategory)]</span></span>
                                     </div>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -426,9 +426,6 @@
   <data name="Tier Lists" xml:space="preserve">
     <value>Tier Lists</value>
   </data>
-  <data name="Title Progress" xml:space="preserve">
-    <value>Title Progress</value>
-  </data>
   <data name="Titles" xml:space="preserve">
     <value>Titles</value>
   </data>
@@ -1890,15 +1887,6 @@
   <data name="Score Distribution By Player Level" xml:space="preserve">
 	  <value>Score Distribution By Player Level</value>
   </data>
-  <data name="Scores by Competitive Level" xml:space="preserve">
-	  <value>Scores by Competitive Level</value>
-  </data>
-  <data name="Passes by Competitive Level" xml:space="preserve">
-	  <value>Passes by Competitive Level</value>
-  </data>
-  <data name="Chart Leaderboard" xml:space="preserve">
-	  <value>Chart Leaderboard</value>
-  </data>
   <data name="Content Lock" xml:space="preserve">
 	  <value>Content Lock</value>
   </data>
@@ -2420,9 +2408,6 @@
   </data>
   <data name="Scores, vs your level" xml:space="preserve">
     <value>Scores, vs your level</value>
-  </data>
-  <data name="Weekly charts" xml:space="preserve">
-    <value>Weekly charts</value>
   </data>
   <data name="weeks. No misses." xml:space="preserve">
     <value>weeks. No misses.</value>
@@ -3023,9 +3008,6 @@
   <data name="Players Like You" xml:space="preserve">
     <value>Players Like You</value>
   </data>
-  <data name="Players like you" xml:space="preserve">
-    <value>Players like you</value>
-  </data>
   <data name="Players within one competitive level of you — closer players count more, and so do those whose folder ratings agree with yours." xml:space="preserve">
     <value>Players within one competitive level of you — closer players count more, and so do those whose folder ratings agree with yours.</value>
   </data>
@@ -3422,9 +3404,6 @@
   <data name="When a new mix arrives, nothing here resets. Every score you've recorded stays — to look back on, compare against, and build from. {0} mixes on record, side by side, 1999 to today." xml:space="preserve">
     <value>When a new mix arrives, nothing here resets. Every score you've recorded stays — to look back on, compare against, and build from. {0} mixes on record, side by side, 1999 to today.</value>
   </data>
-  <data name="today" xml:space="preserve">
-    <value>today</value>
-  </data>
   <data name="Private by default" xml:space="preserve">
     <value>Private by default</value>
   </data>
@@ -3566,9 +3545,6 @@
   <data name="{0} days old" xml:space="preserve">
     <value>{0} days old</value>
   </data>
-  <data name="Scoring level" xml:space="preserve">
-    <value>Scoring level</value>
-  </data>
   <data name="± levels" xml:space="preserve">
     <value>± levels</value>
   </data>
@@ -3631,9 +3607,6 @@
   </data>
   <data name="only {0} hold it" xml:space="preserve">
     <value>only {0} hold it</value>
-  </data>
-  <data name="completed" xml:space="preserve">
-    <value>completed</value>
   </data>
   <data name="now" xml:space="preserve">
     <value>now</value>
@@ -3730,9 +3703,6 @@
   </data>
   <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
     <value>Your Pumbility and competitive level, plus your closest matches.</value>
-  </data>
-  <data name="Pumbility" xml:space="preserve">
-    <value>Pumbility</value>
   </data>
   <data name="Match players on" xml:space="preserve">
     <value>Match players on</value>
@@ -4073,9 +4043,6 @@
   <data name="This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import." xml:space="preserve">
     <value>This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import.</value>
   </data>
-  <data name="Import scores" xml:space="preserve">
-    <value>Import scores</value>
-  </data>
   <data name="Creating Your Home Page" xml:space="preserve">
     <value>Creating Your Home Page</value>
   </data>
@@ -4208,12 +4175,6 @@
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>No scores recorded yet — be the first.</value>
   </data>
-  <data name="your communities" xml:space="preserve">
-    <value>your communities</value>
-  </data>
-  <data name="you" xml:space="preserve">
-    <value>you</value>
-  </data>
   <data name="Show more of {0} scores" xml:space="preserve">
     <value>Show more of {0} scores</value>
   </data>
@@ -4228,9 +4189,6 @@
   </data>
   <data name="Debuted in" xml:space="preserve">
     <value>Debuted in</value>
-  </data>
-  <data name="Pass rate" xml:space="preserve">
-    <value>Pass rate</value>
   </data>
   <data name="The evidence" xml:space="preserve">
     <value>The evidence</value>
@@ -4463,9 +4421,6 @@
   <data name="Chart Board #1s" xml:space="preserve">
     <value>Chart Board #1s</value>
   </data>
-  <data name="Chart Boards" xml:space="preserve">
-    <value>Chart Boards</value>
-  </data>
   <data name="Chart board placements" xml:space="preserve">
     <value>Chart board placements</value>
   </data>
@@ -4568,9 +4523,6 @@
   <data name="PUMBILITY over time" xml:space="preserve">
     <value>PUMBILITY over time</value>
   </data>
-  <data name="rank" xml:space="preserve">
-    <value>rank</value>
-  </data>
   <data name="Rank" xml:space="preserve">
     <value>Rank</value>
   </data>
@@ -4597,9 +4549,6 @@
   </data>
   <data name="Seed baseline from legacy tables" xml:space="preserve">
     <value>Seed baseline from legacy tables</value>
-  </data>
-  <data name="skipped" xml:space="preserve">
-    <value>skipped</value>
   </data>
   <data name="Songs" xml:space="preserve">
     <value>Songs</value>
@@ -4850,9 +4799,6 @@
   <data name="{0} · levels {1}–{2} · {3}" xml:space="preserve">
     <value>{0} · levels {1}–{2} · {3}</value>
   </data>
-  <data name="Co-op" xml:space="preserve">
-    <value>Co-op</value>
-  </data>
   <data name="You don't have a saved preset called &quot;{0}&quot;." xml:space="preserve">
     <value>You don't have a saved preset called &quot;{0}&quot;.</value>
   </data>
@@ -4955,9 +4901,6 @@
   <data name="Show what this channel is registered for" xml:space="preserve">
     <value>Show what this channel is registered for</value>
   </data>
-  <data name="Song name" xml:space="preserve">
-    <value>Song name</value>
-  </data>
   <data name="Which mix (defaults to Phoenix 2)" xml:space="preserve">
     <value>Which mix (defaults to Phoenix 2)</value>
   </data>
@@ -4984,9 +4927,6 @@
   </data>
   <data name="What to work on (default Title Hunt)" xml:space="preserve">
     <value>What to work on (default Title Hunt)</value>
-  </data>
-  <data name="Community name" xml:space="preserve">
-    <value>Community name</value>
   </data>
   <data name="Invite code (private communities only)" xml:space="preserve">
     <value>Invite code (private communities only)</value>
@@ -5110,12 +5050,6 @@
   </data>
   <data name="PIU Scores official mirror" xml:space="preserve">
     <value>PIU Scores official mirror</value>
-  </data>
-  <data name="This week" xml:space="preserve">
-    <value>This week</value>
-  </data>
-  <data name="What it takes" xml:space="preserve">
-    <value>What it takes</value>
   </data>
   <data name="a chart" xml:space="preserve">
     <value>a chart</value>
@@ -5411,9 +5345,6 @@
   <data name="Highest Clear" xml:space="preserve">
     <value>Highest Clear</value>
   </data>
-  <data name="Highest Level" xml:space="preserve">
-    <value>Highest Level</value>
-  </data>
   <data name="I understand — join" xml:space="preserve">
     <value>I understand — join</value>
   </data>
@@ -5500,9 +5431,6 @@
   </data>
   <data name="Show Regional Guests" xml:space="preserve">
     <value>Show Regional Guests</value>
-  </data>
-  <data name="Sign In" xml:space="preserve">
-    <value>Sign In</value>
   </data>
   <data name="Sign in to accept this invite." xml:space="preserve">
     <value>Sign in to accept this invite.</value>
@@ -5603,9 +5531,6 @@
   <data name="Charts Not Yet Featured" xml:space="preserve">
     <value>Charts Not Yet Featured</value>
   </data>
-  <data name="Charts not yet featured" xml:space="preserve">
-    <value>Charts not yet featured</value>
-  </data>
   <data name="Co-op earns no PUMBILITY; the Co-Op view ranks raw score." xml:space="preserve">
     <value>Co-op earns no PUMBILITY; the Co-Op view ranks raw score.</value>
   </data>
@@ -5681,17 +5606,11 @@
   <data name="Your best 4 scores per week of the month count." xml:space="preserve">
     <value>Your best 4 scores per week of the month count.</value>
   </data>
-  <data name="current" xml:space="preserve">
-    <value>current</value>
-  </data>
   <data name="last 14 days" xml:space="preserve">
     <value>last 14 days</value>
   </data>
   <data name="resets in {0}" xml:space="preserve">
     <value>resets in {0}</value>
-  </data>
-  <data name="show all {0}" xml:space="preserve">
-    <value>show all {0}</value>
   </data>
   <data name="show suggested only" xml:space="preserve">
     <value>show suggested only</value>
@@ -5842,9 +5761,6 @@
   </data>
   <data name="Commands — anyone in the server can use these" xml:space="preserve">
     <value>Commands — anyone in the server can use these</value>
-  </data>
-  <data name="calculate a Phoenix score from a result screen" xml:space="preserve">
-    <value>calculate a Phoenix score from a result screen</value>
   </data>
   <data name="pull up a chart's stats and similar charts, with links to its pages" xml:space="preserve">
     <value>pull up a chart's stats and similar charts, with links to its pages</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -414,9 +414,6 @@
   <data name="Tier Lists" xml:space="preserve">
     <value>Brglurgbrgl Rglgurggurgrgl</value>
   </data>
-  <data name="Title Progress" xml:space="preserve">
-    <value>Mrrgl Blublurggrrr</value>
-  </data>
   <data name="Titles" xml:space="preserve">
     <value>Mrglargrlrgl</value>
   </data>
@@ -1886,15 +1883,6 @@
   <data name="Score Distribution By Player Level" xml:space="preserve">
 	  <value>Grglrgl Glubmrrglrgl Blgrl Murglargrl Rglmrgl</value>
   </data>
-  <data name="Scores by Competitive Level" xml:space="preserve">
-	  <value>Grglrglrgl blgrl Grrrmrrglmrg Rglmrgl</value>
-  </data>
-  <data name="Passes by Competitive Level" xml:space="preserve">
-	  <value>Brglurgrgl blgrl Grrrmrrglmrg Rglmrgl</value>
-  </data>
-  <data name="Chart Leaderboard" xml:space="preserve">
-	  <value>Mrglrgl Arglmrgl</value>
-  </data>
   <data name="Sign-In Methods" xml:space="preserve">
 	  <value>Mrgl-Mrgl Grrblubs</value>
   </data>
@@ -2335,9 +2323,6 @@
   </data>
   <data name="Scores, vs your level" xml:space="preserve">
     <value>Mrgl scores</value>
-  </data>
-  <data name="Weekly charts" xml:space="preserve">
-    <value>Mrgl weekly</value>
   </data>
   <data name="weeks. No misses." xml:space="preserve">
     <value>mrgl weeks. No mrgl.</value>
@@ -2937,9 +2922,6 @@
   <data name="Players Like You" xml:space="preserve">
     <value>Mrglplayers Like Mrglyou</value>
   </data>
-  <data name="Players like you" xml:space="preserve">
-    <value>Mrglplayers like mrglyou</value>
-  </data>
   <data name="Players within one competitive level of you — closer players count more, and so do those whose folder ratings agree with yours." xml:space="preserve">
     <value>Mrglplayers within one grrrmrrgl level of you — closer mrglplayers count more, mrgl mrgl!</value>
   </data>
@@ -3336,9 +3318,6 @@
   <data name="When a new mix arrives, nothing here resets. Every score you've recorded stays — to look back on, compare against, and build from. {0} mixes on record, side by side, 1999 to today." xml:space="preserve">
     <value>Whrgln mrgl nrglw mrglx mrglrrrglvs, nrglthng hrglre rrglsrglts. Mrglvrgl scrgle mrgl'vrgl rrglcrgldrgld strglys — mrgl lrglk brglck mrgln, cmrglprglre mrglgrglnst, mrgl brglld frglm. {0} mrglxrgls mrgln rrglcrgld, srglde brgl srglde, 1999 mrgl trgldrgly.</value>
   </data>
-  <data name="today" xml:space="preserve">
-    <value>trgldrgly</value>
-  </data>
   <data name="Private by default" xml:space="preserve">
     <value>Prglvrglte brgl drglfrgllt</value>
   </data>
@@ -3480,9 +3459,6 @@
   <data name="{0} days old" xml:space="preserve">
     <value>{0} mrgl days old</value>
   </data>
-  <data name="Scoring level" xml:space="preserve">
-    <value>Scoring mrgl level</value>
-  </data>
   <data name="± levels" xml:space="preserve">
     <value>± mrgl levels</value>
   </data>
@@ -3545,9 +3521,6 @@
   </data>
   <data name="only {0} hold it" xml:space="preserve">
     <value>only {0} hold it</value>
-  </data>
-  <data name="completed" xml:space="preserve">
-    <value>completed</value>
   </data>
   <data name="now" xml:space="preserve">
     <value>now</value>
@@ -3644,9 +3617,6 @@
   </data>
   <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
     <value>Yer Pumbility an' competitive level, plus yer closest mrglmates.</value>
-  </data>
-  <data name="Pumbility" xml:space="preserve">
-    <value>Pumbility</value>
   </data>
   <data name="Match players on" xml:space="preserve">
     <value>Mrgl players by</value>
@@ -3987,9 +3957,6 @@
   <data name="This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import." xml:space="preserve">
     <value>This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import.</value>
   </data>
-  <data name="Import scores" xml:space="preserve">
-    <value>Import scores</value>
-  </data>
   <data name="Creating Your Home Page" xml:space="preserve">
     <value>Crrgltng Mrgl Hrglme Prglge</value>
   </data>
@@ -4122,12 +4089,6 @@
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Mrgl first-rgl!</value>
   </data>
-  <data name="your communities" xml:space="preserve">
-    <value>mrgl tribergl</value>
-  </data>
-  <data name="you" xml:space="preserve">
-    <value>mrgl (you)</value>
-  </data>
   <data name="Show more of {0} scores" xml:space="preserve">
     <value>Mrgl more {0} scorlgl</value>
   </data>
@@ -4142,9 +4103,6 @@
   </data>
   <data name="Debuted in" xml:space="preserve">
     <value>Debutrgl</value>
-  </data>
-  <data name="Pass rate" xml:space="preserve">
-    <value>Passrglrate</value>
   </data>
   <data name="The evidence" xml:space="preserve">
     <value>Mrgl evidencergl</value>
@@ -4392,9 +4350,6 @@
   <data name="Chart Board #1s" xml:space="preserve">
     <value>Chart Mrgl #1s</value>
   </data>
-  <data name="Chart Boards" xml:space="preserve">
-    <value>Chart Mrglboards</value>
-  </data>
   <data name="Chart board placements" xml:space="preserve">
     <value>Chart mrglboard placemrgls</value>
   </data>
@@ -4497,9 +4452,6 @@
   <data name="PUMBILITY over time" xml:space="preserve">
     <value>PUMBILITY ovrgl time</value>
   </data>
-  <data name="rank" xml:space="preserve">
-    <value>mrglrank</value>
-  </data>
   <data name="Rank" xml:space="preserve">
     <value>Mrglrank</value>
   </data>
@@ -4526,9 +4478,6 @@
   </data>
   <data name="Seed baseline from legacy tables" xml:space="preserve">
     <value>Mrglseed baseline from old mrgltables</value>
-  </data>
-  <data name="skipped" xml:space="preserve">
-    <value>skiprgld</value>
   </data>
   <data name="Songs" xml:space="preserve">
     <value>Mrglsongs</value>
@@ -4782,9 +4731,6 @@
   <data name="{0} · levels {1}–{2} · {3}" xml:space="preserve">
     <value>{0} · lrglvrgls {1}–{2} · {3}</value>
   </data>
-  <data name="Co-op" xml:space="preserve">
-    <value>Crgl-rglp</value>
-  </data>
   <data name="You don't have a saved preset called &quot;{0}&quot;." xml:space="preserve">
     <value>Yrgl drglnt hrglve prrglsrglt &quot;{0}&quot;. Mrgl.</value>
   </data>
@@ -4887,9 +4833,6 @@
   <data name="Show what this channel is registered for" xml:space="preserve">
     <value>Shrglw chrglnnrgl rrglgrglstrrgltions</value>
   </data>
-  <data name="Song name" xml:space="preserve">
-    <value>Srglng nrglme</value>
-  </data>
   <data name="Which mix (defaults to Phoenix 2)" xml:space="preserve">
     <value>Whrglch mrglx (drglfrglt Phoenix 2)</value>
   </data>
@@ -4916,9 +4859,6 @@
   </data>
   <data name="What to work on (default Title Hunt)" xml:space="preserve">
     <value>Whrglt trgl wrglrk rgln (drglfrglt Trgltle Hrglnt)</value>
-  </data>
-  <data name="Community name" xml:space="preserve">
-    <value>Cmrglmrglnrglty nrglme</value>
   </data>
   <data name="Invite code (private communities only)" xml:space="preserve">
     <value>Mrglnvrglte crglde (prrglvate rglnly)</value>
@@ -5042,12 +4982,6 @@
   </data>
   <data name="PIU Scores official mirror" xml:space="preserve">
     <value>PIU Scores rglffrglcial mrglrror</value>
-  </data>
-  <data name="This week" xml:space="preserve">
-    <value>Thrgls wrglk</value>
-  </data>
-  <data name="What it takes" xml:space="preserve">
-    <value>Whrglt rglt trglkes</value>
   </data>
   <data name="a chart" xml:space="preserve">
     <value>rgl chrglrt</value>
@@ -5343,9 +5277,6 @@
   <data name="Highest Clear" xml:space="preserve">
     <value>MRGL grl!</value>
   </data>
-  <data name="Highest Level" xml:space="preserve">
-    <value>Mrgl grlgrl</value>
-  </data>
   <data name="I understand — join" xml:space="preserve">
     <value>Mrgl... mrgl. MRGL.</value>
   </data>
@@ -5432,9 +5363,6 @@
   </data>
   <data name="Show Regional Guests" xml:space="preserve">
     <value>Mrgl grlgrl mrgl</value>
-  </data>
-  <data name="Sign In" xml:space="preserve">
-    <value>MRGL-grl</value>
   </data>
   <data name="Sign in to accept this invite." xml:space="preserve">
     <value>MRGL-grl mrgl mrgl.</value>
@@ -5535,9 +5463,6 @@
   <data name="Charts Not Yet Featured" xml:space="preserve">
     <value>Charts Not Yet Featured</value>
   </data>
-  <data name="Charts not yet featured" xml:space="preserve">
-    <value>Charts not yet featured</value>
-  </data>
   <data name="Co-op earns no PUMBILITY; the Co-Op view ranks raw score." xml:space="preserve">
     <value>Co-op earns no PUMBILITY; the Co-Op view ranks raw score.</value>
   </data>
@@ -5613,17 +5538,11 @@
   <data name="Your best 4 scores per week of the month count." xml:space="preserve">
     <value>Your best 4 scores per week of the month count.</value>
   </data>
-  <data name="current" xml:space="preserve">
-    <value>current</value>
-  </data>
   <data name="last 14 days" xml:space="preserve">
     <value>last 14 days</value>
   </data>
   <data name="resets in {0}" xml:space="preserve">
     <value>resets in {0}</value>
-  </data>
-  <data name="show all {0}" xml:space="preserve">
-    <value>show all {0}</value>
   </data>
   <data name="show suggested only" xml:space="preserve">
     <value>show suggested only</value>
@@ -5774,9 +5693,6 @@
   </data>
   <data name="Commands — anyone in the server can use these" xml:space="preserve">
     <value>Mrgl — MRGL mrgl mrgl!</value>
-  </data>
-  <data name="calculate a Phoenix score from a result screen" xml:space="preserve">
-    <value>mrgl grl Mrgl-mrgl mrgl</value>
   </data>
   <data name="pull up a chart's stats and similar charts, with links to its pages" xml:space="preserve">
     <value>grl mrgl, MRGL grl! Mrgl mrglgl grl-grl!</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -405,9 +405,6 @@
   <data name="Tier Lists" xml:space="preserve">
     <value>Tier Lists</value>
   </data>
-  <data name="Title Progress" xml:space="preserve">
-    <value>Progreso de títulos</value>
-  </data>
   <data name="Titles" xml:space="preserve">
     <value>Títulos</value>
   </data>
@@ -1761,15 +1758,6 @@
   <data name="Score Distribution By Player Level" xml:space="preserve">
     <value>Distribución de scores por nivel de jugador</value>
   </data>
-  <data name="Scores by Competitive Level" xml:space="preserve">
-    <value>Scores por nivel competitivo</value>
-  </data>
-  <data name="Passes by Competitive Level" xml:space="preserve">
-    <value>Passes por nivel competitivo</value>
-  </data>
-  <data name="Chart Leaderboard" xml:space="preserve">
-    <value>Leaderboard del chart</value>
-  </data>
   <data name="Content Lock" xml:space="preserve">
     <value>Bloqueo de contenido</value>
   </data>
@@ -2291,9 +2279,6 @@
   </data>
   <data name="Scores, vs your level" xml:space="preserve">
     <value>Scores frente a tu nivel</value>
-  </data>
-  <data name="Weekly charts" xml:space="preserve">
-    <value>Charts semanales</value>
   </data>
   <data name="weeks. No misses." xml:space="preserve">
     <value>semanas. Ni un Miss.</value>
@@ -2892,9 +2877,6 @@
   <data name="Players Like You" xml:space="preserve">
     <value>Jugadores como tú</value>
   </data>
-  <data name="Players like you" xml:space="preserve">
-    <value>Jugadores como tú</value>
-  </data>
   <data name="Players within one competitive level of you — closer players count more, and so do those whose folder ratings agree with yours." xml:space="preserve">
     <value>Jugadores a un nivel competitivo del tuyo: los más cercanos cuentan más, igual que los que valoran los folders de forma parecida a ti.</value>
   </data>
@@ -3291,9 +3273,6 @@
   <data name="When a new mix arrives, nothing here resets. Every score you've recorded stays — to look back on, compare against, and build from. {0} mixes on record, side by side, 1999 to today." xml:space="preserve">
     <value>Cuando llega una versión nueva, aquí no se reinicia nada. Cada puntuación que registraste se queda — para mirar atrás, comparar y seguir construyendo. {0} versiones registradas, lado a lado, de 1999 a hoy.</value>
   </data>
-  <data name="today" xml:space="preserve">
-    <value>hoy</value>
-  </data>
   <data name="Private by default" xml:space="preserve">
     <value>Privado por defecto</value>
   </data>
@@ -3435,9 +3414,6 @@
   <data name="{0} days old" xml:space="preserve">
     <value>hace {0} días</value>
   </data>
-  <data name="Scoring level" xml:space="preserve">
-    <value>Nivel de puntuación</value>
-  </data>
   <data name="± levels" xml:space="preserve">
     <value>± niveles</value>
   </data>
@@ -3500,9 +3476,6 @@
   </data>
   <data name="only {0} hold it" xml:space="preserve">
     <value>solo {0} lo poseen</value>
-  </data>
-  <data name="completed" xml:space="preserve">
-    <value>completado</value>
   </data>
   <data name="now" xml:space="preserve">
     <value>ahora</value>
@@ -3599,9 +3572,6 @@
   </data>
   <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
     <value>Tu Pumbility y nivel competitivo, además de tus rivales más cercanos.</value>
-  </data>
-  <data name="Pumbility" xml:space="preserve">
-    <value>Pumbility</value>
   </data>
   <data name="Match players on" xml:space="preserve">
     <value>Emparejar jugadores por</value>
@@ -3942,9 +3912,6 @@
   <data name="This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import." xml:space="preserve">
     <value>Esto no es de conocimiento cero: como el inicio de sesión se ejecuta en nuestro servidor, técnicamente podemos descifrar tu credencial en el momento en que importas. No la registramos ni la conservamos, pero nos estás confiando el mismo acceso que ya tenemos en cada importación manual.</value>
   </data>
-  <data name="Import scores" xml:space="preserve">
-    <value>Importar puntuaciones</value>
-  </data>
   <data name="Creating Your Home Page" xml:space="preserve">
     <value>Creando tu página de inicio</value>
   </data>
@@ -4077,12 +4044,6 @@
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Aún no hay puntuaciones — sé la primera persona.</value>
   </data>
-  <data name="your communities" xml:space="preserve">
-    <value>tus comunidades</value>
-  </data>
-  <data name="you" xml:space="preserve">
-    <value>tú</value>
-  </data>
   <data name="Show more of {0} scores" xml:space="preserve">
     <value>Ver más de {0} puntuaciones</value>
   </data>
@@ -4097,9 +4058,6 @@
   </data>
   <data name="Debuted in" xml:space="preserve">
     <value>Debut en</value>
-  </data>
-  <data name="Pass rate" xml:space="preserve">
-    <value>Tasa de passes</value>
   </data>
   <data name="The evidence" xml:space="preserve">
     <value>La evidencia</value>
@@ -4347,9 +4305,6 @@
   <data name="Chart Board #1s" xml:space="preserve">
     <value>Números 1 en leaderboards de charts</value>
   </data>
-  <data name="Chart Boards" xml:space="preserve">
-    <value>Leaderboards de charts</value>
-  </data>
   <data name="Chart board placements" xml:space="preserve">
     <value>Puestos en leaderboards de charts</value>
   </data>
@@ -4452,9 +4407,6 @@
   <data name="PUMBILITY over time" xml:space="preserve">
     <value>PUMBILITY a lo largo del tiempo</value>
   </data>
-  <data name="rank" xml:space="preserve">
-    <value>puesto</value>
-  </data>
   <data name="Rank" xml:space="preserve">
     <value>Puesto</value>
   </data>
@@ -4481,9 +4433,6 @@
   </data>
   <data name="Seed baseline from legacy tables" xml:space="preserve">
     <value>Crear base inicial desde las tablas antiguas</value>
-  </data>
-  <data name="skipped" xml:space="preserve">
-    <value>omitidos</value>
   </data>
   <data name="Songs" xml:space="preserve">
     <value>Canciones</value>
@@ -4734,9 +4683,6 @@
   <data name="{0} · levels {1}–{2} · {3}" xml:space="preserve">
     <value>{0} · niveles {1}–{2} · {3}</value>
   </data>
-  <data name="Co-op" xml:space="preserve">
-    <value>Co-op</value>
-  </data>
   <data name="You don't have a saved preset called &quot;{0}&quot;." xml:space="preserve">
     <value>No tienes un preset guardado llamado &quot;{0}&quot;.</value>
   </data>
@@ -4839,9 +4785,6 @@
   <data name="Show what this channel is registered for" xml:space="preserve">
     <value>Muestra para qué está registrado este canal</value>
   </data>
-  <data name="Song name" xml:space="preserve">
-    <value>Nombre de la canción</value>
-  </data>
   <data name="Which mix (defaults to Phoenix 2)" xml:space="preserve">
     <value>Qué versión (por defecto Phoenix 2)</value>
   </data>
@@ -4868,9 +4811,6 @@
   </data>
   <data name="What to work on (default Title Hunt)" xml:space="preserve">
     <value>En qué trabajar (por defecto Title Hunt)</value>
-  </data>
-  <data name="Community name" xml:space="preserve">
-    <value>Nombre de la comunidad</value>
   </data>
   <data name="Invite code (private communities only)" xml:space="preserve">
     <value>Código de invitación (solo comunidades privadas)</value>
@@ -4994,12 +4934,6 @@
   </data>
   <data name="PIU Scores official mirror" xml:space="preserve">
     <value>espejo oficial de PIU Scores</value>
-  </data>
-  <data name="This week" xml:space="preserve">
-    <value>Esta semana</value>
-  </data>
-  <data name="What it takes" xml:space="preserve">
-    <value>Lo que se necesita</value>
   </data>
   <data name="a chart" xml:space="preserve">
     <value>un chart</value>
@@ -5295,9 +5229,6 @@
   <data name="Highest Clear" xml:space="preserve">
     <value>Máximo superado</value>
   </data>
-  <data name="Highest Level" xml:space="preserve">
-    <value>Nivel máx.</value>
-  </data>
   <data name="I understand — join" xml:space="preserve">
     <value>Lo entiendo — unirme</value>
   </data>
@@ -5384,9 +5315,6 @@
   </data>
   <data name="Show Regional Guests" xml:space="preserve">
     <value>Mostrar invitados regionales</value>
-  </data>
-  <data name="Sign In" xml:space="preserve">
-    <value>Iniciar sesión</value>
   </data>
   <data name="Sign in to accept this invite." xml:space="preserve">
     <value>Inicia sesión para aceptar esta invitación.</value>
@@ -5487,9 +5415,6 @@
   <data name="Charts Not Yet Featured" xml:space="preserve">
     <value>Charts aún no destacados</value>
   </data>
-  <data name="Charts not yet featured" xml:space="preserve">
-    <value>Charts aún no destacados</value>
-  </data>
   <data name="Co-op earns no PUMBILITY; the Co-Op view ranks raw score." xml:space="preserve">
     <value>El co-op no da PUMBILITY; la vista Co-Op ordena por puntuación bruta.</value>
   </data>
@@ -5565,17 +5490,11 @@
   <data name="Your best 4 scores per week of the month count." xml:space="preserve">
     <value>Cuentan tus 4 mejores puntuaciones por semana del mes.</value>
   </data>
-  <data name="current" xml:space="preserve">
-    <value>actual</value>
-  </data>
   <data name="last 14 days" xml:space="preserve">
     <value>últimos 14 días</value>
   </data>
   <data name="resets in {0}" xml:space="preserve">
     <value>se reinicia en {0}</value>
-  </data>
-  <data name="show all {0}" xml:space="preserve">
-    <value>ver los {0}</value>
   </data>
   <data name="show suggested only" xml:space="preserve">
     <value>ver solo sugeridos</value>
@@ -5726,9 +5645,6 @@
   </data>
   <data name="Commands — anyone in the server can use these" xml:space="preserve">
     <value>Comandos — cualquiera del servidor puede usarlos</value>
-  </data>
-  <data name="calculate a Phoenix score from a result screen" xml:space="preserve">
-    <value>calcula un score Phoenix desde una pantalla de resultados</value>
   </data>
   <data name="pull up a chart's stats and similar charts, with links to its pages" xml:space="preserve">
     <value>consulta las estadísticas de un chart y sus charts similares, con enlaces a sus páginas</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -324,9 +324,6 @@
   <data name="Chart Difficulty by Letter Grade" xml:space="preserve">
     <value>Dificultad del chart por grado de letra</value>
   </data>
-  <data name="Chart Leaderboard" xml:space="preserve">
-    <value>Clasificación del chart</value>
-  </data>
   <data name="Chart List Share Description" xml:space="preserve">
     <value>Use este enlace para compartir su lista de charts con otros jugadores.</value>
   </data>
@@ -993,9 +990,6 @@
   <data name="Passes" xml:space="preserve">
     <value>Pases</value>
   </data>
-  <data name="Passes by Competitive Level" xml:space="preserve">
-    <value>Pases por nivel competitivo</value>
-  </data>
   <data name="Passes By Level" xml:space="preserve">
     <value>Pases por nivel</value>
   </data>
@@ -1289,9 +1283,6 @@
   </data>
   <data name="Scores" xml:space="preserve">
     <value>Puntajes</value>
-  </data>
-  <data name="Scores by Competitive Level" xml:space="preserve">
-    <value>Puntajes por nivel competitivo</value>
   </data>
   <data name="Scores Parsed" xml:space="preserve">
     <value>Puntajes analizados</value>
@@ -1589,9 +1580,6 @@
   </data>
   <data name="Title" xml:space="preserve">
     <value>Título</value>
-  </data>
-  <data name="Title Progress" xml:space="preserve">
-    <value>Progreso de títulos</value>
   </data>
   <data name="Titles" xml:space="preserve">
     <value>Títulos</value>
@@ -2292,9 +2280,6 @@
   <data name="Scores, vs your level" xml:space="preserve">
     <value>Puntajes, contra tu nivel</value>
   </data>
-  <data name="Weekly charts" xml:space="preserve">
-    <value>Charts semanales</value>
-  </data>
   <data name="weeks. No misses." xml:space="preserve">
     <value>semanas. Sin faltar.</value>
   </data>
@@ -2894,9 +2879,6 @@
   <data name="Players Like You" xml:space="preserve">
     <value>Jugadores como tú</value>
   </data>
-  <data name="Players like you" xml:space="preserve">
-    <value>Jugadores como tú</value>
-  </data>
   <data name="Players within one competitive level of you — closer players count more, and so do those whose folder ratings agree with yours." xml:space="preserve">
     <value>Jugadores a un nivel competitivo de ti: los más cercanos cuentan más, igual que los que valoran las carpetas parecido a ti.</value>
   </data>
@@ -3293,9 +3275,6 @@
   <data name="When a new mix arrives, nothing here resets. Every score you've recorded stays — to look back on, compare against, and build from. {0} mixes on record, side by side, 1999 to today." xml:space="preserve">
     <value>Cuando llega una versión nueva, aquí no se reinicia nada. Cada puntuación que registraste se queda — para mirar atrás, comparar y seguir construyendo. {0} versiones registradas, lado a lado, de 1999 a hoy.</value>
   </data>
-  <data name="today" xml:space="preserve">
-    <value>hoy</value>
-  </data>
   <data name="Private by default" xml:space="preserve">
     <value>Privado por defecto</value>
   </data>
@@ -3437,9 +3416,6 @@
   <data name="{0} days old" xml:space="preserve">
     <value>hace {0} días</value>
   </data>
-  <data name="Scoring level" xml:space="preserve">
-    <value>Nivel de puntuación</value>
-  </data>
   <data name="± levels" xml:space="preserve">
     <value>± niveles</value>
   </data>
@@ -3502,9 +3478,6 @@
   </data>
   <data name="only {0} hold it" xml:space="preserve">
     <value>solo {0} lo poseen</value>
-  </data>
-  <data name="completed" xml:space="preserve">
-    <value>completado</value>
   </data>
   <data name="now" xml:space="preserve">
     <value>ahora</value>
@@ -3601,9 +3574,6 @@
   </data>
   <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
     <value>Tu Pumbility y nivel competitivo, además de tus rivales más cercanos.</value>
-  </data>
-  <data name="Pumbility" xml:space="preserve">
-    <value>Pumbility</value>
   </data>
   <data name="Match players on" xml:space="preserve">
     <value>Emparejar jugadores por</value>
@@ -3944,9 +3914,6 @@
   <data name="This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import." xml:space="preserve">
     <value>Esto no es de conocimiento cero: como el inicio de sesión se ejecuta en nuestro servidor, técnicamente podemos descifrar tu credencial en el momento en que importas. No la registramos ni la conservamos, pero nos estás confiando el mismo acceso que ya tenemos en cada importación manual.</value>
   </data>
-  <data name="Import scores" xml:space="preserve">
-    <value>Importar puntuaciones</value>
-  </data>
   <data name="Creating Your Home Page" xml:space="preserve">
     <value>Creando tu página de inicio</value>
   </data>
@@ -4079,12 +4046,6 @@
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Aún no hay puntuaciones — sé la primera persona.</value>
   </data>
-  <data name="your communities" xml:space="preserve">
-    <value>tus comunidades</value>
-  </data>
-  <data name="you" xml:space="preserve">
-    <value>tú</value>
-  </data>
   <data name="Show more of {0} scores" xml:space="preserve">
     <value>Ver más de {0} puntuaciones</value>
   </data>
@@ -4099,9 +4060,6 @@
   </data>
   <data name="Debuted in" xml:space="preserve">
     <value>Debut en</value>
-  </data>
-  <data name="Pass rate" xml:space="preserve">
-    <value>Tasa de passes</value>
   </data>
   <data name="The evidence" xml:space="preserve">
     <value>La evidencia</value>
@@ -4349,9 +4307,6 @@
   <data name="Chart Board #1s" xml:space="preserve">
     <value>Primeros lugares en tableros de charts</value>
   </data>
-  <data name="Chart Boards" xml:space="preserve">
-    <value>Tableros de charts</value>
-  </data>
   <data name="Chart board placements" xml:space="preserve">
     <value>Posiciones en tableros de charts</value>
   </data>
@@ -4454,9 +4409,6 @@
   <data name="PUMBILITY over time" xml:space="preserve">
     <value>PUMBILITY en el tiempo</value>
   </data>
-  <data name="rank" xml:space="preserve">
-    <value>lugar</value>
-  </data>
   <data name="Rank" xml:space="preserve">
     <value>Lugar</value>
   </data>
@@ -4483,9 +4435,6 @@
   </data>
   <data name="Seed baseline from legacy tables" xml:space="preserve">
     <value>Crear base inicial desde las tablas anteriores</value>
-  </data>
-  <data name="skipped" xml:space="preserve">
-    <value>omitidos</value>
   </data>
   <data name="Songs" xml:space="preserve">
     <value>Canciones</value>
@@ -4736,9 +4685,6 @@
   <data name="{0} · levels {1}–{2} · {3}" xml:space="preserve">
     <value>{0} · niveles {1}–{2} · {3}</value>
   </data>
-  <data name="Co-op" xml:space="preserve">
-    <value>Co-op</value>
-  </data>
   <data name="You don't have a saved preset called &quot;{0}&quot;." xml:space="preserve">
     <value>No tienes un preset guardado llamado &quot;{0}&quot;.</value>
   </data>
@@ -4841,9 +4787,6 @@
   <data name="Show what this channel is registered for" xml:space="preserve">
     <value>Muestra para qué está registrado este canal</value>
   </data>
-  <data name="Song name" xml:space="preserve">
-    <value>Nombre de la canción</value>
-  </data>
   <data name="Which mix (defaults to Phoenix 2)" xml:space="preserve">
     <value>Qué versión (por defecto Phoenix 2)</value>
   </data>
@@ -4870,9 +4813,6 @@
   </data>
   <data name="What to work on (default Title Hunt)" xml:space="preserve">
     <value>En qué trabajar (por defecto Title Hunt)</value>
-  </data>
-  <data name="Community name" xml:space="preserve">
-    <value>Nombre de la comunidad</value>
   </data>
   <data name="Invite code (private communities only)" xml:space="preserve">
     <value>Código de invitación (solo comunidades privadas)</value>
@@ -4997,12 +4937,6 @@
   <data name="PIU Scores official mirror" xml:space="preserve">
     <value>espejo oficial de PIU Scores</value>
   </data>
-  <data name="This week" xml:space="preserve">
-    <value>Esta semana</value>
-  </data>
-  <data name="What it takes" xml:space="preserve">
-    <value>Lo que se necesita</value>
-  </data>
   <data name="a chart" xml:space="preserve">
     <value>un chart</value>
   </data>
@@ -5115,7 +5049,7 @@
     <value>Mayor mejora de la sesión</value>
   </data>
   <data name="Title progress" xml:space="preserve">
-    <value>Progreso de título</value>
+    <value>Progreso de títulos</value>
   </data>
   <data name="First" xml:space="preserve">
     <value>Primer</value>
@@ -5297,9 +5231,6 @@
   <data name="Highest Clear" xml:space="preserve">
     <value>Nivel máx. pasado</value>
   </data>
-  <data name="Highest Level" xml:space="preserve">
-    <value>Nivel máx</value>
-  </data>
   <data name="I understand — join" xml:space="preserve">
     <value>Entiendo — unirme</value>
   </data>
@@ -5386,9 +5317,6 @@
   </data>
   <data name="Show Regional Guests" xml:space="preserve">
     <value>Mostrar invitados regionales</value>
-  </data>
-  <data name="Sign In" xml:space="preserve">
-    <value>Iniciar sesión</value>
   </data>
   <data name="Sign in to accept this invite." xml:space="preserve">
     <value>Inicie sesión para aceptar esta invitación.</value>
@@ -5489,9 +5417,6 @@
   <data name="Charts Not Yet Featured" xml:space="preserve">
     <value>Charts aún no destacados</value>
   </data>
-  <data name="Charts not yet featured" xml:space="preserve">
-    <value>Charts aún no destacados</value>
-  </data>
   <data name="Co-op earns no PUMBILITY; the Co-Op view ranks raw score." xml:space="preserve">
     <value>El co-op no da PUMBILITY; la vista Co-Op ordena por puntuación bruta.</value>
   </data>
@@ -5567,17 +5492,11 @@
   <data name="Your best 4 scores per week of the month count." xml:space="preserve">
     <value>Cuentan tus 4 mejores puntuaciones por semana del mes.</value>
   </data>
-  <data name="current" xml:space="preserve">
-    <value>actual</value>
-  </data>
   <data name="last 14 days" xml:space="preserve">
     <value>últimos 14 días</value>
   </data>
   <data name="resets in {0}" xml:space="preserve">
     <value>se reinicia en {0}</value>
-  </data>
-  <data name="show all {0}" xml:space="preserve">
-    <value>ver los {0}</value>
   </data>
   <data name="show suggested only" xml:space="preserve">
     <value>ver solo sugeridos</value>
@@ -5728,9 +5647,6 @@
   </data>
   <data name="Commands — anyone in the server can use these" xml:space="preserve">
     <value>Comandos — cualquiera en el servidor puede usarlos</value>
-  </data>
-  <data name="calculate a Phoenix score from a result screen" xml:space="preserve">
-    <value>calcule un puntaje Phoenix desde una pantalla de resultados</value>
   </data>
   <data name="pull up a chart's stats and similar charts, with links to its pages" xml:space="preserve">
     <value>consulte las estadísticas de un chart y charts similares, con enlaces a sus páginas</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -417,9 +417,6 @@
   <data name="Tier Lists" xml:space="preserve">
     <value>Tier Lists</value>
   </data>
-  <data name="Title Progress" xml:space="preserve">
-    <value>Progression des titres</value>
-  </data>
   <data name="Titles" xml:space="preserve">
     <value>Titres</value>
   </data>
@@ -1875,15 +1872,6 @@
   <data name="Score Distribution By Player Level" xml:space="preserve">
     <value>Distribution de scores par niveau de joueur</value>
   </data>
-  <data name="Scores by Competitive Level" xml:space="preserve">
-    <value>Scores par niveau compétitif</value>
-  </data>
-  <data name="Passes by Competitive Level" xml:space="preserve">
-    <value>Pass par niveau compétitif</value>
-  </data>
-  <data name="Chart Leaderboard" xml:space="preserve">
-    <value>Leaderboard du chart</value>
-  </data>
   <data name="Content Lock" xml:space="preserve">
     <value>Verrou de contenu</value>
   </data>
@@ -2405,9 +2393,6 @@
   </data>
   <data name="Scores, vs your level" xml:space="preserve">
     <value>Scores, face à ton niveau</value>
-  </data>
-  <data name="Weekly charts" xml:space="preserve">
-    <value>Charts hebdo</value>
   </data>
   <data name="weeks. No misses." xml:space="preserve">
     <value>semaines. Sans en manquer une.</value>
@@ -3008,9 +2993,6 @@
   <data name="Players Like You" xml:space="preserve">
     <value>Joueurs comme vous</value>
   </data>
-  <data name="Players like you" xml:space="preserve">
-    <value>Joueurs comme vous</value>
-  </data>
   <data name="Players within one competitive level of you — closer players count more, and so do those whose folder ratings agree with yours." xml:space="preserve">
     <value>Les joueurs à un niveau compétitif du vôtre — les plus proches comptent davantage, tout comme ceux dont les évaluations de dossiers rejoignent les vôtres.</value>
   </data>
@@ -3407,9 +3389,6 @@
   <data name="When a new mix arrives, nothing here resets. Every score you've recorded stays — to look back on, compare against, and build from. {0} mixes on record, side by side, 1999 to today." xml:space="preserve">
     <value>Quand un nouveau Mix arrive, rien ne se réinitialise ici. Chaque score enregistré reste — pour se retourner, comparer et progresser. {0} Mix archivés, côte à côte, de 1999 à aujourd'hui.</value>
   </data>
-  <data name="today" xml:space="preserve">
-    <value>aujourd'hui</value>
-  </data>
   <data name="Private by default" xml:space="preserve">
     <value>Privé par défaut</value>
   </data>
@@ -3551,9 +3530,6 @@
   <data name="{0} days old" xml:space="preserve">
     <value>il y a {0} jours</value>
   </data>
-  <data name="Scoring level" xml:space="preserve">
-    <value>Niveau de score</value>
-  </data>
   <data name="± levels" xml:space="preserve">
     <value>± niveaux</value>
   </data>
@@ -3616,9 +3592,6 @@
   </data>
   <data name="only {0} hold it" xml:space="preserve">
     <value>seuls {0} le détiennent</value>
-  </data>
-  <data name="completed" xml:space="preserve">
-    <value>terminé</value>
   </data>
   <data name="now" xml:space="preserve">
     <value>maintenant</value>
@@ -3715,9 +3688,6 @@
   </data>
   <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
     <value>Ton Pumbility et ton niveau compétitif, plus tes rivaux les plus proches.</value>
-  </data>
-  <data name="Pumbility" xml:space="preserve">
-    <value>Pumbility</value>
   </data>
   <data name="Match players on" xml:space="preserve">
     <value>Associer les joueurs selon</value>
@@ -4058,9 +4028,6 @@
   <data name="This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import." xml:space="preserve">
     <value>Ce n'est pas du zéro-connaissance : comme la connexion s'exécute sur notre serveur, nous pouvons techniquement déchiffrer votre identifiant au moment de l'import. Nous ne le journalisons ni ne le conservons — mais vous nous confiez le même accès que nous avons déjà à chaque import manuel.</value>
   </data>
-  <data name="Import scores" xml:space="preserve">
-    <value>Importer les scores</value>
-  </data>
   <data name="Creating Your Home Page" xml:space="preserve">
     <value>Création de votre page d’accueil</value>
   </data>
@@ -4193,12 +4160,6 @@
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Pas encore de scores — soyez le premier.</value>
   </data>
-  <data name="your communities" xml:space="preserve">
-    <value>vos communautés</value>
-  </data>
-  <data name="you" xml:space="preserve">
-    <value>vous</value>
-  </data>
   <data name="Show more of {0} scores" xml:space="preserve">
     <value>Voir plus des {0} scores</value>
   </data>
@@ -4213,9 +4174,6 @@
   </data>
   <data name="Debuted in" xml:space="preserve">
     <value>Apparu dans</value>
-  </data>
-  <data name="Pass rate" xml:space="preserve">
-    <value>Taux de réussite</value>
   </data>
   <data name="The evidence" xml:space="preserve">
     <value>Les preuves</value>
@@ -4463,9 +4421,6 @@
   <data name="Chart Board #1s" xml:space="preserve">
     <value>Premières places sur les leaderboards de charts</value>
   </data>
-  <data name="Chart Boards" xml:space="preserve">
-    <value>Leaderboards de charts</value>
-  </data>
   <data name="Chart board placements" xml:space="preserve">
     <value>Places sur les leaderboards de charts</value>
   </data>
@@ -4568,9 +4523,6 @@
   <data name="PUMBILITY over time" xml:space="preserve">
     <value>PUMBILITY dans le temps</value>
   </data>
-  <data name="rank" xml:space="preserve">
-    <value>rang</value>
-  </data>
   <data name="Rank" xml:space="preserve">
     <value>Rang</value>
   </data>
@@ -4597,9 +4549,6 @@
   </data>
   <data name="Seed baseline from legacy tables" xml:space="preserve">
     <value>Créer la référence initiale depuis les anciennes tables</value>
-  </data>
-  <data name="skipped" xml:space="preserve">
-    <value>ignorés</value>
   </data>
   <data name="Songs" xml:space="preserve">
     <value>Chansons</value>
@@ -4850,9 +4799,6 @@
   <data name="{0} · levels {1}–{2} · {3}" xml:space="preserve">
     <value>{0} · niveaux {1}–{2} · {3}</value>
   </data>
-  <data name="Co-op" xml:space="preserve">
-    <value>Co-op</value>
-  </data>
   <data name="You don't have a saved preset called &quot;{0}&quot;." xml:space="preserve">
     <value>Vous n'avez pas de préréglage enregistré nommé « {0} ».</value>
   </data>
@@ -4955,9 +4901,6 @@
   <data name="Show what this channel is registered for" xml:space="preserve">
     <value>Affichez à quoi ce salon est inscrit</value>
   </data>
-  <data name="Song name" xml:space="preserve">
-    <value>Nom de la chanson</value>
-  </data>
   <data name="Which mix (defaults to Phoenix 2)" xml:space="preserve">
     <value>Quel Mix (par défaut Phoenix 2)</value>
   </data>
@@ -4984,9 +4927,6 @@
   </data>
   <data name="What to work on (default Title Hunt)" xml:space="preserve">
     <value>Sur quoi travailler (par défaut Title Hunt)</value>
-  </data>
-  <data name="Community name" xml:space="preserve">
-    <value>Nom de la communauté</value>
   </data>
   <data name="Invite code (private communities only)" xml:space="preserve">
     <value>Code d'invitation (communautés privées uniquement)</value>
@@ -5111,12 +5051,6 @@
   <data name="PIU Scores official mirror" xml:space="preserve">
     <value>miroir officiel PIU Scores</value>
   </data>
-  <data name="This week" xml:space="preserve">
-    <value>Cette semaine</value>
-  </data>
-  <data name="What it takes" xml:space="preserve">
-    <value>Ce qu'il faut</value>
-  </data>
   <data name="a chart" xml:space="preserve">
     <value>un chart</value>
   </data>
@@ -5229,7 +5163,7 @@
     <value>Plus gros gain de la session</value>
   </data>
   <data name="Title progress" xml:space="preserve">
-    <value>Progression de titre</value>
+    <value>Progression des titres</value>
   </data>
   <data name="First" xml:space="preserve">
     <value>Premier</value>
@@ -5411,9 +5345,6 @@
   <data name="Highest Clear" xml:space="preserve">
     <value>Niveau max Pass</value>
   </data>
-  <data name="Highest Level" xml:space="preserve">
-    <value>Niveau max</value>
-  </data>
   <data name="I understand — join" xml:space="preserve">
     <value>J'ai compris — rejoindre</value>
   </data>
@@ -5500,9 +5431,6 @@
   </data>
   <data name="Show Regional Guests" xml:space="preserve">
     <value>Montrer les invités régionaux</value>
-  </data>
-  <data name="Sign In" xml:space="preserve">
-    <value>Se connecter</value>
   </data>
   <data name="Sign in to accept this invite." xml:space="preserve">
     <value>Connectez-vous pour accepter cette invitation.</value>
@@ -5603,9 +5531,6 @@
   <data name="Charts Not Yet Featured" xml:space="preserve">
     <value>Charts pas encore proposés</value>
   </data>
-  <data name="Charts not yet featured" xml:space="preserve">
-    <value>Charts pas encore proposés</value>
-  </data>
   <data name="Co-op earns no PUMBILITY; the Co-Op view ranks raw score." xml:space="preserve">
     <value>Le co-op ne donne pas de PUMBILITY ; la vue Co-Op classe au score brut.</value>
   </data>
@@ -5681,17 +5606,11 @@
   <data name="Your best 4 scores per week of the month count." xml:space="preserve">
     <value>Tes 4 meilleurs scores par semaine du mois comptent.</value>
   </data>
-  <data name="current" xml:space="preserve">
-    <value>actuelle</value>
-  </data>
   <data name="last 14 days" xml:space="preserve">
     <value>14 derniers jours</value>
   </data>
   <data name="resets in {0}" xml:space="preserve">
     <value>réinitialisation dans {0}</value>
-  </data>
-  <data name="show all {0}" xml:space="preserve">
-    <value>voir les {0}</value>
   </data>
   <data name="show suggested only" xml:space="preserve">
     <value>voir les suggérés</value>
@@ -5842,9 +5761,6 @@
   </data>
   <data name="Commands — anyone in the server can use these" xml:space="preserve">
     <value>Commandes — tout le monde sur le serveur peut les utiliser</value>
-  </data>
-  <data name="calculate a Phoenix score from a result screen" xml:space="preserve">
-    <value>calculer un score Phoenix depuis un écran de résultat</value>
   </data>
   <data name="pull up a chart's stats and similar charts, with links to its pages" xml:space="preserve">
     <value>afficher les statistiques d'un Chart et les Charts similaires, avec des liens vers ses pages</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -417,9 +417,6 @@
   <data name="Tier Lists" xml:space="preserve">
     <value>Tier Lists</value>
   </data>
-  <data name="Title Progress" xml:space="preserve">
-    <value>Progresso dei titoli</value>
-  </data>
   <data name="Titles" xml:space="preserve">
     <value>Titoli</value>
   </data>
@@ -1881,15 +1878,6 @@
   <data name="Score Distribution By Player Level" xml:space="preserve">
     <value>Distribuzione dei punteggi per livello del giocatore</value>
   </data>
-  <data name="Scores by Competitive Level" xml:space="preserve">
-    <value>Punteggi per livello competitivo</value>
-  </data>
-  <data name="Passes by Competitive Level" xml:space="preserve">
-    <value>Pass per livello competitivo</value>
-  </data>
-  <data name="Chart Leaderboard" xml:space="preserve">
-    <value>Classifica del chart</value>
-  </data>
   <data name="Content Lock" xml:space="preserve">
     <value>Blocco dei contenuti</value>
   </data>
@@ -2411,9 +2399,6 @@
   </data>
   <data name="Scores, vs your level" xml:space="preserve">
     <value>Punteggi, contro il tuo livello</value>
-  </data>
-  <data name="Weekly charts" xml:space="preserve">
-    <value>Chart settimanali</value>
   </data>
   <data name="weeks. No misses." xml:space="preserve">
     <value>settimane. Senza saltarne una.</value>
@@ -3014,9 +2999,6 @@
   <data name="Players Like You" xml:space="preserve">
     <value>Giocatori come te</value>
   </data>
-  <data name="Players like you" xml:space="preserve">
-    <value>Giocatori come te</value>
-  </data>
   <data name="Players within one competitive level of you — closer players count more, and so do those whose folder ratings agree with yours." xml:space="preserve">
     <value>Giocatori entro un livello competitivo dal tuo — i più vicini contano di più, come chi valuta le cartelle in modo simile al tuo.</value>
   </data>
@@ -3413,9 +3395,6 @@
   <data name="When a new mix arrives, nothing here resets. Every score you've recorded stays — to look back on, compare against, and build from. {0} mixes on record, side by side, 1999 to today." xml:space="preserve">
     <value>Quando arriva un nuovo Mix, qui non si azzera nulla. Ogni punteggio registrato resta — da rivedere, confrontare e da cui ripartire. {0} Mix in archivio, fianco a fianco, dal 1999 a oggi.</value>
   </data>
-  <data name="today" xml:space="preserve">
-    <value>oggi</value>
-  </data>
   <data name="Private by default" xml:space="preserve">
     <value>Privato per impostazione predefinita</value>
   </data>
@@ -3557,9 +3536,6 @@
   <data name="{0} days old" xml:space="preserve">
     <value>{0} giorni fa</value>
   </data>
-  <data name="Scoring level" xml:space="preserve">
-    <value>Livello di punteggio</value>
-  </data>
   <data name="± levels" xml:space="preserve">
     <value>± livelli</value>
   </data>
@@ -3622,9 +3598,6 @@
   </data>
   <data name="only {0} hold it" xml:space="preserve">
     <value>solo {0} lo possiedono</value>
-  </data>
-  <data name="completed" xml:space="preserve">
-    <value>completato</value>
   </data>
   <data name="now" xml:space="preserve">
     <value>ora</value>
@@ -3721,9 +3694,6 @@
   </data>
   <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
     <value>Il tuo Pumbility e livello competitivo, più i rivali più vicini a te.</value>
-  </data>
-  <data name="Pumbility" xml:space="preserve">
-    <value>Pumbility</value>
   </data>
   <data name="Match players on" xml:space="preserve">
     <value>Abbina i giocatori per</value>
@@ -4064,9 +4034,6 @@
   <data name="This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import." xml:space="preserve">
     <value>Questo non è a conoscenza zero: poiché il login viene eseguito sul nostro server, tecnicamente possiamo decifrare la tua credenziale nel momento in cui importi. Non la registriamo né la conserviamo, ma ci stai affidando lo stesso accesso che abbiamo già a ogni importazione manuale.</value>
   </data>
-  <data name="Import scores" xml:space="preserve">
-    <value>Importa i punteggi</value>
-  </data>
   <data name="Creating Your Home Page" xml:space="preserve">
     <value>Creazione della tua home page</value>
   </data>
@@ -4199,12 +4166,6 @@
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Ancora nessun punteggio — sii il primo.</value>
   </data>
-  <data name="your communities" xml:space="preserve">
-    <value>le tue community</value>
-  </data>
-  <data name="you" xml:space="preserve">
-    <value>tu</value>
-  </data>
   <data name="Show more of {0} scores" xml:space="preserve">
     <value>Mostra altri dei {0} punteggi</value>
   </data>
@@ -4219,9 +4180,6 @@
   </data>
   <data name="Debuted in" xml:space="preserve">
     <value>Debutto in</value>
-  </data>
-  <data name="Pass rate" xml:space="preserve">
-    <value>Tasso di pass</value>
   </data>
   <data name="The evidence" xml:space="preserve">
     <value>Le prove</value>
@@ -4469,9 +4427,6 @@
   <data name="Chart Board #1s" xml:space="preserve">
     <value>Primi posti nelle classifiche dei chart</value>
   </data>
-  <data name="Chart Boards" xml:space="preserve">
-    <value>Classifiche dei chart</value>
-  </data>
   <data name="Chart board placements" xml:space="preserve">
     <value>Posizioni nelle classifiche dei chart</value>
   </data>
@@ -4574,9 +4529,6 @@
   <data name="PUMBILITY over time" xml:space="preserve">
     <value>PUMBILITY nel tempo</value>
   </data>
-  <data name="rank" xml:space="preserve">
-    <value>posizione</value>
-  </data>
   <data name="Rank" xml:space="preserve">
     <value>Posizione</value>
   </data>
@@ -4603,9 +4555,6 @@
   </data>
   <data name="Seed baseline from legacy tables" xml:space="preserve">
     <value>Crea la base iniziale dalle vecchie tabelle</value>
-  </data>
-  <data name="skipped" xml:space="preserve">
-    <value>saltate</value>
   </data>
   <data name="Songs" xml:space="preserve">
     <value>Canzoni</value>
@@ -4856,9 +4805,6 @@
   <data name="{0} · levels {1}–{2} · {3}" xml:space="preserve">
     <value>{0} · livelli {1}–{2} · {3}</value>
   </data>
-  <data name="Co-op" xml:space="preserve">
-    <value>Co-op</value>
-  </data>
   <data name="You don't have a saved preset called &quot;{0}&quot;." xml:space="preserve">
     <value>Non hai un preset salvato chiamato &quot;{0}&quot;.</value>
   </data>
@@ -4961,9 +4907,6 @@
   <data name="Show what this channel is registered for" xml:space="preserve">
     <value>Mostra a cosa è registrato questo canale</value>
   </data>
-  <data name="Song name" xml:space="preserve">
-    <value>Nome della canzone</value>
-  </data>
   <data name="Which mix (defaults to Phoenix 2)" xml:space="preserve">
     <value>Quale Mix (predefinito Phoenix 2)</value>
   </data>
@@ -4990,9 +4933,6 @@
   </data>
   <data name="What to work on (default Title Hunt)" xml:space="preserve">
     <value>Su cosa lavorare (predefinito Title Hunt)</value>
-  </data>
-  <data name="Community name" xml:space="preserve">
-    <value>Nome della community</value>
   </data>
   <data name="Invite code (private communities only)" xml:space="preserve">
     <value>Codice di invito (solo community private)</value>
@@ -5117,12 +5057,6 @@
   <data name="PIU Scores official mirror" xml:space="preserve">
     <value>mirror ufficiale PIU Scores</value>
   </data>
-  <data name="This week" xml:space="preserve">
-    <value>Questa settimana</value>
-  </data>
-  <data name="What it takes" xml:space="preserve">
-    <value>Cosa serve</value>
-  </data>
   <data name="a chart" xml:space="preserve">
     <value>un chart</value>
   </data>
@@ -5235,7 +5169,7 @@
     <value>Miglior guadagno della sessione</value>
   </data>
   <data name="Title progress" xml:space="preserve">
-    <value>Progresso del titolo</value>
+    <value>Progresso dei titoli</value>
   </data>
   <data name="First" xml:space="preserve">
     <value>Primo</value>
@@ -5417,9 +5351,6 @@
   <data name="Highest Clear" xml:space="preserve">
     <value>Livello max superato</value>
   </data>
-  <data name="Highest Level" xml:space="preserve">
-    <value>Livello max</value>
-  </data>
   <data name="I understand — join" xml:space="preserve">
     <value>Ho capito — unisciti</value>
   </data>
@@ -5506,9 +5437,6 @@
   </data>
   <data name="Show Regional Guests" xml:space="preserve">
     <value>Mostra gli ospiti regionali</value>
-  </data>
-  <data name="Sign In" xml:space="preserve">
-    <value>Accedi</value>
   </data>
   <data name="Sign in to accept this invite." xml:space="preserve">
     <value>Accedi per accettare questo invito.</value>
@@ -5609,9 +5537,6 @@
   <data name="Charts Not Yet Featured" xml:space="preserve">
     <value>Chart non ancora proposti</value>
   </data>
-  <data name="Charts not yet featured" xml:space="preserve">
-    <value>Chart non ancora proposti</value>
-  </data>
   <data name="Co-op earns no PUMBILITY; the Co-Op view ranks raw score." xml:space="preserve">
     <value>Il co-op non dà PUMBILITY; la vista Co-Op ordina per punteggio grezzo.</value>
   </data>
@@ -5687,17 +5612,11 @@
   <data name="Your best 4 scores per week of the month count." xml:space="preserve">
     <value>Contano i tuoi 4 migliori punteggi per settimana del mese.</value>
   </data>
-  <data name="current" xml:space="preserve">
-    <value>attuale</value>
-  </data>
   <data name="last 14 days" xml:space="preserve">
     <value>ultimi 14 giorni</value>
   </data>
   <data name="resets in {0}" xml:space="preserve">
     <value>si azzera tra {0}</value>
-  </data>
-  <data name="show all {0}" xml:space="preserve">
-    <value>mostra tutti i {0}</value>
   </data>
   <data name="show suggested only" xml:space="preserve">
     <value>mostra solo consigliati</value>
@@ -5848,9 +5767,6 @@
   </data>
   <data name="Commands — anyone in the server can use these" xml:space="preserve">
     <value>Comandi — chiunque nel server può usarli</value>
-  </data>
-  <data name="calculate a Phoenix score from a result screen" xml:space="preserve">
-    <value>calcola un punteggio Phoenix da una schermata dei risultati</value>
   </data>
   <data name="pull up a chart's stats and similar charts, with links to its pages" xml:space="preserve">
     <value>mostra le statistiche di un chart e i chart simili, con i link alle sue pagine</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -417,9 +417,6 @@
   <data name="Tier Lists" xml:space="preserve">
     <value>ティアリスト</value>
   </data>
-  <data name="Title Progress" xml:space="preserve">
-    <value>タイトル進捗</value>
-  </data>
   <data name="Titles" xml:space="preserve">
     <value>タイトル</value>
   </data>
@@ -1881,15 +1878,6 @@
   <data name="Score Distribution By Player Level" xml:space="preserve">
 	  <value>プレーヤーレベル別スコア分布</value>
   </data>
-  <data name="Scores by Competitive Level" xml:space="preserve">
-	  <value>競技レベル別スコア</value>
-  </data>
-  <data name="Passes by Competitive Level" xml:space="preserve">
-	  <value>競技レベル別クリア</value>
-  </data>
-  <data name="Chart Leaderboard" xml:space="preserve">
-	  <value>譜面ランキング</value>
-  </data>
   <data name="Content Lock" xml:space="preserve">
 	  <value>コンテンツロック</value>
   </data>
@@ -2411,9 +2399,6 @@
   </data>
   <data name="Scores, vs your level" xml:space="preserve">
     <value>スコア（同レベル帯比較）</value>
-  </data>
-  <data name="Weekly charts" xml:space="preserve">
-    <value>ウィークリーチャート</value>
   </data>
   <data name="weeks. No misses." xml:space="preserve">
     <value>週連続。皆勤。</value>
@@ -3014,9 +2999,6 @@
   <data name="Players Like You" xml:space="preserve">
     <value>あなたに近いプレイヤー</value>
   </data>
-  <data name="Players like you" xml:space="preserve">
-    <value>あなたに近いプレイヤー</value>
-  </data>
   <data name="Players within one competitive level of you — closer players count more, and so do those whose folder ratings agree with yours." xml:space="preserve">
     <value>競技レベルが±1以内のプレイヤー — レベルが近いほど、そしてフォルダ評価があなたと一致するほど重く数えられます。</value>
   </data>
@@ -3413,9 +3395,6 @@
   <data name="When a new mix arrives, nothing here resets. Every score you've recorded stays — to look back on, compare against, and build from. {0} mixes on record, side by side, 1999 to today." xml:space="preserve">
     <value>新しいバージョンが来ても、ここでは何もリセットされません。記録したスコアはすべて残ります — 振り返り、比較し、積み上げるために。{0} バージョンの記録が、1999年から今日まで並んでいます。</value>
   </data>
-  <data name="today" xml:space="preserve">
-    <value>現在</value>
-  </data>
   <data name="Private by default" xml:space="preserve">
     <value>デフォルトで非公開</value>
   </data>
@@ -3557,9 +3536,6 @@
   <data name="{0} days old" xml:space="preserve">
     <value>{0}日前</value>
   </data>
-  <data name="Scoring level" xml:space="preserve">
-    <value>スコアリングレベル</value>
-  </data>
   <data name="± levels" xml:space="preserve">
     <value>±レベル</value>
   </data>
@@ -3622,9 +3598,6 @@
   </data>
   <data name="only {0} hold it" xml:space="preserve">
     <value>{0} のみ保持</value>
-  </data>
-  <data name="completed" xml:space="preserve">
-    <value>達成</value>
   </data>
   <data name="now" xml:space="preserve">
     <value>たった今</value>
@@ -3721,9 +3694,6 @@
   </data>
   <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
     <value>あなたのPumbilityと競技レベル、そして最も近いライバル。</value>
-  </data>
-  <data name="Pumbility" xml:space="preserve">
-    <value>Pumbility</value>
   </data>
   <data name="Match players on" xml:space="preserve">
     <value>プレイヤーの一致基準</value>
@@ -4064,9 +4034,6 @@
   <data name="This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import." xml:space="preserve">
     <value>これはゼロ知識ではありません。ログインは私たちのサーバーで実行されるため、あなたがインポートする瞬間には技術的には認証情報を復号できます。私たちはそれを記録も保持もしませんが、手動インポートのたびに既に持っているのと同じアクセスを、あなたは私たちに委ねていることになります。</value>
   </data>
-  <data name="Import scores" xml:space="preserve">
-    <value>スコアをインポート</value>
-  </data>
   <data name="Creating Your Home Page" xml:space="preserve">
     <value>ホームページを作成中</value>
   </data>
@@ -4199,12 +4166,6 @@
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>まだスコアがありません——最初の1人になりましょう。</value>
   </data>
-  <data name="your communities" xml:space="preserve">
-    <value>自分のコミュニティ</value>
-  </data>
-  <data name="you" xml:space="preserve">
-    <value>自分</value>
-  </data>
   <data name="Show more of {0} scores" xml:space="preserve">
     <value>全{0}件のスコアをもっと見る</value>
   </data>
@@ -4219,9 +4180,6 @@
   </data>
   <data name="Debuted in" xml:space="preserve">
     <value>初登場バージョン</value>
-  </data>
-  <data name="Pass rate" xml:space="preserve">
-    <value>クリア率</value>
   </data>
   <data name="The evidence" xml:space="preserve">
     <value>根拠データ</value>
@@ -4469,9 +4427,6 @@
   <data name="Chart Board #1s" xml:space="preserve">
     <value>譜面ボード1位</value>
   </data>
-  <data name="Chart Boards" xml:space="preserve">
-    <value>譜面ボード</value>
-  </data>
   <data name="Chart board placements" xml:space="preserve">
     <value>譜面ボード順位</value>
   </data>
@@ -4574,9 +4529,6 @@
   <data name="PUMBILITY over time" xml:space="preserve">
     <value>PUMBILITYの推移</value>
   </data>
-  <data name="rank" xml:space="preserve">
-    <value>ランキング</value>
-  </data>
   <data name="Rank" xml:space="preserve">
     <value>ランキング</value>
   </data>
@@ -4603,9 +4555,6 @@
   </data>
   <data name="Seed baseline from legacy tables" xml:space="preserve">
     <value>旧テーブルからベースラインを作成</value>
-  </data>
-  <data name="skipped" xml:space="preserve">
-    <value>スキップ</value>
   </data>
   <data name="Songs" xml:space="preserve">
     <value>曲</value>
@@ -4856,9 +4805,6 @@
   <data name="{0} · levels {1}–{2} · {3}" xml:space="preserve">
     <value>{0}・レベル {1}–{2}・{3}</value>
   </data>
-  <data name="Co-op" xml:space="preserve">
-    <value>Co-op</value>
-  </data>
   <data name="You don't have a saved preset called &quot;{0}&quot;." xml:space="preserve">
     <value>「{0}」という保存済みプリセットはありません。</value>
   </data>
@@ -4961,9 +4907,6 @@
   <data name="Show what this channel is registered for" xml:space="preserve">
     <value>このチャンネルの登録内容を表示</value>
   </data>
-  <data name="Song name" xml:space="preserve">
-    <value>曲名</value>
-  </data>
   <data name="Which mix (defaults to Phoenix 2)" xml:space="preserve">
     <value>バージョン（既定は Phoenix 2）</value>
   </data>
@@ -4990,9 +4933,6 @@
   </data>
   <data name="What to work on (default Title Hunt)" xml:space="preserve">
     <value>取り組む目標（既定は称号ハント）</value>
-  </data>
-  <data name="Community name" xml:space="preserve">
-    <value>コミュニティ名</value>
   </data>
   <data name="Invite code (private communities only)" xml:space="preserve">
     <value>招待コード（非公開コミュニティのみ）</value>
@@ -5116,12 +5056,6 @@
   </data>
   <data name="PIU Scores official mirror" xml:space="preserve">
     <value>PIU Scores 公式ミラー</value>
-  </data>
-  <data name="This week" xml:space="preserve">
-    <value>今週</value>
-  </data>
-  <data name="What it takes" xml:space="preserve">
-    <value>必要条件</value>
   </data>
   <data name="a chart" xml:space="preserve">
     <value>譜面</value>
@@ -5417,9 +5351,6 @@
   <data name="Highest Clear" xml:space="preserve">
     <value>最高クリア</value>
   </data>
-  <data name="Highest Level" xml:space="preserve">
-    <value>最高レベル</value>
-  </data>
   <data name="I understand — join" xml:space="preserve">
     <value>理解しました — 参加する</value>
   </data>
@@ -5506,9 +5437,6 @@
   </data>
   <data name="Show Regional Guests" xml:space="preserve">
     <value>地域ゲスト表示</value>
-  </data>
-  <data name="Sign In" xml:space="preserve">
-    <value>ログイン</value>
   </data>
   <data name="Sign in to accept this invite." xml:space="preserve">
     <value>招待を受けるにはログインしてください。</value>
@@ -5609,9 +5537,6 @@
   <data name="Charts Not Yet Featured" xml:space="preserve">
     <value>まだ出題されていない譜面</value>
   </data>
-  <data name="Charts not yet featured" xml:space="preserve">
-    <value>まだ出題されていない譜面</value>
-  </data>
   <data name="Co-op earns no PUMBILITY; the Co-Op view ranks raw score." xml:space="preserve">
     <value>CO-OPはPUMBILITYになりません。Co-Op表示は素点で順位付けします。</value>
   </data>
@@ -5687,17 +5612,11 @@
   <data name="Your best 4 scores per week of the month count." xml:space="preserve">
     <value>月内の各週で上位4件のスコアが対象です。</value>
   </data>
-  <data name="current" xml:space="preserve">
-    <value>今週</value>
-  </data>
   <data name="last 14 days" xml:space="preserve">
     <value>過去14日</value>
   </data>
   <data name="resets in {0}" xml:space="preserve">
     <value>{0}後にリセット</value>
-  </data>
-  <data name="show all {0}" xml:space="preserve">
-    <value>すべて{0}件を表示</value>
   </data>
   <data name="show suggested only" xml:space="preserve">
     <value>おすすめのみ表示</value>
@@ -5848,9 +5767,6 @@
   </data>
   <data name="Commands — anyone in the server can use these" xml:space="preserve">
     <value>コマンド — サーバーの誰でも使えます</value>
-  </data>
-  <data name="calculate a Phoenix score from a result screen" xml:space="preserve">
-    <value>リザルト画面からPhoenixスコアを計算</value>
   </data>
   <data name="pull up a chart's stats and similar charts, with links to its pages" xml:space="preserve">
     <value>譜面のステータスと類似譜面を表示、ページへのリンク付き</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -393,9 +393,6 @@
   <data name="Tier Lists" xml:space="preserve">
     <value>서열표</value>
   </data>
-  <data name="Title Progress" xml:space="preserve">
-    <value>칭호 진행상태</value>
-  </data>
   <data name="Titles" xml:space="preserve">
     <value>칭호</value>
   </data>
@@ -1762,15 +1759,6 @@
   <data name="Score Distribution By Player Level" xml:space="preserve">
     <value>플레이어 레벨별 점수 분포</value>
   </data>
-  <data name="Scores by Competitive Level" xml:space="preserve">
-    <value>경쟁 레벨별 점수</value>
-  </data>
-  <data name="Passes by Competitive Level" xml:space="preserve">
-    <value>경쟁 레벨별 클리어</value>
-  </data>
-  <data name="Chart Leaderboard" xml:space="preserve">
-    <value>채보 리더보드</value>
-  </data>
   <data name="Content Lock" xml:space="preserve">
     <value>콘텐츠 잠금</value>
   </data>
@@ -2292,9 +2280,6 @@
   </data>
   <data name="Scores, vs your level" xml:space="preserve">
     <value>점수 (동레벨 비교)</value>
-  </data>
-  <data name="Weekly charts" xml:space="preserve">
-    <value>주간 채보</value>
   </data>
   <data name="weeks. No misses." xml:space="preserve">
     <value>주 연속. 개근.</value>
@@ -2895,9 +2880,6 @@
   <data name="Players Like You" xml:space="preserve">
     <value>나와 비슷한 플레이어</value>
   </data>
-  <data name="Players like you" xml:space="preserve">
-    <value>나와 비슷한 플레이어</value>
-  </data>
   <data name="Players within one competitive level of you — closer players count more, and so do those whose folder ratings agree with yours." xml:space="preserve">
     <value>경쟁 레벨이 ±1 이내인 플레이어 — 레벨이 가까울수록, 그리고 폴더 평가가 나와 일치할수록 더 크게 반영됩니다.</value>
   </data>
@@ -3294,9 +3276,6 @@
   <data name="When a new mix arrives, nothing here resets. Every score you've recorded stays — to look back on, compare against, and build from. {0} mixes on record, side by side, 1999 to today." xml:space="preserve">
     <value>새 시리즈가 나와도 여기서는 아무것도 초기화되지 않습니다. 기록한 모든 스코어가 남아 — 돌아보고, 비교하고, 쌓아 올릴 수 있습니다. 1999년부터 오늘까지 {0}개 시리즈가 나란히 기록되어 있습니다.</value>
   </data>
-  <data name="today" xml:space="preserve">
-    <value>현재</value>
-  </data>
   <data name="Private by default" xml:space="preserve">
     <value>기본은 비공개</value>
   </data>
@@ -3438,9 +3417,6 @@
   <data name="{0} days old" xml:space="preserve">
     <value>{0}일 전</value>
   </data>
-  <data name="Scoring level" xml:space="preserve">
-    <value>스코어링 레벨</value>
-  </data>
   <data name="± levels" xml:space="preserve">
     <value>± 레벨</value>
   </data>
@@ -3503,9 +3479,6 @@
   </data>
   <data name="only {0} hold it" xml:space="preserve">
     <value>{0}만 보유</value>
-  </data>
-  <data name="completed" xml:space="preserve">
-    <value>달성</value>
   </data>
   <data name="now" xml:space="preserve">
     <value>방금</value>
@@ -3602,9 +3575,6 @@
   </data>
   <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
     <value>당신의 Pumbility와 경쟁 레벨, 그리고 가장 가까운 상대.</value>
-  </data>
-  <data name="Pumbility" xml:space="preserve">
-    <value>Pumbility</value>
   </data>
   <data name="Match players on" xml:space="preserve">
     <value>매칭 기준</value>
@@ -3945,9 +3915,6 @@
   <data name="This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import." xml:space="preserve">
     <value>이것은 영지식이 아닙니다. 로그인은 우리 서버에서 실행되므로, 당신이 가져오는 순간에는 기술적으로 자격 증명을 복호화할 수 있습니다. 우리는 그것을 기록하거나 보관하지 않지만, 매번 수동 가져오기에서 이미 가진 것과 동일한 접근 권한을 당신은 우리에게 맡기는 것입니다.</value>
   </data>
-  <data name="Import scores" xml:space="preserve">
-    <value>점수 가져오기</value>
-  </data>
   <data name="Creating Your Home Page" xml:space="preserve">
     <value>홈 화면을 만드는 중</value>
   </data>
@@ -4080,12 +4047,6 @@
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>아직 기록된 점수가 없습니다 — 첫 주인공이 되어 보세요.</value>
   </data>
-  <data name="your communities" xml:space="preserve">
-    <value>내 커뮤니티</value>
-  </data>
-  <data name="you" xml:space="preserve">
-    <value>나</value>
-  </data>
   <data name="Show more of {0} scores" xml:space="preserve">
     <value>{0}개 점수 더 보기</value>
   </data>
@@ -4100,9 +4061,6 @@
   </data>
   <data name="Debuted in" xml:space="preserve">
     <value>데뷔 시리즈</value>
-  </data>
-  <data name="Pass rate" xml:space="preserve">
-    <value>클리어율</value>
   </data>
   <data name="The evidence" xml:space="preserve">
     <value>근거 데이터</value>
@@ -4350,9 +4308,6 @@
   <data name="Chart Board #1s" xml:space="preserve">
     <value>채보 보드 1위</value>
   </data>
-  <data name="Chart Boards" xml:space="preserve">
-    <value>채보 보드</value>
-  </data>
   <data name="Chart board placements" xml:space="preserve">
     <value>채보 보드 순위</value>
   </data>
@@ -4455,9 +4410,6 @@
   <data name="PUMBILITY over time" xml:space="preserve">
     <value>PUMBILITY 추이</value>
   </data>
-  <data name="rank" xml:space="preserve">
-    <value>랭킹</value>
-  </data>
   <data name="Rank" xml:space="preserve">
     <value>랭킹</value>
   </data>
@@ -4484,9 +4436,6 @@
   </data>
   <data name="Seed baseline from legacy tables" xml:space="preserve">
     <value>기존 테이블에서 기준점 시드 생성</value>
-  </data>
-  <data name="skipped" xml:space="preserve">
-    <value>건너뜀</value>
   </data>
   <data name="Songs" xml:space="preserve">
     <value>곡</value>
@@ -4737,9 +4686,6 @@
   <data name="{0} · levels {1}–{2} · {3}" xml:space="preserve">
     <value>{0} · 레벨 {1}–{2} · {3}</value>
   </data>
-  <data name="Co-op" xml:space="preserve">
-    <value>코옵</value>
-  </data>
   <data name="You don't have a saved preset called &quot;{0}&quot;." xml:space="preserve">
     <value>&quot;{0}&quot;(이)라는 저장된 프리셋이 없습니다.</value>
   </data>
@@ -4842,9 +4788,6 @@
   <data name="Show what this channel is registered for" xml:space="preserve">
     <value>이 채널의 등록 내역 보기</value>
   </data>
-  <data name="Song name" xml:space="preserve">
-    <value>곡 이름</value>
-  </data>
   <data name="Which mix (defaults to Phoenix 2)" xml:space="preserve">
     <value>시리즈 (기본값 Phoenix 2)</value>
   </data>
@@ -4871,9 +4814,6 @@
   </data>
   <data name="What to work on (default Title Hunt)" xml:space="preserve">
     <value>목표 (기본 칭호 사냥)</value>
-  </data>
-  <data name="Community name" xml:space="preserve">
-    <value>커뮤니티 이름</value>
   </data>
   <data name="Invite code (private communities only)" xml:space="preserve">
     <value>초대 코드 (비공개 커뮤니티 전용)</value>
@@ -4998,12 +4938,6 @@
   <data name="PIU Scores official mirror" xml:space="preserve">
     <value>PIU Scores 공식 미러</value>
   </data>
-  <data name="This week" xml:space="preserve">
-    <value>이번 주</value>
-  </data>
-  <data name="What it takes" xml:space="preserve">
-    <value>필요 조건</value>
-  </data>
   <data name="a chart" xml:space="preserve">
     <value>채보</value>
   </data>
@@ -5116,7 +5050,7 @@
     <value>세션 최대 상승</value>
   </data>
   <data name="Title progress" xml:space="preserve">
-    <value>타이틀 진행도</value>
+    <value>칭호 진행상태</value>
   </data>
   <data name="First" xml:space="preserve">
     <value>첫</value>
@@ -5298,9 +5232,6 @@
   <data name="Highest Clear" xml:space="preserve">
     <value>최고 클리어</value>
   </data>
-  <data name="Highest Level" xml:space="preserve">
-    <value>최고 레벨</value>
-  </data>
   <data name="I understand — join" xml:space="preserve">
     <value>이해했습니다 — 가입</value>
   </data>
@@ -5387,9 +5318,6 @@
   </data>
   <data name="Show Regional Guests" xml:space="preserve">
     <value>지역 게스트 표시</value>
-  </data>
-  <data name="Sign In" xml:space="preserve">
-    <value>로그인</value>
   </data>
   <data name="Sign in to accept this invite." xml:space="preserve">
     <value>초대를 수락하려면 로그인해주세요.</value>
@@ -5490,9 +5418,6 @@
   <data name="Charts Not Yet Featured" xml:space="preserve">
     <value>아직 출제되지 않은 채보</value>
   </data>
-  <data name="Charts not yet featured" xml:space="preserve">
-    <value>아직 출제되지 않은 채보</value>
-  </data>
   <data name="Co-op earns no PUMBILITY; the Co-Op view ranks raw score." xml:space="preserve">
     <value>협동은 PUMBILITY를 얻지 않습니다; Co-Op 보기는 원점수로 순위를 매깁니다.</value>
   </data>
@@ -5568,17 +5493,11 @@
   <data name="Your best 4 scores per week of the month count." xml:space="preserve">
     <value>한 달 중 매주 상위 4개 점수가 반영됩니다.</value>
   </data>
-  <data name="current" xml:space="preserve">
-    <value>현재</value>
-  </data>
   <data name="last 14 days" xml:space="preserve">
     <value>최근 14일</value>
   </data>
   <data name="resets in {0}" xml:space="preserve">
     <value>{0} 후 초기화</value>
-  </data>
-  <data name="show all {0}" xml:space="preserve">
-    <value>전체 {0}개 보기</value>
   </data>
   <data name="show suggested only" xml:space="preserve">
     <value>추천만 보기</value>
@@ -5729,9 +5648,6 @@
   </data>
   <data name="Commands — anyone in the server can use these" xml:space="preserve">
     <value>명령어 — 서버의 누구나 사용할 수 있습니다</value>
-  </data>
-  <data name="calculate a Phoenix score from a result screen" xml:space="preserve">
-    <value>결과 화면으로 Phoenix 점수를 계산합니다</value>
   </data>
   <data name="pull up a chart's stats and similar charts, with links to its pages" xml:space="preserve">
     <value>채보의 통계와 유사 채보를 보여주고 페이지 링크도 안내합니다</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -396,9 +396,6 @@
   <data name="Tier Lists" xml:space="preserve">
     <value>Faixas de dificuldade</value>
   </data>
-  <data name="Title Progress" xml:space="preserve">
-    <value>Progresso do título</value>
-  </data>
   <data name="Titles" xml:space="preserve">
     <value>Títulos</value>
   </data>
@@ -1149,9 +1146,6 @@
   <data name="Chart Difficulty by Letter Grade" xml:space="preserve">
     <value>Dificuldade do chart por letra de nota</value>
   </data>
-  <data name="Chart Leaderboard" xml:space="preserve">
-    <value>Classificação do chart</value>
-  </data>
   <data name="Combined" xml:space="preserve">
     <value>Combinado</value>
   </data>
@@ -1215,9 +1209,6 @@
   <data name="Parsed Scores" xml:space="preserve">
     <value>Pontuações processadas</value>
   </data>
-  <data name="Passes by Competitive Level" xml:space="preserve">
-    <value>Passes por nível competitivo</value>
-  </data>
   <data name="Plate Breakdown" xml:space="preserve">
     <value>Detalhamento de plates</value>
   </data>
@@ -1244,9 +1235,6 @@
   </data>
   <data name="Scores" xml:space="preserve">
     <value>Pontuações</value>
-  </data>
-  <data name="Scores by Competitive Level" xml:space="preserve">
-    <value>Pontuações por nível competitivo</value>
   </data>
   <data name="See Leaderboards" xml:space="preserve">
     <value>Ver classificações</value>
@@ -2298,9 +2286,6 @@
   <data name="Scores, vs your level" xml:space="preserve">
     <value>Scores, contra seu nível</value>
   </data>
-  <data name="Weekly charts" xml:space="preserve">
-    <value>Charts semanais</value>
-  </data>
   <data name="weeks. No misses." xml:space="preserve">
     <value>semanas. Sem faltar.</value>
   </data>
@@ -2897,9 +2882,6 @@
   <data name="Players Like You" xml:space="preserve">
     <value>Jogadores como você</value>
   </data>
-  <data name="Players like you" xml:space="preserve">
-    <value>Jogadores como você</value>
-  </data>
   <data name="Players within one competitive level of you — closer players count more, and so do those whose folder ratings agree with yours." xml:space="preserve">
     <value>Jogadores a um nível competitivo do seu — os mais próximos contam mais, assim como os que avaliam as pastas parecido com você.</value>
   </data>
@@ -3293,9 +3275,6 @@
   <data name="When a new mix arrives, nothing here resets. Every score you've recorded stays — to look back on, compare against, and build from. {0} mixes on record, side by side, 1999 to today." xml:space="preserve">
     <value>Quando uma versão nova chega, nada aqui é zerado. Cada pontuação que você registrou fica — para revisitar, comparar e construir em cima. {0} versões registradas, lado a lado, de 1999 até hoje.</value>
   </data>
-  <data name="today" xml:space="preserve">
-    <value>hoje</value>
-  </data>
   <data name="Private by default" xml:space="preserve">
     <value>Privado por padrão</value>
   </data>
@@ -3437,9 +3416,6 @@
   <data name="{0} days old" xml:space="preserve">
     <value>há {0} dias</value>
   </data>
-  <data name="Scoring level" xml:space="preserve">
-    <value>Nível de pontuação</value>
-  </data>
   <data name="± levels" xml:space="preserve">
     <value>± níveis</value>
   </data>
@@ -3502,9 +3478,6 @@
   </data>
   <data name="only {0} hold it" xml:space="preserve">
     <value>só {0} possuem</value>
-  </data>
-  <data name="completed" xml:space="preserve">
-    <value>concluído</value>
   </data>
   <data name="now" xml:space="preserve">
     <value>agora</value>
@@ -3601,9 +3574,6 @@
   </data>
   <data name="Your Pumbility and competitive level, plus your closest matches." xml:space="preserve">
     <value>Seu Pumbility e nível competitivo, além dos seus rivais mais próximos.</value>
-  </data>
-  <data name="Pumbility" xml:space="preserve">
-    <value>Pumbility</value>
   </data>
   <data name="Match players on" xml:space="preserve">
     <value>Combinar jogadores por</value>
@@ -3944,9 +3914,6 @@
   <data name="This is not zero-knowledge: because the login runs on our server, we can technically decrypt your credential at the moment you import. We don't log or keep it — but you are trusting us with the same access we already have on every manual import." xml:space="preserve">
     <value>Isto não é conhecimento zero: como o login roda no nosso servidor, tecnicamente podemos descriptografar sua credencial no momento em que você importa. Não registramos nem guardamos — mas você está nos confiando o mesmo acesso que já temos em cada importação manual.</value>
   </data>
-  <data name="Import scores" xml:space="preserve">
-    <value>Importar pontuações</value>
-  </data>
   <data name="Creating Your Home Page" xml:space="preserve">
     <value>Criando sua página inicial</value>
   </data>
@@ -4079,12 +4046,6 @@
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Ainda não há pontuações — seja a primeira pessoa.</value>
   </data>
-  <data name="your communities" xml:space="preserve">
-    <value>suas comunidades</value>
-  </data>
-  <data name="you" xml:space="preserve">
-    <value>você</value>
-  </data>
   <data name="Show more of {0} scores" xml:space="preserve">
     <value>Mostrar mais de {0} pontuações</value>
   </data>
@@ -4099,9 +4060,6 @@
   </data>
   <data name="Debuted in" xml:space="preserve">
     <value>Estreia em</value>
-  </data>
-  <data name="Pass rate" xml:space="preserve">
-    <value>Taxa de passes</value>
   </data>
   <data name="The evidence" xml:space="preserve">
     <value>As evidências</value>
@@ -4340,9 +4298,6 @@
   <data name="Chart Board #1s" xml:space="preserve">
     <value>Primeiros lugares em placares de charts</value>
   </data>
-  <data name="Chart Boards" xml:space="preserve">
-    <value>Placares de charts</value>
-  </data>
   <data name="Chart board placements" xml:space="preserve">
     <value>Posições nos placares de charts</value>
   </data>
@@ -4445,9 +4400,6 @@
   <data name="PUMBILITY over time" xml:space="preserve">
     <value>PUMBILITY ao longo do tempo</value>
   </data>
-  <data name="rank" xml:space="preserve">
-    <value>posição</value>
-  </data>
   <data name="Rank" xml:space="preserve">
     <value>Posição</value>
   </data>
@@ -4474,9 +4426,6 @@
   </data>
   <data name="Seed baseline from legacy tables" xml:space="preserve">
     <value>Criar base inicial a partir das tabelas antigas</value>
-  </data>
-  <data name="skipped" xml:space="preserve">
-    <value>ignorados</value>
   </data>
   <data name="Songs" xml:space="preserve">
     <value>Músicas</value>
@@ -4727,9 +4676,6 @@
   <data name="{0} · levels {1}–{2} · {3}" xml:space="preserve">
     <value>{0} · níveis {1}–{2} · {3}</value>
   </data>
-  <data name="Co-op" xml:space="preserve">
-    <value>Co-op</value>
-  </data>
   <data name="You don't have a saved preset called &quot;{0}&quot;." xml:space="preserve">
     <value>Você não tem um preset salvo chamado &quot;{0}&quot;.</value>
   </data>
@@ -4832,9 +4778,6 @@
   <data name="Show what this channel is registered for" xml:space="preserve">
     <value>Mostre para o que este canal está registrado</value>
   </data>
-  <data name="Song name" xml:space="preserve">
-    <value>Nome da música</value>
-  </data>
   <data name="Which mix (defaults to Phoenix 2)" xml:space="preserve">
     <value>Qual versão (padrão Phoenix 2)</value>
   </data>
@@ -4861,9 +4804,6 @@
   </data>
   <data name="What to work on (default Title Hunt)" xml:space="preserve">
     <value>No que trabalhar (padrão Title Hunt)</value>
-  </data>
-  <data name="Community name" xml:space="preserve">
-    <value>Nome da comunidade</value>
   </data>
   <data name="Invite code (private communities only)" xml:space="preserve">
     <value>Código de convite (apenas comunidades privadas)</value>
@@ -4988,12 +4928,6 @@
   <data name="PIU Scores official mirror" xml:space="preserve">
     <value>espelho oficial do PIU Scores</value>
   </data>
-  <data name="This week" xml:space="preserve">
-    <value>Esta semana</value>
-  </data>
-  <data name="What it takes" xml:space="preserve">
-    <value>O que é preciso</value>
-  </data>
   <data name="a chart" xml:space="preserve">
     <value>um chart</value>
   </data>
@@ -5106,7 +5040,7 @@
     <value>Maior ganho da sessão</value>
   </data>
   <data name="Title progress" xml:space="preserve">
-    <value>Progresso de título</value>
+    <value>Progresso do título</value>
   </data>
   <data name="First" xml:space="preserve">
     <value>Primeiro</value>
@@ -5288,9 +5222,6 @@
   <data name="Highest Clear" xml:space="preserve">
     <value>Nível máx. com pass</value>
   </data>
-  <data name="Highest Level" xml:space="preserve">
-    <value>Nível máx.</value>
-  </data>
   <data name="I understand — join" xml:space="preserve">
     <value>Entendi — entrar</value>
   </data>
@@ -5377,9 +5308,6 @@
   </data>
   <data name="Show Regional Guests" xml:space="preserve">
     <value>Mostrar convidados regionais</value>
-  </data>
-  <data name="Sign In" xml:space="preserve">
-    <value>Entrar</value>
   </data>
   <data name="Sign in to accept this invite." xml:space="preserve">
     <value>Entre para aceitar este convite.</value>
@@ -5480,9 +5408,6 @@
   <data name="Charts Not Yet Featured" xml:space="preserve">
     <value>Charts ainda não destacados</value>
   </data>
-  <data name="Charts not yet featured" xml:space="preserve">
-    <value>Charts ainda não destacados</value>
-  </data>
   <data name="Co-op earns no PUMBILITY; the Co-Op view ranks raw score." xml:space="preserve">
     <value>O co-op não gera PUMBILITY; a visão Co-Op ordena pela pontuação bruta.</value>
   </data>
@@ -5558,17 +5483,11 @@
   <data name="Your best 4 scores per week of the month count." xml:space="preserve">
     <value>Contam suas 4 melhores pontuações por semana do mês.</value>
   </data>
-  <data name="current" xml:space="preserve">
-    <value>atual</value>
-  </data>
   <data name="last 14 days" xml:space="preserve">
     <value>últimos 14 dias</value>
   </data>
   <data name="resets in {0}" xml:space="preserve">
     <value>reinicia em {0}</value>
-  </data>
-  <data name="show all {0}" xml:space="preserve">
-    <value>ver todos os {0}</value>
   </data>
   <data name="show suggested only" xml:space="preserve">
     <value>ver só sugeridos</value>
@@ -5719,9 +5638,6 @@
   </data>
   <data name="Commands — anyone in the server can use these" xml:space="preserve">
     <value>Comandos — qualquer pessoa no servidor pode usá-los</value>
-  </data>
-  <data name="calculate a Phoenix score from a result screen" xml:space="preserve">
-    <value>calcule uma pontuação Phoenix a partir de uma tela de resultado</value>
   </data>
   <data name="pull up a chart's stats and similar charts, with links to its pages" xml:space="preserve">
     <value>veja as estatísticas de um chart e charts parecidos, com links para as páginas dele</value>

--- a/docs/LOCALIZATION-es-MX.md
+++ b/docs/LOCALIZATION-es-MX.md
@@ -68,7 +68,7 @@ These have at least one existing translation in `App.es-MX.resx`. New translatio
 | Save Scores | Guardar puntajes | |
 | Submit | (untranslated stub) | Existing entry is the English string `Submit`. Translate as `Enviar` when next touched. |
 | Text View | (untranslated stub) | Existing entry is the English string `Text View`. Translate as `Vista de texto`. |
-| Title (in-game title award) | Título | "Title Progress" → `Progreso de títulos`; "Titles" → `Títulos`. |
+| Title (in-game title award) | Título | "Title progress" → `Progreso de títulos`; "Titles" → `Títulos`. |
 | To Do | Cosas que hacer | Literal "things to do." Used compositionally: `Agregar a Cosas que hacer`, `Borrar de la lista de Cosas que hacer`. Alternative `Pendientes` (matches pt-BR) is more idiomatic and shorter; consider switching in a future cleanup. |
 | Tools | Herramientas | |
 | Total Count | Total | `Count` left implicit. |

--- a/docs/LOCALIZATION-fr-FR.md
+++ b/docs/LOCALIZATION-fr-FR.md
@@ -107,7 +107,7 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Tag / Tags | Tag / Tags | Loanwords. |
 | Text View | Vue Textuelle | |
 | Tier Lists | Tier Lists | Untranslated. |
-| Title Progress | Progression des titres | |
+| Title progress | Progression des titres | |
 | Titles | Titres | |
 | To Do | À Faire | "ToDo List" / "ToDo Charts" stay English in compounds, but bare "To Do" → `À Faire`. |
 | To Leaderboard | Vers le Leaderboard | Nav label pointing at the leaderboard page. |
@@ -178,7 +178,7 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Skill | Compétence | |
 | Stage Pass | Stage Pass | Untranslated. |
 | Suggested Chart | Chart Suggérée | |
-| Title (in-game title award) | Titre | "Title Progress" → "Progression des titres"; "Titles" → "Titres". |
+| Title (in-game title award) | Titre | "Title progress" → "Progression des titres"; "Titles" → "Titres". |
 | Favorites | Favoris | "Add to Favorites" → "Ajouter aux favoris". |
 | Progress Charts | Statistiques Joueur | nabulator-style interpretive rendering ("player statistics" rather than "progress charts"). Title Case. Loses the literal meaning — see Known issues. |
 | Player Stats | (covered by Progress Charts) | |

--- a/docs/LOCALIZATION-it-IT.md
+++ b/docs/LOCALIZATION-it-IT.md
@@ -161,7 +161,7 @@ Prescribed ahead of the first batch and applied by it — these are now in force
 | Suggested Chart | Chart suggerito | Masculine agreement per Charts gender decision below. |
 | Tag / Tags | Tag / Tag | Loanword, masculine. Italian loanwords are invariable in plural — don't write `Tags`. |
 | Text View | Vista testo | Or `Visualizzazione testo`; pick the shorter for a column header. |
-| Title | Titolo | "Title Progress" → `Progresso dei titoli`; "Titles" → `Titoli`. |
+| Title | Titolo | "Title progress" → `Progresso dei titoli`; "Titles" → `Titoli`. |
 | TLDR | TLDR | Acronym preserved (matches all other locales). |
 | To Do | Da fare | Bare "To Do" → `Da fare`. Compounds keep `ToDo` English (`ToDo List`, `ToDo Charts`). |
 | Tools | Strumenti | Masculine plural. |
@@ -299,7 +299,7 @@ Prescribed ahead of the first batch and applied by it — these are now in force
 | Top 50 X | Top 50 {0} | |
 | What Should I Play (?) | Cosa dovrei giocare(?) | Both with-and-without-`?` source variants present. |
 | XX Progress | Progresso XX | No article (matches pt-BR/fr-FR/es-MX pattern, sidesteps gender ambiguity). |
-| Title (in-game title award) | Titolo | "Title Progress" → `Progresso dei titoli`; "Titles" → `Titoli`. |
+| Title (in-game title award) | Titolo | "Title progress" → `Progresso dei titoli`; "Titles" → `Titoli`. |
 | Favorites | Preferiti | (Cross-reference.) |
 
 ### Game-mechanic vocabulary

--- a/docs/LOCALIZATION-ja-JP.md
+++ b/docs/LOCALIZATION-ja-JP.md
@@ -78,7 +78,7 @@ These have at least one existing translation in `App.ja-JP.resx`. New translatio
 | Stats / Statistics | 統計 | "Player Stats" → 進捗中の譜面 (note: nabulator interpreted this as in-progress charts, not literal stats — see Known issues). "Game Stats" → ゲーム統計. |
 | Submit | 登録 | Also used for "Submission". |
 | Tag(s) | タグ | |
-| Title (in-game title award) | タイトル | "Title Progress" → タイトル進捗, "Titles" → タイトル. |
+| Title (in-game title award) | タイトル | "Title progress" → タイトル進捗, "Titles" → タイトル. |
 | To Do | やること | Compounds use やることリスト. |
 | Tools | ツール | Also "this tool" mid-prose: このツール. |
 | Total | 総計 | |

--- a/docs/LOCALIZATION-ko-KR.md
+++ b/docs/LOCALIZATION-ko-KR.md
@@ -65,7 +65,7 @@ These have at least one existing translation in `App.ko-KR.resx`. New translatio
 | Show | 표시 | "Show Score Distribution" → 점수 분포 표시. Suffix pattern. |
 | Show Only X | X만 보기 | "Show Only ToDo Charts" → 목표 채보만 보기. Particle `만` ("only") + 보기 ("view"). |
 | Submit | 제출 | "Submission Page" → 제출 페이지. |
-| Title (in-game title award) | 칭호 | "Title Progress" → 칭호 진행상태, "Titles" → 칭호. |
+| Title (in-game title award) | 칭호 | "Title progress" → 칭호 진행상태, "Titles" → 칭호. |
 | To Do | 목표 | Rendered as "goal." "Add to ToDo" → 목표 목록에 추가; "Show Only ToDo Charts" → 목표 채보만 보기. |
 | Tools | 도구 | |
 | Total Count | 총 | Rendered as bare 총 ("total"); the `Count` is implicit. |

--- a/docs/LOCALIZATION-pt-BR.md
+++ b/docs/LOCALIZATION-pt-BR.md
@@ -97,7 +97,7 @@ These have **at least one** existing translation in `App.pt-BR.resx`. New transl
 | Song | Música | "Song Name" → "Nome da música"; "Song Duration" → "Duração da música". |
 | Song Artist | Artista da música | |
 | Song Type | Tipo de música | |
-| Title (in-game title award) | Título | "Title Progress" → "Progresso do título"; "Titles" → "Títulos". |
+| Title (in-game title award) | Título | "Title progress" → "Progresso do título"; "Titles" → "Títulos". |
 | To Do | Pendentes | "Add to ToDo" → "Adicionar à lista de tarefas"; "Show Only ToDo Charts" → `Mostrar somente charts "Pendentes"`. |
 | Favorites | Favoritos | "Add to Favorites" → "Adicionar aos favoritos". |
 | Tier Lists | Faixas de dificuldade | |


### PR DESCRIPTION
## What

`ScoreTracker/ScoreTracker/Resources/App.*.resx` held **29 key pairs differing only by case** — `Song Name`/`Song name`, `Import Scores`/`Import scores`, `You`/`you`, and so on. .NET resource lookup is case-sensitive, so these were genuinely distinct keys: nothing was broken, but translators localized the same phrase twice across nine locales and the two copies drifted.

**28 pairs are now one key each.** For each pair the canonical spelling is the one with more real call sites (ties → Title Case); every call site uses it, and the redundant key is deleted from all nine resx files.

- 31 call sites updated across 22 files
- 28 keys × 9 locales removed (3-line blocks, 84 deletions per file)
- 5 resx values repaired, 6 glossary docs updated

## The pair that was NOT merged

**`min` and `Min` are not a case pair — they are different words.**

| key | meaning | es | ja | ko |
|---|---|---|---|---|
| `min` | **minutes** (session-roundup duration) | `min` | `分` | `분` |
| `Min` | **minimum** (paired with Max/Median/Avg) | `Mín.` | `最小` | `최소` |

Merging them would have made a duration read "42 Min" and forced *minutes* and *minimum* to share one translation slot. Both stay. This is now the **only** case collision left in the catalogues, and it is deliberate.

## Two judgement calls worth a look

**`Scoring Level` wins its pair despite fewer call sites.** It doubles as a persisted `ChartSkills` grouping token (`ValidGroupings`, the `GroupByScoringLevel()` switch, `ChangeGrouping`) as well as a resx key, so merging the other direction would have rewritten saved user settings and bookmarked state. The two `Scoring level` sites moved instead.

**`Your Communities` wins over `your communities`** even though the lowercase form has more sites — the lowercase sites are legend labels that pair with `You`, and the winner's site is an `<h6>` heading that would read wrong in lowercase.

Casing is invisible at several merged sites anyway: `.chart-fact-label`, `.dash-acct-eyebrow` and MudBlazor's `Typo.overline` are all `text-transform: uppercase`.

## Why the census had to be redone

Grepping `L["..."]` **under-counts**. Keys also reach the localizer through:

1. `L.GetString("Key")` — `TitleProgressBar`
2. `_localizer.Get(culture, "Key")` — the Discord sagas
3. **Dynamic string catalogs** — `PiuCommandCatalog` runs *every* Discord command/option description and translatable choice name through the localizer, so bare literals like `"Highest level"`, `"Song name"`, `"Community name"` are live keys. Same shape: `L[dimension.Label]`, `L[_groupBy]`, `L[result.Status]`, `WidgetRegistry`.
4. Test pins asserting rendered English, often with the key embedded in a longer literal (`Assert.Contains("-# Co-op", …)`).

The first pass marked five live keys dead and picked the wrong winner twice. Most visibly: `Highest level` is a live Discord option description, so it wins over the genuinely-unreferenced `Highest Level`.

## Translation repair

Merging collapses two translations into one, and in five locales that dropped a value the glossaries had already ratified. The documented translation is carried onto the surviving `Title progress` key for es-MX, fr-FR, it-IT, ko-KR and pt-BR. **ko mattered most** — the surviving value used the loanword `타이틀` where `LOCALIZATION-ko-KR.md` mandates `칭호`. The glossary docs now cite the canonical spelling.

Worth noting the merge also *improved* several locales: es-ES's volunteer rejects `puntuación` (score → `score`), and it-IT / fr-FR document `Livello di scoring` / `Taux de Pass` — the surviving values were the ratified ones and the retired duplicates were the stale ones.

## Verification

resx files are UTF-8-with-BOM + CRLF and have been corrupted by bulk edits before, so all four guards were run on all nine files:

| check | result |
|---|---|
| `git diff --numstat` | 0 ins / 84 del ×4; 1 ins / 85 del ×5 (the value repairs) — no line-ending rewrite |
| conflict markers | 0 across all 37 changed files |
| case-sensitive duplicate keys | 0 |
| `XmlDocument.Load` parse | all nine pass; BOM + zero lone LFs retained |
| case-insensitive collisions | exactly 1 per file — the intentional `min`/`Min` |

Plus the round-trip the task called for: **no removed key is still referenced anywhere**, and **every canonical key resolves in `App.en-US.resx`**.

Fast suites (built and run in a throwaway worktree, since VS locks the Debug bins): **1667 / 60 / 293 passed, exit 0** each. One test pin needed updating — `CommunitySagaTests` asserted `"-# Co-op"` for the Discord co-op bucket label.

## Reviewer notes

- **Discord command descriptions shift casing** where the web side won the pair: the `/piu` catalog now shows `Song Name`, `Community Name`, `Co-Op`. Cosmetic, and it makes the bot and site agree.
- **`Skipped` renders `(+3 Omitido)`** on the leaderboards admin page — its es/fr/it/pt values are singular and gender-inconsistent. That is pre-existing drift in a key no glossary governs, so it is flagged rather than rewritten. Admin-only.
- Out of scope, unchanged: 154 pre-existing `L[...]` keys missing from en-US, almost entirely `ChartRandomizer` / `RandomizerSettingsPanel` (PR #143's deferred C11 l10n pass). They fall back to the key text, which is the English UI string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
