### PR TITLE
fix(i18n): the import CTA was labelled "upload" in every locale

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/SuggestedChartsWidgetTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/SuggestedChartsWidgetTests.cs
@@ -230,7 +230,7 @@ public sealed class SuggestedChartsWidgetTests : ComponentTestBase
         var cut = Render();
 
         Assert.Contains("No matching standouts yet, go push yourself to start getting suggestions!", cut.Markup);
-        Assert.DoesNotContain("Upload Scores", cut.Markup);
+        Assert.DoesNotContain("Import Scores", cut.Markup);
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/ByLevelBreakdownWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/ByLevelBreakdownWidget.razor
@@ -24,7 +24,7 @@ else if (_kind == BreakdownChartKind.Empty)
     <div class="dash-widget-message">
         <div>
             <MudText Typo="Typo.body2">@L["No scores in this range yet — record or import to see your breakdown."]</MudText>
-            <MudLink Href="/UploadPhoenixScores" Typo="Typo.body2">@L["Upload Scores"]</MudLink>
+            <MudLink Href="/UploadPhoenixScores" Typo="Typo.body2">@L["Import Scores"]</MudLink>
         </div>
     </div>
 }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelWidget.razor
@@ -25,7 +25,7 @@ else if (!_series.Any())
     <div class="dash-widget-message">
         <div>
             <MudText Typo="Typo.body2">@L["Your level history starts tracking with your next import."]</MudText>
-            <MudLink Href="/UploadPhoenixScores" Typo="Typo.body2">@L["Upload Scores"]</MudLink>
+            <MudLink Href="/UploadPhoenixScores" Typo="Typo.body2">@L["Import Scores"]</MudLink>
         </div>
     </div>
 }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
@@ -26,7 +26,7 @@ else if (_stats == null || ((int)_stats.SkillRating == 0 && _stats.ClearCount ==
     <div class="dash-widget-message">
         <div>
             <MudText Typo="Typo.body2">@L["No scores yet — Pumbility starts with your first import."]</MudText>
-            <MudLink Href="/UploadPhoenixScores" Typo="Typo.body2">@L["Upload Scores"]</MudLink>
+            <MudLink Href="/UploadPhoenixScores" Typo="Typo.body2">@L["Import Scores"]</MudLink>
         </div>
     </div>
 }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsWidget.razor
@@ -39,7 +39,7 @@ else if (!_sections.Any(s => s.Rows.Any()))
             else
             {
                 <MudText Typo="Typo.body2">@L["Nothing to suggest yet — play and import some scores first."]</MudText>
-                <MudLink Href="/UploadPhoenixScores" Typo="Typo.body2">@L["Upload Scores"]</MudLink>
+                <MudLink Href="/UploadPhoenixScores" Typo="Typo.body2">@L["Import Scores"]</MudLink>
             }
         </div>
     </div>

--- a/docs/LOCALIZATION-fr-FR.md
+++ b/docs/LOCALIZATION-fr-FR.md
@@ -55,6 +55,7 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Filters | Filtres | |
 | Full Privacy Policy | Politique de confidentialité complète | |
 | Home | Accueil | Sidebar nav label. |
+| Import Scores | Importer les scores | The verb for bringing scores in from PIUGame — nothing is sent, so never `Téléverser`/`Télécharger`. Every CTA pointing at `/UploadPhoenixScores` uses this key. |
 | Language | Langue | |
 | Last Updated | Dernière mise à jour | |
 | Level | Niveau | |
@@ -116,8 +117,8 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Tournaments | Tournois | |
 | UCS Leaderboard | Leaderboard UCS | Postfixed UCS. |
 | Upload Image | Uploader l'image | Loanword verb `uploader`. |
-| Upload Scores | Téléverser les scores | `Téléverser` = upload (the old `Télécharger` wrong-direction values were fixed in the 2026-07 QC pass). |
-| Upload XX Scores | Téléverser les scores XX | |
+| Upload Scores | Téléverser les scores | `Téléverser` = upload (the old `Télécharger` wrong-direction values were fixed in the 2026-07 QC pass). Reaches the screen only as the XX page's file-picker button, where a file really is sent; bringing scores in from PIUGame is `Import Scores`. |
+| Upload XX Scores | Téléverser les scores XX | The XX page is a genuine spreadsheet upload, so `Téléverser` is right here. |
 | Uploader | Uploadeur | Role/agent noun derived from `uploader`. |
 | Use Script | Utiliser le script | |
 | Used Primarily for debugging | Utilisé principalement pour déboguer | |
@@ -144,7 +145,7 @@ These have at least one existing translation in `App.fr-FR.resx`. New translatio
 | Difficulty Categorization | Catégorisation par difficulté | |
 | Letter Grade | Rang (lettres) | Translated as `Rang` with parenthetical `(lettres)` to disambiguate from numeric rank. Min/Max forms keep the parenthetical. |
 | Mix | Mix | Untranslated. (Compare ja-JP `バージョン`/`ベーション`, ko-KR `시리즈`, pt-BR `Versão`.) |
-| Phoenix / XX | Phoenix / XX | Game versions, untranslated proper nouns. "Phoenix Score Calculator" → "Calculateur de score Phoenix" (Phoenix postfixed). "Import Phoenix Scores" → "Importer les Scores Phoenix"; "Upload XX Scores" → "Télécharger Scores XX". |
+| Phoenix / XX | Phoenix / XX | Game versions, untranslated proper nouns. "Phoenix Score Calculator" → "Calculateur de score Phoenix" (Phoenix postfixed). "Import Phoenix Scores" → "Importer les Scores Phoenix"; "Upload XX Scores" → "Téléverser les scores XX". |
 | Plate | Plaque | **Translated** — `Plaque` is a literal French rendering. (Compare ja-JP `プレート` loanword, pt-BR `Plate` untranslated, ko-KR `플레이트` loanword.) French is the only locale that translates this. The comment notes `MG, PG, UG` are the in-game tier abbreviations. |
 | Pass / Passed / Not Passed | Pass / Passed / Non Passed | **Untranslated**, kept English. `Passed Count` → `Passed`; `Not Passed Count` → `Non Passed`; `Stage Pass` → `Stage Pass`. The `Unpassed ToDos` prose keeps `Pass` in English mid-French-sentence: `que vous n'avez pas Pass`. |
 | Score (singular) | Score | Identical, loanword. |


### PR DESCRIPTION
Errlena reported the French home-dashboard link reading **"Téléverser les scores"** where it should say *importer*. The French value was a faithful translation of its key — the key was wrong.

## What was actually broken

The four home widgets link to `/UploadPhoenixScores`, which is the credential-based **Import Scores** page: you hand over a PIUGame login and the site pulls your scores. Nothing is uploaded. They were labelled with the `Upload Scores` key, so every locale rendered a wrong-direction verb:

| Locale | Rendered | Should be |
|---|---|---|
| fr-FR | Téléverser les scores | Importer les scores |
| es-ES / es-MX | Subir Scores / Subir puntajes | Importar scores / Importar puntajes |
| it-IT | Carica i punteggi | Importa punteggi |
| pt-BR | Upload de pontuações | Importar pontuações |
| ja-JP | スコア更新 | スコアインポート |
| ko-KR | 점수 등록 | 점수 가져오기 |

English hid it because "upload scores" reads loosely. French does not extend that courtesy. The import widget directly below already said **IMPORTER LES SCORES**, which is what made the mismatch visible on a single screen.

## The fix

Repointed the four widgets to the **existing** `Import Scores` key. That fixes all nine locales at once, adds no resx keys — so no alphabetical or case-collision ratchet risk — and makes the CTA match the title of the page it lands on.

- `Components/HomeWidgets/ByLevelBreakdownWidget.razor`
- `Components/HomeWidgets/CompetitiveLevelWidget.razor`
- `Components/HomeWidgets/PumbilityWidget.razor`
- `Components/HomeWidgets/SuggestedChartsWidget.razor`

`Upload Scores` survives at its one honest call site — the XX page's file-picker button (`Pages/UploadXXScores.razor:127`), where a spreadsheet really is sent and `Téléverser` is correct. The key stops straddling two different actions.

## Reviewer notes

- **The widget test was about to go quiet.** `SuggestedChartsWidgetTests` asserted `DoesNotContain("Upload Scores")` for the Hot Streak empty state; after the rename it would have kept passing while guarding nothing. It now names the new label. (Verified `Import Scores` appears nowhere else in that widget's markup, so the assertion still means something.)
- **The fr-FR glossary had a row pointing the wrong way.** It told translators to render `"Upload XX Scores"` as `"Télécharger Scores XX"` — the exact wrong-direction word the 2026-07 QC pass had already fixed two sections earlier in the same file. Corrected, and a new `Import Scores` row states the score-import verb is never `Téléverser`/`Télécharger`.
- **Nothing else references either label** — no hits in the API, integration, or E2E suites.

## Verification

- `dotnet build ScoreTracker/ScoreTracker.sln -c Debug` — 0 errors
- `ScoreTracker.Tests` — 2217 passed
- `ScoreTracker.Tests.Components` — 611 passed

Integration and E2E were not run (Docker); the change is label-only markup with no call-site coverage in either suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
