### PR TITLE
fix(leaderboards): boards follow the mix they are shown in

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/ChartLeaderboardDialogTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/ChartLeaderboardDialogTests.cs
@@ -156,8 +156,46 @@ public sealed class ChartLeaderboardDialogTests : ComponentTestBase
         Assert.Empty(dialog.FindAll("[data-testid='cld-community-picker']"));
     }
 
+    [Fact]
+    public void EveryBoardReadCarriesTheMixItWasGiven()
+    {
+        // Phoenix and Phoenix 2 share chart ids, so a board that drops the mix reads as a
+        // full, plausible leaderboard — of the wrong game.
+        var dialog = RenderDialog(MixEnum.Phoenix2, ChartLeaderboardDialog.LeaderboardScope.CompetitivePeers);
+
+        dialog.WaitForAssertion(() => VerifyWorldBoardRead(MixEnum.Phoenix2));
+        _mediator.Verify(m => m.Send(It.Is<GetChartsQuery>(q => q.Mix == MixEnum.Phoenix2),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        _mediator.Verify(m => m.Send(It.Is<GetCompetitivePlayersQuery>(q => q.Mix == MixEnum.Phoenix2),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public void ChangingMixOnTheSameChartRebuildsTheBoard()
+    {
+        // The sessions page keeps one dialog and swaps its mix as the hero session changes,
+        // so a load keyed on the chart alone serves the previous mix's board back.
+        RenderComponent<MudDialogProvider>();
+        var dialog = RenderComponent<ChartLeaderboardDialog>(p => p
+            .Add(c => c.Visible, true)
+            .Add(c => c.ChartId, ChartId)
+            .Add(c => c.Mix, MixEnum.Phoenix));
+        dialog.WaitForAssertion(() => VerifyWorldBoardRead(MixEnum.Phoenix));
+
+        dialog.SetParametersAndRender(p => p.Add(c => c.Mix, MixEnum.Phoenix2));
+
+        dialog.WaitForAssertion(() => VerifyWorldBoardRead(MixEnum.Phoenix2));
+    }
+
+    private void VerifyWorldBoardRead(MixEnum mix)
+    {
+        _mediator.Verify(m => m.Send(It.Is<GetPhoenixRecordsForCommunityQuery>(q => q.Mix == mix),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
     /// <summary>Inline MudDialogs render through the provider, so the fragment hosts both.</summary>
-    private IRenderedFragment RenderDialog()
+    private IRenderedFragment RenderDialog(MixEnum mix = MixEnum.Phoenix,
+        ChartLeaderboardDialog.LeaderboardScope scope = ChartLeaderboardDialog.LeaderboardScope.World)
     {
         return Render(builder =>
         {
@@ -166,7 +204,8 @@ public sealed class ChartLeaderboardDialogTests : ComponentTestBase
             builder.OpenComponent<ChartLeaderboardDialog>(1);
             builder.AddAttribute(2, nameof(ChartLeaderboardDialog.Visible), true);
             builder.AddAttribute(3, nameof(ChartLeaderboardDialog.ChartId), ChartId);
-            builder.AddAttribute(4, nameof(ChartLeaderboardDialog.Mix), MixEnum.Phoenix);
+            builder.AddAttribute(4, nameof(ChartLeaderboardDialog.Mix), mix);
+            builder.AddAttribute(5, nameof(ChartLeaderboardDialog.InitialScope), scope);
             builder.CloseComponent();
         });
     }

--- a/ScoreTracker/ScoreTracker/Components/ChartLeaderboardDialog.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartLeaderboardDialog.razor
@@ -148,7 +148,14 @@
 
     private Chart? _chart;
     private bool _loading = true;
-    private Guid? _loadedFor;
+
+    /// <summary>
+    ///     The chart AND the mix: Phoenix and Phoenix 2 share chart ids, and the sessions page
+    ///     keeps one dialog whose mix follows the hero session. Keyed on the chart alone, the
+    ///     same song opened under the other mix serves the previous mix's board back — a full,
+    ///     plausible leaderboard of the wrong game.
+    /// </summary>
+    private (Guid Chart, MixEnum Mix)? _loadedFor;
     private LeaderboardScope _scope;
     private Name? _community;
     private IReadOnlyList<Name> _myCommunities = Array.Empty<Name>();
@@ -162,8 +169,8 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (!Visible || _loadedFor == ChartId) return;
-        _loadedFor = ChartId;
+        if (!Visible || _loadedFor == (ChartId, Mix)) return;
+        _loadedFor = (ChartId, Mix);
         _scope = InitialScope;
         await LoadChartAsync();
     }

--- a/ScoreTracker/ScoreTracker/Pages/ChartDetails.razor
+++ b/ScoreTracker/ScoreTracker/Pages/ChartDetails.razor
@@ -34,8 +34,8 @@
            key values only, so two keyed siblings sharing a chart id collide even when
            they are different component types. *@
         <div class="chart-hero-jacket-col">
-            <ChartVideoPlayer @rendermode="RenderModes.Interactive" ChartId="_chart.Id" Mix="_mix" @key="(_chart.Id, nameof(ChartVideoPlayer))"></ChartVideoPlayer>
-            <ChartRecordPanel @rendermode="RenderModes.Interactive" ChartId="_chart.Id" Mix="_mix" @key="(_chart.Id, nameof(ChartRecordPanel))"></ChartRecordPanel>
+            <ChartVideoPlayer @rendermode="RenderModes.Interactive" ChartId="_chart.Id" Mix="_chart.Mix" @key="(_chart.Id, nameof(ChartVideoPlayer))"></ChartVideoPlayer>
+            <ChartRecordPanel @rendermode="RenderModes.Interactive" ChartId="_chart.Id" Mix="_chart.Mix" @key="(_chart.Id, nameof(ChartRecordPanel))"></ChartRecordPanel>
         </div>
         <div class="chart-hero-id">
             <h1 class="chart-hero-title">@_chart.Song.Name</h1>
@@ -116,7 +116,7 @@
         <div class="chart-section-head">
             <MudText Typo="Typo.h5">@L["Chart Stats"]</MudText>
         </div>
-        <ChartEvidenceSection @rendermode="RenderModes.Interactive" ChartId="_chart.Id" Mix="_mix" @key="_chart.Id"></ChartEvidenceSection>
+        <ChartEvidenceSection @rendermode="RenderModes.Interactive" ChartId="_chart.Id" Mix="_chart.Mix" @key="_chart.Id"></ChartEvidenceSection>
     </section>
 
     @if (_skillChips.Any() || _analysis != null)
@@ -157,7 +157,7 @@
         <div class="chart-section-head">
             <MudText Typo="Typo.h5">@L["Leaderboard"]</MudText>
         </div>
-        <ChartLeaderboardSection @rendermode="RenderModes.Interactive" ChartId="_chart.Id" Mix="_mix" @key="_chart.Id"></ChartLeaderboardSection>
+        <ChartLeaderboardSection @rendermode="RenderModes.Interactive" ChartId="_chart.Id" Mix="_chart.Mix" @key="_chart.Id"></ChartLeaderboardSection>
     </section>
 
     <section class="chart-section">
@@ -169,9 +169,9 @@
            the island, and its data-island-ready hides this copy on connect. *@
         <div class="chart-shelf-wrap">
             <div class="chart-shelf-static">
-                <SimilarChartsStaticGrid ChartId="_chart.Id" Mix="_mix" @key="_chart.Id"></SimilarChartsStaticGrid>
+                <SimilarChartsStaticGrid ChartId="_chart.Id" Mix="_chart.Mix" @key="_chart.Id"></SimilarChartsStaticGrid>
             </div>
-            <SimilarChartsShelf @rendermode="RenderModes.Interactive" ChartId="_chart.Id" Mix="_mix" @key="_chart.Id"></SimilarChartsShelf>
+            <SimilarChartsShelf @rendermode="RenderModes.Interactive" ChartId="_chart.Id" Mix="_chart.Mix" @key="_chart.Id"></SimilarChartsShelf>
         </div>
         <p class="chart-section-credit">
             @L["Chart analysis made possible by"]
@@ -201,7 +201,11 @@
     [CascadingParameter]
     private HttpContext? HttpContext { get; set; }
 
-    private MixEnum _mix = MixEnum.Phoenix;
+    // The viewer's preference decides WHICH chart the URL resolves to, and nothing beyond
+    // that: every per-mix read — leaderboard, record panel, evidence, similar charts —
+    // follows the resolved chart's own mix instead, so a chart the viewer's mix dropped
+    // shows its own era's board rather than a board from a mix it isn't in.
+    private MixEnum _viewerMix = MixEnum.Phoenix;
     private bool _initialized;
     private Chart? _chart;
     private IReadOnlyList<ChartVerdictFacet> _facets = Array.Empty<ChartVerdictFacet>();
@@ -225,7 +229,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _mix = await UiSettings.GetSelectedMix();
+        _viewerMix = await UiSettings.GetSelectedMix();
         _initialized = true;
     }
 
@@ -262,7 +266,7 @@
         // every legacy-only chart, for one — renders from the mix the URL names rather than
         // 404ing; the URL resolved, so the chart exists. After the 301 that mix IS the
         // canonical one, so the page's content and its canonical URL always agree.
-        var chart = await UrlResolver.FindInMixOrUrlMix(resolution.ChartId, _mix, resolution.Mix,
+        var chart = await UrlResolver.FindInMixOrUrlMix(resolution.ChartId, _viewerMix, resolution.Mix,
             HttpContext?.RequestAborted ?? default);
         if (chart == null)
         {


### PR DESCRIPTION
The leaderboard dialog was showing Phoenix 1 boards on Phoenix 2 charts. Two separate causes, both fixed.

## The reads were never the problem

Every hop is mix-scoped already — `GetPhoenixRecordsForCommunityQuery` → `CommunitySaga` → `IScoreReader.GetPhoenixScores` → a `MixId` filter in SQL, same for the competitive-cohort and chart reads. The prod-synced database agrees: Switronic S15 carries 17 Phoenix 2 records against 853 Phoenix 1 ones. The boards read the right mix — when they read at all.

## 1. The dialog kept the previous mix's board

`ChartLeaderboardDialog` keyed its load on `ChartId` alone. The sessions page keeps **one** dialog instance and swaps its `Mix` as the hero session changes, and Phoenix / Phoenix 2 share chart ids — so opening a song's board on a Phoenix 1 session, viewing a Phoenix 2 session, then opening the same song short-circuited the load and re-showed the Phoenix 1 board. It renders as a full, plausible leaderboard of the wrong game, which is why it reads as "aggregated" rather than obviously broken.

The key is `(ChartId, Mix)` now. The failing test came first — `ChangingMixOnTheSameChartRebuildsTheBoard` reproduced it exactly (the second read never fired). A companion test pins that all three reads carry the mix they were given, which nothing asserted before.

## 2. The chart page read its islands in the viewer's mix

Separate defect, same symptom. `/Charts/{mix}/{song}/{difficulty}` resolves the URL against the viewer's preferred mix and falls back to the mix the URL names when the chart does not live there — so the chart on screen is not always in the viewer's mix. The page's own reads already followed `chart.Mix`; the islands were handed the viewer's mix instead, so a Phoenix 2 chart viewed with Phoenix selected asked for the Phoenix leaderboard.

Leaderboard, record panel, video, evidence and similar-charts all take `_chart.Mix` now, matching what the page's own comment already claimed. The field is renamed `_viewerMix` so what it actually decides — which chart the URL resolves to, and nothing beyond that — is hard to lose again.

## Verification

Debug build clean. Fast suites green: 1887 unit/architecture, 528 component, 65 API contract.

Worth a field test on the sessions page specifically: open a chart's board on a session in one mix, switch to a session in the other, and open the same chart again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
