### PR TITLE
Stop the compact-bucket row helper from masking the assertion that failed

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -774,6 +774,15 @@ public sealed class CommunitySagaTests
         ctx.GivenUserCommunitiesWithChannel(userId, communityName: "Acme", channelId: 12345);
         ctx.GivenScoreAnnouncementLookups(MixEnum.Phoenix, userId, singles.Append(coOp).ToArray(),
             score: 950000);
+        // The card is captured and asserted on afterwards rather than matched inside an It.Is
+        // predicate: the row assertions then name which expectation broke and print the card,
+        // instead of collapsing into one opaque "0 matching invocations".
+        var sent = new List<RichBotMessage>();
+        ctx.Bot.Setup(b => b.SendRichMessages(It.IsAny<IEnumerable<RichBotMessage>>(),
+                It.IsAny<IEnumerable<ulong>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<RichBotMessage>, IEnumerable<ulong>, CancellationToken>(
+                (msgs, _, _) => sent.AddRange(msgs))
+            .Returns(Task.CompletedTask);
 
         // S11 and the co-op upscore off 945,000 (AA+ → AAA); every other chart is a fresh pass.
         var changes = singles.Select(c => Change(c, c == singles[1] ? 945000 : null))
@@ -781,14 +790,14 @@ public sealed class CommunitySagaTests
         await ctx.Saga.Consume(BuildContext(ScoreHighlightsCapturedEvent.Create(Now, userId,
             MixEnum.Phoenix, null, changes)));
 
-        ctx.Bot.Verify(b => b.SendRichMessages(
-            It.Is<IEnumerable<RichBotMessage>>(msgs =>
-                BucketRow(msgs, "More scores", "S11")
-                    .Contains("**950,000** (+5,000) #LETTERGRADE|AAPlus|False# → #LETTERGRADE|AAA")
-                && !BucketRow(msgs, "More scores", "S10").Contains("(+")
-                && BucketRow(msgs, "Co-Op", "CoOp2").Contains("(+5,000) #LETTERGRADE|AAPlus|False# →")),
-            It.IsAny<IEnumerable<ulong>>(),
-            It.IsAny<CancellationToken>()), Times.Once);
+        var card = Assert.Single(sent);
+        Assert.Contains("**950,000** (+5,000) #LETTERGRADE|AAPlus|False# → #LETTERGRADE|AAA",
+            BucketRow(card, "More scores", "S11"));
+        var freshPass = BucketRow(card, "More scores", "S10");
+        // The score runs straight into the grade — no gain fragment between them.
+        Assert.Contains("**950,000** #LETTERGRADE|AAA", freshPass);
+        Assert.DoesNotContain("(+", freshPass);
+        Assert.Contains("(+5,000) #LETTERGRADE|AAPlus|False# →", BucketRow(card, "Co-Op", "CoOp2"));
     }
 
     private static ScoreHighlightsCapturedEvent.HighlightedChange Change(Chart chart, int? oldScore)
@@ -797,12 +806,19 @@ public sealed class CommunitySagaTests
             950000, "SuperbGame", false, HighlightFlags.None);
     }
 
-    // One row out of a labelled compact bucket, picked by its difficulty token.
-    private static string BucketRow(IEnumerable<RichBotMessage> msgs, string label, string difficulty)
+    // One row out of a labelled compact bucket, picked by its difficulty token. A missing bucket
+    // or row fails here, naming what it looked for and printing the card, so a moved bucket label
+    // or row format says which one moved. It must not hand a substitute string back to the caller:
+    // a dump of the card satisfies the callers' Assert.Contains and passes a broken test.
+    private static string BucketRow(RichBotMessage card, string label, string difficulty)
     {
-        return msgs.Single().Blocks.OfType<RichBotText>()
-            .First(t => t.Markdown.StartsWith($"-# {label}")).Markdown
-            .Split('\n').First(l => l.Contains($"#DIFFICULTY|{difficulty}#"));
+        var blocks = card.Blocks.OfType<RichBotText>().ToArray();
+        var row = blocks.Where(t => t.Markdown.StartsWith($"-# {label}"))
+            .SelectMany(t => t.Markdown.Split('\n'))
+            .FirstOrDefault(l => l.Contains($"#DIFFICULTY|{difficulty}#"));
+        Assert.True(row != null, $"No {difficulty} row under \"{label}\". Card text blocks:\n"
+                                 + string.Join("\n", blocks.Select(t => t.Markdown)));
+        return row!;
     }
 
     [Fact]


### PR DESCRIPTION
## What changed

`CommunitySagaTests.CompactBucketUpscoresCarryTheGainAndTheGradeTheyCrossed` now captures the sent card and asserts on it with plain xUnit, instead of matching inside an `It.Is` predicate. The `BucketRow` helper takes one card, and a missing bucket or row fails at the point of the miss with the card's text blocks attached.

## Why

`BucketRow` reached its row with two `First()` calls from inside a Moq predicate. When a bucket label or row format moved, the test failed with `InvalidOperationException: Sequence contains no matching element` pointing at the helper — not at which of the three expectations broke, and with nothing about what the card actually rendered.

That is not hypothetical. PR #196 landed this test asserting `BucketRow(msgs, "Co-op", "CoOp2")`, correct at the time. Hours later PR #197 canonicalized the resx key `"Co-op"` → `"Co-Op"` (two keys differing only by case can't coexist — `GenerateResource` drops one), which moved the session card's bucket label to `-# Co-Op`. That sweep did update the `Contains("-# Co-op")` assertion in this same file, but missed the bare-string *argument* form. The test failed on `main` at `eace2afe`, and the message gave a reader nothing to go on.

**The label itself is already fixed** — repaired in merge commit `442fa25e`, shipped with PR #198, so `main` is green today. This PR is only about the diagnosis being unreadable. (`git log -S` can't find that repair, because merge diffs are simplified away by default; `--diff-merges=first-parent` shows it.)

Re-breaking the label now produces:

```
No CoOp2 row under "Co-op". Card text blocks:
-# More scores
#DIFFICULTY|S11# Test Song — **950,000** (+5,000) #LETTERGRADE|AAPlus|False# → ...
-# Co-Op
#DIFFICULTY|CoOp2# Test Song — **950,000** (+5,000) ...
```

## Reviewer notes

- **`BucketRow` deliberately does not return a substitute string on a miss.** Returning a dump of the card reads like the obvious fix, and it passes a genuinely broken test: the callers assert with `Assert.Contains`, and the expected substring is present inside the dump. I hit exactly that while writing this, and verified the final shape by re-breaking the label both ways. The constraint is in the comment so it survives a later cleanup.
- The `S10` "fresh pass stays bare" case gained a positive assertion (`**950,000** #LETTERGRADE|AAA` — score running straight into the grade) alongside the existing `DoesNotContain("(+")`. `DoesNotContain` alone would pass if the row vanished entirely.
- `Assert.Single(sent)` replaces the old `Times.Once`, so "exactly one card" is still pinned.
- The `Callback`-capture shape matches the existing precedent in `DiscordFeedSagaTests`.
- No production code is touched, and the sibling helper `MoreScoresAreLevelDescending` has the same masking shape but was left alone as out of scope.

## Testing

`dotnet test ScoreTracker/ScoreTracker.Tests/ScoreTracker.Tests.csproj` — 1823/1823 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
