### PR TITLE
fix(seo): stop crawlers walking the mix-switch endpoint

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.E2E/NonComponentEndpointTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/NonComponentEndpointTests.cs
@@ -121,6 +121,23 @@ public sealed class NonComponentEndpointTests : IAsyncLifetime
     }
 
     /// <summary>
+    ///     The shell's mix menu renders an anchor per mix on every page, each one
+    ///     /Mix/Set?mix=X&amp;redirectUrl=&lt;this page&gt;. Left crawlable that is 31 redirect-only
+    ///     URLs per indexable page — the whole chart catalogue multiplied — so the endpoint is
+    ///     robots-blocked and the casing has to match the anchors, which robots.txt compares
+    ///     case-sensitively.
+    /// </summary>
+    [Fact]
+    public async Task RobotsTxtKeepsCrawlersOffTheMixSwitchEndpoint()
+    {
+        var response = await _client.GetAsync("/robots.txt");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Disallow: /Mix/Set", body);
+    }
+
+    /// <summary>
     ///     The chart head is the SEO payoff: a crawler runs no circuit, so the chart's name,
     ///     description and jacket must be in the raw HTML the server returns — this reads the
     ///     document exactly as a crawler does, no browser.

--- a/ScoreTracker/ScoreTracker/wwwroot/robots.txt
+++ b/ScoreTracker/ScoreTracker/wwwroot/robots.txt
@@ -3,5 +3,6 @@ Disallow: /hangfire
 Disallow: /api/
 Disallow: /Dev/
 Disallow: /Admin
+Disallow: /Mix/Set
 
 Sitemap: https://piuscores.arroweclip.se/sitemap.xml


### PR DESCRIPTION
## Why

Google was indexing URLs like `https://piuscores.arroweclip.se/Mix/Set?mix=Infinity&redirectUrl=%2FPhoenixToXXCalculator`. Two things combine to produce those:

1. `ShellMixMenu` renders in the **static server-rendered header on every page** (`App.razor:121`), and each entry is a plain anchor to `/Mix/Set?mix={mix}&redirectUrl={UrlEncode(ReturnUrl)}` (`ShellMixMenu.razor:76`), where `ReturnUrl` is the current path+query. That is 31 anchors — the primary trio plus 28 legacy mixes — sitting in the raw HTML a crawler reads. The nested `<details>` disclosures don't hide them; collapsed `<details>` content is still in the source.
2. Nothing stopped the follow. `robots.txt` disallowed only `/hangfire`, `/api/`, `/Dev/`, `/Admin`, and `ShellMenuItem` sets `rel` only for `External` links (`noopener`), so these carry no `rel="nofollow"`.

The scale is the actual problem. It is 31 mixes × **every** URL in the sitemap — every chart in every mix, every Singles/Doubles tier-list folder, every adjacent mix-changes pair. On the order of 10^5 redirect-only URLs, each one a 302 back to a page Google already had, all competing for crawl budget with the chart pages that should be getting it.

Worth noting alongside: `/Mix/Set` is a GET with side effects — it writes the mix cookie and, for signed-in users, persists `Universal__CurrentMix` (`MixController.cs:38-47`). Harmless for an anonymous cookie-less crawler, but it is exactly why crawlers and link prefetchers should not be reaching it.

## What changed

- **`wwwroot/robots.txt`** — one line, `Disallow: /Mix/Set`. robots.txt matches against path *and* query string, so the single prefix covers every `?mix=…&redirectUrl=…` variant.
- **`Tests.E2E/NonComponentEndpointTests.cs`** — a fact pinning that line. The existing robots.txt test asserted only the `Sitemap:` pointer, so the new entry could have been dropped in a future cleanup without anything going red.

## Reviewer notes

- **`Disallow` stops the crawl, not necessarily the listing.** The anchors remain in the HTML with no `rel="nofollow"`, so Google can still discover these URLs and may surface a few as "Indexed, though blocked by robots.txt" — a bare URL, no snippet. The crawl-budget bleed stops either way, which is the problem being fixed. Adding `rel="nofollow"` to the mix anchors would close discovery too (`ShellMenuItem` already has the `Rel` seam); deliberately left out of this PR to keep it to one actionable.
- **Search Console will look worse before it looks better.** Already-discovered `/Mix/Set` URLs move from "Page with redirect" into "Blocked by robots.txt". That is the fix working.
- **Casing is load-bearing.** robots.txt path matching is case-sensitive while ASP.NET routing is not, so `Disallow: /Mix/Set` would not block `/mix/set`. The anchors emit the exact literal `/Mix/Set`, and discovery only happens through them, so no lowercase variant can be reached. The test comment records this.
- `/Culture/Set` is the same class of endpoint but is reached via `NavigateTo` (`ProfilePanel.razor:169`) rather than an anchor, and `/Logout` renders only for signed-in users — neither is crawler-reachable, so both were left alone.
- `docs/design/seo-friendly-site.md:217` describes this file's contents, but as a record of what PR-1 was scoped to do on 2026-07-16. It is history, not a live spec, so it was not rewritten.
- No scope creep to declare beyond the test, which pins the change itself.

## Testing

- `dotnet test ScoreTracker.Tests` — 1812 passed, 0 failed
- `dotnet test ScoreTracker.Tests.Api` — 65 passed, 0 failed
- `dotnet build ScoreTracker.Tests.E2E -c Debug` — 0 errors

The new E2E fact was **not** executed locally: the suite needs Docker and stands up SQL Server, Kestrel, WireMock and headless Chromium to assert one string in a static file. CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
