### PR TITLE
Rivals of you: add them back from the row

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/RivalsOfMeListTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/RivalsOfMeListTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bunit;
+using ScoreTracker.Rivals.Contracts;
+using ScoreTracker.Web.Components.Rivals;
+using Xunit;
+
+namespace ScoreTracker.Tests.Components;
+
+/// <summary>
+///     The reverse list. Its add-back button answers to the same add-time gate the picker does
+///     (docs/design/rivals.md D9) — somebody's arrow at you is not a basis for yours at them — so
+///     the row only offers it where the command would actually succeed.
+/// </summary>
+public sealed class RivalsOfMeListTests : ComponentTestBase
+{
+    private const string AddLabel = "Add as rival";
+
+    private static readonly Guid PublicStranger = Guid.NewGuid();
+
+    private static RivalOfMeRecord Rival(Guid userId, string name, bool isPublic = true,
+        bool sharesCommunity = false, bool isMutual = false) =>
+        new(Guid.NewGuid(), userId, name, new Uri("https://piu.test/avatar.png"), isPublic,
+            sharesCommunity, isMutual, DateTimeOffset.Parse("2026-07-01T00:00:00Z"));
+
+    private IRenderedComponent<RivalsOfMeList> Render(IReadOnlyList<RivalOfMeRecord> rivals,
+        Action<RivalOfMeRecord>? onAdd = null) =>
+        RenderComponent<RivalsOfMeList>(p => p
+            .Add(c => c.Rivals, rivals)
+            .Add(c => c.Blocked, Array.Empty<BlockedPlayerRecord>())
+            .Add(c => c.OnAdd, onAdd ?? (_ => { })));
+
+    private static IEnumerable<string> ButtonLabels(IRenderedComponent<RivalsOfMeList> cut) =>
+        cut.FindAll("button").Select(b => b.TextContent.Trim());
+
+    [Fact]
+    public void APublicPlayerWhoRivalsYouCanBeRivalledBackFromTheRow()
+    {
+        var cut = Render(new[] { Rival(PublicStranger, "ALICE") });
+
+        Assert.Contains(AddLabel, ButtonLabels(cut));
+    }
+
+    [Fact]
+    public void AddingBackHandsTheWholeRowUpSoTheCallerCanNameThePlayer()
+    {
+        RivalOfMeRecord? added = null;
+        var cut = Render(new[] { Rival(PublicStranger, "ALICE") }, r => added = r);
+
+        cut.FindAll("button").First(b => b.TextContent.Trim() == AddLabel).Click();
+
+        Assert.Equal(PublicStranger, added?.UserId);
+    }
+
+    /// <summary>
+    ///     The row already says "you rival them too"; offering the add again would resolve to the
+    ///     edge that sentence is describing.
+    /// </summary>
+    [Fact]
+    public void SomebodyYouAlreadyRivalIsNotOfferedAgain()
+    {
+        var cut = Render(new[] { Rival(PublicStranger, "ALICE", isMutual: true) });
+
+        Assert.DoesNotContain(AddLabel, ButtonLabels(cut));
+    }
+
+    /// <summary>
+    ///     A private player can rival a public one (D13), so this row exists — but the reverse add
+    ///     has no basis, and a button that comes back "not available" is worse than none.
+    /// </summary>
+    [Fact]
+    public void APrivateStrangerIsListedButNotOffered()
+    {
+        var cut = Render(new[] { Rival(Guid.NewGuid(), "GHOSTLY", false) });
+
+        Assert.Contains("GHOSTLY", cut.Markup);
+        Assert.DoesNotContain(AddLabel, ButtonLabels(cut));
+    }
+
+    /// <summary>A shared community is a basis of its own, private account or not (D9c).</summary>
+    [Fact]
+    public void APrivateClubmateIsOffered()
+    {
+        var cut = Render(new[] { Rival(Guid.NewGuid(), "CLUBMATE", false, true) });
+
+        Assert.Contains(AddLabel, ButtonLabels(cut));
+    }
+
+    /// <summary>Revocation is the point of this list and stays on every row regardless.</summary>
+    [Fact]
+    public void EveryRowKeepsRemoveAndBlock()
+    {
+        var cut = Render(new[]
+        {
+            Rival(PublicStranger, "ALICE"),
+            Rival(Guid.NewGuid(), "GHOSTLY", false),
+            Rival(Guid.NewGuid(), "MUTUAL", isMutual: true)
+        });
+
+        var labels = ButtonLabels(cut).ToArray();
+        Assert.Equal(3, labels.Count(l => l == "Remove"));
+        Assert.Equal(3, labels.Count(l => l == "Block"));
+    }
+}

--- a/ScoreTracker/ScoreTracker/Components/Rivals/RivalsOfMeList.razor
+++ b/ScoreTracker/ScoreTracker/Components/Rivals/RivalsOfMeList.razor
@@ -38,10 +38,19 @@ else
                     </div>
                     <div class="rvl-row-meta">@Meta(rival)</div>
                 </div>
-                <MudButton Size="Size.Small" Variant="Variant.Outlined"
-                           OnClick="() => OnRemove.InvokeAsync(rival.EdgeId)">@L["Remove"]</MudButton>
-                <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Error"
-                           OnClick="() => OnBlock.InvokeAsync(rival.UserId)">@L["Block"]</MudButton>
+                <div class="rvl-row-actions">
+                    @* Adding back is the one constructive thing to do from this list, so it leads
+                       and it is the only filled button in the row. *@
+                    @if (CanAddBack(rival))
+                    {
+                        <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                   OnClick="() => OnAdd.InvokeAsync(rival)">@L["Add as rival"]</MudButton>
+                    }
+                    <MudButton Size="Size.Small" Variant="Variant.Outlined"
+                               OnClick="() => OnRemove.InvokeAsync(rival.EdgeId)">@L["Remove"]</MudButton>
+                    <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Error"
+                               OnClick="() => OnBlock.InvokeAsync(rival.UserId)">@L["Block"]</MudButton>
+                </div>
             </div>
         }
     </div>
@@ -77,6 +86,14 @@ else
     [Parameter] public EventCallback<Guid> OnRemove { get; set; }
     [Parameter] public EventCallback<Guid> OnBlock { get; set; }
     [Parameter] public EventCallback<Guid> OnUnblock { get; set; }
+    [Parameter] public EventCallback<RivalOfMeRecord> OnAdd { get; set; }
+
+    // Reciprocating is an ordinary add and answers to the ordinary gate: their arrow at you is not
+    // a basis for yours at them (docs/design/rivals.md D9). A private stranger can rival you off
+    // your public profile and still not be addable, so the button is offered only where it would
+    // succeed — one that comes back "not available" is worse than none.
+    private static bool CanAddBack(RivalOfMeRecord rival) =>
+        !rival.IsMutual && (rival.IsPublic || rival.SharesCommunity);
 
     // Everyone here already rivals you, so a red ring would mark the whole list. Green for a
     // clubmate is the only marker that says anything.

--- a/ScoreTracker/ScoreTracker/Pages/Compete/Rivals.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Compete/Rivals.razor
@@ -65,7 +65,7 @@ else
 
         <MudTabPanel Text="@L["Rivals of you"]">
             <RivalsOfMeList Rivals="_rivalsOfMe" Blocked="_blocked" OnRemove="RemoveRival"
-                            OnBlock="Block" OnUnblock="Unblock"></RivalsOfMeList>
+                            OnBlock="Block" OnUnblock="Unblock" OnAdd="AddBack"></RivalsOfMeList>
         </MudTabPanel>
 
     </MudTabs>
@@ -175,6 +175,25 @@ else
         await Mediator.Send(new RemoveRivalCommand(edgeId));
         Snackbar.Add(L["Rival removed."].Value, Severity.Success);
         await Reload();
+    }
+
+    /// <summary>
+    ///     The same add the picker makes, from the row that told you about them. The refusal is
+    ///     still possible — a block can land between the render and the click — and is reported the
+    ///     same deliberately generic way it is on the picker.
+    /// </summary>
+    private async Task AddBack(RivalOfMeRecord rival)
+    {
+        try
+        {
+            await Mediator.Send(new AddRivalCommand(rival.UserId, null));
+            Snackbar.Add(L["{0} added as a rival.", rival.PlayerName].Value, Severity.Success);
+            await Reload();
+        }
+        catch (RivalNotAvailableException e)
+        {
+            Snackbar.Add(e.Message, Severity.Warning);
+        }
     }
 
     private async Task Block(Guid userId)

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -436,6 +436,9 @@
   <data name="Add a rival" xml:space="preserve">
     <value>Add a rival</value>
   </data>
+  <data name="Add as rival" xml:space="preserve">
+    <value>Add as rival</value>
+  </data>
   <data name="Add photo" xml:space="preserve">
     <value>Add photo</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -436,6 +436,9 @@
   <data name="Add a rival" xml:space="preserve">
     <value>Glorg gro Murgmorp</value>
   </data>
+  <data name="Add as rival" xml:space="preserve">
+    <value>Glorg mrp Murgmorp</value>
+  </data>
   <data name="Add photo" xml:space="preserve">
     <value>Glorg murpplgl</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -435,6 +435,9 @@
   <data name="Add a rival" xml:space="preserve">
     <value>Añadir un rival</value>
   </data>
+  <data name="Add as rival" xml:space="preserve">
+    <value>Añadir como rival</value>
+  </data>
   <data name="Add photo" xml:space="preserve">
     <value>Añadir foto</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -435,6 +435,9 @@
   <data name="Add a rival" xml:space="preserve">
     <value>Agregar un rival</value>
   </data>
+  <data name="Add as rival" xml:space="preserve">
+    <value>Agregar como rival</value>
+  </data>
   <data name="Add photo" xml:space="preserve">
     <value>Agregar foto</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -436,6 +436,9 @@
   <data name="Add a rival" xml:space="preserve">
     <value>Ajouter un rival</value>
   </data>
+  <data name="Add as rival" xml:space="preserve">
+    <value>Ajouter comme rival</value>
+  </data>
   <data name="Add photo" xml:space="preserve">
     <value>Ajouter une photo</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -436,6 +436,9 @@
   <data name="Add a rival" xml:space="preserve">
     <value>Aggiungi un rivale</value>
   </data>
+  <data name="Add as rival" xml:space="preserve">
+    <value>Aggiungi come rivale</value>
+  </data>
   <data name="Add photo" xml:space="preserve">
     <value>Aggiungi foto</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -436,6 +436,9 @@
   <data name="Add a rival" xml:space="preserve">
     <value>ライバルを追加</value>
   </data>
+  <data name="Add as rival" xml:space="preserve">
+    <value>ライバルに追加</value>
+  </data>
   <data name="Add photo" xml:space="preserve">
     <value>写真を追加</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -435,6 +435,9 @@
   <data name="Add a rival" xml:space="preserve">
     <value>라이벌 추가</value>
   </data>
+  <data name="Add as rival" xml:space="preserve">
+    <value>라이벌로 추가</value>
+  </data>
   <data name="Add photo" xml:space="preserve">
     <value>사진 추가</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -435,6 +435,9 @@
   <data name="Add a rival" xml:space="preserve">
     <value>Adicionar um rival</value>
   </data>
+  <data name="Add as rival" xml:space="preserve">
+    <value>Adicionar como rival</value>
+  </data>
   <data name="Add photo" xml:space="preserve">
     <value>Adicionar foto</value>
   </data>

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -11906,6 +11906,16 @@ button.chart-card-art {
     margin-top: 1px;
 }
 
+/* The reverse list carries three buttons on one row; on a phone they wrap into a block rather
+   than pushing the row wider than the screen. */
+.rvl-row-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
 .rvl-tag {
     font-size: .6rem;
     text-transform: uppercase;

--- a/docs/design/rivals.md
+++ b/docs/design/rivals.md
@@ -223,6 +223,13 @@ Remove / Block / Unblock (D14–D15), with the symmetric rule stated on the row 
 Private players appear by name (D13). No notification exists, so this list *is* the discovery
 mechanism (D47); the `/Account` private toggle links here (D12).
 
+Since it is the discovery mechanism, the row also carries **Add as rival** — the one constructive
+action here, and the only filled button among the two revocations. It is an ordinary add answering
+to the ordinary gate: their arrow at you is **not** a fifth basis (D9), so the button appears only
+where the add would succeed — not on somebody you already rival (the row says so), and not on a
+private stranger who rivalled you off your public profile. Offering it there would resolve to
+"that player isn't available", which is a worse answer than no button.
+
 ### 3.3 Head-to-head — the shared player summary
 
 `/Community/Player`'s member summary + folder compare is lifted into a shared component with
@@ -573,7 +580,7 @@ Backfill: copy the last 30 days of `CommunityHighlight` into `PlayerHighlight`, 
 | `ScoreTracker.Tests/DomainTests` | `RivalVisibilityPolicy` (all four bases + the private-ghost exception), `RivalInviteCode` value type, the tier-2 policy after its move |
 | `ScoreTracker.Tests/ApplicationTests` | Add/Remove/Block/Unblock handlers (block symmetry both directions), `RivalSubjectResolver` (D4 normalization), the two promote/rename consumers, `GetRivalScoresForChartsHandler` merging site + official sources |
 | `ScoreTracker.Tests/ArchitectureTests` | the existing ratchets pick up the new vertical automatically — `AccountPurgeCoverageTests`, `ModelContributionRegistrationTests`, `VerticalBoundaryTests`, `UiColorTokenTests`, `LocalizationKeyTests`, `ResxKeysAreStoredAlphabetically` |
-| `ScoreTracker.Tests.Components` | roster rendering (ghost tag + asterisk + footnote), the sessions toggle, the fifth dialog scope, the four highlight states, feed cross-markers |
+| `ScoreTracker.Tests.Components` | roster rendering (ghost tag + asterisk + footnote), the sessions toggle, the fifth dialog scope, the four highlight states, feed cross-markers, which reverse-list rows offer **Add as rival** |
 | `ScoreTracker.Tests.Integration` | the three repositories against real SQL, the unique filtered indexes, the purge covering both directions of `Rival` |
 | `ScoreTracker.Tests.E2E` | not a critical whole-workflow path — nothing new |
 


### PR DESCRIPTION
The "Rivals of you" list was revocation-only — Remove and Block. But most of what
a player wants there is the opposite: somebody added you, and you want them on
your roster too. Doing that meant memorising a name, switching tabs, and
retyping it into the picker.

Each row now carries **Add as rival** — filled and `Color.Primary`, the one
constructive action among two revocations.

## Where it appears

Reciprocating is an ordinary add, so it answers to the ordinary add-time gate
([rivals.md D9](docs/design/rivals.md)): their arrow at you is **not** a fifth
basis for yours at them. The button shows only where the command would actually
succeed.

| Row | Button? |
|---|---|
| Public player who rivals you | ✅ |
| Private clubmate (shared community) | ✅ |
| Someone you already rival (`IsMutual`) | ❌ — the row already says "you rival them too" |
| Private stranger who rivalled you off your public profile | ❌ — the add has no basis |

**The last row is the judgment call worth a reviewer's attention.** A private
player can rival a public one (D13), so that row exists; but under D9 you can't
rival them back without their invite code. I show no button rather than one that
resolves to *"that player isn't available"* — the same stance
`RivalCandidateRecord.AlreadyRival` takes in the picker, and the same reason D20
keeps private strangers out of it entirely. Loosening this would mean a new
consent basis, which is a design decision, not a UI change.

## What changed

- `RivalsOfMeList.razor` — the button, plus a `.rvl-row-actions` wrapper. Three
  buttons on one flex row would push past a phone viewport; they wrap now
  instead of overflowing.
- `Rivals.razor` — `AddBack` sends the same `AddRivalCommand` the picker sends,
  snackbars through the existing `{0} added as a rival.` key, and reloads, so the
  row flips to mutual and the new rival lands in the roster and the feed without
  a refresh. A block landing between render and click still surfaces the
  deliberately generic refusal.
- One new resx key, `Add as rival`, spliced into alphabetical position in all
  nine locales. The snackbar reuses a key that already exists. en-ZW composes
  from established terms: `Glorg` + `mrp` + `Murgmorp`.
- `.rvl-row-actions` in `site.css`; §3.2 and the test table in
  `docs/design/rivals.md`.
- New `RivalsOfMeListTests.cs` — six bUnit facts pinning which rows offer the
  button, that clicking hands the whole record up, and that Remove/Block stay on
  every row regardless.

## Testing

Fast suites, all green: **2,216** unit/architecture · **611** bUnit (+6) ·
**148** API contract. No integration or E2E surface changed. Not field-tested —
the button's look on a phone row is worth an eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
