### PR TITLE
Show the upscore gain on the session card's compact score rows

### DIFF
--- a/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
@@ -454,7 +454,8 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         var lines = new List<string>();
         foreach (var c in rows)
         {
-            var row = CompactRow(inputs.Charts[c.ChartId], inputs.Bests[c.ChartId], ReclearMark(inputs, c.ChartId));
+            var row = CompactRow(c, inputs.Charts[c.ChartId], inputs.Bests[c.ChartId],
+                ReclearMark(inputs, c.ChartId));
             var cost = Estimate(row) + 1; // + newline
             if (used + cost > remaining) break;
             used += cost;
@@ -467,10 +468,28 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         blocks.Add(new RichBotText($"-# {label}\n" + string.Join("\n", lines)));
     }
 
-    private static string CompactRow(Chart chart, RecordedPhoenixScore best, string reclearMark)
+    private static string CompactRow(ScoreHighlightsCapturedEvent.HighlightedChange change, Chart chart,
+        RecordedPhoenixScore best, string reclearMark)
     {
-        return $"#DIFFICULTY|{chart.DifficultyString}# {chart.Song.Name}{reclearMark} — **{(int)best.Score!.Value:N0}** " +
-               $"#LETTERGRADE|{best.Score!.Value.LetterGradeFor(chart.Mix)}|{best.IsBroken}##PLATE|{best.Plate}#";
+        return $"#DIFFICULTY|{chart.DifficultyString}# {chart.Song.Name}{reclearMark} — **{(int)best.Score!.Value:N0}**" +
+               UpscoreDelta(change, chart, best) +
+               $" #LETTERGRADE|{best.Score!.Value.LetterGradeFor(chart.Mix)}|{best.IsBroken}##PLATE|{best.Plate}#";
+    }
+
+    // The gain an upscore earned, plus the grade it came from when it crossed one:
+    // " (+12,340) <A> →". Shared by the notable art rows and the compact buckets, so an
+    // upscore reads the same wherever it lands. New passes have nothing to compare against
+    // and render bare. The batch only records an old score when the new one beat it, so the
+    // gain is always positive.
+    private static string UpscoreDelta(ScoreHighlightsCapturedEvent.HighlightedChange change, Chart chart,
+        RecordedPhoenixScore best)
+    {
+        if (change.IsNewPass || change.OldScore == null) return string.Empty;
+        var gain = $" (+{(int)best.Score!.Value - change.OldScore.Value:N0})";
+        var oldLetter = PhoenixScore.From(change.OldScore.Value).LetterGradeFor(chart.Mix);
+        return oldLetter == best.Score!.Value.LetterGradeFor(chart.Mix)
+            ? gain
+            : gain + $" #LETTERGRADE|{oldLetter}|False# →";
     }
 
     private void AddOverflowLine(List<IRichBotBlock> blocks, SnapshotInputs inputs, string? culture,
@@ -720,17 +739,9 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
     private string UpscoreRow(ScoreHighlightsCapturedEvent.HighlightedChange change, Chart chart,
         RecordedPhoenixScore best, bool bigGain, string? culture)
     {
-        var row = $"#DIFFICULTY|{chart.DifficultyString}# {SongLink(change, chart, bigGain)} " +
-                  $"**{(int)best.Score!.Value:N0}**";
-        if (change.OldScore != null)
-        {
-            row += $" (+{(int)best.Score!.Value - change.OldScore.Value:N0})";
-            var oldLetter = PhoenixScore.From(change.OldScore.Value).LetterGradeFor(chart.Mix);
-            if (oldLetter != best.Score!.Value.LetterGradeFor(chart.Mix))
-                row += $" #LETTERGRADE|{oldLetter}|False# →";
-        }
-
-        return row + $" #LETTERGRADE|{best.Score!.Value.LetterGradeFor(chart.Mix)}|{best.IsBroken}##PLATE|{best.Plate}#" +
+        return $"#DIFFICULTY|{chart.DifficultyString}# {SongLink(change, chart, bigGain)} " +
+               $"**{(int)best.Score!.Value:N0}**" + UpscoreDelta(change, chart, best) +
+               $" #LETTERGRADE|{best.Score!.Value.LetterGradeFor(chart.Mix)}|{best.IsBroken}##PLATE|{best.Plate}#" +
                FlagCaption(change, chart, best, bigGain, culture);
     }
 

--- a/ScoreTracker/ScoreTracker.ExplorationTests/DiscordCanary/DiscordCanaryTests.cs
+++ b/ScoreTracker/ScoreTracker.ExplorationTests/DiscordCanary/DiscordCanaryTests.cs
@@ -99,7 +99,9 @@ public sealed class DiscordCanaryTests
                 new RichBotSection(
                     "#DIFFICULTY|s18# **Turkey March -Minimal Tunes-**\n**972,340** #LETTERGRADE|SSS|False##PLATE|SuperbGame#\n-# 🏅 [DRILL] Lv.4 (972k/990k) · 📊 #3 of 47 peers",
                     new Uri("https://piuimages.arroweclip.se/songs/TurkeyMarchMinimalTunes.png")),
-                new RichBotText("-# More scores\n#DIFFICULTY|s16# Bad Apple — **945,120** #LETTERGRADE|SS|False##PLATE|MarvelousGame#"),
+                // Bad Apple is this sample's one upscore, so its compact row carries the gain
+                // and the grade it crossed — the same fragment the art rows use.
+                new RichBotText("-# More scores\n#DIFFICULTY|s16# Bad Apple — **945,120** (+5,120) #LETTERGRADE|SPlus|False# → #LETTERGRADE|SS|False##PLATE|MarvelousGame#"),
                 new RichBotDivider(),
                 new RichBotText("#DIFFICULTY|d19# 84/141 · #DIFFICULTY|s18# 182/195")
             },
@@ -127,8 +129,10 @@ public sealed class DiscordCanaryTests
                 new RichBotSection(
                     "#DIFFICULTY|d20# **Removable Disk0**\n**962,410** #LETTERGRADE|AAAPlus|False##PLATE|FairGame#\n-# 👑 #7 in your PUMBILITY",
                     new Uri("https://piuimages.arroweclip.se/songs/RemovableDisk0.png")),
+                // One upscore (gain + crossing) beside one fresh pass (bare) — both compact
+                // shapes in a single bucket.
                 new RichBotText("-# More scores\n" +
-                                "#DIFFICULTY|d19# Yog-Sothoth — **951,020** #LETTERGRADE|SS|False##PLATE|SuperbGame#\n" +
+                                "#DIFFICULTY|d19# Yog-Sothoth — **951,020** (+7,410) #LETTERGRADE|SPlus|False# → #LETTERGRADE|SS|False##PLATE|SuperbGame#\n" +
                                 "#DIFFICULTY|s21# Errorcode 0 — **933,400** #LETTERGRADE|S|False##PLATE|MarvelousGame#"),
                 new RichBotText("+2,008 more: D23 ×12, S22 ×48, S21 ×95, CO-OP ×31"),
                 new RichBotDivider(),

--- a/ScoreTracker/ScoreTracker.ExplorationTests/DiscordCanary/PiuCardCanaryTests.cs
+++ b/ScoreTracker/ScoreTracker.ExplorationTests/DiscordCanary/PiuCardCanaryTests.cs
@@ -67,7 +67,7 @@ public sealed class PiuCardCanaryTests
                 new RichBotText(
                     "-# 그 외 점수\n" +
                     "#DIFFICULTY|S19# Trashy Innocence\\* — **984,120** #LETTERGRADE|SS|False##PLATE|SuperbGame#\n" +
-                    "#DIFFICULTY|S18# Bee — **977,860** #LETTERGRADE|SS|False##PLATE|SuperbGame#"),
+                    "#DIFFICULTY|S18# Bee — **977,860** (+6,560) #LETTERGRADE|S|False# → #LETTERGRADE|SS|False##PLATE|SuperbGame#"),
                 new RichBotDivider(),
                 new RichBotText("#DIFFICULTY|S21# 3/42 · #DIFFICULTY|S18# 12/58")
             },
@@ -170,7 +170,7 @@ public sealed class PiuCardCanaryTests
                 new RichBotText(
                     "-# More scores\n" +
                     "#DIFFICULTY|S19# Trashy Innocence\\* — **984,120** #LETTERGRADE|SS|False##PLATE|SuperbGame#\n" +
-                    "#DIFFICULTY|S18# Bee — **977,860** #LETTERGRADE|SS|False##PLATE|SuperbGame#"),
+                    "#DIFFICULTY|S18# Bee — **977,860** (+6,560) #LETTERGRADE|S|False# → #LETTERGRADE|SS|False##PLATE|SuperbGame#"),
                 new RichBotDivider(),
                 new RichBotText("#DIFFICULTY|S21# 3/42 · #DIFFICULTY|S18# 12/58")
             },

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -758,6 +758,54 @@ public sealed class CommunitySagaTests
     }
 
     [Fact]
+    public async Task CompactBucketUpscoresCarryTheGainAndTheGradeTheyCrossed()
+    {
+        // An upscore that falls to a compact bucket reads like one that won an art row — the
+        // gain, then the grade it came from. Both buckets ("More scores" and "Co-op") do it; a
+        // fresh pass has nothing to compare against and stays bare. Gains sit under the 💥
+        // threshold so nothing gets promoted out of the buckets.
+        var userId = Guid.NewGuid();
+        var singles = Enumerable.Range(10, 7) // S10..S16 — the top five take the art rows
+            .Select(level => new ChartBuilder().WithType(ChartType.Single).WithLevel(level).Build())
+            .ToArray();
+        var coOp = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(2).Build();
+        var ctx = new HandlerContext();
+        ctx.GivenUser(userId, name: "alice");
+        ctx.GivenUserCommunitiesWithChannel(userId, communityName: "Acme", channelId: 12345);
+        ctx.GivenScoreAnnouncementLookups(MixEnum.Phoenix, userId, singles.Append(coOp).ToArray(),
+            score: 950000);
+
+        // S11 and the co-op upscore off 945,000 (AA+ → AAA); every other chart is a fresh pass.
+        var changes = singles.Select(c => Change(c, c == singles[1] ? 945000 : null))
+            .Append(Change(coOp, 945000)).ToArray();
+        await ctx.Saga.Consume(BuildContext(ScoreHighlightsCapturedEvent.Create(Now, userId,
+            MixEnum.Phoenix, null, changes)));
+
+        ctx.Bot.Verify(b => b.SendRichMessages(
+            It.Is<IEnumerable<RichBotMessage>>(msgs =>
+                BucketRow(msgs, "More scores", "S11")
+                    .Contains("**950,000** (+5,000) #LETTERGRADE|AAPlus|False# → #LETTERGRADE|AAA")
+                && !BucketRow(msgs, "More scores", "S10").Contains("(+")
+                && BucketRow(msgs, "Co-op", "CoOp2").Contains("(+5,000) #LETTERGRADE|AAPlus|False# →")),
+            It.IsAny<IEnumerable<ulong>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static ScoreHighlightsCapturedEvent.HighlightedChange Change(Chart chart, int? oldScore)
+    {
+        return new ScoreHighlightsCapturedEvent.HighlightedChange(chart.Id, oldScore == null, oldScore,
+            950000, "SuperbGame", false, HighlightFlags.None);
+    }
+
+    // One row out of a labelled compact bucket, picked by its difficulty token.
+    private static string BucketRow(IEnumerable<RichBotMessage> msgs, string label, string difficulty)
+    {
+        return msgs.Single().Blocks.OfType<RichBotText>()
+            .First(t => t.Markdown.StartsWith($"-# {label}")).Markdown
+            .Split('\n').First(l => l.Contains($"#DIFFICULTY|{difficulty}#"));
+    }
+
+    [Fact]
     public async Task StatsAndAchievementsOpenTheCardAsTheirOwnSections()
     {
         var userId = Guid.NewGuid();

--- a/docs/design/discord-rich-score-notifications.md
+++ b/docs/design/discord-rich-score-notifications.md
@@ -75,6 +75,14 @@ PR. Decisions and rationale:
    with one flagged score showed one jacket over a bare list. **Co-ops are eligible** — they sort
    last so they never take a slot an S/D score could fill, but a co-op-only session gets jackets
    instead of nothing. ("Co-ops lost their dedicated art rows" was never an owner decision.)
+
+   ⚠ **Amended 2026-07-26 — compact rows show the upscore gain.** A one-liner used to render
+   only the resulting score, so an upscore in a bucket was indistinguishable from a fresh pass.
+   Both buckets now carry the same `(+12,340)` gain and the same `<old grade> →` crossing the
+   art rows use — one `UpscoreDelta` helper builds the fragment for both, so the two can't
+   drift. New passes have nothing to compare against and stay bare. The buckets already pack
+   by estimated rendered width, so the wider rows just mean a full card spills one row earlier
+   into "+N more".
 2. **Score-computable title completions ride the card.** The "piugame site detected" legacy
    message now covers only badges the score pipeline can't compute (`CompletionRequired == 0`:
    events, play/plate counts, staff). Difficulty, skill, boss-breaker and co-op completions


### PR DESCRIPTION
The "More scores" and "Co-op" buckets on the Discord session-snapshot card rendered only a score's resulting value, so an upscore that landed in a bucket was indistinguishable from a fresh pass. Both buckets now carry the gain and the grade crossing that the notable art rows already showed.

## What a row reads like

Before:

```
More scores
[D19] Yog-Sothoth — 951,020 [SS][SG]
[S21] Errorcode 0 — 933,400 [S][MG]
```

After (Yog-Sothoth was an upscore, Errorcode 0 a fresh pass):

```
More scores
[D19] Yog-Sothoth — 951,020 (+7,410) [S+] → [SS][SG]
[S21] Errorcode 0 — 933,400 [S][MG]
```

## What changed

- The gain fragment moves out of `UpscoreRow` into a shared `UpscoreDelta`, which both the art rows and `CompactRow` build from — the two shapes can't drift apart. The notable rows render byte-identically to before.
- New passes have nothing to compare against and stay bare.
- The **Co-op** bucket gets the same treatment; it shares the row builder.
- Three hand-authored Discord canary sample cards updated — they were still showing the old bare shape.
- ⚠ amendment on the compact-row spec in `docs/design/discord-rich-score-notifications.md`.

## Reviewer notes

- **The gain is always positive.** The batch only records an old score when the new one strictly beat it (`UpdatePhoenixRecordHandler`), so there is no `(+0)` or negative case to guard.
- **The arrow renders only on an actual grade crossing** — same rule as the art rows. An upscore inside one band shows just `(+5,000)`.
- **No character-ceiling risk.** `AddCompactBucket` already measures each row's estimated rendered width (literal length + per-emoji-token width) before adding it, so the wider rows just mean a very full card spills one row earlier into the "+N more" count line.
- No new localization keys — the fragment is numbers and emoji tokens, built inline exactly as the art rows already did.

## Testing

New pinning test `CompactBucketUpscoresCarryTheGainAndTheGradeTheyCrossed` covers both buckets plus the bare-pass case.

Fast suites green locally: `ScoreTracker.Tests` 1802, `Tests.Api` 65, `Tests.Components` 433; solution builds Debug with 0 errors. Integration and E2E were not run locally — this is string composition inside one saga with no schema, API, or page surface, and all of `CommunitySaga`'s coverage lives in the fast suite. CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
