### PR TITLE
The 20,000 PUMBILITY capstone gets its real name

### DIFF
--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix2/Phoenix2TitleList.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/Phoenix2/Phoenix2TitleList.cs
@@ -171,8 +171,12 @@ public static class Phoenix2TitleList
         // players wearing them on the live PUMBILITY ranking (Phoenix2PumbilityTitleReconTests).
         // BRONZE..ALEXANDRITE confirmed 2026-07-23 by worn titles whose lowest wearer sits just
         // above each threshold (SILVER@12,804 .. ALEXANDRITE@19,047 for the 12500..19000 rungs).
-        // The 20000 tier exists on title.php but is still unreached (top of board ~19,640), so its
-        // name stays masked — re-run the recon to reveal it once someone earns it.
+        // The 20000 capstone was revealed 2026-08-04, the day FEFEMZ#1489 cleared it at 20,000.92
+        // and became its only wearer. It drops the [P.B] prefix, exactly as SINGLE/DOUBLE MASTER
+        // do at the top of their own ladders; its rail comes from the pool, not the name, so it
+        // still draws as the eighth gem. The site's string carries a trailing space
+        // ("ABYSS ABSOLUTE ", 15 chars on both the ranking and title.php's 15-"?" mask) — Name
+        // trims it, and the two surfaces agree on the rest character for character.
         new Phoenix2PumbilityTitle("[P.B] BRONZE", PumbilityPool.Total, 10000),
         new Phoenix2PumbilityTitle("[P.B] SILVER", PumbilityPool.Total, 12500),
         new Phoenix2PumbilityTitle("[P.B] GOLD", PumbilityPool.Total, 15000),
@@ -180,7 +184,7 @@ public static class Phoenix2TitleList
         new Phoenix2PumbilityTitle("[P.B] DIAMOND", PumbilityPool.Total, 17000),
         new Phoenix2PumbilityTitle("[P.B] RED BERYL", PumbilityPool.Total, 18000),
         new Phoenix2PumbilityTitle("[P.B] ALEXANDRITE", PumbilityPool.Total, 19000),
-        new Phoenix2PumbilityTitle("[P.B] ??? 20000", PumbilityPool.Total, 20000),
+        new Phoenix2PumbilityTitle("ABYSS ABSOLUTE", PumbilityPool.Total, 20000),
 
         // ---- Skill ladders (chart + grade) ----
         new Phoenix2ChartGradeTitle("[TWIST S] LV.1", "TWIST S", "Scorpion King", ChartType.Single, 15, PhoenixLetterGrade.SSS),

--- a/ScoreTracker/ScoreTracker.ExplorationTests/LiveSite/Phoenix2PumbilityTitleReconTests.cs
+++ b/ScoreTracker/ScoreTracker.ExplorationTests/LiveSite/Phoenix2PumbilityTitleReconTests.cs
@@ -1,17 +1,22 @@
+using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 using ScoreTracker.SharedKernel.Enums;
 using Xunit.Abstractions;
 
 namespace ScoreTracker.ExplorationTests.LiveSite;
 
 /// <summary>
-///     Reveals the names behind the masked total-PUMBILITY tiers (our <c>[P.B] ??? …</c>
-///     placeholders in <see cref="ScoreTracker.Domain.Models.Titles.Phoenix2.Phoenix2TitleList" />).
+///     Reveals the names behind the masked total-PUMBILITY tiers of
+///     <see cref="ScoreTracker.Domain.Models.Titles.Phoenix2.Phoenix2TitleList" />.
 ///     title.php masks a tier the *service account* has not earned, so higher tiers stay "????"
 ///     there — but the ranking board renders every top player's *worn* title verbatim, so a
 ///     player who earned RED BERYL and wears it spells the name out for us. Crawls the All tab
 ///     deep, then aggregates each worn <c>[P.B]</c> title to the PB range of its wearers: the
-///     minimum PB of a tier's wearers approximates that tier's threshold from above.
+///     minimum PB of a tier's wearers approximates that tier's threshold from above. The pair of
+///     facts here is the whole method: the ranking names a tier, title.php prices it, and the
+///     mask length is what pins one onto the other. The ladder was completed 2026-08-04 when
+///     FEFEMZ#1489 became the first and only wearer of the 20,000 capstone, ABYSS ABSOLUTE.
 ///     Read-only (GETs of a login-gated ranking). Run on demand:
 ///     <c>dotnet test ScoreTracker/ScoreTracker.ExplorationTests/... --filter "FullyQualifiedName~Phoenix2PumbilityTitleRecon"</c>
 /// </summary>
@@ -90,6 +95,108 @@ public sealed class Phoenix2PumbilityTitleReconTests : IClassFixture<PiuGameSess
         await File.WriteAllTextAsync(path, report, ct);
         _output.WriteLine($"(report written to {path})");
     }
+
+    /// <summary>
+    ///     The other half of the mapping: the ranking names a worn tier but not its threshold,
+    ///     while title.php lists every masked tier next to the requirement text that IS the
+    ///     threshold. Printing each mask with its length, requirement and DOM neighbours pins
+    ///     a revealed name onto the exact rung — a mask is only ambiguous by length, and the
+    ///     requirement disambiguates it.
+    /// </summary>
+    [LiveSiteFact]
+    public async Task Masked_tiers_on_title_php_carry_the_requirement_that_names_their_rung()
+    {
+        var ct = CancellationToken.None;
+        var client = await _fixture.GetAuthenticatedPhoenix2Client(ct);
+        var raw = await client.GetStringAsync("https://piugame.com/my_page/title.php", ct);
+
+        var entries = ExtractEntries(raw);
+        Assert.NotEmpty(entries);
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"title.php entries in DOM order: {entries.Count}");
+        sb.AppendLine();
+
+        sb.AppendLine("MASKED ROWS (index | mask length | requirement | category):");
+        foreach (var (i, e) in entries.Index().Where(x => IsMasked(x.Item.Name)))
+        {
+            var prev = i > 0 ? entries[i - 1].Name : "(start)";
+            var next = i < entries.Count - 1 ? entries[i + 1].Name : "(end)";
+            sb.AppendLine($"  #{i,-4} len={e.Name.Length,-3} [{e.Col}]  {e.Requirement}");
+            sb.AppendLine($"          prev: {prev}   next: {next}");
+        }
+
+        sb.AppendLine();
+        // The mask runs one character shorter than the names we hold, so data-name and the worn
+        // display string are not the same string. Dump the raw <li> for the ladder's last known
+        // rung and for every gem so the relationship is readable rather than inferred.
+        sb.AppendLine("RAW <li> MARKUP (SINGLE MASTER control + the gem rungs):");
+        var rawLis = Regex.Matches(Regex.Match(raw, "(?s)data_titleList2.*?</ul>").Value,
+            "(?s)<li[^>]*\\bdata-name=\"([^\"]*)\"[^>]*>(.*?)</li>");
+        foreach (var idx in new[] { 85, 116, 117, 119, 122, 123, 124 })
+        {
+            if (idx >= rawLis.Count) continue;
+            sb.AppendLine($"  --- #{idx} ---");
+            sb.AppendLine("  " + Regex.Replace(rawLis[idx].Value, @"\s+", " "));
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("EVERY ROW WHOSE REQUIREMENT MENTIONS PUMBILITY (index | name | requirement):");
+        foreach (var (i, e) in entries.Index()
+                     .Where(x => x.Item.Requirement.Contains("PUMBILITY", StringComparison.OrdinalIgnoreCase)))
+            sb.AppendLine($"  #{i,-4} {Trunc(e.Name, 24),-24}  {e.Requirement}");
+
+        // A mask counts every character; the board's reader trims. Read the top of the ranking
+        // raw and print the worn title code point by code point, so "one character longer than
+        // what we store" resolves to a specific character instead of a guess.
+        var board = await client.GetStringAsync(
+            "https://piugame.com/leaderboard/pumbility_ranking.php?t=&page=1", ct);
+        sb.AppendLine();
+        sb.AppendLine("RAW profile_title MARKUP, top 3 board rows:");
+        foreach (Match m in Regex.Matches(board, "(?s)profile_title[^>]*>(.*?)</div>").Cast<Match>().Take(3))
+        {
+            var inner = m.Groups[1].Value;
+            var decoded = WebUtility.HtmlDecode(Regex.Replace(inner, "<[^>]+>", ""));
+            sb.AppendLine($"  raw     : {Escape(inner)}");
+            sb.AppendLine($"  decoded : len={decoded.Length} trimmed={decoded.Trim().Length}  {Escape(decoded)}");
+            sb.AppendLine($"  codes   : {string.Join(" ", decoded.Trim().Select(c => $"{(int)c:X2}"))}");
+        }
+
+        var report = sb.ToString();
+        _output.WriteLine(report);
+        var path = Path.Combine(Path.GetTempPath(), "pumbility-title-masks.txt");
+        await File.WriteAllTextAsync(path, report, ct);
+        _output.WriteLine($"(report written to {path})");
+    }
+
+    private static List<(string Name, string Col, string Requirement)> ExtractEntries(string html)
+    {
+        var result = new List<(string, string, string)>();
+        var scope = Regex.Match(html, "(?s)data_titleList2.*?</ul>");
+        var body = scope.Success ? scope.Value : html;
+        foreach (Match li in Regex.Matches(body, "(?s)<li[^>]*\\bdata-name=\"([^\"]*)\"[^>]*>(.*?)</li>"))
+        {
+            var inner = li.Groups[2].Value;
+            result.Add((
+                WebUtility.HtmlDecode(li.Groups[1].Value).Trim(),
+                Regex.Match(inner, "class=\"t1[^\"]*\\b(col\\d+)").Groups[1].Value,
+                WebUtility.HtmlDecode(Regex.Match(inner, "(?s)t3\\b.*?<i class=\"txt\">(.*?)</i>").Groups[1].Value)
+                    .Trim()));
+        }
+
+        return result;
+    }
+
+    private static bool IsMasked(string name) => name.Length > 0 && name.All(c => c == '?');
+
+    private static string Escape(string s) =>
+        string.Concat(s.Select(c => c switch
+        {
+            '\n' => "\\n", '\r' => "\\r", '\t' => "\\t",
+            ' ' => "·",
+            _ when c < 32 || c > 126 => $"\\u{(int)c:X4}",
+            _ => c.ToString()
+        }));
 
     private static string Trunc(string s, int max) => s.Length <= max ? s : s[..(max - 1)] + "…";
 }

--- a/ScoreTracker/ScoreTracker.ExplorationTests/LiveSite/Phoenix2TitleCatalogReconTests.cs
+++ b/ScoreTracker/ScoreTracker.ExplorationTests/LiveSite/Phoenix2TitleCatalogReconTests.cs
@@ -18,7 +18,7 @@ namespace ScoreTracker.ExplorationTests.LiveSite;
 ///     <para>
 ///         Report-only (a workbench probe, not a gate): asserts only that the crawl worked, then
 ///         prints the diff for a human, because "missing" needs judgment. Masked tiers (all-"?"
-///         names the account hasn't revealed) are our <c>[P.B] ??? …</c> placeholders under a mask;
+///         names the account hasn't revealed) are the total-PUMBILITY gems under a mask;
 ///         the duplicate <c>LOVERS</c> data-names are our suffixed CO-OP titles. Only genuinely-new
 ///         names are actionable, and their requirement text comes from the page's txt_w2 block.
 ///         Run on demand:
@@ -57,7 +57,7 @@ public sealed class Phoenix2TitleCatalogReconTests : IClassFixture<PiuGameSessio
 
         var missingAll = site.Where(n => !ours.Contains(n)).ToArray();
         // Masks (a title the account hasn't revealed renders as all "?") aren't new titles —
-        // they're our [P.B] ??? placeholders under a different disguise. Bucket them apart so the
+        // they're the total-PUMBILITY gems under a different disguise. Bucket them apart so the
         // actionable list is only genuinely-new names.
         var masked = missingAll.Where(IsMasked).OrderBy(n => n.Length).ToArray();
         var missing = missingAll.Where(n => !IsMasked(n)).OrderBy(n => n, StringComparer.Ordinal).ToArray();
@@ -87,7 +87,7 @@ public sealed class Phoenix2TitleCatalogReconTests : IClassFixture<PiuGameSessio
         foreach (var n in crossVersion)
             _output.WriteLine($"    {n}  ->  {Req(n)}");
         _output.WriteLine("");
-        _output.WriteLine($"Masked tiers the account hasn't revealed ({masked.Length}) — our [P.B] ??? placeholders:");
+        _output.WriteLine($"Masked tiers the account hasn't revealed ({masked.Length}) — the PUMBILITY gems:");
         foreach (var n in masked) _output.WriteLine($"    {n}  (len {n.Length})");
         _output.WriteLine("");
         _output.WriteLine($"OURS not on the live page — masked/deduped/renamed, review ({stale.Length}):");

--- a/docs/design/titles-overhaul.md
+++ b/docs/design/titles-overhaul.md
@@ -41,8 +41,9 @@ shares. They legitimately differ, and Advanced is the worked example: three scor
 Most rails fall out of constructor arguments that were already being passed and discarded — a
 skill's name and level, a boss chart's mix. Basic titles have no requirement to sort by, so they
 declare their rail as data. **Nothing keys off a title's name**: Phoenix 2's 272 names are
-verbatim scrape output (typos preserved, one masked as `[P.B] ??? 20000`), so a name is external
-data and a rename would silently collapse a rail.
+verbatim scrape output (typos preserved — the 20,000 PUMBILITY capstone `ABYSS ABSOLUTE` even
+carries a trailing space on the site), so a name is external data and a rename would silently
+collapse a rail.
 
 ## The page
 


### PR DESCRIPTION
FEFEMZ#1489 cleared the last masked Phoenix 2 rung at **20,000.92** and is its only wearer, so the title ladder's final tier stops rendering as `[P.B] ??? 20000` and reads **ABYSS ABSOLUTE**. That was the last unknown name in the Phoenix 2 catalog.

## How the name was pinned

Neither official page answers this alone. The ranking board renders a *worn* title verbatim but never says what it cost; `title.php` prices every tier in its requirement text but masks any name the service account has not earned. Mask length joins them — and the site masks character for character, so a mask is a length measurement.

All eight Total-PUMBILITY rungs sit at `title.php` indices #117–#124, each beside its `Total Pumbility of N +` requirement. Seven were already known, and their lengths line up. The eighth is 15 characters.

The board's raw `profile_title` for FEFEMZ resolves it:

```
ABYSS·ABSOLUTE·   →  len=15, trimmed=14
41 42 59 53 53 20 41 42 53 4F 4C 55 54 45
```

The site's string carries a **trailing space**, which is why 15 matches the mask. `Name.From` trims, so the stored name is the 14-character form. Two independent surfaces, agreeing byte for byte.

## Two things that would have been easy to get wrong

**No `[P.B]` prefix.** Every other tier is `[P.B] BRONZE` … `[P.B] ALEXANDRITE`, but the capstone is bare — the same shape `SINGLE MASTER` and `DOUBLE MASTER` take at the top of their ladders. It stays on the gem rail regardless, because `TitleRails` keys the rail off `PoolRail(t.Pool)` and never off the name, so the eight-rung rail assertion is untouched.

**The masked bucket reads 7 when 8 gems are masked.** Row #52 (len 7) is `[CO-OP Step] 5000+ Plays`, not a gem, and BRONZE/SILVER both mask to 12 and dedup together. Reading that 7 as a gem length sends you looking for a name that does not exist.

## Also here

A new exploration fact, `Masked_tiers_on_title_php_carry_the_requirement_that_names_their_rung`, prints every masked tier with its requirement, its DOM neighbours and the board's raw code points — so the next masked name resolves from one run instead of from inference.

## Known, not addressed

The seven `[P.B] <gem>` names we store are each one character longer than their mask, so the site's `data-name` is likely `[P.B]BRONZE` with no space and what we hold is the board's *display* string. It costs nothing today — pumbility titles are computed (`PopulatesFromDatabase => false`) and never matched against site data-names — but those seven should not be assumed byte-exact. Left alone rather than changed on inference, since no live surface can currently confirm them.

## Testing

Fast suites green: **2216 / 148 / 605**. All three live recon facts green against the real site, including the catalog probe's `actionable == 0` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
