### PR TITLE
Chart details dialog: three tabs, similar charts, and a dead bookmark fixed

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/ChartDetailsDialogTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/ChartDetailsDialogTests.cs
@@ -67,6 +67,10 @@ public sealed class ChartDetailsDialogTests : TestContext
             .ReturnsAsync(Array.Empty<UserPhoenixScore>());
         _mediator.Setup(m => m.Send(It.IsAny<GetChartsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<Chart>());
+        // The similarity graph is empty on a fresh database and until the nightly rebuild has
+        // run once, so that is the default here too — the drill-down test seeds its own.
+        _mediator.Setup(m => m.Send(It.IsAny<GetSimilarChartsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ChartSimilarityRecord>());
         var localizer = new Mock<IStringLocalizer<App>>();
         localizer.Setup(l => l[It.IsAny<string>()])
             .Returns((string key) => new LocalizedString(key, key));
@@ -210,5 +214,47 @@ public sealed class ChartDetailsDialogTests : TestContext
 
         _mediator.Verify(m => m.Send(It.IsAny<GetPhoenixRecordsForCommunityQuery>(),
             It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    ///     Tapping a similar chart swaps the dialog in place and offers the way back. The host
+    ///     owns Visible, so a second dialog would mean teaching nineteen call sites a
+    ///     chart-change callback for what is one piece of state in here.
+    /// </summary>
+    [Fact]
+    public void TappingASimilarChartSwapsTheDialogAndLeavesACrumbBack()
+    {
+        var anchor = SetupChart(null);
+        var neighbour = ChartSlugsTests.BuildChart(song: "TRICKL4SH 220");
+        _mediator.Setup(m => m.Send(It.IsAny<GetSimilarChartsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ChartSimilarityRecord(neighbour.Id, 0.81, 0.8, 0.8, Array.Empty<ChartSharedBadgeRecord>())
+            });
+        _mediator.Setup(m => m.Send(It.IsAny<GetChartsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { neighbour });
+
+        var cut = RenderDialog(anchor, ChartDetailsDialog.DetailsTab.Stats);
+
+        cut.WaitForAssertion(() => cut.Find("[data-testid='chart-similar-tile']").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(neighbour.Song.Name.ToString(), cut.Find(".chart-details-title").TextContent);
+            Assert.Contains(anchor.Song.Name.ToString(), cut.Find(".chart-details-crumb").TextContent);
+        });
+    }
+
+    /// <summary>
+    ///     A chart with no edges is every chart until the nightly rebuild has run at least
+    ///     once, so the panel says "not yet" rather than rendering an empty grid.
+    /// </summary>
+    [Fact]
+    public void AChartWithNoSimilarityEdgesSaysSoRatherThanShowingAnEmptyGrid()
+    {
+        var cut = RenderDialog(SetupChart(null), ChartDetailsDialog.DetailsTab.Stats);
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".chart-similar-empty")));
+        Assert.Empty(cut.FindAll("[data-testid='chart-similar-tile']"));
     }
 }

--- a/ScoreTracker/ScoreTracker.Tests.Components/ChartDetailsDialogTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/ChartDetailsDialogTests.cs
@@ -22,6 +22,7 @@ using ScoreTracker.SharedKernel.ValueTypes;
 using ScoreTracker.Web;
 using ScoreTracker.Web.Components;
 using ScoreTracker.Web.Services;
+using ScoreTracker.Web.Services.Contracts;
 using Xunit;
 
 namespace ScoreTracker.Tests.Components;
@@ -36,6 +37,7 @@ public sealed class ChartDetailsDialogTests : TestContext
     private readonly Mock<ICurrentUserAccessor> _currentUser = new();
     private readonly Mock<IMediator> _mediator = new();
     private readonly Mock<IAdminNotificationClient> _notifications = new();
+    private readonly Mock<IUiSettingsAccessor> _uiSettings = new();
 
     public ChartDetailsDialogTests()
     {
@@ -44,6 +46,10 @@ public sealed class ChartDetailsDialogTests : TestContext
         Services.AddSingleton(_mediator.Object);
         Services.AddSingleton(_notifications.Object);
         Services.AddSingleton(_currentUser.Object);
+        // The tab the dialog opens on is remembered per user; nothing stored means the default.
+        Services.AddSingleton(_uiSettings.Object);
+        _uiSettings.Setup(s => s.GetSetting(It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<Guid?>()))
+            .ReturnsAsync((string?)null);
         _currentUser.Setup(u => u.IsLoggedIn).Returns(false);
         // The bubble nested in the title row injects this and reads through it.
         _mediator.Setup(m => m.Send(It.IsAny<GetChartScoringLevelsQuery>(), It.IsAny<CancellationToken>()))
@@ -83,7 +89,7 @@ public sealed class ChartDetailsDialogTests : TestContext
     }
 
     /// <summary>Inline MudDialogs render through the provider, so the fragment hosts both.</summary>
-    private IRenderedFragment RenderDialog(Chart chart)
+    private IRenderedFragment RenderDialog(Chart chart, ChartDetailsDialog.DetailsTab? initialTab = null)
     {
         return Render(builder =>
         {
@@ -92,6 +98,7 @@ public sealed class ChartDetailsDialogTests : TestContext
             builder.OpenComponent<ChartDetailsDialog>(1);
             builder.AddAttribute(2, nameof(ChartDetailsDialog.Chart), chart);
             builder.AddAttribute(3, nameof(ChartDetailsDialog.Visible), true);
+            builder.AddAttribute(4, nameof(ChartDetailsDialog.InitialTab), initialTab);
             builder.CloseComponent();
         });
     }
@@ -123,17 +130,63 @@ public sealed class ChartDetailsDialogTests : TestContext
     /// <summary>
     ///     The dialog hosts the shared board rather than growing one of its own. Asserting on
     ///     the scope rail is what distinguishes the two — a private copy would have no scopes.
+    ///     It is also the default tab, so this doubles as the check that the dialog opens on it.
     /// </summary>
     [Fact]
-    public void TheSharedBoardRendersInsideTheDialog()
+    public void TheSharedBoardRendersInsideTheDialogAndIsTheDefaultTab()
     {
         var cut = RenderDialog(SetupChart(null));
 
         cut.WaitForAssertion(() =>
         {
-            Assert.NotEmpty(cut.FindAll(".chart-details-board"));
             Assert.NotEmpty(cut.FindAll("[data-testid='cld-scope-World']"));
+            Assert.Equal("true",
+                cut.Find("[data-testid='cdt-tab-Leaderboard']").GetAttribute("aria-selected"));
         });
+    }
+
+    /// <summary>
+    ///     The point of the tabs. A panel nobody selected must not fetch: the stats panel's
+    ///     badge chips are the cheapest thing to assert on, because the meta grid renders from
+    ///     the Chart itself and would be present either way.
+    /// </summary>
+    [Fact]
+    public void AnUnselectedTabFetchesNothing()
+    {
+        RenderDialog(SetupChart(null));
+
+        _mediator.Verify(m => m.Send(It.IsAny<GetChartBadgeChipsQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    ///     A caller that opens this dialog for one section says so, and is obeyed — which is
+    ///     what keeps recording a score one tap away from the widgets that exist to record.
+    /// </summary>
+    [Fact]
+    public void InitialTabDecidesWhereTheDialogOpens()
+    {
+        var cut = RenderDialog(SetupChart(null), ChartDetailsDialog.DetailsTab.Stats);
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("true", cut.Find("[data-testid='cdt-tab-Stats']").GetAttribute("aria-selected"));
+            _mediator.Verify(m => m.Send(It.IsAny<GetChartBadgeChipsQuery>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        });
+    }
+
+    /// <summary>
+    ///     Score History is your journal plus your recording inputs. Signed out both are empty,
+    ///     so the tab is not offered at all rather than opening onto nothing.
+    /// </summary>
+    [Fact]
+    public void SignedOutThereIsNoScoreHistoryTab()
+    {
+        var cut = RenderDialog(SetupChart(null));
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[data-testid='cdt-tab-Stats']")));
+        Assert.Empty(cut.FindAll("[data-testid='cdt-tab-History']"));
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker.Tests.Components/ChartDetailsDialogTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/ChartDetailsDialogTests.cs
@@ -246,6 +246,31 @@ public sealed class ChartDetailsDialogTests : TestContext
     }
 
     /// <summary>
+    ///     Recording went behind a tab, so the header keeps a one-tap way back to it — that is
+    ///     what round 11's always-visible inputs were protecting. Crucially it does NOT write
+    ///     the remembered tab: using a shortcut once is not a standing preference.
+    /// </summary>
+    [Fact]
+    public void TheRecordShortcutOpensHistoryWithoutRememberingIt()
+    {
+        _currentUser.SetupGet(u => u.IsLoggedIn).Returns(true);
+        // The board reads CurrentUser.User to find your own row, so IsLoggedIn alone is a
+        // half-built user and NREs before anything under test runs.
+        _currentUser.SetupGet(u => u.User)
+            .Returns(new User(Guid.NewGuid(), "Me", true, null, new Uri("https://piu.test/me.png"), null));
+        _mediator.Setup(m => m.Send(It.IsAny<GetMyCommunitiesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CommunityOverviewRecord>());
+        var cut = RenderDialog(SetupChart(null));
+
+        cut.WaitForAssertion(() => cut.Find("[data-testid='cdt-record-shortcut']").Click());
+
+        cut.WaitForAssertion(() => Assert.Equal("true",
+            cut.Find("[data-testid='cdt-tab-History']").GetAttribute("aria-selected")));
+        _uiSettings.Verify(s => s.SetSetting(It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
     ///     A chart with no edges is every chart until the nightly rebuild has run at least
     ///     once, so the panel says "not yet" rather than rendering an empty grid.
     /// </summary>

--- a/ScoreTracker/ScoreTracker.Tests.Components/ChartDetailsDialogTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/ChartDetailsDialogTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Bunit;
 using MediatR;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Moq;
@@ -93,7 +94,8 @@ public sealed class ChartDetailsDialogTests : TestContext
     }
 
     /// <summary>Inline MudDialogs render through the provider, so the fragment hosts both.</summary>
-    private IRenderedFragment RenderDialog(Chart chart, ChartDetailsDialog.DetailsTab? initialTab = null)
+    private IRenderedFragment RenderDialog(Chart chart, ChartDetailsDialog.DetailsTab? initialTab = null,
+        EventCallback<Guid>? onToDo = null)
     {
         return Render(builder =>
         {
@@ -103,32 +105,64 @@ public sealed class ChartDetailsDialogTests : TestContext
             builder.AddAttribute(2, nameof(ChartDetailsDialog.Chart), chart);
             builder.AddAttribute(3, nameof(ChartDetailsDialog.Visible), true);
             builder.AddAttribute(4, nameof(ChartDetailsDialog.InitialTab), initialTab);
+            if (onToDo != null) builder.AddAttribute(5, nameof(ChartDetailsDialog.OnToDo), onToDo.Value);
             builder.CloseComponent();
         });
     }
 
+    /// <summary>
+    ///     The video leads the dialog and is the one thing outside the tabs, so a chart with
+    ///     one shows it above the title regardless of which tab is open.
+    /// </summary>
     [Fact]
-    public void ReportingAVideoNamesTheChartToAnAdmin()
+    public void AChartWithAVideoLeadsWithIt()
     {
-        var chart = SetupChart("https://www.youtube.com/embed/abc");
-        var cut = RenderDialog(chart);
+        var cut = RenderDialog(SetupChart("https://www.youtube.com/embed/abc"));
 
-        cut.WaitForAssertion(() => cut.Find(".chart-details-video-report button").Click());
-
-        _notifications.Verify(n => n.NotifyAdmin(
-            It.Is<string>(m => m.Contains(chart.Song.Name.ToString()) && m.Contains(chart.DifficultyString)),
-            It.IsAny<CancellationToken>()), Times.Once);
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("iframe.chart-details-video")));
     }
 
     [Fact]
-    public void NoVideoMeansNothingToReport()
+    public void AChartWithNoVideoRendersTheRestOfTheDialog()
     {
+        var cut = RenderDialog(SetupChart(null), ChartDetailsDialog.DetailsTab.Stats);
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".chart-details-meta")));
+        Assert.Empty(cut.FindAll("iframe.chart-details-video"));
+    }
+
+    /// <summary>
+    ///     Ten of the thirteen hosts never wire OnToDo, and every one of them used to render a
+    ///     bookmark whose click invoked an unbound callback. A control that does nothing is
+    ///     worse than an absent one, so the affordance follows the delegate.
+    /// </summary>
+    [Fact]
+    public void TheToDoBookmarkIsAbsentWhereNoHostHandlesIt()
+    {
+        SignIn();
         var cut = RenderDialog(SetupChart(null));
 
-        // The dialog rendered (its meta grid is there) but no report affordance exists —
-        // reporting is the video's action, not the chart's.
-        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".chart-details-meta")));
-        Assert.Empty(cut.FindAll(".chart-details-video-report"));
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".chart-details-title")));
+        Assert.Empty(cut.FindAll("[aria-label='To Do']"));
+    }
+
+    [Fact]
+    public void TheToDoBookmarkAppearsWhereAHostHandlesIt()
+    {
+        SignIn();
+        var cut = RenderDialog(SetupChart(null), onToDo: EventCallback.Factory.Create<Guid>(this, _ => { }));
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[aria-label='To Do']")));
+    }
+
+    /// <summary>The board reads CurrentUser.User, so IsLoggedIn alone is a half-built user.</summary>
+    private void SignIn()
+    {
+        _currentUser.SetupGet(u => u.IsLoggedIn).Returns(true);
+        _currentUser.SetupGet(u => u.User)
+            .Returns(new User(Guid.NewGuid(), "Me", true, null, new Uri("https://piu.test/me.png"), null));
+        _mediator.Setup(m => m.Send(It.IsAny<GetMyCommunitiesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CommunityOverviewRecord>());
     }
 
     /// <summary>
@@ -243,31 +277,6 @@ public sealed class ChartDetailsDialogTests : TestContext
             Assert.Contains(neighbour.Song.Name.ToString(), cut.Find(".chart-details-title").TextContent);
             Assert.Contains(anchor.Song.Name.ToString(), cut.Find(".chart-details-crumb").TextContent);
         });
-    }
-
-    /// <summary>
-    ///     Recording went behind a tab, so the header keeps a one-tap way back to it — that is
-    ///     what round 11's always-visible inputs were protecting. Crucially it does NOT write
-    ///     the remembered tab: using a shortcut once is not a standing preference.
-    /// </summary>
-    [Fact]
-    public void TheRecordShortcutOpensHistoryWithoutRememberingIt()
-    {
-        _currentUser.SetupGet(u => u.IsLoggedIn).Returns(true);
-        // The board reads CurrentUser.User to find your own row, so IsLoggedIn alone is a
-        // half-built user and NREs before anything under test runs.
-        _currentUser.SetupGet(u => u.User)
-            .Returns(new User(Guid.NewGuid(), "Me", true, null, new Uri("https://piu.test/me.png"), null));
-        _mediator.Setup(m => m.Send(It.IsAny<GetMyCommunitiesQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<CommunityOverviewRecord>());
-        var cut = RenderDialog(SetupChart(null));
-
-        cut.WaitForAssertion(() => cut.Find("[data-testid='cdt-record-shortcut']").Click());
-
-        cut.WaitForAssertion(() => Assert.Equal("true",
-            cut.Find("[data-testid='cdt-tab-History']").GetAttribute("aria-selected")));
-        _uiSettings.Verify(s => s.SetSetting(It.IsAny<string>(), It.IsAny<string>(),
-            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
@@ -6,7 +6,6 @@
 @using ScoreTracker.Domain.Models
 @using ScoreTracker.Domain.Records
 @using ScoreTracker.Domain.SecondaryPorts
-@using ScoreTracker.PlayerProgress.Contracts.Commands
 @using ScoreTracker.ScoreLedger.Contracts.Commands
 @using ScoreTracker.ScoreLedger.Contracts.Queries
 @using ScoreTracker.SharedKernel.Enums
@@ -16,7 +15,6 @@
 @using ChartType = ScoreTracker.SharedKernel.Enums.ChartType
 @inject IMediator Mediator
 @inject ICurrentUserAccessor CurrentUser
-@inject ISnackbar Snackbar
 @inject IUiSettingsAccessor UiSettings
 
 @* The one shared chart-details surface (design doc §4): leads with the video like
@@ -118,15 +116,6 @@
         }
     </DialogContent>
     <DialogActions>
-        @* Suggestion context (opened from a Suggested Charts row): a quick thumbs-up
-           feeds the same store as WSIP's feedback. The veto path lives on the widget's
-           edit-mode ✕ — negative feedback wants the reason dialog, not one tap. *@
-        @if (!IsDrilled && SuggestionCategory != null && CurrentUser.IsLoggedIn && Chart != null)
-        {
-            <MudButton StartIcon="@Icons.Material.Filled.ThumbUp" Color="Color.Secondary"
-                       Disabled="_isSaving || _feedbackSent"
-                       OnClick="SubmitGoodSuggestion">@L["Good Suggestion"]</MudButton>
-        }
         @* The dialog is a summary; the chart page is the whole record (videos, similar charts,
            the score distribution). A real link, so it opens in a tab like any other. *@
         @if (ViewChart != null)
@@ -285,7 +274,6 @@
     private readonly DialogOptions _options = new()
         { CloseOnEscapeKey = true, FullWidth = true, MaxWidth = MaxWidth.False };
     private Guid _loadedChartId = Guid.Empty;
-    private bool _isSaving;
     private string? _videoUrl;
     private DetailsTab _tab = DetailsTab.Leaderboard;
     private DetailsTab? _remembered;
@@ -351,12 +339,6 @@
     [Parameter] public int? OfficialPlace { get; set; }
 
     [Parameter] public int? OfficialFolderPlace { get; set; }
-
-    /// <summary>
-    ///     The recommendation category this chart was suggested under (Suggested Charts
-    ///     widget). Non-null unlocks the Good Suggestion action.
-    /// </summary>
-    [Parameter] public string? SuggestionCategory { get; set; }
 
     /// <summary>
     ///     Which tab to open on. A caller that reaches this dialog in order to record a score
@@ -455,7 +437,6 @@
     private async Task LoadChart(Guid chartId)
     {
         _loadedChartId = chartId;
-        _feedbackSent = false;
         _videoUrl = (await Mediator.Send(new GetChartVideosQuery(new[] { chartId })))
             .FirstOrDefault()?.VideoUrl.ToString();
     }
@@ -490,19 +471,6 @@
 
         // A remembered History from a previous session is not a tab an anonymous visitor has.
         if (!AvailableTabs.Contains(_tab)) _tab = DetailsTab.Leaderboard;
-    }
-
-    private bool _feedbackSent;
-
-    private async Task SubmitGoodSuggestion()
-    {
-        if (Chart == null || SuggestionCategory == null) return;
-        _isSaving = true;
-        await Mediator.Send(new SubmitFeedbackCommand(new SuggestionFeedbackRecord(
-            SuggestionCategory, "Positive", string.Empty, ShouldHide: false, IsPositive: true, Chart.Id)));
-        Snackbar.Add(L["Feedback Submitted, Thank You!"].Value, Severity.Success);
-        _feedbackSent = true;
-        _isSaving = false;
     }
 
     private Task Close()

--- a/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
@@ -51,40 +51,6 @@
                     </MudTooltip>
                 }
             </div>
-            <div class="chart-details-meta">
-                @if (Chart.Song.Bpm != null)
-                {
-                    <div><span class="chart-details-meta-label">@L["BPM"]</span><span>@Chart.Song.Bpm</span></div>
-                }
-                @if (Chart.NoteCount != null)
-                {
-                    <div><span class="chart-details-meta-label">@L["Note Count"]</span><span>@Chart.NoteCount</span></div>
-                }
-                @if (Chart.StepArtist != null)
-                {
-                    <div><span class="chart-details-meta-label">@L["Step Artist"]</span><span>@Chart.StepArtist</span></div>
-                }
-                <div><span class="chart-details-meta-label">@L["Song Artist"]</span><span>@Chart.Song.Artist</span></div>
-                <div><span class="chart-details-meta-label">@L["Song Type"]</span><span>@Chart.Song.Type</span></div>
-                @* Two separate facts, because they answer different questions: how played this
-                   chart is across the whole mix, and how played it is against its own folder —
-                   a chart four hundredth overall can still be the most played thing in its
-                   folder. Both are piugame's play ranking, not this site's score counts. *@
-                @if (OfficialPlace != null)
-                {
-                    <div>
-                        <span class="chart-details-meta-label">@L["Popularity overall"]</span>
-                        <span>@L["#{0}", OfficialPlace.Value.ToString("N0")]</span>
-                    </div>
-                }
-                @if (OfficialFolderPlace != null)
-                {
-                    <div>
-                        <span class="chart-details-meta-label">@L["Popularity in {0}", Chart.DifficultyString]</span>
-                        <span>@L["#{0}", OfficialFolderPlace.Value.ToString("N0")]</span>
-                    </div>
-                }
-            </div>
             @if (Score?.Score != null)
             {
                 <div class="chart-details-score">
@@ -96,73 +62,16 @@
                     }
                 </div>
             }
-            @if (_placements.Any())
-            {
-                <div class="chart-details-placements">
-                    @foreach (var placement in _placements)
-                    {
-                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined"
-                                 Style="@($"color:{placement.Color};border-color:{placement.Color}")">@placement.Label</MudChip>
-                    }
-                </div>
-            }
-            @* Badge coverage bars — granular piucenter badges, dominance-first (their top-3
-               pick, then coverage). A pre-crawl chart shows nothing here rather than falling
-               back to the rollup tags: an arbitrary "Technical" is worse than silence
-               (docs/design/nuke-old-skill-categories.md). *@
-            @if (_skillChips.Any())
-            {
-                <MudText Typo="Typo.overline">@L["Skills"]</MudText>
-                @* Bars extracted to SkillCoverageBars (chart-page overhaul): one concept,
-                   one component — the page renders the same bars at section scale. *@
-                <SkillCoverageBars Chips="_skillChips"></SkillCoverageBars>
-            }
+            @* Keys carry each panel's identity alongside the chart id: Blazor's sibling key
+               lookup compares key VALUES only, so two keyed siblings sharing a chart id
+               collide even when they are different component types. *@
+            <ChartStatsTab Chart="Chart" Mix="Mix" OfficialPlace="OfficialPlace"
+                           OfficialFolderPlace="OfficialFolderPlace"
+                           @key="(Chart.Id, nameof(ChartStatsTab))"></ChartStatsTab>
             @* Round 4 (piucenter): "Your journey" renamed Score History and moved next
                to the recording inputs it feeds — past scores directly above the new one. *@
-            @if (_journey.Any())
-            {
-                <MudText Typo="Typo.overline">@L["Score History"]</MudText>
-                <div class="chart-details-journey">
-                    @foreach (var entry in _journey)
-                    {
-                        <div class="chart-details-journey-row">
-                            <span class="chart-details-journey-date">@entry.OccurredAt.ToString("yyyy-MM-dd")</span>
-                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@MixName(entry.Mix)</MudChip>
-                            <span class="chart-details-journey-score">@(entry.Score?.ToString() ?? "—")</span>
-                            @if (entry.Score != null)
-                            {
-                                <LetterGradeIcon Grade="entry.Score.Value.LetterGradeFor(Mix)" IsBroken="entry.IsBroken" Height="16"></LetterGradeIcon>
-                            }
-                        </div>
-                    }
-                </div>
-            }
-            @* Round 10: buttons never shrink into vertical letter-stacks (nowrap + wrap
-               to their own line instead); the PIU Center link gets its own line.
-               Round 11: the score inputs are always visible (no Record Score toggle) and
-               purpose-built — EditChartGrid brought duplicate To-Do/favorite buttons and
-               a layout that fell apart on phones. To-Do moved to the title-row icon. *@
-            @if (CurrentUser.IsLoggedIn)
-            {
-                <div class="chart-details-record">
-                    <MudText Typo="Typo.overline">@L["Record Score"]</MudText>
-                    <div class="chart-details-record-row">
-                        <MudNumericField T="int?" Label="@L["Score"]" @bind-Value="_inputScore" Min="0" Max="1000000"
-                                         HideSpinButtons="true" Class="chart-details-record-score"></MudNumericField>
-                        <MudSelect T="PhoenixPlate?" Label="@L["Plate"]" @bind-Value="_inputPlate" Clearable="true"
-                                   Class="chart-details-record-plate">
-                            @foreach (var plate in Enum.GetValues<PhoenixPlate>())
-                            {
-                                <MudSelectItem T="PhoenixPlate?" Value="plate">@plate.GetName()</MudSelectItem>
-                            }
-                        </MudSelect>
-                        <MudCheckBox T="bool" @bind-Value="_inputBroken" Label="@L["Broken"]" Class="chart-details-record-broken"></MudCheckBox>
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_isSaving"
-                                   OnClick="SaveScore">@L["Save"]</MudButton>
-                    </div>
-                </div>
-            }
-            <MudLink Href="@PiuCenterUrl" Target="_blank" Typo="Typo.caption" Class="chart-details-piucenter">@L["View full chart on PIU Center"]</MudLink>
+            <ChartScoreHistoryTab Chart="Chart" Mix="Mix" Score="Score" OnScoreRecorded="OnScoreRecorded"
+                                  @key="(Chart.Id, nameof(ChartScoreHistoryTab))"></ChartScoreHistoryTab>
             @* The chart page's board, unchanged — the dialog is the third host of one component
                rather than a third leaderboard. Active follows Visible so a dialog nobody has
                opened issues no queries, which matters here: ten call sites render this. *@
@@ -235,21 +144,6 @@
         margin: 8px 0;
     }
 
-    .chart-details-meta {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-        gap: 4px 12px;
-        margin-bottom: 8px;
-    }
-
-    .chart-details-meta-label {
-        color: var(--mud-palette-text-secondary);
-        font-size: .7rem;
-        text-transform: uppercase;
-        letter-spacing: .08em;
-        display: block;
-    }
-
     .chart-details-score {
         margin: 8px 0;
     }
@@ -270,60 +164,6 @@
         margin-top: 12px;
     }
 
-    .chart-details-journey-row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        padding: 2px 0;
-        border-bottom: 1px dashed var(--mud-palette-lines-default);
-    }
-
-    .chart-details-journey-date {
-        color: var(--mud-palette-text-secondary);
-        font-variant-numeric: tabular-nums;
-    }
-
-    /* No flex-grow: the grade icon sits beside the score, not floated to the far
-       right (owner, piucenter round 4). */
-    .chart-details-journey-score {
-        font-variant-numeric: tabular-nums;
-    }
-
-    .chart-details-placements, .chart-details-skills {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 4px;
-        margin: 8px 0;
-    }
-
-    .chart-details-piucenter {
-        display: inline-block;
-        margin-top: 8px;
-    }
-
-    .chart-details-record {
-        margin-top: 8px;
-    }
-
-    /* Round 12: a grid keeps everything left-packed (the trailing 1fr ghost column
-       absorbs the slack — Broken stays glued to Plate, not to Save). */
-    .chart-details-record-row {
-        display: grid;
-        grid-template-columns: minmax(130px, 200px) minmax(130px, 170px) max-content max-content 1fr;
-        align-items: center;
-        gap: 12px;
-    }
-
-    .chart-details-record-broken {
-        white-space: nowrap;
-        margin: 0;
-    }
-
-    @@media (max-width: 599.98px) {
-        .chart-details-record-row {
-            grid-template-columns: 1fr 1fr;
-        }
-    }
 </style>
 
 @code {
@@ -333,13 +173,8 @@
     private readonly DialogOptions _options = new()
         { CloseOnEscapeKey = true, FullWidth = true, MaxWidth = MaxWidth.False };
     private Guid _loadedChartId = Guid.Empty;
-    private int? _inputScore;
-    private PhoenixPlate? _inputPlate;
-    private bool _inputBroken;
     private bool _isSaving;
     private string? _videoUrl;
-    private IReadOnlyList<ScoreJournalEntry> _journey = Array.Empty<ScoreJournalEntry>();
-    private IReadOnlyList<(string Label, string Color)> _placements = Array.Empty<(string, string)>();
 
     [Parameter] public Chart? Chart { get; set; }
 
@@ -403,109 +238,10 @@
         if (!Visible || Chart == null || Chart.Id == _loadedChartId) return;
         _loadedChartId = Chart.Id;
         _feedbackSent = false;
-        // Prefill the recording inputs from the current best (round 11).
-        _inputScore = Score?.Score == null ? null : (int)Score.Score.Value;
-        _inputPlate = Score?.Plate;
-        _inputBroken = Score?.IsBroken ?? false;
+        // The video is all this component reads now — the stats and history panels own the
+        // rest, so a host that never shows one never pays for its queries.
         _videoUrl = (await Mediator.Send(new GetChartVideosQuery(new[] { Chart.Id })))
             .FirstOrDefault()?.VideoUrl.ToString();
-        _journey = CurrentUser.IsLoggedIn
-            ? (await Mediator.Send(new GetChartScoreJourneyQuery(Chart.Id))).ToArray()
-            : Array.Empty<ScoreJournalEntry>();
-        _placements = await LoadPlacements(Chart.Id);
-        // The alias table's key beats the guessed one (crawler project hardening).
-        _externalKey = (await Mediator.Send(new GetChartStepAnalysisQuery(Chart.Id)))?.ExternalKey;
-        // Coverage bars: granular piucenter badges, dominance-ordered, from the banked metrics.
-        _skillChips = (await Mediator.Send(new GetChartBadgeChipsQuery(new[] { Chart.Id })))
-            .GetValueOrDefault(Chart.Id) ?? Array.Empty<ChartBadgeChipRecord>();
-    }
-
-    private async Task<IReadOnlyList<(string, string)>> LoadPlacements(Guid chartId)
-    {
-        var placements = new List<(string, string)>();
-        foreach (var (listName, label) in new (string, string)[]
-                 {
-                     ("Pass Count", L["Pass Difficulty"].ToString()),
-                     ("Scores", L["Score Difficulty"].ToString())
-                 })
-        {
-            var result = await Mediator.Send(new GetTierListWithFallbackQuery(listName, Mix));
-            var entry = result.Entries.FirstOrDefault(e => e.ChartId == chartId);
-            if (entry == null || entry.Category == TierListCategory.Unrecorded) continue;
-            placements.Add(($"{label}: {DifficultyName(entry.Category)}",
-                ThemeScales.DifficultyColor(entry.Category)));
-        }
-
-        return placements;
-    }
-
-    private string DifficultyName(TierListCategory category)
-    {
-        return category switch
-        {
-            TierListCategory.Overrated => L["1+ Level Easier"],
-            TierListCategory.VeryEasy => L["Very Easy"],
-            TierListCategory.Easy => L["Easy"],
-            TierListCategory.Medium => L["Medium"],
-            TierListCategory.Hard => L["Hard"],
-            TierListCategory.VeryHard => L["Very Hard"],
-            TierListCategory.Underrated => L["1+ Level Harder"],
-            _ => L["Not Rated"]
-        };
-    }
-
-    private static string MixName(MixEnum mix)
-    {
-        return mix == MixEnum.Phoenix2 ? "Phoenix 2" : mix.ToString();
-    }
-
-    private string? _externalKey;
-    private IReadOnlyList<ChartBadgeChipRecord> _skillChips = Array.Empty<ChartBadgeChipRecord>();
-
-    // The resolved alias key when the crawler has one; otherwise a best-effort guess
-    // in the current key format ("<Song>_-_<Artist>_<S|D><level>_<SONGTYPE>").
-    private string PiuCenterUrl
-    {
-        get
-        {
-            if (_externalKey != null)
-                return $"https://www.piucenter.com/chart/{Uri.EscapeDataString(_externalKey)}";
-            if (Chart == null) return "https://www.piucenter.com/chart";
-            var suffix = Chart.Song.Type switch
-            {
-                SongType.Remix => "REMIX",
-                SongType.ShortCut => "SHORTCUT",
-                SongType.FullSong => "FULLSONG",
-                _ => "ARCADE"
-            };
-            var key =
-                $"{Chart.Song.Name}_-_{Chart.Song.Artist}_{Chart.Type.GetShortHand()}{(int)Chart.Level}_{suffix}"
-                    .Replace(' ', '_');
-            return $"https://www.piucenter.com/chart/{Uri.EscapeDataString(key)}";
-        }
-    }
-
-    private async Task SaveScore()
-    {
-        if (Chart == null) return;
-        _isSaving = true;
-        try
-        {
-            var parsedScore = _inputScore == null ? null :
-                PhoenixScore.TryParse(_inputScore.Value, out var score) ? (PhoenixScore?)score : null;
-            await Mediator.Send(new UpdatePhoenixBestAttemptCommand(Chart.Id, _inputBroken, parsedScore, _inputPlate,
-                Mix: Mix));
-            Snackbar.Add($"Recorded {(_inputBroken ? "Broken" : "Passing")} for {Chart.Song.Name}", Severity.Success);
-            await OnScoreRecorded.InvokeAsync();
-            // The journey timeline gains the new entry immediately.
-            _journey = (await Mediator.Send(new GetChartScoreJourneyQuery(Chart.Id))).ToArray();
-        }
-        catch (Exception)
-        {
-            Snackbar.Add("There was an error while recording the score", Severity.Error);
-        }
-
-        _isSaving = false;
     }
 
     /// <summary>Names the chart to an admin — wrong videos get caught by whoever is watching.</summary>

--- a/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
@@ -26,8 +26,17 @@
    (their full chart rendering is deliberately not imported — §8a). *@
 <MudDialog Visible="Visible" VisibleChanged="VisibleChanged" Options="_options" Class="chart-details-dialog">
     <DialogContent>
-        @if (Chart != null)
+        @if (ViewChart != null)
         {
+            @* Drilled in from Charts like this. A crumb rather than a second dialog: the host
+               owns Visible, and nineteen of them would each need to learn a chart-change
+               callback for what is one piece of state in here. *@
+            @if (IsDrilled && Chart != null)
+            {
+                <MudButton Size="Size.Small" Variant="Variant.Text" Class="chart-details-crumb"
+                           StartIcon="@Icons.Material.Filled.ArrowBack"
+                           OnClick="BackToAnchor">@L["Back to {0}", Chart.Song.Name]</MudButton>
+            }
             @if (!string.IsNullOrWhiteSpace(_videoUrl))
             {
                 <iframe class="chart-details-video" src="@EmbedUrl" allow="@(AutoPlay ? "autoplay; encrypted-media" : "encrypted-media")" allowfullscreen></iframe>
@@ -39,10 +48,13 @@
                 </div>
             }
             <div class="chart-details-title">
-                <DifficultyBubble Chart="Chart"></DifficultyBubble>
-                <MudText Typo="Typo.h5">@Chart.Song.Name</MudText>
+                <DifficultyBubble Chart="ViewChart"></DifficultyBubble>
+                <MudText Typo="Typo.h5">@ViewChart.Song.Name</MudText>
                 <MudSpacer></MudSpacer>
-                @if (CurrentUser.IsLoggedIn)
+                @* Score, To-Do, the suggestion action and the popularity places all describe
+                   the chart the HOST passed. While drilled into a neighbour they would be
+                   describing the wrong one, so they stand down rather than lie. *@
+                @if (!IsDrilled && CurrentUser.IsLoggedIn && Chart != null)
                 {
                     <MudTooltip Text="@(IsToDo ? L["On ToDo List"] : L["Add to ToDo List"])">
                         <MudIconButton Icon="@(IsToDo ? Icons.Material.Filled.Bookmark : Icons.Material.Outlined.BookmarkBorder)"
@@ -52,7 +64,7 @@
                     </MudTooltip>
                 }
             </div>
-            @if (Score?.Score != null)
+            @if (!IsDrilled && Score?.Score != null)
             {
                 <div class="chart-details-score">
                     <ScoreBreakdown Score="Score.Score.Value" IsBroken="Score.IsBroken" Mix="Mix" OneLine="true" ShowScore="true"
@@ -82,28 +94,31 @@
                dialog nobody opened nor a tab nobody picked issues a query. Nineteen call sites
                render this. *@
             <div class="@PanelClass(DetailsTab.Leaderboard)">
-                <ChartLeaderboardScopes ChartId="Chart.Id" Mix="Mix"
+                <ChartLeaderboardScopes ChartId="ViewChart.Id" Mix="Mix"
                                         Active="IsLive(DetailsTab.Leaderboard)"
                                         InitialScope="BoardScope"
-                                        @key="(Chart.Id, Mix)"></ChartLeaderboardScopes>
+                                        @key="(ViewChart.Id, Mix)"></ChartLeaderboardScopes>
             </div>
             @* Keys carry each panel's identity alongside the chart id: Blazor's key lookup
                compares key VALUES only, so two keyed siblings sharing a chart id collide even
                when they are different component types. *@
             <div class="@PanelClass(DetailsTab.Stats)">
-                <ChartStatsTab Chart="Chart" Mix="Mix" OfficialPlace="OfficialPlace"
-                               OfficialFolderPlace="OfficialFolderPlace"
+                <ChartStatsTab Chart="ViewChart" Mix="Mix"
+                               OfficialPlace="@(IsDrilled ? null : OfficialPlace)"
+                               OfficialFolderPlace="@(IsDrilled ? null : OfficialFolderPlace)"
                                Active="IsLive(DetailsTab.Stats)"
-                               @key="(Chart.Id, nameof(ChartStatsTab))"></ChartStatsTab>
+                               OnSimilarChartSelected="Drill"
+                               @key="(ViewChart.Id, nameof(ChartStatsTab))"></ChartStatsTab>
             </div>
             @* Round 4 (piucenter): "Your journey" renamed Score History and kept next to the
                recording inputs it feeds — past scores directly above the new one. The tab is
                the heading now, so the panel no longer prints one of its own. *@
             <div class="@PanelClass(DetailsTab.History)">
-                <ChartScoreHistoryTab Chart="Chart" Mix="Mix" Score="Score" ShowHeading="false"
+                <ChartScoreHistoryTab Chart="ViewChart" Mix="Mix" ShowHeading="false"
+                                      Score="@(IsDrilled ? null : Score)"
                                       OnScoreRecorded="OnScoreRecorded"
                                       Active="IsLive(DetailsTab.History)"
-                                      @key="(Chart.Id, nameof(ChartScoreHistoryTab))"></ChartScoreHistoryTab>
+                                      @key="(ViewChart.Id, nameof(ChartScoreHistoryTab))"></ChartScoreHistoryTab>
             </div>
         }
     </DialogContent>
@@ -111,7 +126,7 @@
         @* Suggestion context (opened from a Suggested Charts row): a quick thumbs-up
            feeds the same store as WSIP's feedback. The veto path lives on the widget's
            edit-mode ✕ — negative feedback wants the reason dialog, not one tap. *@
-        @if (SuggestionCategory != null && CurrentUser.IsLoggedIn && Chart != null)
+        @if (!IsDrilled && SuggestionCategory != null && CurrentUser.IsLoggedIn && Chart != null)
         {
             <MudButton StartIcon="@Icons.Material.Filled.ThumbUp" Color="Color.Secondary"
                        Disabled="_isSaving || _feedbackSent"
@@ -119,10 +134,10 @@
         }
         @* The dialog is a summary; the chart page is the whole record (videos, similar charts,
            the score distribution). A real link, so it opens in a tab like any other. *@
-        @if (Chart != null)
+        @if (ViewChart != null)
         {
             <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.OpenInNew"
-                       Href="@ChartSlugs.CanonicalPath(Chart)">@L["More info"]</MudButton>
+                       Href="@ChartSlugs.CanonicalPath(ViewChart)">@L["More info"]</MudButton>
         }
         <MudSpacer></MudSpacer>
         <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Close"
@@ -226,6 +241,10 @@
         display: none;
     }
 
+    .chart-details-crumb {
+        margin-bottom: 2px;
+    }
+
     /* Age reads under the score, not beside it (owner, piucenter round 3). */
     .chart-details-score-age {
         display: block;
@@ -277,6 +296,16 @@
     private DetailsTab? _remembered;
     private bool _rememberRead;
     private bool _wasVisible;
+    private Guid _anchorId = Guid.Empty;
+    private Chart? _drilled;
+
+    /// <summary>
+    ///     The chart currently on screen: the host's, or the neighbour the reader drilled into
+    ///     from Charts like this.
+    /// </summary>
+    private Chart? ViewChart => _drilled ?? Chart;
+
+    private bool IsDrilled => _drilled != null;
 
     [Parameter] public Chart? Chart { get; set; }
 
@@ -387,8 +416,10 @@
         {
             // Resolved once per opening rather than on every parameter change: re-applying
             // InitialTab while the dialog is open would snap the user back out of any tab
-            // they picked themselves.
+            // they picked themselves. A drill-down is scoped to one opening for the same
+            // reason — reopening from a row starts at the chart that row names.
             _wasVisible = false;
+            _drilled = null;
             return;
         }
 
@@ -399,13 +430,45 @@
             await ResolveOpeningTab();
         }
 
-        if (Chart.Id == _loadedChartId) return;
-        _loadedChartId = Chart.Id;
+        // A new chart from the host replaces whatever the reader had drilled into.
+        if (Chart.Id != _anchorId)
+        {
+            _anchorId = Chart.Id;
+            _drilled = null;
+        }
+
+        if (ViewChart!.Id == _loadedChartId) return;
+        await LoadChart(ViewChart.Id);
+    }
+
+    /// <summary>
+    ///     The video is all this component reads — the stats, history and leaderboard panels
+    ///     own the rest and only read when they are the selected tab.
+    /// </summary>
+    private async Task LoadChart(Guid chartId)
+    {
+        _loadedChartId = chartId;
         _feedbackSent = false;
-        // The video is all this component reads now — the stats, history and leaderboard
-        // panels own the rest and only read when they are the selected tab.
-        _videoUrl = (await Mediator.Send(new GetChartVideosQuery(new[] { Chart.Id })))
+        _videoUrl = (await Mediator.Send(new GetChartVideosQuery(new[] { chartId })))
             .FirstOrDefault()?.VideoUrl.ToString();
+    }
+
+    /// <summary>
+    ///     Swap to a neighbour without leaving the dialog. The tab stays put — the reader was
+    ///     on Chart Stats to tap this, and landing them somewhere else would lose the shelf
+    ///     they are browsing.
+    /// </summary>
+    private async Task Drill(Chart chart)
+    {
+        if (chart.Id == ViewChart?.Id) return;
+        _drilled = chart;
+        await LoadChart(chart.Id);
+    }
+
+    private async Task BackToAnchor()
+    {
+        _drilled = null;
+        if (Chart != null) await LoadChart(Chart.Id);
     }
 
     private async Task ResolveOpeningTab()

--- a/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
@@ -17,7 +17,6 @@
 @inject IMediator Mediator
 @inject ICurrentUserAccessor CurrentUser
 @inject ISnackbar Snackbar
-@inject IAdminNotificationClient Notifications
 @inject IUiSettingsAccessor UiSettings
 
 @* The one shared chart-details surface (design doc §4): leads with the video like
@@ -40,33 +39,17 @@
             @if (!string.IsNullOrWhiteSpace(_videoUrl))
             {
                 <iframe class="chart-details-video" src="@EmbedUrl" allow="@(AutoPlay ? "autoplay; encrypted-media" : "encrypted-media")" allowfullscreen></iframe>
-                <div class="chart-details-video-report">
-                    <MudTooltip Text=@L["Report Video Tooltip"]>
-                        <MudButton Size="Size.Small" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Report"
-                                   OnClick="ReportVideo">@L["Report Video"]</MudButton>
-                    </MudTooltip>
-                </div>
             }
             <div class="chart-details-title">
                 <DifficultyBubble Chart="ViewChart"></DifficultyBubble>
                 <MudText Typo="Typo.h5">@ViewChart.Song.Name</MudText>
                 <MudSpacer></MudSpacer>
-                @* Recording moved behind a tab, so it gets a way back to one tap. Round 11
-                   made the inputs always-visible for a reason and this is that reason kept.
-                   It does NOT write the remembered tab: a shortcut used once is not a
-                   preference, and only picking a tab by hand should read as one. *@
-                @if (CurrentUser.IsLoggedIn)
-                {
-                    <MudTooltip Text="@L["Record a score"]">
-                        <MudIconButton Icon="@Icons.Material.Filled.EditNote" Color="Color.Default"
-                                       OnClick="JumpToRecord" data-testid="cdt-record-shortcut"
-                                       aria-label="@L["Record a score"]"></MudIconButton>
-                    </MudTooltip>
-                }
                 @* Score, To-Do, the suggestion action and the popularity places all describe
                    the chart the HOST passed. While drilled into a neighbour they would be
-                   describing the wrong one, so they stand down rather than lie. *@
-                @if (!IsDrilled && CurrentUser.IsLoggedIn && Chart != null)
+                   describing the wrong one, so they stand down rather than lie.
+                   HasDelegate is load-bearing: ten of the thirteen hosts never wire OnToDo, and
+                   without it they all rendered a bookmark whose click went nowhere. *@
+                @if (!IsDrilled && CurrentUser.IsLoggedIn && Chart != null && OnToDo.HasDelegate)
                 {
                     <MudTooltip Text="@(IsToDo ? L["On ToDo List"] : L["Add to ToDo List"])">
                         <MudIconButton Icon="@(IsToDo ? Icons.Material.Filled.Bookmark : Icons.Material.Outlined.BookmarkBorder)"
@@ -181,12 +164,6 @@
         border: 0;
     }
 
-    .chart-details-video-report {
-        display: flex;
-        justify-content: flex-end;
-        margin-top: 2px;
-    }
-
     .chart-details-title {
         display: flex;
         align-items: center;
@@ -246,6 +223,12 @@
     .chart-details-tab:focus-visible {
         outline: 2px solid var(--mud-palette-primary);
         outline-offset: -2px;
+    }
+
+    /* Panels sat flush against the strip, so the first row of every tab read as part of
+       the tabs rather than under them. */
+    .chart-details-panel {
+        padding-top: 12px;
     }
 
     /* Hidden, not unmounted — see the panel comment in the markup. */
@@ -413,15 +396,6 @@
         };
     }
 
-    /// <summary>
-    ///     The header shortcut. Deliberately not <see cref="SelectTab" />: jumping to record
-    ///     once should not make History the tab every chart opens on from then on.
-    /// </summary>
-    private void JumpToRecord()
-    {
-        _tab = DetailsTab.History;
-    }
-
     private async Task SelectTab(DetailsTab tab)
     {
         if (_tab == tab) return;
@@ -516,16 +490,6 @@
 
         // A remembered History from a previous session is not a tab an anonymous visitor has.
         if (!AvailableTabs.Contains(_tab)) _tab = DetailsTab.Leaderboard;
-    }
-
-    /// <summary>Names the chart to an admin — wrong videos get caught by whoever is watching.</summary>
-    private async Task ReportVideo()
-    {
-        if (Chart == null) return;
-        await Notifications.NotifyAdmin(
-            $"The video for {Chart.Song.Name} {Chart.DifficultyString} was reported by {(CurrentUser.IsLoggedIn ? CurrentUser.User.Name : "Unknown")}",
-            CancellationToken.None);
-        Snackbar.Add("Notification was sent", Severity.Success);
     }
 
     private bool _feedbackSent;

--- a/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
@@ -306,7 +306,6 @@
     private string? _videoUrl;
     private DetailsTab _tab = DetailsTab.Leaderboard;
     private DetailsTab? _remembered;
-    private bool _rememberRead;
     private bool _wasVisible;
     private Guid _anchorId = Guid.Empty;
     private Chart? _drilled;
@@ -431,6 +430,19 @@
         await UiSettings.SetSetting(TabSettingKey, tab.ToString());
     }
 
+    /// <summary>
+    ///     Reads the remembered tab once per instance, and here rather than on the open path.
+    ///     Signed out this setting lives in browser storage, so the read is a JS interop round
+    ///     trip; awaiting it inside the click that opens the dialog would put it in front of
+    ///     everything the dialog renders. Every other consumer of GetSetting reads it here for
+    ///     the same reason (ProfilePanel, ChartsExportDialog, CommunityToolsAnnouncement).
+    /// </summary>
+    protected override async Task OnInitializedAsync()
+    {
+        var stored = await UiSettings.GetSetting(TabSettingKey);
+        if (Enum.TryParse<DetailsTab>(stored, out var restored)) _remembered = restored;
+    }
+
     protected override async Task OnParametersSetAsync()
     {
         if (!Visible)
@@ -448,7 +460,7 @@
         if (!_wasVisible)
         {
             _wasVisible = true;
-            await ResolveOpeningTab();
+            ResolveOpeningTab();
         }
 
         // A new chart from the host replaces whatever the reader had drilled into.
@@ -492,25 +504,15 @@
         if (Chart != null) await LoadChart(Chart.Id);
     }
 
-    private async Task ResolveOpeningTab()
+    /// <summary>
+    ///     Synchronous on purpose: nothing here may go to storage or to the browser, because
+    ///     this runs on the click that opens the dialog and anything awaited here delays the
+    ///     content behind it.
+    /// </summary>
+    private void ResolveOpeningTab()
     {
-        if (InitialTab is { } forced)
-        {
-            _tab = forced;
-        }
-        else
-        {
-            // Read once per instance. Signed in this is a query, and paying it on every open
-            // of a dialog that nineteen call sites render is exactly the cost the tabs removed.
-            if (!_rememberRead)
-            {
-                _rememberRead = true;
-                var stored = await UiSettings.GetSetting(TabSettingKey);
-                if (Enum.TryParse<DetailsTab>(stored, out var restored)) _remembered = restored;
-            }
-
-            if (_remembered is { } remembered) _tab = remembered;
-        }
+        if (InitialTab is { } forced) _tab = forced;
+        else if (_remembered is { } remembered) _tab = remembered;
 
         // A remembered History from a previous session is not a tab an anonymous visitor has.
         if (!AvailableTabs.Contains(_tab)) _tab = DetailsTab.Leaderboard;

--- a/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
@@ -12,12 +12,13 @@
 @using ScoreTracker.SharedKernel.Enums
 @using ScoreTracker.SharedKernel.Models
 @using ScoreTracker.SharedKernel.ValueTypes
-@using ScoreTracker.Web.Services.Theming
+@using ScoreTracker.Web.Services.Contracts
 @using ChartType = ScoreTracker.SharedKernel.Enums.ChartType
 @inject IMediator Mediator
 @inject ICurrentUserAccessor CurrentUser
 @inject ISnackbar Snackbar
 @inject IAdminNotificationClient Notifications
+@inject IUiSettingsAccessor UiSettings
 
 @* The one shared chart-details surface (design doc §4): leads with the video like
    today's video dialog, then meta, the cross-mix score journey (ScoreEventJournal),
@@ -62,26 +63,48 @@
                     }
                 </div>
             }
-            @* Keys carry each panel's identity alongside the chart id: Blazor's sibling key
-               lookup compares key VALUES only, so two keyed siblings sharing a chart id
-               collide even when they are different component types. *@
-            <ChartStatsTab Chart="Chart" Mix="Mix" OfficialPlace="OfficialPlace"
-                           OfficialFolderPlace="OfficialFolderPlace"
-                           @key="(Chart.Id, nameof(ChartStatsTab))"></ChartStatsTab>
-            @* Round 4 (piucenter): "Your journey" renamed Score History and moved next
-               to the recording inputs it feeds — past scores directly above the new one. *@
-            <ChartScoreHistoryTab Chart="Chart" Mix="Mix" Score="Score" OnScoreRecorded="OnScoreRecorded"
-                                  @key="(Chart.Id, nameof(ChartScoreHistoryTab))"></ChartScoreHistoryTab>
+            @* Sticky so a tall header — video, title, your score — scrolls away underneath the
+               strip instead of taking it with it. The panels below all stay mounted and are
+               gated on Active rather than unmounted: switching tabs would otherwise throw away
+               the board's scope selection and re-query on the way back.
+               Comments becomes the first tab when that feature lands (docs/design/chart-comments). *@
+            <div class="chart-details-tabs" role="tablist">
+                @foreach (var tab in AvailableTabs)
+                {
+                    var t = tab;
+                    <button type="button" role="tab" class="@TabClass(t)" data-testid="@($"cdt-tab-{t}")"
+                            aria-selected="@((_tab == t).ToString().ToLowerInvariant())"
+                            @onclick="() => SelectTab(t)">@TabLabel(t)</button>
+                }
+            </div>
             @* The chart page's board, unchanged — the dialog is the third host of one component
-               rather than a third leaderboard. Active follows Visible so a dialog nobody has
-               opened issues no queries, which matters here: ten call sites render this. *@
-            <div class="chart-details-board">
-                <MudText Typo="Typo.overline">@L["Leaderboard"]</MudText>
-                <ChartLeaderboardScopes ChartId="Chart.Id" Mix="Mix" Active="Visible"
+               rather than a third leaderboard. Active is Visible AND selected, so neither a
+               dialog nobody opened nor a tab nobody picked issues a query. Nineteen call sites
+               render this. *@
+            <div class="@PanelClass(DetailsTab.Leaderboard)">
+                <ChartLeaderboardScopes ChartId="Chart.Id" Mix="Mix"
+                                        Active="IsLive(DetailsTab.Leaderboard)"
                                         InitialScope="BoardScope"
                                         @key="(Chart.Id, Mix)"></ChartLeaderboardScopes>
             </div>
-            @* Reserved slot: chart comments land here if user-generated content ever ships. *@
+            @* Keys carry each panel's identity alongside the chart id: Blazor's key lookup
+               compares key VALUES only, so two keyed siblings sharing a chart id collide even
+               when they are different component types. *@
+            <div class="@PanelClass(DetailsTab.Stats)">
+                <ChartStatsTab Chart="Chart" Mix="Mix" OfficialPlace="OfficialPlace"
+                               OfficialFolderPlace="OfficialFolderPlace"
+                               Active="IsLive(DetailsTab.Stats)"
+                               @key="(Chart.Id, nameof(ChartStatsTab))"></ChartStatsTab>
+            </div>
+            @* Round 4 (piucenter): "Your journey" renamed Score History and kept next to the
+               recording inputs it feeds — past scores directly above the new one. The tab is
+               the heading now, so the panel no longer prints one of its own. *@
+            <div class="@PanelClass(DetailsTab.History)">
+                <ChartScoreHistoryTab Chart="Chart" Mix="Mix" Score="Score" ShowHeading="false"
+                                      OnScoreRecorded="OnScoreRecorded"
+                                      Active="IsLive(DetailsTab.History)"
+                                      @key="(Chart.Id, nameof(ChartScoreHistoryTab))"></ChartScoreHistoryTab>
+            </div>
         }
     </DialogContent>
     <DialogActions>
@@ -148,6 +171,61 @@
         margin: 8px 0;
     }
 
+    /* Sticky against the dialog content, which is the scroll container. It does not bleed to
+       the content's padding edges on purpose: matching MudBlazor's own gutter by hand risks
+       overflowing it, and a dialog that scrolls sideways is a worse bug than a 24px gutter. */
+    .chart-details-tabs {
+        position: sticky;
+        top: 0;
+        z-index: 3;
+        display: flex;
+        gap: 2px;
+        margin-top: 10px;
+        overflow-x: auto;
+        scrollbar-width: none;
+        background: var(--mud-palette-surface);
+        border-top: 1px solid var(--mud-palette-lines-default);
+        border-bottom: 1px solid var(--mud-palette-lines-default);
+    }
+
+    .chart-details-tabs::-webkit-scrollbar {
+        display: none;
+    }
+
+    /* Labels stay whole words and the strip scrolls instead. Four of them do not fit a 390px
+       phone, and abbreviating "Leaderboard" into jargon to buy 40px is the worse trade. */
+    .chart-details-tab {
+        appearance: none;
+        background: none;
+        border: none;
+        border-bottom: 2px solid transparent;
+        color: var(--mud-palette-text-secondary);
+        font: inherit;
+        font-size: .82rem;
+        padding: 10px 12px 8px;
+        white-space: nowrap;
+        cursor: pointer;
+    }
+
+    .chart-details-tab:hover {
+        color: var(--mud-palette-text-primary);
+    }
+
+    .chart-details-tab-on {
+        color: var(--mud-palette-primary);
+        border-bottom-color: var(--mud-palette-primary);
+    }
+
+    .chart-details-tab:focus-visible {
+        outline: 2px solid var(--mud-palette-primary);
+        outline-offset: -2px;
+    }
+
+    /* Hidden, not unmounted — see the panel comment in the markup. */
+    .chart-details-panel-hidden {
+        display: none;
+    }
+
     /* Age reads under the score, not beside it (owner, piucenter round 3). */
     .chart-details-score-age {
         display: block;
@@ -167,6 +245,26 @@
 </style>
 
 @code {
+    /// <summary>
+    ///     The dialog's sections. Comments joins as the first tab when that feature lands
+    ///     (docs/design/chart-comments); until it has something behind it, shipping a fourth
+    ///     tab would just be a dead control.
+    /// </summary>
+    public enum DetailsTab
+    {
+        Leaderboard,
+        Stats,
+        History
+    }
+
+    /// <summary>
+    ///     Per user, not per page. The density preference is keyed by page because a table on
+    ///     one screen says nothing about a table on another; this dialog is the same object
+    ///     everywhere it opens, so remembering it nineteen times over would be nineteen answers
+    ///     to one question.
+    /// </summary>
+    private const string TabSettingKey = "ChartDetails__Tab";
+
     // MaxWidth.False on purpose: Small would tag the dialog `mud-dialog-width-sm`, which
     // charts.scss globally forces to `max-width: none !important`. The cap lives in this
     // component's own stylesheet instead — see the note beside it.
@@ -175,6 +273,10 @@
     private Guid _loadedChartId = Guid.Empty;
     private bool _isSaving;
     private string? _videoUrl;
+    private DetailsTab _tab = DetailsTab.Leaderboard;
+    private DetailsTab? _remembered;
+    private bool _rememberRead;
+    private bool _wasVisible;
 
     [Parameter] public Chart? Chart { get; set; }
 
@@ -233,15 +335,101 @@
     /// </summary>
     [Parameter] public string? SuggestionCategory { get; set; }
 
+    /// <summary>
+    ///     Which tab to open on. A caller that reaches this dialog in order to record a score
+    ///     has already said which section it means, and making them tap for it would undo what
+    ///     always-visible inputs were for. Null defers to the remembered choice.
+    /// </summary>
+    [Parameter] public DetailsTab? InitialTab { get; set; }
+
+    private IReadOnlyList<DetailsTab> AvailableTabs => CurrentUser.IsLoggedIn
+        ? new[] { DetailsTab.Leaderboard, DetailsTab.Stats, DetailsTab.History }
+        // Score History is your journal plus your recording inputs. Signed out it is an empty
+        // box with a heading, which is worse than one fewer tab.
+        : new[] { DetailsTab.Leaderboard, DetailsTab.Stats };
+
+    private bool IsLive(DetailsTab tab)
+    {
+        return Visible && _tab == tab;
+    }
+
+    private string TabClass(DetailsTab tab)
+    {
+        return _tab == tab ? "chart-details-tab chart-details-tab-on" : "chart-details-tab";
+    }
+
+    private string PanelClass(DetailsTab tab)
+    {
+        return _tab == tab ? "chart-details-panel" : "chart-details-panel chart-details-panel-hidden";
+    }
+
+    private string TabLabel(DetailsTab tab)
+    {
+        return tab switch
+        {
+            DetailsTab.Stats => L["Chart Stats"],
+            DetailsTab.History => L["Score History"],
+            _ => L["Leaderboard"]
+        };
+    }
+
+    private async Task SelectTab(DetailsTab tab)
+    {
+        if (_tab == tab) return;
+        _tab = tab;
+        _remembered = tab;
+        await UiSettings.SetSetting(TabSettingKey, tab.ToString());
+    }
+
     protected override async Task OnParametersSetAsync()
     {
-        if (!Visible || Chart == null || Chart.Id == _loadedChartId) return;
+        if (!Visible)
+        {
+            // Resolved once per opening rather than on every parameter change: re-applying
+            // InitialTab while the dialog is open would snap the user back out of any tab
+            // they picked themselves.
+            _wasVisible = false;
+            return;
+        }
+
+        if (Chart == null) return;
+        if (!_wasVisible)
+        {
+            _wasVisible = true;
+            await ResolveOpeningTab();
+        }
+
+        if (Chart.Id == _loadedChartId) return;
         _loadedChartId = Chart.Id;
         _feedbackSent = false;
-        // The video is all this component reads now — the stats and history panels own the
-        // rest, so a host that never shows one never pays for its queries.
+        // The video is all this component reads now — the stats, history and leaderboard
+        // panels own the rest and only read when they are the selected tab.
         _videoUrl = (await Mediator.Send(new GetChartVideosQuery(new[] { Chart.Id })))
             .FirstOrDefault()?.VideoUrl.ToString();
+    }
+
+    private async Task ResolveOpeningTab()
+    {
+        if (InitialTab is { } forced)
+        {
+            _tab = forced;
+        }
+        else
+        {
+            // Read once per instance. Signed in this is a query, and paying it on every open
+            // of a dialog that nineteen call sites render is exactly the cost the tabs removed.
+            if (!_rememberRead)
+            {
+                _rememberRead = true;
+                var stored = await UiSettings.GetSetting(TabSettingKey);
+                if (Enum.TryParse<DetailsTab>(stored, out var restored)) _remembered = restored;
+            }
+
+            if (_remembered is { } remembered) _tab = remembered;
+        }
+
+        // A remembered History from a previous session is not a tab an anonymous visitor has.
+        if (!AvailableTabs.Contains(_tab)) _tab = DetailsTab.Leaderboard;
     }
 
     /// <summary>Names the chart to an admin — wrong videos get caught by whoever is watching.</summary>

--- a/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartDetailsDialog.razor
@@ -51,6 +51,18 @@
                 <DifficultyBubble Chart="ViewChart"></DifficultyBubble>
                 <MudText Typo="Typo.h5">@ViewChart.Song.Name</MudText>
                 <MudSpacer></MudSpacer>
+                @* Recording moved behind a tab, so it gets a way back to one tap. Round 11
+                   made the inputs always-visible for a reason and this is that reason kept.
+                   It does NOT write the remembered tab: a shortcut used once is not a
+                   preference, and only picking a tab by hand should read as one. *@
+                @if (CurrentUser.IsLoggedIn)
+                {
+                    <MudTooltip Text="@L["Record a score"]">
+                        <MudIconButton Icon="@Icons.Material.Filled.EditNote" Color="Color.Default"
+                                       OnClick="JumpToRecord" data-testid="cdt-record-shortcut"
+                                       aria-label="@L["Record a score"]"></MudIconButton>
+                    </MudTooltip>
+                }
                 @* Score, To-Do, the suggestion action and the popularity places all describe
                    the chart the HOST passed. While drilled into a neighbour they would be
                    describing the wrong one, so they stand down rather than lie. *@
@@ -400,6 +412,15 @@
             DetailsTab.History => L["Score History"],
             _ => L["Leaderboard"]
         };
+    }
+
+    /// <summary>
+    ///     The header shortcut. Deliberately not <see cref="SelectTab" />: jumping to record
+    ///     once should not make History the tab every chart opens on from then on.
+    /// </summary>
+    private void JumpToRecord()
+    {
+        _tab = DetailsTab.History;
     }
 
     private async Task SelectTab(DetailsTab tab)

--- a/ScoreTracker/ScoreTracker/Components/ChartScoreHistoryTab.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartScoreHistoryTab.razor
@@ -1,0 +1,181 @@
+@namespace ScoreTracker.Web.Components
+@using MediatR
+@using ScoreTracker.Domain.Models
+@using ScoreTracker.Domain.Records
+@using ScoreTracker.Domain.SecondaryPorts
+@using ScoreTracker.ScoreLedger.Contracts.Commands
+@using ScoreTracker.ScoreLedger.Contracts.Queries
+@using ScoreTracker.SharedKernel.Enums
+@using ScoreTracker.SharedKernel.ValueTypes
+@inject IMediator Mediator
+@inject ICurrentUserAccessor CurrentUser
+@inject ISnackbar Snackbar
+
+@* Your record on this chart, extracted from ChartDetailsDialog: the cross-mix journey
+   from the ScoreEventJournal with the recording inputs directly beneath it. That
+   adjacency is deliberate (piucenter round 4) — past scores sit above the new one, so
+   the number you are about to type has its own history for context. *@
+@if (Chart != null && CurrentUser.IsLoggedIn)
+{
+    @if (ShowHeading)
+    {
+        <MudText Typo="Typo.overline">@L["Score History"]</MudText>
+    }
+    @if (_journey.Any())
+    {
+        <div class="chart-details-journey">
+            @foreach (var entry in _journey)
+            {
+                <div class="chart-details-journey-row">
+                    <span class="chart-details-journey-date">@entry.OccurredAt.ToString("yyyy-MM-dd")</span>
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@MixName(entry.Mix)</MudChip>
+                    <span class="chart-details-journey-score">@(entry.Score?.ToString() ?? "—")</span>
+                    @if (entry.Score != null)
+                    {
+                        <LetterGradeIcon Grade="entry.Score.Value.LetterGradeFor(Mix)" IsBroken="entry.IsBroken" Height="16"></LetterGradeIcon>
+                    }
+                </div>
+            }
+        </div>
+    }
+    else
+    {
+        <MudText Typo="Typo.body2" Class="chart-details-journey-empty">@L["No scores recorded on this chart yet."]</MudText>
+    }
+    @* Round 10: buttons never shrink into vertical letter-stacks (nowrap + wrap
+       to their own line instead).
+       Round 11: the score inputs are always visible (no Record Score toggle) and
+       purpose-built — EditChartGrid brought duplicate To-Do/favorite buttons and
+       a layout that fell apart on phones. To-Do lives on the dialog's title row. *@
+    <div class="chart-details-record">
+        <MudText Typo="Typo.overline">@L["Record Score"]</MudText>
+        <div class="chart-details-record-row">
+            <MudNumericField T="int?" Label="@L["Score"]" @bind-Value="_inputScore" Min="0" Max="1000000"
+                             HideSpinButtons="true" Class="chart-details-record-score"></MudNumericField>
+            <MudSelect T="PhoenixPlate?" Label="@L["Plate"]" @bind-Value="_inputPlate" Clearable="true"
+                       Class="chart-details-record-plate">
+                @foreach (var plate in Enum.GetValues<PhoenixPlate>())
+                {
+                    <MudSelectItem T="PhoenixPlate?" Value="plate">@plate.GetName()</MudSelectItem>
+                }
+            </MudSelect>
+            <MudCheckBox T="bool" @bind-Value="_inputBroken" Label="@L["Broken"]" Class="chart-details-record-broken"></MudCheckBox>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_isSaving"
+                       OnClick="SaveScore">@L["Save"]</MudButton>
+        </div>
+    </div>
+}
+
+<style>
+    .chart-details-journey-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 2px 0;
+        border-bottom: 1px dashed var(--mud-palette-lines-default);
+    }
+
+    .chart-details-journey-date {
+        color: var(--mud-palette-text-secondary);
+        font-variant-numeric: tabular-nums;
+    }
+
+    /* No flex-grow: the grade icon sits beside the score, not floated to the far
+       right (owner, piucenter round 4). */
+    .chart-details-journey-score {
+        font-variant-numeric: tabular-nums;
+    }
+
+    .chart-details-journey-empty {
+        color: var(--mud-palette-text-secondary);
+    }
+
+    .chart-details-record {
+        margin-top: 8px;
+    }
+
+    /* Round 12: a grid keeps everything left-packed (the trailing 1fr ghost column
+       absorbs the slack — Broken stays glued to Plate, not to Save). */
+    .chart-details-record-row {
+        display: grid;
+        grid-template-columns: minmax(130px, 200px) minmax(130px, 170px) max-content max-content 1fr;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .chart-details-record-broken {
+        white-space: nowrap;
+        margin: 0;
+    }
+
+    @@media (max-width: 599.98px) {
+        .chart-details-record-row {
+            grid-template-columns: 1fr 1fr;
+        }
+    }
+</style>
+
+@code {
+    [Parameter] public Chart? Chart { get; set; }
+
+    [Parameter] public MixEnum Mix { get; set; } = MixEnum.Phoenix;
+
+    /// <summary>The current best, used to prefill the inputs (round 11).</summary>
+    [Parameter] public RecordedPhoenixScore? Score { get; set; }
+
+    [Parameter] public EventCallback OnScoreRecorded { get; set; }
+
+    /// <summary>
+    ///     Whether the block labels itself. A host that renders it inline among other sections
+    ///     needs the heading to tell them apart; a host whose tab is already called History does
+    ///     not, and printing it twice is just noise.
+    /// </summary>
+    [Parameter] public bool ShowHeading { get; set; } = true;
+
+    private Guid _loadedChartId = Guid.Empty;
+    private int? _inputScore;
+    private PhoenixPlate? _inputPlate;
+    private bool _inputBroken;
+    private bool _isSaving;
+    private IReadOnlyList<ScoreJournalEntry> _journey = Array.Empty<ScoreJournalEntry>();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Chart == null || Chart.Id == _loadedChartId) return;
+        _loadedChartId = Chart.Id;
+        _inputScore = Score?.Score == null ? null : (int)Score.Score.Value;
+        _inputPlate = Score?.Plate;
+        _inputBroken = Score?.IsBroken ?? false;
+        _journey = CurrentUser.IsLoggedIn
+            ? (await Mediator.Send(new GetChartScoreJourneyQuery(Chart.Id))).ToArray()
+            : Array.Empty<ScoreJournalEntry>();
+    }
+
+    private static string MixName(MixEnum mix)
+    {
+        return mix == MixEnum.Phoenix2 ? "Phoenix 2" : mix.ToString();
+    }
+
+    private async Task SaveScore()
+    {
+        if (Chart == null) return;
+        _isSaving = true;
+        try
+        {
+            var parsedScore = _inputScore == null ? null :
+                PhoenixScore.TryParse(_inputScore.Value, out var score) ? (PhoenixScore?)score : null;
+            await Mediator.Send(new UpdatePhoenixBestAttemptCommand(Chart.Id, _inputBroken, parsedScore, _inputPlate,
+                Mix: Mix));
+            Snackbar.Add($"Recorded {(_inputBroken ? "Broken" : "Passing")} for {Chart.Song.Name}", Severity.Success);
+            await OnScoreRecorded.InvokeAsync();
+            // The journey timeline gains the new entry immediately.
+            _journey = (await Mediator.Send(new GetChartScoreJourneyQuery(Chart.Id))).ToArray();
+        }
+        catch (Exception)
+        {
+            Snackbar.Add("There was an error while recording the score", Severity.Error);
+        }
+
+        _isSaving = false;
+    }
+}

--- a/ScoreTracker/ScoreTracker/Components/ChartScoreHistoryTab.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartScoreHistoryTab.razor
@@ -48,7 +48,7 @@
        purpose-built — EditChartGrid brought duplicate To-Do/favorite buttons and
        a layout that fell apart on phones. To-Do lives on the dialog's title row. *@
     <div class="chart-details-record">
-        <MudText Typo="Typo.overline">@L["Record Score"]</MudText>
+        <MudText Typo="Typo.overline">@L["Manual score edit"]</MudText>
         <div class="chart-details-record-row">
             <MudNumericField T="int?" Label="@L["Score"]" @bind-Value="_inputScore" Min="0" Max="1000000"
                              HideSpinButtons="true" Class="chart-details-record-score"></MudNumericField>
@@ -132,6 +132,12 @@
     /// </summary>
     [Parameter] public bool ShowHeading { get; set; } = true;
 
+    /// <summary>
+    ///     Set false by a host that renders this behind a tab nobody has selected, so a panel
+    ///     out of sight does not fetch a journey nobody is reading.
+    /// </summary>
+    [Parameter] public bool Active { get; set; } = true;
+
     private Guid _loadedChartId = Guid.Empty;
     private int? _inputScore;
     private PhoenixPlate? _inputPlate;
@@ -141,7 +147,7 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (Chart == null || Chart.Id == _loadedChartId) return;
+        if (!Active || Chart == null || Chart.Id == _loadedChartId) return;
         _loadedChartId = Chart.Id;
         _inputScore = Score?.Score == null ? null : (int)Score.Score.Value;
         _inputPlate = Score?.Plate;

--- a/ScoreTracker/ScoreTracker/Components/ChartStatsTab.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartStatsTab.razor
@@ -114,6 +114,12 @@
 
     [Parameter] public int? OfficialFolderPlace { get; set; }
 
+    /// <summary>
+    ///     Set false by a host that renders this behind a tab nobody has selected, so a panel
+    ///     out of sight issues none of its three reads.
+    /// </summary>
+    [Parameter] public bool Active { get; set; } = true;
+
     private Guid _loadedChartId = Guid.Empty;
     private string? _externalKey;
     private IReadOnlyList<(string Label, string Color)> _placements = Array.Empty<(string, string)>();
@@ -121,7 +127,7 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (Chart == null || Chart.Id == _loadedChartId) return;
+        if (!Active || Chart == null || Chart.Id == _loadedChartId) return;
         _loadedChartId = Chart.Id;
         _placements = await LoadPlacements(Chart.Id);
         // The alias table's key beats the guessed one (crawler project hardening).

--- a/ScoreTracker/ScoreTracker/Components/ChartStatsTab.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartStatsTab.razor
@@ -67,6 +67,9 @@
            one component — the page renders the same bars at section scale. *@
         <SkillCoverageBars Chips="_skillChips"></SkillCoverageBars>
     }
+    <MudText Typo="Typo.overline">@L["Charts like this"]</MudText>
+    <SimilarChartsCompactGrid ChartId="Chart.Id" Mix="Mix" Active="Active"
+                              OnChartSelected="OnSimilarChartSelected"></SimilarChartsCompactGrid>
     <MudLink Href="@PiuCenterUrl" Target="_blank" Typo="Typo.caption" Class="chart-details-piucenter">@L["View full chart on PIU Center"]</MudLink>
 }
 
@@ -119,6 +122,12 @@
     ///     out of sight issues none of its three reads.
     /// </summary>
     [Parameter] public bool Active { get; set; } = true;
+
+    /// <summary>
+    ///     Raised when a similar chart is tapped. Passed straight through from the grid — this
+    ///     panel has no opinion about what opening one means, and its host does.
+    /// </summary>
+    [Parameter] public EventCallback<Chart> OnSimilarChartSelected { get; set; }
 
     private Guid _loadedChartId = Guid.Empty;
     private string? _externalKey;

--- a/ScoreTracker/ScoreTracker/Components/ChartStatsTab.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartStatsTab.razor
@@ -1,0 +1,190 @@
+@namespace ScoreTracker.Web.Components
+@using MediatR
+@using ScoreTracker.Catalog.Contracts
+@using ScoreTracker.ChartIntelligence.Contracts
+@using ScoreTracker.SharedKernel.Enums
+@using ScoreTracker.Web.Services.Theming
+@inject IMediator Mediator
+
+@* What the chart IS, extracted from ChartDetailsDialog: the meta grid, where the tier
+   lists place it, what it is made of, and the way out to PIU Center. It owns the three
+   reads that feed those — placements, the alias key, and the badge chips — so a host that
+   never shows this block never pays for them. *@
+@if (Chart != null)
+{
+    <div class="chart-details-meta">
+        @if (Chart.Song.Bpm != null)
+        {
+            <div><span class="chart-details-meta-label">@L["BPM"]</span><span>@Chart.Song.Bpm</span></div>
+        }
+        @if (Chart.NoteCount != null)
+        {
+            <div><span class="chart-details-meta-label">@L["Note Count"]</span><span>@Chart.NoteCount</span></div>
+        }
+        @if (Chart.StepArtist != null)
+        {
+            <div><span class="chart-details-meta-label">@L["Step Artist"]</span><span>@Chart.StepArtist</span></div>
+        }
+        <div><span class="chart-details-meta-label">@L["Song Artist"]</span><span>@Chart.Song.Artist</span></div>
+        <div><span class="chart-details-meta-label">@L["Song Type"]</span><span>@Chart.Song.Type</span></div>
+        @* Two separate facts, because they answer different questions: how played this
+           chart is across the whole mix, and how played it is against its own folder —
+           a chart four hundredth overall can still be the most played thing in its
+           folder. Both are piugame's play ranking, not this site's score counts. *@
+        @if (OfficialPlace != null)
+        {
+            <div>
+                <span class="chart-details-meta-label">@L["Popularity overall"]</span>
+                <span>@L["#{0}", OfficialPlace.Value.ToString("N0")]</span>
+            </div>
+        }
+        @if (OfficialFolderPlace != null)
+        {
+            <div>
+                <span class="chart-details-meta-label">@L["Popularity in {0}", Chart.DifficultyString]</span>
+                <span>@L["#{0}", OfficialFolderPlace.Value.ToString("N0")]</span>
+            </div>
+        }
+    </div>
+    @if (_placements.Any())
+    {
+        <div class="chart-details-placements">
+            @foreach (var placement in _placements)
+            {
+                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined"
+                         Style="@($"color:{placement.Color};border-color:{placement.Color}")">@placement.Label</MudChip>
+            }
+        </div>
+    }
+    @* Badge coverage bars — granular piucenter badges, dominance-first (their top-3
+       pick, then coverage). A pre-crawl chart shows nothing here rather than falling
+       back to the rollup tags: an arbitrary "Technical" is worse than silence
+       (docs/design/nuke-old-skill-categories.md). *@
+    @if (_skillChips.Any())
+    {
+        <MudText Typo="Typo.overline">@L["Skills"]</MudText>
+        @* Bars extracted to SkillCoverageBars (chart-page overhaul): one concept,
+           one component — the page renders the same bars at section scale. *@
+        <SkillCoverageBars Chips="_skillChips"></SkillCoverageBars>
+    }
+    <MudLink Href="@PiuCenterUrl" Target="_blank" Typo="Typo.caption" Class="chart-details-piucenter">@L["View full chart on PIU Center"]</MudLink>
+}
+
+<style>
+    .chart-details-meta {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+        gap: 4px 12px;
+        margin-bottom: 8px;
+    }
+
+    .chart-details-meta-label {
+        color: var(--mud-palette-text-secondary);
+        font-size: .7rem;
+        text-transform: uppercase;
+        letter-spacing: .08em;
+        display: block;
+    }
+
+    .chart-details-placements, .chart-details-skills {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin: 8px 0;
+    }
+
+    .chart-details-piucenter {
+        display: inline-block;
+        margin-top: 8px;
+    }
+</style>
+
+@code {
+    [Parameter] public Chart? Chart { get; set; }
+
+    [Parameter] public MixEnum Mix { get; set; } = MixEnum.Phoenix;
+
+    /// <summary>
+    ///     The chart's place on piugame's play ranking for the whole mix, and its place among
+    ///     the charts of its own folder. Optional: a caller that has not fetched the official
+    ///     board leaves both null and neither line renders. Not this site's Popularity sort,
+    ///     which counts scores recorded here.
+    /// </summary>
+    [Parameter] public int? OfficialPlace { get; set; }
+
+    [Parameter] public int? OfficialFolderPlace { get; set; }
+
+    private Guid _loadedChartId = Guid.Empty;
+    private string? _externalKey;
+    private IReadOnlyList<(string Label, string Color)> _placements = Array.Empty<(string, string)>();
+    private IReadOnlyList<ChartBadgeChipRecord> _skillChips = Array.Empty<ChartBadgeChipRecord>();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Chart == null || Chart.Id == _loadedChartId) return;
+        _loadedChartId = Chart.Id;
+        _placements = await LoadPlacements(Chart.Id);
+        // The alias table's key beats the guessed one (crawler project hardening).
+        _externalKey = (await Mediator.Send(new GetChartStepAnalysisQuery(Chart.Id)))?.ExternalKey;
+        // Coverage bars: granular piucenter badges, dominance-ordered, from the banked metrics.
+        _skillChips = (await Mediator.Send(new GetChartBadgeChipsQuery(new[] { Chart.Id })))
+            .GetValueOrDefault(Chart.Id) ?? Array.Empty<ChartBadgeChipRecord>();
+    }
+
+    private async Task<IReadOnlyList<(string, string)>> LoadPlacements(Guid chartId)
+    {
+        var placements = new List<(string, string)>();
+        foreach (var (listName, label) in new (string, string)[]
+                 {
+                     ("Pass Count", L["Pass Difficulty"].ToString()),
+                     ("Scores", L["Score Difficulty"].ToString())
+                 })
+        {
+            var result = await Mediator.Send(new GetTierListWithFallbackQuery(listName, Mix));
+            var entry = result.Entries.FirstOrDefault(e => e.ChartId == chartId);
+            if (entry == null || entry.Category == TierListCategory.Unrecorded) continue;
+            placements.Add(($"{label}: {DifficultyName(entry.Category)}",
+                ThemeScales.DifficultyColor(entry.Category)));
+        }
+
+        return placements;
+    }
+
+    private string DifficultyName(TierListCategory category)
+    {
+        return category switch
+        {
+            TierListCategory.Overrated => L["1+ Level Easier"],
+            TierListCategory.VeryEasy => L["Very Easy"],
+            TierListCategory.Easy => L["Easy"],
+            TierListCategory.Medium => L["Medium"],
+            TierListCategory.Hard => L["Hard"],
+            TierListCategory.VeryHard => L["Very Hard"],
+            TierListCategory.Underrated => L["1+ Level Harder"],
+            _ => L["Not Rated"]
+        };
+    }
+
+    // The resolved alias key when the crawler has one; otherwise a best-effort guess
+    // in the current key format ("<Song>_-_<Artist>_<S|D><level>_<SONGTYPE>").
+    private string PiuCenterUrl
+    {
+        get
+        {
+            if (_externalKey != null)
+                return $"https://www.piucenter.com/chart/{Uri.EscapeDataString(_externalKey)}";
+            if (Chart == null) return "https://www.piucenter.com/chart";
+            var suffix = Chart.Song.Type switch
+            {
+                SongType.Remix => "REMIX",
+                SongType.ShortCut => "SHORTCUT",
+                SongType.FullSong => "FULLSONG",
+                _ => "ARCADE"
+            };
+            var key =
+                $"{Chart.Song.Name}_-_{Chart.Song.Artist}_{Chart.Type.GetShortHand()}{(int)Chart.Level}_{suffix}"
+                    .Replace(' ', '_');
+            return $"https://www.piucenter.com/chart/{Uri.EscapeDataString(key)}";
+        }
+    }
+}

--- a/ScoreTracker/ScoreTracker/Components/DifficultyBubble.razor
+++ b/ScoreTracker/ScoreTracker/Components/DifficultyBubble.razor
@@ -13,7 +13,7 @@
     @* MudTooltip renders a popover, which throws in static SSR (no provider in the static
        tree). The tooltip is a hover affordance, so a static render drops it and keeps the
        bubble; in a circuit it comes back. *@
-    @if (RendererInfo.IsInteractive)
+    @if (RendererInfo.IsInteractive && Tooltip)
     {
         <MudTooltip ShowOnFocus="true" Placement="Placement.Right">
             <ChildContent>@Bubble</ChildContent>
@@ -72,6 +72,14 @@
 
     [Parameter]
     public bool Small { get; set; } = false;
+
+    /// <summary>
+    ///     Off when the bubble sits inside something that already explains itself on hover —
+    ///     two overlapping tooltips on one tile is worse than none. Same opt-out ScoreBreakdown
+    ///     carries.
+    /// </summary>
+    [Parameter]
+    public bool Tooltip { get; set; } = true;
 
     [Parameter]
     public int? Height { get; set; }

--- a/ScoreTracker/ScoreTracker/Components/MixChangesSongSheet.razor
+++ b/ScoreTracker/ScoreTracker/Components/MixChangesSongSheet.razor
@@ -69,7 +69,10 @@
     }
 </div>
 
-<ChartDetailsDialog @bind-Visible="_open" Chart="_chart" Mix="Mix"></ChartDetailsDialog>
+@* Opens on Chart Stats: this sheet exists to answer what changed about a chart between two
+   mixes, and the meta grid is where that answer is. Everywhere else wants the board. *@
+<ChartDetailsDialog @bind-Visible="_open" Chart="_chart" Mix="Mix"
+                    InitialTab="ChartDetailsDialog.DetailsTab.Stats"></ChartDetailsDialog>
 
 @code {
     [Parameter] [EditorRequired] public IReadOnlyList<MixDiffSongRecord> Songs { get; set; } = Array.Empty<MixDiffSongRecord>();

--- a/ScoreTracker/ScoreTracker/Components/SimilarChartsCompactGrid.razor
+++ b/ScoreTracker/ScoreTracker/Components/SimilarChartsCompactGrid.razor
@@ -20,26 +20,31 @@ else if (_matches.Count == 0)
 }
 else
 {
+    @* Jacket and bubble, nothing else. The song name is what SongImage's own tooltip is for,
+       and spelling it out under a 70px tile only ever showed "Darkside of ..." anyway. The
+       bubble's tooltip is off because two of them fired on one tile. *@
     <div class="chart-similar-grid">
         @foreach (var match in _matches)
         {
             var chart = match;
             <button type="button" class="chart-similar-tile" data-testid="chart-similar-tile"
-                    title="@($"{chart.Song.Name} {chart.DifficultyString}")"
                     @onclick="() => OnChartSelected.InvokeAsync(chart)">
-                <SongImage Song="chart.Song" Height="40"></SongImage>
-                <DifficultyBubble Chart="chart" Small="true"></DifficultyBubble>
-                <span class="chart-similar-name">@chart.Song.Name</span>
+                <span class="chart-similar-jacket"><SongImage Song="chart.Song"></SongImage></span>
+                <span class="chart-similar-bubble">
+                    <DifficultyBubble Chart="chart" Small="true" Tooltip="false"></DifficultyBubble>
+                </span>
             </button>
         }
     </div>
 }
 
 <style>
+    /* Six fixed columns rather than auto-fill: the jackets are landscape and their intrinsic
+       width was deciding the track count, which is how a 572px dialog ended up fitting five. */
     .chart-similar-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(76px, 1fr));
-        gap: 8px;
+        grid-template-columns: repeat(6, 1fr);
+        gap: 6px;
         margin: 8px 0;
     }
 
@@ -50,13 +55,31 @@ else
         font: inherit;
         border: 1px solid var(--mud-palette-lines-default);
         border-radius: 6px;
-        padding: 6px 4px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 4px;
+        padding: 0;
+        overflow: hidden;
+        position: relative;
+        display: block;
+        line-height: 0;
         cursor: pointer;
         min-width: 0;
+    }
+
+    /* Width-driven, not height-driven. SongImage sizes by height, so landscape and square
+       jackets came out different widths and the row never lined up. Scoped to the jacket so
+       it cannot catch the bubble's own image, and !important because MudImage writes its
+       height inline, which no normal-weight rule can beat. */
+    .chart-similar-jacket .mud-image {
+        width: 100%;
+        height: auto !important;
+        display: block;
+    }
+
+    .chart-similar-bubble {
+        position: absolute;
+        right: 1px;
+        bottom: 1px;
+        line-height: 0;
+        pointer-events: none;
     }
 
     .chart-similar-tile:hover {
@@ -66,15 +89,6 @@ else
     .chart-similar-tile:focus-visible {
         outline: 2px solid var(--mud-palette-primary);
         outline-offset: 1px;
-    }
-
-    .chart-similar-name {
-        font-size: .68rem;
-        color: var(--mud-palette-text-secondary);
-        max-width: 100%;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
     }
 
     .chart-similar-empty {

--- a/ScoreTracker/ScoreTracker/Components/SimilarChartsCompactGrid.razor
+++ b/ScoreTracker/ScoreTracker/Components/SimilarChartsCompactGrid.razor
@@ -95,6 +95,14 @@ else
         color: var(--mud-palette-text-secondary);
         margin: 8px 0;
     }
+
+    /* Six columns on a phone put a 22px bubble on a ~25px-tall jacket, so the tile was all
+       bubble and no art. Three is the point where the jacket is still a picture. */
+    @@media (max-width: 499.98px) {
+        .chart-similar-grid {
+            grid-template-columns: repeat(3, 1fr);
+        }
+    }
 </style>
 
 @code {

--- a/ScoreTracker/ScoreTracker/Components/SimilarChartsCompactGrid.razor
+++ b/ScoreTracker/ScoreTracker/Components/SimilarChartsCompactGrid.razor
@@ -1,0 +1,127 @@
+@namespace ScoreTracker.Web.Components
+@using MediatR
+@using ScoreTracker.ChartIntelligence.Contracts
+@using ScoreTracker.SharedKernel.Enums
+@inject IMediator Mediator
+
+@* The dialog's read of the similarity graph: stored match order, floored, and nothing else.
+   The chart page's shelf owns the ordering lenses, the four range filters and the least-similar
+   mode; none of that belongs in a quick look, so this is deliberately a grid of jackets you tap.
+   Tapping one swaps the dialog to that chart rather than opening a second one. *@
+@if (_loading)
+{
+    <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="my-2"></MudProgressLinear>
+}
+else if (_matches.Count == 0)
+{
+    @* Every chart looks like this until the nightly rebuild has run at least once, so this
+       reads as "not yet" rather than "this chart is unlike anything". *@
+    <MudText Typo="Typo.body2" Class="chart-similar-empty">@L["No similar charts for this one yet."]</MudText>
+}
+else
+{
+    <div class="chart-similar-grid">
+        @foreach (var match in _matches)
+        {
+            var chart = match;
+            <button type="button" class="chart-similar-tile" data-testid="chart-similar-tile"
+                    title="@($"{chart.Song.Name} {chart.DifficultyString}")"
+                    @onclick="() => OnChartSelected.InvokeAsync(chart)">
+                <SongImage Song="chart.Song" Height="40"></SongImage>
+                <DifficultyBubble Chart="chart" Small="true"></DifficultyBubble>
+                <span class="chart-similar-name">@chart.Song.Name</span>
+            </button>
+        }
+    </div>
+}
+
+<style>
+    .chart-similar-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(76px, 1fr));
+        gap: 8px;
+        margin: 8px 0;
+    }
+
+    .chart-similar-tile {
+        appearance: none;
+        background: none;
+        color: inherit;
+        font: inherit;
+        border: 1px solid var(--mud-palette-lines-default);
+        border-radius: 6px;
+        padding: 6px 4px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        cursor: pointer;
+        min-width: 0;
+    }
+
+    .chart-similar-tile:hover {
+        border-color: var(--mud-palette-primary);
+    }
+
+    .chart-similar-tile:focus-visible {
+        outline: 2px solid var(--mud-palette-primary);
+        outline-offset: 1px;
+    }
+
+    .chart-similar-name {
+        font-size: .68rem;
+        color: var(--mud-palette-text-secondary);
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .chart-similar-empty {
+        color: var(--mud-palette-text-secondary);
+        margin: 8px 0;
+    }
+</style>
+
+@code {
+    [Parameter] public Guid ChartId { get; set; }
+
+    [Parameter] public MixEnum Mix { get; set; } = MixEnum.Phoenix;
+
+    /// <summary>Set false behind an unselected tab, so nothing is fetched for a panel out of sight.</summary>
+    [Parameter] public bool Active { get; set; } = true;
+
+    /// <summary>Raised with the tapped chart. The host decides what "open it" means.</summary>
+    [Parameter] public EventCallback<Chart> OnChartSelected { get; set; }
+
+    private (Guid Chart, MixEnum Mix)? _loadedFor;
+    private bool _loading = true;
+    private IReadOnlyList<Chart> _matches = Array.Empty<Chart>();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!Active || _loadedFor == (ChartId, Mix)) return;
+        _loadedFor = (ChartId, Mix);
+        _loading = true;
+
+        var edges = (await Mediator.Send(new GetSimilarChartsQuery(ChartId, Mix)))
+            // The graph stores its top twenty floor-free because where the bar falls is a
+            // render decision. This is that decision, and it is the same constant the shelf
+            // and the Hot Streak expansion use, so "a match" means one thing site-wide.
+            .Where(e => e.Score >= ChartSimilarityRecord.MatchFloor)
+            .ToArray();
+        if (edges.Length == 0)
+        {
+            _matches = Array.Empty<Chart>();
+            _loading = false;
+            return;
+        }
+
+        var charts = (await Mediator.Send(new GetChartsQuery(Mix, ChartIds: edges.Select(e => e.ChartId).ToArray())))
+            .ToDictionary(c => c.Id);
+        // Stored match order, preserved — GetChartsQuery has an ordering of its own and it is
+        // not this one. A chart the mix no longer carries simply drops out.
+        _matches = edges.Where(e => charts.ContainsKey(e.ChartId)).Select(e => charts[e.ChartId]).ToArray();
+        _loading = false;
+    }
+}

--- a/ScoreTracker/ScoreTracker/Pages/HomeDashboard.razor
+++ b/ScoreTracker/ScoreTracker/Pages/HomeDashboard.razor
@@ -295,8 +295,7 @@ else if (_loaded)
         <ChartDetailsDialog @bind-Visible="_showChartDetails" Chart="_detailsChart"
                             Mix="EffectiveMixFor(_selectedPage)"
                             IsToDo="_detailsChart != null && _todos != null && _todos.Contains(_detailsChart.Id)"
-                            OnToDo="ToggleToDo"
-                            SuggestionCategory="_detailsSuggestionCategory"/>
+                            OnToDo="ToggleToDo"/>
     }
 
     <MudDialog @bind-Visible="_showConfigure" Options="CompactDialog">
@@ -463,7 +462,6 @@ else if (_loaded)
     // dialog (browse mode only — edit mode owns clicks for arranging).
     private bool _showChartDetails;
     private Chart? _detailsChart;
-    private string? _detailsSuggestionCategory;
     private ISet<Guid>? _todos;
 
     private async Task OpenChartDetails(ChartClickContext context)
@@ -474,7 +472,6 @@ else if (_loaded)
             .Select(t => t.ChartId)
             .ToHashSet();
         _detailsChart = context.Chart;
-        _detailsSuggestionCategory = context.SuggestionCategory;
         _showChartDetails = true;
     }
 

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -775,6 +775,9 @@
   <data name="Back to Weekly Charts" xml:space="preserve">
     <value>Back to Weekly Charts</value>
   </data>
+  <data name="Back to {0}" xml:space="preserve">
+    <value>Back to {0}</value>
+  </data>
   <data name="Backfill" xml:space="preserve">
     <value>Backfill</value>
   </data>
@@ -3169,6 +3172,9 @@
   <data name="Manual import — console script + CSV" xml:space="preserve">
     <value>Manual import — console script + CSV</value>
   </data>
+  <data name="Manual score edit" xml:space="preserve">
+    <value>Manual score edit</value>
+  </data>
   <data name="Marked for review" xml:space="preserve">
     <value>Marked for review</value>
   </data>
@@ -3639,6 +3645,9 @@
   <data name="No scores in this range yet — record or import to see your breakdown." xml:space="preserve">
     <value>No scores in this range yet — record or import to see your breakdown.</value>
   </data>
+  <data name="No scores recorded on this chart yet." xml:space="preserve">
+    <value>No scores recorded on this chart yet.</value>
+  </data>
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>No scores recorded yet — be the first.</value>
   </data>
@@ -3656,6 +3665,9 @@
   </data>
   <data name="No significant matches — here's the closest we could find." xml:space="preserve">
     <value>No significant matches — here's the closest we could find.</value>
+  </data>
+  <data name="No similar charts for this one yet." xml:space="preserve">
+    <value>No similar charts for this one yet.</value>
   </data>
   <data name="No snapshot yet - thresholds appear after the first weekly import." xml:space="preserve">
     <value>No snapshot yet - thresholds appear after the first weekly import.</value>
@@ -4867,6 +4879,9 @@
   </data>
   <data name="Record" xml:space="preserve">
     <value>Record</value>
+  </data>
+  <data name="Record a score" xml:space="preserve">
+    <value>Record a score</value>
   </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Record a score by hand for any chart.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -2360,9 +2360,6 @@
   <data name="Good count" xml:space="preserve">
     <value>Good count</value>
   </data>
-  <data name="Good Suggestion" xml:space="preserve">
-	  <value>Good Suggestion</value>
-  </data>
   <data name="Goods give no life, and — unlike perfects and greats — they do not build the multiplier either. They never hurt you. They just do not count." xml:space="preserve">
     <value>Goods give no life, and — unlike perfects and greats — they do not build the multiplier either. They never hurt you. They just do not count.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -4880,9 +4880,6 @@
   <data name="Record" xml:space="preserve">
     <value>Record</value>
   </data>
-  <data name="Record a score" xml:space="preserve">
-    <value>Record a score</value>
-  </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Record a score by hand for any chart.</value>
   </data>
@@ -5017,12 +5014,6 @@
   </data>
   <data name="Replay" xml:space="preserve">
     <value>Replay</value>
-  </data>
-  <data name="Report Video" xml:space="preserve">
-    <value>Report Video</value>
-  </data>
-  <data name="Report Video Tooltip" xml:space="preserve">
-    <value>Report Broken, or Incorrect Video</value>
   </data>
   <data name="Request Header" xml:space="preserve">
     <value>Request Header</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -4880,9 +4880,6 @@
   <data name="Record" xml:space="preserve">
     <value>Blubgrorp</value>
   </data>
-  <data name="Record a score" xml:space="preserve">
-    <value>Blubgrorp a mrglrgl</value>
-  </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Blubgrorp gro mrglrgl murm mrurg ro ro murgl.</value>
   </data>
@@ -5017,12 +5014,6 @@
   </data>
   <data name="Replay" xml:space="preserve">
     <value>Murpmurp</value>
-  </data>
-  <data name="Report Video" xml:space="preserve">
-    <value>Mrglmurp Grrrgl</value>
-  </data>
-  <data name="Report Video Tooltip" xml:space="preserve">
-    <value>Mrglmurp Morgl, argl Gromurggrrgl Grrrgl</value>
   </data>
   <data name="Request Header" xml:space="preserve">
     <value>Murgm Grumba</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -2360,9 +2360,6 @@
   <data name="Good count" xml:space="preserve">
     <value>Lurggrgl glorgmurp</value>
   </data>
-  <data name="Good Suggestion" xml:space="preserve">
-	  <value>Lurggrgl Maglgllurg</value>
-  </data>
   <data name="Goods give no life, and — unlike perfects and greats — they do not build the multiplier either. They never hurt you. They just do not count." xml:space="preserve">
     <value>Lurgplgl blgrlgro mrp glorgrgl, ro — maglgrgl plglgrglurg ro blarggl — maglgro urg murm glorgmurg mrp glmurmargl blargmagl. Maglgro glargl urgblgrl blub. Maglgro murgmorg urg murm glorgmurp.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -775,6 +775,9 @@
   <data name="Back to Weekly Charts" xml:space="preserve">
     <value>Arglblgrl grgl Murmmr Murgl</value>
   </data>
+  <data name="Back to {0}" xml:space="preserve">
+    <value>Arglblgrl ro {0}</value>
+  </data>
   <data name="Backfill" xml:space="preserve">
     <value>Mrglrglmrp</value>
   </data>
@@ -3169,6 +3172,9 @@
   <data name="Manual import — console script + CSV" xml:space="preserve">
     <value>Murggrgl glorggl — blubmrmr blubblgrl + CSV</value>
   </data>
+  <data name="Manual score edit" xml:space="preserve">
+    <value>Blargurg mrglrgl murmmurp</value>
+  </data>
   <data name="Marked for review" xml:space="preserve">
     <value>Marogl bo grumba</value>
   </data>
@@ -3639,6 +3645,9 @@
   <data name="No scores in this range yet — record or import to see your breakdown." xml:space="preserve">
     <value>Mrp mgrlgmrg mrp grglmrp blubmrgl argl — blubgrorp argl glorggl grgl blarg gromurp maglgrogrrgl.</value>
   </data>
+  <data name="No scores recorded on this chart yet." xml:space="preserve">
+    <value>Bo mgrlgmrg blubgrorp ap grglmrp murgl larg.</value>
+  </data>
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Mrp mgrlgmrg murmgrglurg argl — glorg mrp murpargl.</value>
   </data>
@@ -3656,6 +3665,9 @@
   </data>
   <data name="No significant matches — here's the closest we could find." xml:space="preserve">
     <value>Mrp glgrglromrgl morgmaglblgrl — grglgl mrp murmurgmurp mrgl arglgro blubgl.</value>
+  </data>
+  <data name="No similar charts for this one yet." xml:space="preserve">
+    <value>Bo plglrogrgl murgl ba grglmrp mrp larg.</value>
   </data>
   <data name="No snapshot yet - thresholds appear after the first weekly import." xml:space="preserve">
     <value>Mrp mrpmaglmurp argl - glmrpblub gromr glmrp mrp murpargl murmmr glorggl.</value>
@@ -4867,6 +4879,9 @@
   </data>
   <data name="Record" xml:space="preserve">
     <value>Blubgrorp</value>
+  </data>
+  <data name="Record a score" xml:space="preserve">
+    <value>Blubgrorp a mrglrgl</value>
   </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Blubgrorp gro mrglrgl murm mrurg ro ro murgl.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -4839,9 +4839,6 @@
   <data name="Record" xml:space="preserve">
     <value>Registrar</value>
   </data>
-  <data name="Record a score" xml:space="preserve">
-    <value>Registrar un score</value>
-  </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Anota una puntuación a mano para cualquier chart.</value>
   </data>
@@ -4973,12 +4970,6 @@
   </data>
   <data name="Replay" xml:space="preserve">
     <value>Reenviar</value>
-  </data>
-  <data name="Report Video" xml:space="preserve">
-    <value>Reportar vídeo</value>
-  </data>
-  <data name="Report Video Tooltip" xml:space="preserve">
-    <value>Reportar vídeo roto o incorrecto</value>
   </data>
   <data name="Request Header" xml:space="preserve">
     <value>Cabecera de la petición</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -768,6 +768,9 @@
   <data name="Back to Weekly Charts" xml:space="preserve">
     <value>Volver a Weekly Charts</value>
   </data>
+  <data name="Back to {0}" xml:space="preserve">
+    <value>Volver a {0}</value>
+  </data>
   <data name="Backfill" xml:space="preserve">
     <value>Backfill</value>
   </data>
@@ -3147,6 +3150,9 @@
   <data name="Manual import — console script + CSV" xml:space="preserve">
     <value>Importación manual — script de consola + CSV</value>
   </data>
+  <data name="Manual score edit" xml:space="preserve">
+    <value>Edición manual del score</value>
+  </data>
   <data name="Marked for review" xml:space="preserve">
     <value>Marcada para revisión</value>
   </data>
@@ -3609,6 +3615,9 @@
   <data name="No scores in this range yet — record or import to see your breakdown." xml:space="preserve">
     <value>Aún no hay puntuaciones en este rango: registra o importa para ver tu desglose.</value>
   </data>
+  <data name="No scores recorded on this chart yet." xml:space="preserve">
+    <value>Aún no hay scores registrados en este chart.</value>
+  </data>
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Aún no hay puntuaciones — sé la primera persona.</value>
   </data>
@@ -3626,6 +3635,9 @@
   </data>
   <data name="No significant matches — here's the closest we could find." xml:space="preserve">
     <value>Sin coincidencias significativas: estos son los más parecidos.</value>
+  </data>
+  <data name="No similar charts for this one yet." xml:space="preserve">
+    <value>Aún no hay charts similares a este.</value>
   </data>
   <data name="No snapshot yet - thresholds appear after the first weekly import." xml:space="preserve">
     <value>Aún no hay instantánea: los umbrales aparecen tras la primera importación semanal.</value>
@@ -4826,6 +4838,9 @@
   </data>
   <data name="Record" xml:space="preserve">
     <value>Registrar</value>
+  </data>
+  <data name="Record a score" xml:space="preserve">
+    <value>Registrar un score</value>
   </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Anota una puntuación a mano para cualquier chart.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -2343,9 +2343,6 @@
   <data name="Good count" xml:space="preserve">
     <value>Cantidad de Goods</value>
   </data>
-  <data name="Good Suggestion" xml:space="preserve">
-    <value>Buena sugerencia</value>
-  </data>
   <data name="Goods give no life, and — unlike perfects and greats — they do not build the multiplier either. They never hurt you. They just do not count." xml:space="preserve">
     <value>Los Goods no dan vida y, a diferencia de los Perfects y los Greats, tampoco construyen el multiplicador. Nunca te perjudican. Simplemente no cuentan.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -768,6 +768,9 @@
   <data name="Back to Weekly Charts" xml:space="preserve">
     <value>Volver a Weekly Charts</value>
   </data>
+  <data name="Back to {0}" xml:space="preserve">
+    <value>Volver a {0}</value>
+  </data>
   <data name="Backfill" xml:space="preserve">
     <value>Retroactivo</value>
   </data>
@@ -3147,6 +3150,9 @@
   <data name="Manual import — console script + CSV" xml:space="preserve">
     <value>Importación manual — script de consola + CSV</value>
   </data>
+  <data name="Manual score edit" xml:space="preserve">
+    <value>Edición manual del puntaje</value>
+  </data>
   <data name="Marked for review" xml:space="preserve">
     <value>Marcada para revisión</value>
   </data>
@@ -3609,6 +3615,9 @@
   <data name="No scores in this range yet — record or import to see your breakdown." xml:space="preserve">
     <value>Aún no hay puntuaciones en este rango: registra o importa para ver tu desglose.</value>
   </data>
+  <data name="No scores recorded on this chart yet." xml:space="preserve">
+    <value>Aún no hay puntajes registrados en este chart.</value>
+  </data>
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Aún no hay puntuaciones — sé la primera persona.</value>
   </data>
@@ -3626,6 +3635,9 @@
   </data>
   <data name="No significant matches — here's the closest we could find." xml:space="preserve">
     <value>Sin coincidencias significativas: estos son los más parecidos.</value>
+  </data>
+  <data name="No similar charts for this one yet." xml:space="preserve">
+    <value>Aún no hay charts similares a este.</value>
   </data>
   <data name="No snapshot yet - thresholds appear after the first weekly import." xml:space="preserve">
     <value>Aún no hay instantánea: los umbrales aparecen después de la primera importación semanal.</value>
@@ -4828,6 +4840,9 @@
   </data>
   <data name="Record" xml:space="preserve">
     <value>Registrar</value>
+  </data>
+  <data name="Record a score" xml:space="preserve">
+    <value>Registrar un puntaje</value>
   </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Anota una puntuación a mano para cualquier chart.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -2343,9 +2343,6 @@
   <data name="Good count" xml:space="preserve">
     <value>Cantidad de Goods</value>
   </data>
-  <data name="Good Suggestion" xml:space="preserve">
-    <value>Buena sugerencia</value>
-  </data>
   <data name="Goods give no life, and — unlike perfects and greats — they do not build the multiplier either. They never hurt you. They just do not count." xml:space="preserve">
     <value>Los Goods no dan vida y, a diferencia de los Perfects y los Greats, tampoco construyen el multiplicador. Nunca te perjudican. Simplemente no cuentan.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -4841,9 +4841,6 @@
   <data name="Record" xml:space="preserve">
     <value>Registrar</value>
   </data>
-  <data name="Record a score" xml:space="preserve">
-    <value>Registrar un puntaje</value>
-  </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Anota una puntuación a mano para cualquier chart.</value>
   </data>
@@ -4975,12 +4972,6 @@
   </data>
   <data name="Replay" xml:space="preserve">
     <value>Reenviar</value>
-  </data>
-  <data name="Report Video" xml:space="preserve">
-    <value>Reportar video</value>
-  </data>
-  <data name="Report Video Tooltip" xml:space="preserve">
-    <value>Reportar video de baja calidad, roto o incorrecto</value>
   </data>
   <data name="Request Header" xml:space="preserve">
     <value>Encabezado de la petición</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -4879,9 +4879,6 @@
   <data name="Record" xml:space="preserve">
     <value>Enregistrer</value>
   </data>
-  <data name="Record a score" xml:space="preserve">
-    <value>Enregistrer un score</value>
-  </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Saisissez un score à la main pour n'importe quel chart.</value>
   </data>
@@ -5016,12 +5013,6 @@
   </data>
   <data name="Replay" xml:space="preserve">
     <value>Rejouer</value>
-  </data>
-  <data name="Report Video" xml:space="preserve">
-    <value>Signaler vidéo</value>
-  </data>
-  <data name="Report Video Tooltip" xml:space="preserve">
-    <value>Signaler lien endommagé, ou vidéo incorrecte</value>
   </data>
   <data name="Request Header" xml:space="preserve">
     <value>En-tête de requête</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -775,6 +775,9 @@
   <data name="Back to Weekly Charts" xml:space="preserve">
     <value>Retour à Weekly Charts</value>
   </data>
+  <data name="Back to {0}" xml:space="preserve">
+    <value>Retour à {0}</value>
+  </data>
   <data name="Backfill" xml:space="preserve">
     <value>Rétroactif</value>
   </data>
@@ -3168,6 +3171,9 @@
   <data name="Manual import — console script + CSV" xml:space="preserve">
     <value>Import manuel — script console + CSV</value>
   </data>
+  <data name="Manual score edit" xml:space="preserve">
+    <value>Modification manuelle du score</value>
+  </data>
   <data name="Marked for review" xml:space="preserve">
     <value>Marqué pour relecture</value>
   </data>
@@ -3638,6 +3644,9 @@
   <data name="No scores in this range yet — record or import to see your breakdown." xml:space="preserve">
     <value>Aucun score dans cette plage pour l'instant — enregistrez ou importez pour voir votre répartition.</value>
   </data>
+  <data name="No scores recorded on this chart yet." xml:space="preserve">
+    <value>Aucun score enregistré sur ce chart pour le moment.</value>
+  </data>
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Pas encore de scores — soyez le premier.</value>
   </data>
@@ -3655,6 +3664,9 @@
   </data>
   <data name="No significant matches — here's the closest we could find." xml:space="preserve">
     <value>Aucune correspondance significative — voici les plus proches.</value>
+  </data>
+  <data name="No similar charts for this one yet." xml:space="preserve">
+    <value>Aucun chart similaire à celui-ci pour le moment.</value>
   </data>
   <data name="No snapshot yet - thresholds appear after the first weekly import." xml:space="preserve">
     <value>Pas encore d'instantané - les seuils apparaissent après le premier import hebdomadaire.</value>
@@ -4866,6 +4878,9 @@
   </data>
   <data name="Record" xml:space="preserve">
     <value>Enregistrer</value>
+  </data>
+  <data name="Record a score" xml:space="preserve">
+    <value>Enregistrer un score</value>
   </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Saisissez un score à la main pour n'importe quel chart.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -2359,9 +2359,6 @@
   <data name="Good count" xml:space="preserve">
     <value>Nombre de Goods</value>
   </data>
-  <data name="Good Suggestion" xml:space="preserve">
-    <value>Bonne suggestion</value>
-  </data>
   <data name="Goods give no life, and — unlike perfects and greats — they do not build the multiplier either. They never hurt you. They just do not count." xml:space="preserve">
     <value>Les Goods ne donnent aucune vie et, contrairement aux Perfects et aux Greats, ils ne construisent pas non plus le multiplicateur. Ils ne vous pénalisent jamais. Ils ne comptent simplement pas.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -775,6 +775,9 @@
   <data name="Back to Weekly Charts" xml:space="preserve">
     <value>Torna a Weekly Charts</value>
   </data>
+  <data name="Back to {0}" xml:space="preserve">
+    <value>Torna a {0}</value>
+  </data>
   <data name="Backfill" xml:space="preserve">
     <value>Retroattivo</value>
   </data>
@@ -3169,6 +3172,9 @@
   <data name="Manual import — console script + CSV" xml:space="preserve">
     <value>Importazione manuale — script da console + CSV</value>
   </data>
+  <data name="Manual score edit" xml:space="preserve">
+    <value>Modifica manuale del punteggio</value>
+  </data>
   <data name="Marked for review" xml:space="preserve">
     <value>Segnato per la revisione</value>
   </data>
@@ -3639,6 +3645,9 @@
   <data name="No scores in this range yet — record or import to see your breakdown." xml:space="preserve">
     <value>Ancora nessun punteggio in questo intervallo: registra o importa per vedere la tua ripartizione.</value>
   </data>
+  <data name="No scores recorded on this chart yet." xml:space="preserve">
+    <value>Nessun punteggio ancora registrato su questa chart.</value>
+  </data>
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Ancora nessun punteggio — sii il primo.</value>
   </data>
@@ -3656,6 +3665,9 @@
   </data>
   <data name="No significant matches — here's the closest we could find." xml:space="preserve">
     <value>Nessuna corrispondenza significativa — ecco le più vicine.</value>
+  </data>
+  <data name="No similar charts for this one yet." xml:space="preserve">
+    <value>Nessuna chart simile a questa.</value>
   </data>
   <data name="No snapshot yet - thresholds appear after the first weekly import." xml:space="preserve">
     <value>Nessuno snapshot ancora - le soglie compaiono dopo la prima importazione settimanale.</value>
@@ -4867,6 +4879,9 @@
   </data>
   <data name="Record" xml:space="preserve">
     <value>Registra</value>
+  </data>
+  <data name="Record a score" xml:space="preserve">
+    <value>Registra un punteggio</value>
   </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Registra un punteggio a mano per qualsiasi chart.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -2360,9 +2360,6 @@
   <data name="Good count" xml:space="preserve">
     <value>Numero di Goods</value>
   </data>
-  <data name="Good Suggestion" xml:space="preserve">
-    <value>Suggerimento corretto</value>
-  </data>
   <data name="Goods give no life, and — unlike perfects and greats — they do not build the multiplier either. They never hurt you. They just do not count." xml:space="preserve">
     <value>I Good non danno vita e, a differenza di Perfect e Great, non costruiscono nemmeno il moltiplicatore. Non ti danneggiano mai. Semplicemente non contano.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -4880,9 +4880,6 @@
   <data name="Record" xml:space="preserve">
     <value>Registra</value>
   </data>
-  <data name="Record a score" xml:space="preserve">
-    <value>Registra un punteggio</value>
-  </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Registra un punteggio a mano per qualsiasi chart.</value>
   </data>
@@ -5017,12 +5014,6 @@
   </data>
   <data name="Replay" xml:space="preserve">
     <value>Rimanda</value>
-  </data>
-  <data name="Report Video" xml:space="preserve">
-    <value>Segnala video</value>
-  </data>
-  <data name="Report Video Tooltip" xml:space="preserve">
-    <value>Segnala video rotto o errato</value>
   </data>
   <data name="Request Header" xml:space="preserve">
     <value>Intestazione della richiesta</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -775,6 +775,9 @@
   <data name="Back to Weekly Charts" xml:space="preserve">
     <value>Weekly Charts に戻る</value>
   </data>
+  <data name="Back to {0}" xml:space="preserve">
+    <value>{0}に戻る</value>
+  </data>
   <data name="Backfill" xml:space="preserve">
     <value>バックフィル</value>
   </data>
@@ -3169,6 +3172,9 @@
   <data name="Manual import — console script + CSV" xml:space="preserve">
     <value>手動インポート — コンソールスクリプト + CSV</value>
   </data>
+  <data name="Manual score edit" xml:space="preserve">
+    <value>スコアを手動で編集</value>
+  </data>
   <data name="Marked for review" xml:space="preserve">
     <value>確認待ちにしました</value>
   </data>
@@ -3639,6 +3645,9 @@
   <data name="No scores in this range yet — record or import to see your breakdown." xml:space="preserve">
     <value>この範囲のスコアはまだありません — 記録またはインポートすると内訳が表示されます。</value>
   </data>
+  <data name="No scores recorded on this chart yet." xml:space="preserve">
+    <value>この譜面にはまだスコアが記録されていません。</value>
+  </data>
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>まだスコアがありません——最初の1人になりましょう。</value>
   </data>
@@ -3656,6 +3665,9 @@
   </data>
   <data name="No significant matches — here's the closest we could find." xml:space="preserve">
     <value>明確な一致はありません — 最も近い譜面です。</value>
+  </data>
+  <data name="No similar charts for this one yet." xml:space="preserve">
+    <value>この譜面に似ている譜面はまだありません。</value>
   </data>
   <data name="No snapshot yet - thresholds appear after the first weekly import." xml:space="preserve">
     <value>まだスナップショットがありません - 最初の週間インポート後にしきい値が表示されます。</value>
@@ -4867,6 +4879,9 @@
   </data>
   <data name="Record" xml:space="preserve">
     <value>記録</value>
+  </data>
+  <data name="Record a score" xml:space="preserve">
+    <value>スコアを記録</value>
   </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>任意の譜面のスコアを手入力で記録します。</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -2360,9 +2360,6 @@
   <data name="Good count" xml:space="preserve">
     <value>Good 数</value>
   </data>
-  <data name="Good Suggestion" xml:space="preserve">
-	  <value>良いおすすめ</value>
-  </data>
   <data name="Goods give no life, and — unlike perfects and greats — they do not build the multiplier either. They never hurt you. They just do not count." xml:space="preserve">
     <value>Good は体力を与えず、Perfect や Great と違って倍率も積みません。害はありませんが、ただ数に入らないだけです。</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -4880,9 +4880,6 @@
   <data name="Record" xml:space="preserve">
     <value>記録</value>
   </data>
-  <data name="Record a score" xml:space="preserve">
-    <value>スコアを記録</value>
-  </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>任意の譜面のスコアを手入力で記録します。</value>
   </data>
@@ -5017,12 +5014,6 @@
   </data>
   <data name="Replay" xml:space="preserve">
     <value>再送</value>
-  </data>
-  <data name="Report Video" xml:space="preserve">
-    <value>ビデオを報告</value>
-  </data>
-  <data name="Report Video Tooltip" xml:space="preserve">
-    <value>間違いとか壊れたビデオを報告</value>
   </data>
   <data name="Request Header" xml:space="preserve">
     <value>リクエストヘッダー</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -768,6 +768,9 @@
   <data name="Back to Weekly Charts" xml:space="preserve">
     <value>Weekly Charts로 돌아가기</value>
   </data>
+  <data name="Back to {0}" xml:space="preserve">
+    <value>{0}(으)로 돌아가기</value>
+  </data>
   <data name="Backfill" xml:space="preserve">
     <value>백필</value>
   </data>
@@ -3147,6 +3150,9 @@
   <data name="Manual import — console script + CSV" xml:space="preserve">
     <value>수동 가져오기 — 콘솔 스크립트 + CSV</value>
   </data>
+  <data name="Manual score edit" xml:space="preserve">
+    <value>점수 직접 입력</value>
+  </data>
   <data name="Marked for review" xml:space="preserve">
     <value>검토 대기로 표시됨</value>
   </data>
@@ -3609,6 +3615,9 @@
   <data name="No scores in this range yet — record or import to see your breakdown." xml:space="preserve">
     <value>이 범위에 아직 점수가 없습니다 — 기록하거나 가져오면 구성을 볼 수 있습니다.</value>
   </data>
+  <data name="No scores recorded on this chart yet." xml:space="preserve">
+    <value>이 채보에 기록된 점수가 아직 없습니다.</value>
+  </data>
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>아직 기록된 점수가 없습니다 — 첫 주인공이 되어 보세요.</value>
   </data>
@@ -3626,6 +3635,9 @@
   </data>
   <data name="No significant matches — here's the closest we could find." xml:space="preserve">
     <value>뚜렷한 일치 항목이 없습니다 — 가장 비슷한 채보입니다.</value>
+  </data>
+  <data name="No similar charts for this one yet." xml:space="preserve">
+    <value>이 채보와 비슷한 채보가 아직 없습니다.</value>
   </data>
   <data name="No snapshot yet - thresholds appear after the first weekly import." xml:space="preserve">
     <value>아직 스냅샷이 없습니다 - 첫 주간 가져오기 후 기준선이 표시됩니다.</value>
@@ -4828,6 +4840,9 @@
   </data>
   <data name="Record" xml:space="preserve">
     <value>기록</value>
+  </data>
+  <data name="Record a score" xml:space="preserve">
+    <value>점수 기록하기</value>
   </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>아무 채보나 점수를 직접 입력해 기록하세요.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -4841,9 +4841,6 @@
   <data name="Record" xml:space="preserve">
     <value>기록</value>
   </data>
-  <data name="Record a score" xml:space="preserve">
-    <value>점수 기록하기</value>
-  </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>아무 채보나 점수를 직접 입력해 기록하세요.</value>
   </data>
@@ -4975,12 +4972,6 @@
   </data>
   <data name="Replay" xml:space="preserve">
     <value>재전송</value>
-  </data>
-  <data name="Report Video" xml:space="preserve">
-    <value>동영상 신고</value>
-  </data>
-  <data name="Report Video Tooltip" xml:space="preserve">
-    <value>저화질, 깨짐, 관련없는 동영상 신고</value>
   </data>
   <data name="Request Header" xml:space="preserve">
     <value>요청 헤더</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -2343,9 +2343,6 @@
   <data name="Good count" xml:space="preserve">
     <value>굿 수</value>
   </data>
-  <data name="Good Suggestion" xml:space="preserve">
-    <value>좋은 추천</value>
-  </data>
   <data name="Goods give no life, and — unlike perfects and greats — they do not build the multiplier either. They never hurt you. They just do not count." xml:space="preserve">
     <value>Good은 라이프를 주지 않고, Perfect나 Great과 달리 배율도 쌓지 않습니다. 해롭지는 않습니다. 그저 셈에 들어가지 않을 뿐입니다.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -4841,9 +4841,6 @@
   <data name="Record" xml:space="preserve">
     <value>Registrar</value>
   </data>
-  <data name="Record a score" xml:space="preserve">
-    <value>Registrar uma pontuação</value>
-  </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Registre uma pontuação à mão para qualquer chart.</value>
   </data>
@@ -4975,12 +4972,6 @@
   </data>
   <data name="Replay" xml:space="preserve">
     <value>Reenviar</value>
-  </data>
-  <data name="Report Video" xml:space="preserve">
-    <value>Denunciar vídeo</value>
-  </data>
-  <data name="Report Video Tooltip" xml:space="preserve">
-    <value>Denunciar vídeo de baixa qualidade, quebrado ou incorreto</value>
   </data>
   <data name="Request Header" xml:space="preserve">
     <value>Cabeçalho da requisição</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -2343,9 +2343,6 @@
   <data name="Good count" xml:space="preserve">
     <value>Quantidade de Goods</value>
   </data>
-  <data name="Good Suggestion" xml:space="preserve">
-    <value>Boa sugestão</value>
-  </data>
   <data name="Goods give no life, and — unlike perfects and greats — they do not build the multiplier either. They never hurt you. They just do not count." xml:space="preserve">
     <value>Goods não dão vida e, diferente dos Perfects e Greats, também não constroem o multiplicador. Nunca prejudicam você. Só não contam.</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -768,6 +768,9 @@
   <data name="Back to Weekly Charts" xml:space="preserve">
     <value>Voltar para Weekly Charts</value>
   </data>
+  <data name="Back to {0}" xml:space="preserve">
+    <value>Voltar para {0}</value>
+  </data>
   <data name="Backfill" xml:space="preserve">
     <value>Retroativo</value>
   </data>
@@ -3147,6 +3150,9 @@
   <data name="Manual import — console script + CSV" xml:space="preserve">
     <value>Importação manual — script de console + CSV</value>
   </data>
+  <data name="Manual score edit" xml:space="preserve">
+    <value>Edição manual da pontuação</value>
+  </data>
   <data name="Marked for review" xml:space="preserve">
     <value>Marcada para revisão</value>
   </data>
@@ -3609,6 +3615,9 @@
   <data name="No scores in this range yet — record or import to see your breakdown." xml:space="preserve">
     <value>Ainda não há pontuações neste intervalo — registre ou importe para ver seu detalhamento.</value>
   </data>
+  <data name="No scores recorded on this chart yet." xml:space="preserve">
+    <value>Nenhuma pontuação registrada neste chart ainda.</value>
+  </data>
   <data name="No scores recorded yet — be the first." xml:space="preserve">
     <value>Ainda não há pontuações — seja a primeira pessoa.</value>
   </data>
@@ -3626,6 +3635,9 @@
   </data>
   <data name="No significant matches — here's the closest we could find." xml:space="preserve">
     <value>Nenhuma correspondência significativa — estes são os mais próximos.</value>
+  </data>
+  <data name="No similar charts for this one yet." xml:space="preserve">
+    <value>Ainda não há charts semelhantes a este.</value>
   </data>
   <data name="No snapshot yet - thresholds appear after the first weekly import." xml:space="preserve">
     <value>Ainda sem instantâneo: os limites aparecem após a primeira importação semanal.</value>
@@ -4828,6 +4840,9 @@
   </data>
   <data name="Record" xml:space="preserve">
     <value>Registrar</value>
+  </data>
+  <data name="Record a score" xml:space="preserve">
+    <value>Registrar uma pontuação</value>
   </data>
   <data name="Record a score by hand for any chart." xml:space="preserve">
     <value>Registre uma pontuação à mão para qualquer chart.</value>

--- a/docs/LOCALIZATION-en-ZW.md
+++ b/docs/LOCALIZATION-en-ZW.md
@@ -151,6 +151,23 @@ file on 2026-07-28. **Reuse these; do not re-coin them.**
 | More / Most | Mrrgl / Mrrrgl | |
 | Less / Least | Mgl / Mggl | |
 
+### Function words
+
+English function words have no Murloc equivalent to recover, but the word-count rule means a
+seven-word English sentence needs seven Murloc words — so they get coined once and reused rather
+than dropped. Kept deliberately short, since the length rule tracks the English.
+
+| English | en-ZW | Notes |
+|---|---|---|
+| a | a | |
+| for | ba | |
+| on | ap | |
+| to | ro | Not `mo`, which is the negation prefix (`Momurgloo`). |
+| one | mrp | The pronoun ("similar to this **one**"), not the numeral. |
+| yet | larg | |
+| Manual | Blargurg | Coined 2026-08-05 for the score dialog's manual edit heading. |
+| Similar | Plglrogrgl | Distinct from `plglro` ("like"), which the *Charts like this* heading already uses. |
+
 ## Process for future batches
 
 1. A new en-US key gets an en-ZW value **in the same pass**, like every other locale.

--- a/docs/design/HomePageWidgets/suggested-charts.md
+++ b/docs/design/HomePageWidgets/suggested-charts.md
@@ -42,8 +42,11 @@ re-roll in the body meta row. The page's vestigial `LevelOffset` UI is supersede
   names. Sizes 1x2 / 2x1 / 2x2, default 1x2.
 - **Feedback**: veto ✕ (edit mode) → WSIP's reason dialog (reason/notes/hide, hide default-on) →
   `SubmitFeedbackCommand` into the same per-category server-side store the engine already honors —
-  deliberately NOT widget config. Thumbs-up = one-tap **Good Suggestion** in the shared
-  ChartDetailsDialog, unlocked when the row click carries a suggestion category.
+  deliberately NOT widget config. There was also a one-tap **Good Suggestion** in the shared
+  ChartDetailsDialog, unlocked when the row click carries a suggestion category; **removed
+  2026-08-05** (owner: nobody used it, and it wrapped the dialog's action bar onto two lines on
+  a phone). The veto path above is untouched. `ChartClickContext` still carries the category —
+  it is part of the render contract — but nothing reads it now.
 - **Shell extensions this widget introduced**: `WidgetDescriptor.DrawerPresets` (one add-drawer card
   per pre-filled config, D10) and `ChartClickContext` (the OnChartClick payload — chart + optional
   suggestion category; all widgets raise it).

--- a/docs/design/chart-comments/README.md
+++ b/docs/design/chart-comments/README.md
@@ -58,8 +58,9 @@ lens, no filters — that machinery belongs to the chart page's shelf. A compact
 difficulty bubble; tapping one **swaps the dialog in place** via an internal chart override with a
 "← back to \<song\>" crumb, rather than pushing a chart-change callback out to nineteen hosts.
 
-⚠ The graph is empty until `recalculate-chart-similarity` is triggered once in `/hangfire`. Owner,
-post-deploy, still owed from the chart-page overhaul.
+The graph is populated — `recalculate-chart-similarity` is on a daily cron and has been running
+since the chart-page overhaul deployed. Build the empty state anyway; it is what a chart the
+piucenter crawl never covered shows, which is 139 of 4,426.
 
 ---
 

--- a/docs/design/chart-comments/README.md
+++ b/docs/design/chart-comments/README.md
@@ -1,0 +1,453 @@
+# Chart comments &amp; the details dialog overhaul
+
+The chart details dialog becomes four tabs — **Comments, Leaderboard, Chart Stats, Score History** —
+with the video staying above them. Comments are the feature; the rest is a reorganisation of what
+the dialog already renders.
+
+**[mock.html](mock.html) is the UI reference.** Open it before building any surface described here:
+it carries the real Phoenix palette at true widths (572 px desktop, 390 px mobile) and shows every
+state in one place — language badges, threads, the composer, the rules card, the link interstitial,
+the report dialog, the moderation queue row.
+
+> **Two parts of this folder are scaffolding and get deleted when the feature ships:**
+> **`mock.html`**, and **Part 2 — Technical scope** below. What survives is Part 1, the feature
+> requirements. Anything in Part 2 that turns out to be a durable architectural fact belongs in
+> `ARCHITECTURE.md` or `CLAUDE.md` instead, moved there rather than left here.
+
+---
+
+# Part 1 — Feature requirements
+
+---
+
+## 1. The dialog
+
+Nineteen call sites render `ChartDetailsDialog`. That number drives most of the structural calls.
+
+**Header (outside the tabs):** video → title row (difficulty bubble, song name, To-Do) → your score
+and standing. Three things you want without a click.
+
+**Tab strip is sticky** inside the scroll container, so a tall header scrolls away underneath it
+instead of taking the tabs with it. On 390 px the strip **scrolls horizontally** rather than
+truncating labels to jargon — the header alone is 274 px, so the fourth tab peeking is honest about
+what is off-screen.
+
+| Tab | Contents |
+|---|---|
+| **Comments** | Scope rail, sort, reader-language control, threads, composer. Count badge on the tab. |
+| **Leaderboard** | `ChartLeaderboardScopes` unchanged — a move, not a rewrite. |
+| **Chart Stats** | Meta grid, tier placements, skill bars, **similar charts**, PIU Center link. |
+| **Score History** | The cross-mix journal, with **manual score edit at the bottom**. |
+
+- **Every tab is lazy.** No queries until selected. The board already gates on `Active="Visible"`;
+  the rest follow.
+- **Default tab is Leaderboard**, last choice persisted in a `ChartDetails__Tab` UiSetting. The
+  comment count badge is what makes anyone open Comments the first time.
+- **Score History hides when logged out** — it is your journal plus your score inputs.
+- ⚠ **Recording a score became two taps**, and several call sites exist only to record
+  (`QuickRecordWidget`, `DailyStepWidget`, Charts' quick record). An **`InitialTab` parameter**
+  alongside the existing `BoardScope` lets those callers open straight on Score History, so Round
+  11's always-visible-inputs decision survives for the people it was made for.
+- **`FocusCommentId`** is the second new parameter: the moderation queue opens the dialog on
+  Comments, anchored to the reported one.
+
+### Similar charts stays deliberately dumb
+
+Stored match order from `GetSimilarChartsQuery` at the 0.55 floor. No re-sorting, no difficulty
+lens, no filters — that machinery belongs to the chart page's shelf. A compact tile is song image +
+difficulty bubble; tapping one **swaps the dialog in place** via an internal chart override with a
+"← back to \<song\>" crumb, rather than pushing a chart-change callback out to nineteen hosts.
+
+⚠ The graph is empty until `recalculate-chart-similarity` is triggered once in `/hangfire`. Owner,
+post-deploy, still owed from the chart-page overhaul.
+
+---
+
+## 2. Comments
+
+### The scope rail is the audience picker
+
+Same `.cld-chip` vocabulary as the leaderboard's scopes, doing double duty: it filters what you read
+*and* decides what you post to. "Which community am I posting to" is answered by where you are
+standing, not by a second dropdown, and the composer states it in prose — *Posting to **Public** as
+ERRLENA*.
+
+**Audiences are Public + your non-regional communities.** World and country boards are ownerless and
+carry no roles, so a comment posted there would have no moderator and would fall to the site admin
+by default — the opposite of the deal in §4.
+
+### Threads
+
+Root plus **one level of replies**; replying to a reply targets the root. A reply **inherits its
+root's audience as a domain invariant on the aggregate**, not as a field the UI sets — you cannot
+move a thread between communities or between community and public.
+
+A removed comment leaves a stub (*Removed by a community admin · 4 days ago*) so the thread keeps
+its shape.
+
+### Votes
+
+Thumbs up only, one per user, never on your own. Sort defaults to **Top** (votes desc, then newest)
+with a **Newest** toggle.
+
+### Editing
+
+An edit writes a revision row, stamps `EditedAt`, and renders *(edited &lt;time&gt;)*. History is
+retained for moderation. Deletion is soft — `DeletedAt`, `DeletedByUserId`, reason — so the row stays
+queryable.
+
+⚠ **An edit invalidates the translations** and re-queues the comment. The monthly ceiling is a fuse
+against *bugs*; an edit loop is a **user-driven** cost amplifier it cannot see. A per-comment
+re-translation cooldown is the mitigation, not a limit on editing.
+
+### Markdown
+
+**Bold, italic, strikethrough, inline code, links, bare-URL autolink, line breaks, bullets.** No
+headings, images, tables, or raw HTML. The 500-character cap counts the **raw markdown**.
+
+**The parser lives in the vertical's Domain and emits a token tree.** Web renders tokens as real
+Blazor elements and **never touches `MarkupString`** — which is precisely the temptation the
+translation spec warns about when link support arrives
+([comment-translation.md §5](../comment-translation.md)).
+
+This is also why a WYSIWYG library was rejected. Comments render in five languages from
+machine-translated text, so the safe renderer exists **either way**; a rich-text editor does not
+replace it, it sits on top of it and adds HTML storage, server-side sanitisation, an HTML↔markdown
+bridge, and unmeasured HTML round-tripping through an LLM. Once the parser exists, the editor is a
+textarea, six buttons that wrap the selection, and a Write/Preview toggle. 500 characters is a tweet
+and a half; GitHub, Reddit and Discord all ship exactly this and none of them ship WYSIWYG.
+
+If the raw split ever needs upgrading, keep markdown on the wire and swap the input widget
+(EasyMDE, MIT, ~40 KB). **Storing HTML is the door that does not close again.**
+
+### Link trust
+
+Trusted hosts open straight through with `rel="noopener noreferrer nofollow ugc"`; everything else
+gets an interstitial naming the host.
+
+| Trusted | Matching |
+|---|---|
+| piuscores, youtube / youtu.be, reddit / redd.it, `pumpout2020.anyhowstep.com`, piugame, piucenter | **Dot-boundary suffix** — `host == d \|\| host.EndsWith("." + d)`, so `youtube.com.evil.tld` cannot slip through |
+| Every **public** Community Tool's URL | **Exact host only** — a tool at `tools.example.com` must not bless `evil.example.com` |
+
+- Only `http` and `https` parse. `javascript:` and `data:` are rejected at parse time.
+- The interstitial shows the **parsed host**, never the link text, which is author-controlled.
+- The tool list is data, so the allowlist is dynamic and memory-cached on a short TTL.
+- ⚠ **Trust is resolved inside the vertical, not in Web.** Each link node in the token tree ships
+  with its `IsTrusted` boolean already decided, so the presentation layer makes no policy call.
+
+### Language
+
+Five renderings: the **en-US pivot** plus **es-ES, fr-FR, ko-KR, pt-BR**. Everything else falls back
+to English.
+
+- ja-JP and it-IT are **deliberately out for launch** — a cost decision, revisited if volume proves
+  cheap (§3).
+- **es-MX** maps to es-ES. Mutually intelligible, the es-MX catalogue is contaminated, and the
+  original is always available.
+- **en-ZW (Murloc) is never a translation target.** Murloc readers get English.
+
+Display resolution, in order:
+
+1. Reader locale → mapped rendering locale.
+2. Comment's source shares that language → show the **original**, no badge. Silence is the common case.
+3. A rendering exists → show it, badged *Translated from 한국어*, with a per-comment **Show original**.
+4. Not yet translated → show the **original** badged *Queued for translation*. The comment already
+   exists in *some* language; an empty box is worse than the author's own words.
+
+⚠ **Never render a comment back into its own language.** The round trip is a measured rewrite —
+register raised, community vocabulary flattened, the most contemptuous phrase dropped, `1000%`
+corrupted to `100%`. `TranslationTarget.ForSource` already encodes this; **absence of a key is the
+instruction to show the original.**
+
+An unsupported source language (Indonesian, say) is detected by stage one — 34/34 across the
+corpus — and named for the reader via `CultureInfo.DisplayName`.
+
+### The rules card
+
+Shown before a first comment, following `ToolRulesCard` exactly: bold lead, body, checkbox, every
+string through `L[…]`. Copy is in [mock.html](mock.html) §03.
+
+Two consents, collected when they become true:
+
+| Record | Fires |
+|---|---|
+| `AgreedToTermsAt` + `TermsVersion` | Once, on the first comment of any kind. Versioned, so editing the rules re-prompts. |
+| `ConsentedToPublicIdentityAt` | The first time a **private-profile** user posts to **Public**. |
+
+Post to a community first and you see one checkbox; the identity checkbox appears later, when it is
+actually true. These are real rows rather than UiSettings keys — an agreement wants a timestamp and
+a version, and it should be auditable if a dispute lands.
+
+⚠ A Murloc rendering exists purely to satisfy `LocalizationKeyTests` and
+`MurlocValuesUseOnlyTheMurlocAlphabet`. Accepted risk, owner's call: someone browsing in Murloc may
+accept text they cannot read.
+
+---
+
+## 3. Translation pipeline
+
+**Sonnet 5, batched, pivot through English**, exactly as measured in
+[comment-translation.md](../comment-translation.md). Nightly, oldest-first, with a **rolling monthly
+$30 ceiling as the primary gate** and a nightly count (~50) underneath as smoothing.
+
+### Cost
+
+Derived from the workbench's measured $0.0211/comment by splitting on its stated ~60% input share:
+~6,330 input + ~844 output tokens per comment. **Intro pricing ($2/$10 per MTok) ends 2026-08-31**;
+everything below is standard $3/$15.
+
+| Pipeline | Per comment, batched | 1,000/mo | 2,000/mo |
+|---|---|---|---|
+| **4 locales, as-built** ← shipping | $0.0158 | $15.83 | $31.66 |
+| 6 locales (+ja +it), as-built | $0.0188 | $18.84 | $37.68 |
+| 4 locales, glossary split | $0.0130 | $12.98 | $25.96 |
+| 6 locales, glossary split | $0.0158 | $15.82 | $31.64 |
+
+$30 buys **~1,900 comments/month** as shipped, against a realistic 100–300 steady state.
+
+**The glossary split is deliberately not taken for launch.** It is the doc's own identified
+optimisation (§3, ~30% input reduction) and it exactly pays for the two extra locales — but it means
+re-tuning a prompt validated against a real corpus, and that sweep already showed a missing glossary
+row producing `las tiradas` instead of `los runs`. It is the lever to pull when volume grows, by
+which point there will be real data on which rows each stage uses.
+
+### The batch state machine
+
+The Batch API is asynchronous — most batches finish inside an hour, **maximum 24**, results retained
+29 days, and **results return unordered, keyed by `custom_id`**. With two stages that is a four-state
+machine per comment:
+
+```
+Pending → PivotSubmitted → PivotDone → FanOutSubmitted → Translated
+                      ↘  Failed  ↙
+```
+
+Two recurring jobs: **Submit** (nightly — builds and submits both stages' batches) and **Collect**
+(hourly — polls open batches, writes results, advances state, records usage).
+
+- The **ceiling is checked at submit time**, against rolling 30-day actual usage from completed
+  batches plus an estimate for in-flight ones. Spending is not something to discover afterwards.
+- A `translated_by` provenance column on every rendering — model and path. It is what makes "why do
+  these two hundred read differently?" answerable.
+- ⚠ **A rendering whose link set differs from the source's is rejected.** Required by
+  [comment-translation.md §5](../comment-translation.md) and non-negotiable: it is the deterministic,
+  free defence against the only prompt injection worth an attacker's effort.
+- Re-translation after a prompt or glossary change is **admin-triggered only**, and quotes its cost
+  first.
+- Admin page: backlog depth, oldest pending age, rolling spend against the ceiling, last run,
+  failures, **Drain now**.
+
+⚠ **This retires a documented safety property.** Today `ILanguageModelClient` has no implementation
+in `Data` and no DI registration, so no shipping code path can spend a token. This feature ends that
+on purpose. The ceiling, the nightly count and the submit-time check are what replace it.
+
+---
+
+## 4. Moderation
+
+The deal, in the owner's words: **communities moderate themselves; public comments are the site
+admin's; hate, discrimination and threats escalate regardless.**
+
+### Permissions
+
+A new flag on the existing `[Flags]` enum, which was built for exactly this:
+
+```
+ModerateComments = 1 << 4        // All: 15 → 31,  DefaultAdminPermissionsSeed: 13 → 29
+```
+
+- **Creators need nothing** — `PermissionsOf` returns `All` for the owner at read time.
+- ⚠ `DefaultAdminPermissionsSeed` is **13**, not 15 — it deliberately excludes `PromoteAdmins`. So
+  there are **two** populations to bump: `13 → 29` (the default kit grew) and `15 → 31` (explicit
+  All). A hand-picked subset is left alone.
+- ⚠ The backfill must hit **both** `CommunityMembership.Permissions` *and* `Community`'s stored
+  `DefaultAdminPermissions`. Miss the second and every *future* admin in an existing club silently
+  lacks the power, discovered months later.
+
+### Sanctions
+
+One table, two scopes:
+
+`CommentRestriction(UserId, Scope: Site|Community, CommunityId?, RestrictedByUserId, Reason?, CreatedAt, LiftedAt?)`
+
+- **Site scope** is the owner's content lock — blocks commenting everywhere.
+- **Community scope** is the admin's mute — blocks that community only. This is deliberately
+  *lighter* than the existing community ban, which ejects someone entirely; you stay in the club and
+  lose the mic.
+- Both are **prospective**. Existing comments stay unless separately deleted, matching the
+  tool-maker ban pattern.
+- A community **ban** already blocks commenting for free — no membership, no community comments.
+- ⚠ Two Guid `*UserId` columns means `[PurgeKey(nameof(UserId))]` is required, exactly as on
+  `CommunityMembership.GrantedByUserId`. Without it account deletion purges the wrong person.
+
+### Reports route by audience
+
+One Report action, a **closed reason vocabulary**, and the reason decides routing — the reporter
+never has to work out whose problem it is, and the routing is **not advertised in the UI**.
+
+| Reason | Goes to |
+|---|---|
+| Spam or advertising · Off topic · Wrong information | Community admins (or the site admin, if public) |
+| **Hate or discrimination** · **Threats or harassment** | Community admins **and** the site admin |
+
+⚠ **The report row stamps the rendering the reporter was reading.** Translation launders the thing
+being detected, and the language-asymmetry case (benign Korean, hostile Spanish) is *only* a
+moderation problem, because a moderator ever sees one language. The moderation view therefore shows
+**the original and what the reporter saw**. Without it, an admin reading ko-KR cannot evaluate a
+report filed against the es-ES rendering.
+
+### Surfacing
+
+A conditional panel — rendered only when that moderator has open reports — on the community admin
+page and on `/Admin`. One row: difficulty bubble → song image → reported user → reporter → **Open**,
+which launches the dialog with `InitialTab=Comments` and `FocusCommentId`. Moderation happens in the
+surface the comment lives in; there is no second console to build or keep in sync.
+
+The **shield glyph on a comment is the permission** — site admin sees it everywhere, a community
+admin only inside their own club, nobody else renders it. Report lives in the `⋯` for everyone
+signed in.
+
+---
+
+## 5. Deliberately out of scope
+
+- **A notification system.** Owner, explicit. Accepted consequence: a reply three days later is a
+  reply the asker never sees.
+- **Comments on the chart page** (`/Charts/{mix}/{song}/{difficulty}`). Dialog only for v1. The page
+  is static SSR and would need a second render path; public comments there would be strong
+  crawlable content, so this is a likely follow-up rather than a rejection.
+- **Cross-chart comment history for moderators.** Owner: avoid the surveillance UX problem for now.
+- **A moderation *layer*** (automated flagging). Owner, and the corpus supports it — its three
+  heated comments are all about charts, never identity, so an over-flagging layer catches all three
+  and teaches everyone to ignore it. If ever added it must read the **original**, never the English
+  pivot.
+- **A public API surface.** Comments are not on `api/v1` or `api/v2`.
+
+---
+---
+
+# Part 2 — Technical scope
+
+> **Delete this entire part when the feature ships.** It describes how the thing gets built, not
+> what it does. Durable facts (the vertical's package allowlist row, the retired token-spend
+> invariant, the new Domain port) move to `CLAUDE.md` / `ARCHITECTURE.md` as they land, and do not
+> survive here.
+
+## 6. Verticals
+
+### `ScoreTracker.ChartComments` — new
+
+Owns comments, revisions, votes, restrictions, reports, consent records, and the renderings.
+Standard vertical shape (`WeeklyChallenge` is the template): `Contracts/` and `Wiring/` public,
+everything else internal.
+
+Packages: `MediatR`, full `MassTransit` (the `AddChartCommentsConsumers` hook needs
+`IRegistrationConfigurator`), `Microsoft.Extensions.DependencyInjection.Abstractions`,
+`Microsoft.Extensions.Caching.Memory` (the tool-host allowlist cache). **Nothing new to the
+solution** — one row added to CLAUDE.md's allowlist table.
+
+### `ScoreTracker.Translations` — grows up
+
+Today it owns no tables and is wired into nothing. It takes the **whole batch pipeline**: prompts,
+glossary, batch-tracking tables, the spend ceiling, the admin page, and the
+`ILanguageModelBatchClient` interaction. Its public surface becomes:
+
+```
+QueueTextForTranslationCommand(sourceKey, text)
+    → publishes → TextTranslatedEvent(sourceKey, pivot, translations, provenance)
+```
+
+ChartComments publishes the command on post/edit and consumes the event to write renderings onto the
+comment.
+
+The rejected alternative was ChartComments building request payloads itself. That leaks
+`LanguageModelRequest` shapes across the boundary and makes any prompt change a two-vertical edit.
+The split above keeps prompt knowledge where the glossary lives, keeps *comment* data in the
+comments vertical, and means community descriptions or tool blurbs can reuse the pipeline later
+without a rewrite.
+
+⚠ ARCHITECTURE.md currently describes Translations as *"owns no tables, references no `Data`, and is
+wired into nothing."* That sentence dies in the same PR.
+
+### Cross-vertical reads
+
+Three references out of ChartComments, all through contracts, no cycles — nothing referenced here
+references back.
+
+| To | For | Via |
+|---|---|---|
+| `Communities` | Which clubs the reader may read/post to, and whether they hold `ModerateComments` | `GetMyCommunityRolesQuery` — returns `(CommunityName, Role, Permissions)`, both answers in one call |
+| `CommunityTools` | Public tool URLs for the link allowlist | the existing public-tools query, memory-cached on a short TTL |
+| `Translations` | Queue and consume | the command/event pair above |
+
+Charts are **not** referenced. ChartComments stores a `ChartId` and knows nothing about charts; the
+moderation queue row resolves song and difficulty in Web via Catalog, which keeps the boundary
+clean for one join that only presentation needs.
+
+## 7. Layers
+
+| Layer | Change |
+|---|---|
+| **SharedKernel** | One line — `ModerateComments = 1 << 4`, `All` → 31. |
+| **Domain** | One new port: `ILanguageModelBatchClient` (submit / status / results), beside `ILanguageModelClient`. `Complete()` is synchronous-per-request and cannot express a 24-hour batch. |
+| **Application** | Nothing. It is shrinking by design and this does not reverse that. |
+| **Data** | `AnthropicBatchClient : ILanguageModelBatchClient` in `Clients/`, plus migrations. Reflection DI binds it automatically. |
+| **Web** | Dialog restructure + `ChartCommentsTab`, `CommentThread`, `CommentComposer`, `CommentMarkdownView`, `CommentRulesCard`, `LinkInterstitialDialog`, `ReportCommentDialog`, `SimilarChartsCompactGrid`, `ChartScoreHistoryTab`, `ReportedCommentsPanel`. One small JS file for the composer's `wrapSelection`, shipped through `@Assets`. |
+| **CompositionRoot** | `AddChartComments()`; `ChartCommentsModelContribution` into `VerticalModelContributions.All()`. |
+
+### ChartComments internals
+
+| Folder | Contents |
+|---|---|
+| `Domain/` | The `Comment` aggregate — audience invariant, edit→revision, soft delete, restriction gate. A `TournamentSession`-class rich model; the rules are dense enough to earn it. Plus `CommentMarkdown` (parser → token tree) and `LinkTrust`, both pure. Vertical-internal repository ports. |
+| `Application/` | `CommentSaga`, `CommentModerationSaga`, `CommentTranslationSaga` (consumes `TextTranslatedEvent`), read handlers. |
+| `Infrastructure/` | EF entities + repositories on `Set<TEntity>()`, the `UserOwned` purge manifest. |
+| `Contracts/` | Commands, queries, records, events. |
+
+### The token tree crosses as a contract type
+
+Each link node ships with its `IsTrusted` boolean **already resolved inside the vertical**. Web
+renders nodes as Blazor elements and makes zero policy calls — it never sees raw markdown, never
+parses, never consults the allowlist, and `MarkupString` is structurally unreachable rather than
+merely discouraged. The parser stays internal.
+
+## 8. Two CLAUDE.md amendments
+
+1. **`Anthropic` enters `ScoreTracker.Data`'s package allowlist**, plus the ChartComments allowlist
+   row.
+2. ⚠ **A documented safety property is retired on purpose.** Today nothing that ships can spend a
+   token, precisely because `ILanguageModelClient` has no implementation in `Data` and no DI
+   registration. This feature ends that. What replaces it: the submit-time ceiling check against
+   rolling 30-day usage, the nightly count cap, and the admin page. That trade gets written down
+   rather than discovered later.
+
+## 9. Ratchets that bite if forgotten
+
+| Miss | Consequence |
+|---|---|
+| `VerticalModelContributions.All()` | Scaffolded migrations silently drop every ChartComments table |
+| `AddChartCommentsConsumers(...)` in `Program.cs` | MassTransit's scan skips internal types — CommunityTools once shipped with all 33 handlers unregistered and every suite green |
+| Purge manifest **plus a real integration test** | A mocked purge test cannot catch over-deletion; only the decoy-account test can |
+| `[PurgeKey(nameof(UserId))]` on `CommentRestriction` | Two `*UserId` columns — purges the moderator instead of the restricted user |
+| resx in all nine locales, alphabetical, no case-collisions | A case collision renders English in every non-English locale while English itself looks perfect |
+| `SCHEDULED-JOBS.md` + `DATABASE-SCHEMA.md` rows | Same-PR requirement |
+
+## 10. Build order
+
+Four slices. Each ships something usable; the expensive and irreversible parts land last, on
+foundations that already work.
+
+| | Slice | Tabs | New tables | Spends money |
+|---|---|---|---|---|
+| **1** | Dialog re-shape — sticky tab strip, `InitialTab`, Chart Stats absorbs the meta/skills/similar charts, Score History tab with the manual score edit | **3** | none | no |
+| **2** | Comments — vertical, aggregate, parser, link trust, threads, votes, composer, rules card, `FocusCommentId` | **4** | yes | no |
+| **3** | Moderation — permission flag + backfill, restrictions, reports, queue panels | 4 | yes | no |
+| **4** | Translation — batch client, the four-state pipeline, ceiling, admin page | 4 | yes | **yes** |
+
+⚠ **Slice 1 ships three tabs.** A Comments tab with nothing behind it is not shippable, and
+`FocusCommentId` has nothing to focus. The fourth tab arrives with the feature — which also means
+the 390 px tab-strip overflow gets measured twice, at three and again at four.
+
+⚠ **Do not announce comments until slice 3 is deployed.** A UGC surface with no delete button is a
+bad week. Slices 2 and 3 may be separate PRs provided they go out together.

--- a/docs/design/chart-comments/mock.html
+++ b/docs/design/chart-comments/mock.html
@@ -1,0 +1,827 @@
+<title>Chart Details Overhaul — mocks</title>
+<style>
+/* ============================================================
+   Two layers, deliberately different materials:
+   - ANNOTATION layer: slate ground, mono eyebrows, theme-aware.
+   - APP layer: the real Phoenix palette, always dark, because the
+     site is dark-only by design (PaletteLight == PaletteDark).
+   Nothing in the annotation layer may look like product UI.
+   ============================================================ */
+:root {
+  --paper: #eef1f5;
+  --paper-2: #e2e7ee;
+  --edge: #c2cbd8;
+  --note: #2b3648;
+  --note-soft: #5d6b80;
+  --mark: #0b5fa5;
+  --warn-bg: #fdf0e3;
+  --warn-edge: #e2a86a;
+  --warn-ink: #7a4410;
+
+  /* App tokens — verbatim from Services/Theming/MixThemes.cs, Phoenix */
+  --mix-bg: #070B15;
+  --mix-surface: #161E2C;
+  --mix-surface-muted: #1E2A3D;
+  --mix-nav: #0D1626;
+  --mix-primary: #3FA9F5;
+  --mix-primary-contrast: #06101C;
+  --mix-secondary: #FF6B35;
+  --mix-accent: #FFD24A;
+  --mix-ink: #E9EFF7;
+  --mix-ink-muted: #93A3B8;
+  --mix-lines: #2A3648;
+
+  --ok: #3ec98b;
+  --bad: #f2555a;
+
+  --sans: ui-sans-serif, system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
+  --cond: "Arial Narrow", "Helvetica Neue", var(--sans);
+}
+@media (prefers-color-scheme: dark) {
+  :root { --paper:#10151d; --paper-2:#161d27; --edge:#28323f; --note:#dde4ee; --note-soft:#8c9bb0; --mark:#6bb8f5;
+          --warn-bg:#2a2013; --warn-edge:#6b4a1c; --warn-ink:#f0c589; }
+}
+:root[data-theme="dark"] { --paper:#10151d; --paper-2:#161d27; --edge:#28323f; --note:#dde4ee; --note-soft:#8c9bb0; --mark:#6bb8f5;
+          --warn-bg:#2a2013; --warn-edge:#6b4a1c; --warn-ink:#f0c589; }
+:root[data-theme="light"] { --paper:#eef1f5; --paper-2:#e2e7ee; --edge:#c2cbd8; --note:#2b3648; --note-soft:#5d6b80; --mark:#0b5fa5;
+          --warn-bg:#fdf0e3; --warn-edge:#e2a86a; --warn-ink:#7a4410; }
+
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--paper); color: var(--note);
+  font-family: var(--sans); font-size: 15px; line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+.wrap { max-width: 1180px; margin: 0 auto; padding: 40px 24px 100px; }
+
+/* ---------- annotation typography ---------- */
+h1 { font-family: var(--cond); font-size: clamp(30px, 5vw, 46px); font-weight: 700; letter-spacing: .01em;
+     text-wrap: balance; margin: 0 0 6px; }
+h2 { font-family: var(--cond); font-size: 27px; font-weight: 700; margin: 0; text-wrap: balance; }
+h3 { font-size: 16px; font-weight: 650; margin: 0 0 6px; }
+p  { margin: 0 0 12px; max-width: 68ch; }
+a  { color: var(--mark); }
+code { font-family: var(--mono); font-size: .88em; background: var(--paper-2); border: 1px solid var(--edge);
+       border-radius: 4px; padding: 1px 5px; }
+.eyebrow { font-family: var(--mono); font-size: 11px; letter-spacing: .16em; text-transform: uppercase;
+           color: var(--note-soft); }
+.lede { font-size: 17px; color: var(--note-soft); max-width: 70ch; }
+
+section { margin-top: 56px; }
+.sec-head { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap;
+            border-bottom: 2px solid var(--edge); padding-bottom: 10px; margin-bottom: 22px; }
+.sec-head .n { font-family: var(--mono); font-size: 12px; color: var(--note-soft); letter-spacing: .1em; }
+
+.cols { display: grid; grid-template-columns: minmax(0, 1fr); gap: 30px; align-items: start; }
+@media (min-width: 900px) { .cols.split { grid-template-columns: minmax(0,var(--w,420px)) minmax(0,1fr); } }
+
+.note ul { margin: 0 0 12px; padding-left: 18px; }
+.note li { margin-bottom: 7px; max-width: 62ch; }
+
+.flag { background: var(--warn-bg); border-left: 3px solid var(--warn-edge); color: var(--warn-ink);
+        padding: 10px 14px; border-radius: 0 6px 6px 0; font-size: 14px; margin: 0 0 14px; max-width: 66ch; }
+.flag b { font-weight: 700; }
+
+table.spec { border-collapse: collapse; width: 100%; font-size: 14px; }
+table.spec th, table.spec td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--edge); vertical-align: top; }
+table.spec th { font-family: var(--mono); font-size: 11px; letter-spacing: .09em; text-transform: uppercase;
+                color: var(--note-soft); border-bottom-width: 2px; }
+table.spec td.num { font-variant-numeric: tabular-nums; white-space: nowrap; }
+.scroller { overflow-x: auto; }
+
+/* ---------- device frames ---------- */
+.frame { background: var(--mix-bg); border: 1px solid var(--edge); border-radius: 12px;
+         padding: 16px; box-shadow: 0 14px 40px rgba(0,0,0,.22); }
+.frame .cap { font-family: var(--mono); font-size: 10.5px; letter-spacing: .13em; text-transform: uppercase;
+              color: var(--mix-ink-muted); margin-bottom: 12px; }
+.frame.narrow { width: 100%; max-width: 424px; }
+
+/* ============================================================
+   APP LAYER — everything below .app mimics the running dialog
+   ============================================================ */
+.app { font-family: var(--sans); color: var(--mix-ink); font-size: 14px; line-height: 1.5; }
+.dlg { background: var(--mix-surface); border: 1px solid var(--mix-lines); border-radius: 8px;
+       overflow: hidden; max-width: 572px; }
+.dlg.mobile { max-width: 390px; }
+
+.video { aspect-ratio: 16/9; background:
+   radial-gradient(120% 90% at 30% 20%, #24354d 0%, #0d1524 60%, #070b15 100%);
+   display: grid; place-items: center; position: relative; }
+.video .play { width: 52px; height: 36px; border-radius: 8px; background: rgba(255,255,255,.14);
+   display: grid; place-items: center; border: 1px solid rgba(255,255,255,.2); }
+.video .play::after { content: ""; border-left: 12px solid var(--mix-ink); border-top: 8px solid transparent;
+   border-bottom: 8px solid transparent; margin-left: 3px; }
+
+.pad { padding: 10px 14px; }
+.title-row { display: flex; align-items: center; gap: 10px; padding: 10px 14px 4px; }
+.song { font-family: var(--cond); font-size: 21px; font-weight: 700; letter-spacing: .01em; flex: 1;
+        overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bub { width: 38px; height: 38px; border-radius: 50%; display: grid; place-items: center; flex: none;
+       font-weight: 800; font-size: 12px; color: #0b0f18; letter-spacing: -.02em;
+       background: linear-gradient(160deg, #ff8a4c, #e0442c); box-shadow: 0 0 0 2px rgba(255,255,255,.09) inset; }
+.bub.d { background: linear-gradient(160deg, #62c2ff, #2b6fd6); }
+.bub.sm { width: 30px; height: 30px; font-size: 10.5px; }
+.icon-btn { width: 32px; height: 32px; border-radius: 50%; border: 1px solid var(--mix-lines);
+            background: transparent; color: var(--mix-ink-muted); display: grid; place-items: center;
+            font-size: 15px; cursor: pointer; flex: none; }
+.icon-btn.on { color: var(--mix-primary); border-color: rgba(63,169,245,.5); }
+
+.scoreline { display: flex; align-items: center; gap: 10px; padding: 4px 14px 12px; flex-wrap: wrap; }
+.score-v { font-family: var(--cond); font-size: 22px; font-weight: 700; font-variant-numeric: tabular-nums;
+           color: var(--mix-accent); }
+.grade { width: 26px; height: 26px; border-radius: 5px; display: grid; place-items: center; font-weight: 800;
+         font-size: 11px; background: linear-gradient(160deg,#ffe27a,#e8a41d); color: #2a1a00; }
+.muted { color: var(--mix-ink-muted); }
+.tiny { font-size: 11.5px; }
+
+/* tab strip — sticky inside the scroll container */
+.tabs { display: flex; gap: 2px; background: var(--mix-nav); border-top: 1px solid var(--mix-lines);
+        border-bottom: 1px solid var(--mix-lines); padding: 0 6px; overflow-x: auto; scrollbar-width: none; }
+.tabs::-webkit-scrollbar { display: none; }
+.tab { appearance: none; background: none; border: none; color: var(--mix-ink-muted); font: inherit;
+       font-size: 12.5px; padding: 11px 12px 9px; border-bottom: 2px solid transparent; cursor: pointer;
+       white-space: nowrap; display: flex; align-items: center; gap: 6px; }
+.tab.on { color: var(--mix-primary); border-bottom-color: var(--mix-primary); }
+.tab .cnt { background: var(--mix-surface-muted); color: var(--mix-ink); border-radius: 9px; padding: 0 6px;
+            font-size: 10.5px; font-variant-numeric: tabular-nums; }
+.tab.on .cnt { background: var(--mix-primary); color: var(--mix-primary-contrast); }
+
+/* scope rail — the .cld-chip vocabulary from ChartLeaderboardScopes */
+.rail { display: flex; gap: 6px; flex-wrap: wrap; padding: 12px 14px 8px; }
+.chip { appearance: none; font: inherit; font-size: 12px; padding: 4px 11px; border-radius: 999px;
+        border: 1px solid var(--mix-lines); background: transparent; color: var(--mix-ink-muted); cursor: pointer; }
+.chip.on { background: var(--mix-primary); border-color: var(--mix-primary); color: var(--mix-primary-contrast);
+           font-weight: 650; }
+.chip.off { opacity: .38; cursor: not-allowed; }
+
+.subbar { display: flex; align-items: center; gap: 8px; padding: 2px 14px 10px; flex-wrap: wrap;
+          font-size: 11.5px; color: var(--mix-ink-muted); }
+.select { background: var(--mix-surface-muted); border: 1px solid var(--mix-lines); color: var(--mix-ink);
+          border-radius: 5px; font: inherit; font-size: 11.5px; padding: 3px 7px; }
+
+/* comment */
+.clist { display: flex; flex-direction: column; }
+.cmt { display: grid; grid-template-columns: 34px minmax(0,1fr); gap: 10px; padding: 12px 14px;
+       border-top: 1px solid var(--mix-lines); }
+/* The thread rail is absolutely positioned on purpose: a static ::before inside a grid
+   container becomes a THIRD grid item against two columns, which wraps the comment body
+   onto its own row and stacks the whole reply vertically. */
+.cmt.reply { padding-left: 40px; background: rgba(255,255,255,.017); position: relative; }
+.cmt.reply::before { content: ""; position: absolute; left: 20px; top: 0; bottom: 0; width: 2px;
+                     background: var(--mix-lines); border-radius: 1px; }
+.av { width: 34px; height: 34px; border-radius: 50%; background: linear-gradient(150deg,#43536b,#243044);
+      display: grid; place-items: center; font-size: 13px; font-weight: 700; color: var(--mix-ink); }
+.chead { display: flex; align-items: baseline; gap: 7px; flex-wrap: wrap; margin-bottom: 4px; }
+.cname { font-weight: 650; font-size: 13px; }
+.cmeta { font-size: 11px; color: var(--mix-ink-muted); }
+.badge { font-size: 10px; letter-spacing: .04em; padding: 1.5px 7px; border-radius: 999px;
+         border: 1px solid var(--mix-lines); color: var(--mix-ink-muted); background: var(--mix-surface-muted); }
+.badge.orig { border-color: rgba(255,210,74,.4); color: var(--mix-accent); }
+.badge.tr { border-color: rgba(63,169,245,.4); color: var(--mix-primary); }
+.badge.q { border-color: rgba(255,107,53,.45); color: var(--mix-secondary); }
+.cbody { font-size: 13.5px; }
+.cbody p { margin: 0 0 7px; max-width: none; }
+.cbody p:last-child { margin-bottom: 0; }
+.cbody strong { color: #fff; }
+.cbody code { background: var(--mix-surface-muted); border-color: var(--mix-lines); color: var(--mix-accent); }
+.cbody ul { margin: 4px 0; padding-left: 18px; }
+.lnk { color: var(--mix-primary); text-decoration: underline; text-underline-offset: 2px; }
+.lnk.untrusted { color: var(--mix-secondary); }
+.lnk.untrusted::after { content: " ⚠"; font-size: .85em; }
+
+.cfoot { display: flex; align-items: center; gap: 4px; margin-top: 7px; }
+.act { appearance: none; background: none; border: none; font: inherit; font-size: 11.5px;
+       color: var(--mix-ink-muted); padding: 3px 7px; border-radius: 5px; cursor: pointer;
+       display: inline-flex; align-items: center; gap: 4px; }
+.act:hover { background: var(--mix-surface-muted); color: var(--mix-ink); }
+.act.voted { color: var(--mix-accent); }
+.act.shield { color: var(--mix-primary); }
+.spacer { flex: 1; }
+.removed { font-size: 12.5px; color: var(--mix-ink-muted); font-style: italic; }
+
+/* composer */
+.comp { border-top: 1px solid var(--mix-lines); background: var(--mix-nav); padding: 10px 14px 12px; }
+.comp-tabs { display: flex; gap: 3px; margin-bottom: 8px; }
+.ct { appearance: none; background: none; border: none; font: inherit; font-size: 11.5px; padding: 3px 9px;
+      border-radius: 5px; color: var(--mix-ink-muted); cursor: pointer; }
+.ct.on { background: var(--mix-surface-muted); color: var(--mix-ink); }
+.tools { display: flex; gap: 2px; align-items: center; margin-bottom: 6px; }
+.tbtn { width: 26px; height: 26px; border-radius: 5px; border: 1px solid var(--mix-lines); background: transparent;
+        color: var(--mix-ink-muted); font-size: 12px; cursor: pointer; display: grid; place-items: center; }
+.tbtn b, .tbtn i { pointer-events: none; }
+.ta { width: 100%; min-height: 62px; background: var(--mix-surface); border: 1px solid var(--mix-lines);
+      border-radius: 6px; color: var(--mix-ink); font: inherit; font-size: 13px; padding: 8px 10px; resize: vertical; }
+.ta:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: 1px; }
+.prev { width: 100%; min-height: 62px; background: var(--mix-surface); border: 1px dashed var(--mix-lines);
+        border-radius: 6px; padding: 8px 10px; font-size: 13.5px; }
+.comp-foot { display: flex; align-items: center; gap: 10px; margin-top: 8px; }
+.count { font-size: 11px; color: var(--mix-ink-muted); font-variant-numeric: tabular-nums; }
+.count.warn { color: var(--mix-secondary); }
+.btn { appearance: none; font: inherit; font-size: 12.5px; font-weight: 650; padding: 6px 15px; border-radius: 6px;
+       border: 1px solid transparent; cursor: pointer; }
+.btn.primary { background: var(--mix-primary); color: var(--mix-primary-contrast); }
+.btn.ghost { background: transparent; border-color: var(--mix-lines); color: var(--mix-ink-muted); }
+.btn.danger { background: var(--bad); color: #fff; }
+.btn:disabled { opacity: .4; cursor: not-allowed; }
+.posting-as { font-size: 11px; color: var(--mix-ink-muted); }
+.posting-as b { color: var(--mix-primary); }
+
+/* modal */
+.modal { background: var(--mix-surface); border: 1px solid var(--mix-lines); border-radius: 8px; max-width: 520px; }
+.modal-h { font-family: var(--cond); font-size: 19px; font-weight: 700; padding: 14px 16px 8px; }
+.modal-b { padding: 0 16px 4px; font-size: 13px; }
+.rules { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 11px; }
+.rules li { display: grid; grid-template-columns: 8px minmax(0,1fr); gap: 10px; }
+.rules li::before { content: ""; width: 4px; border-radius: 2px; background: var(--mix-primary); opacity: .55;
+                    margin-top: 3px; }
+.rules b { display: block; color: #fff; font-size: 13px; margin-bottom: 1px; }
+.rules span { color: var(--mix-ink-muted); font-size: 12.5px; }
+.chk { display: flex; gap: 9px; align-items: flex-start; padding: 11px 16px 0; font-size: 12.5px; }
+.chk .box { width: 16px; height: 16px; border-radius: 3px; border: 1.5px solid var(--mix-primary); flex: none;
+            margin-top: 2px; display: grid; place-items: center; font-size: 11px; color: var(--mix-primary-contrast); }
+.chk .box.on { background: var(--mix-primary); }
+.chk.consent .box { border-color: var(--mix-secondary); }
+.chk.consent .box.on { background: var(--mix-secondary); }
+.modal-f { display: flex; gap: 8px; justify-content: flex-end; padding: 14px 16px; }
+
+/* similar charts grid */
+.simgrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(84px, 1fr)); gap: 8px; padding: 4px 14px 14px; }
+.simtile { background: var(--mix-surface-muted); border: 1px solid var(--mix-lines); border-radius: 7px;
+           padding: 7px; text-align: center; cursor: pointer; }
+.simtile:hover { border-color: var(--mix-primary); }
+.jacket { aspect-ratio: 1; border-radius: 5px; margin-bottom: 6px; display: grid; place-items: center;
+          font-family: var(--cond); font-weight: 700; font-size: 11px; color: rgba(255,255,255,.72); padding: 4px;
+          line-height: 1.15; text-align: center; overflow: hidden; }
+.simtile .nm { font-size: 10px; color: var(--mix-ink-muted); white-space: nowrap; overflow: hidden;
+               text-overflow: ellipsis; margin-top: 5px; }
+.simtile .bub { margin: 0 auto; }
+
+/* stats */
+.ovr { font-size: 10.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--mix-ink-muted);
+       border-top: 1px solid var(--mix-lines); padding: 11px 14px 6px; }
+.metagrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 5px 12px; padding: 0 14px 10px; }
+.metagrid .k { display: block; font-size: 10px; letter-spacing: .08em; text-transform: uppercase; color: var(--mix-ink-muted); }
+.metagrid .v { font-size: 13.5px; font-variant-numeric: tabular-nums; }
+.bars { padding: 0 14px 10px; display: flex; flex-direction: column; gap: 6px; }
+.bar { display: grid; grid-template-columns: 78px minmax(0,1fr) 34px; gap: 8px; align-items: center; font-size: 11.5px; }
+.bar .track { height: 7px; border-radius: 4px; background: var(--mix-surface-muted); overflow: hidden; }
+.bar .fill { height: 100%; border-radius: 4px; background: linear-gradient(90deg, var(--mix-primary), var(--mix-accent)); }
+.bar .p { text-align: right; color: var(--mix-ink-muted); font-variant-numeric: tabular-nums; }
+.tierchips { display: flex; gap: 5px; flex-wrap: wrap; padding: 0 14px 12px; }
+.tchip { font-size: 11px; padding: 2px 9px; border-radius: 999px; border: 1px solid currentColor; }
+
+/* history rows */
+.hrow { display: grid; grid-template-columns: 86px 68px minmax(0,1fr) auto; gap: 9px; align-items: center;
+        padding: 7px 14px; border-bottom: 1px dashed var(--mix-lines); font-size: 12.5px; }
+.hrow .d { color: var(--mix-ink-muted); font-variant-numeric: tabular-nums; }
+.hrow .s { font-variant-numeric: tabular-nums; font-weight: 650; }
+.mixchip { font-size: 10px; padding: 1px 7px; border-radius: 999px; border: 1px solid var(--mix-lines);
+           color: var(--mix-ink-muted); text-align: center; }
+.editrow { display: grid; grid-template-columns: minmax(90px,1fr) minmax(90px,1fr) auto auto; gap: 9px;
+           align-items: center; padding: 12px 14px 14px; }
+.fld { background: var(--mix-surface); border: 1px solid var(--mix-lines); border-radius: 6px; padding: 6px 9px; }
+.fld .k { display: block; font-size: 9.5px; letter-spacing: .09em; text-transform: uppercase; color: var(--mix-ink-muted); }
+.fld .v { font-size: 13px; font-variant-numeric: tabular-nums; }
+
+/* moderation queue row */
+.qrow { display: grid; grid-template-columns: 40px 44px minmax(0,1fr) auto; gap: 11px; align-items: center;
+        padding: 10px 12px; border-bottom: 1px solid var(--mix-lines); }
+.qrow .who { font-size: 12.5px; min-width: 0; }
+.qrow .who .r { color: var(--mix-ink-muted); font-size: 11px; }
+.qrow .reason { font-size: 10px; padding: 1.5px 7px; border-radius: 999px; border: 1px solid var(--bad);
+                color: var(--bad); white-space: nowrap; }
+
+/* decision table */
+.vs { display: grid; grid-template-columns: minmax(0,1fr); gap: 0; border: 1px solid var(--edge); border-radius: 8px;
+      overflow: hidden; }
+.vs .r { display: grid; grid-template-columns: minmax(130px, 1fr) minmax(0,1.3fr) minmax(0,1.3fr);
+         border-bottom: 1px solid var(--edge); font-size: 13.5px; }
+.vs .r:last-child { border-bottom: none; }
+.vs .r > div { padding: 9px 12px; border-right: 1px solid var(--edge); }
+.vs .r > div:last-child { border-right: none; }
+.vs .r.h > div { font-family: var(--mono); font-size: 11px; letter-spacing: .09em; text-transform: uppercase;
+                 color: var(--note-soft); background: var(--paper-2); }
+.vs .k { font-weight: 600; background: var(--paper-2); }
+.yes { color: #1c7a4d; font-weight: 650; }
+.no { color: #a83338; font-weight: 650; }
+@media (prefers-color-scheme: dark) { .yes { color: #4fd493; } .no { color: #f2777c; } }
+:root[data-theme="dark"] .yes { color: #4fd493; } :root[data-theme="dark"] .no { color: #f2777c; }
+:root[data-theme="light"] .yes { color: #1c7a4d; } :root[data-theme="light"] .no { color: #a83338; }
+@media (max-width: 700px) { .vs .r { grid-template-columns: minmax(0,1fr); } .vs .r > div { border-right: none; } }
+
+.callout { border: 2px solid var(--mark); border-radius: 8px; padding: 16px 18px; background: var(--paper-2); }
+.callout h3 { font-size: 17px; margin-bottom: 8px; }
+</style>
+
+<div class="wrap">
+
+<header>
+  <div class="eyebrow">PIU Scores · design review</div>
+  <h1>Chart details overhaul</h1>
+  <p class="lede">Four tabs, community comments with nightly translation, and moderation that lives where the community does. Mocks are at true width — 572&nbsp;px desktop, 390&nbsp;px mobile — on the real Phoenix palette.</p>
+  <p class="tiny" style="color:var(--note-soft);margin-top:14px">The mocked dialog stays dark in both page themes, because the site is dark-only by design — <code>PaletteLight</code> and <code>PaletteDark</code> are deliberately identical.</p>
+</header>
+
+<!-- ══════════════════════════════════════════════════ -->
+<section>
+  <div class="sec-head"><span class="n">01</span><h2>Anatomy</h2></div>
+  <div class="cols split" style="--w:424px">
+    <div class="frame narrow">
+      <div class="cap">Header + tab strip</div>
+      <div class="app"><div class="dlg">
+        <div class="video"><span class="play"></span></div>
+        <div class="title-row">
+          <span class="bub">S20</span>
+          <span class="song">Baroque Virus</span>
+          <button class="icon-btn on" aria-label="On to-do list">★</button>
+        </div>
+        <div class="scoreline">
+          <span class="grade">AA+</span>
+          <span class="score-v">964,102</span>
+          <span class="muted tiny">#84 of 2,317 · recorded 12 days ago</span>
+        </div>
+        <div class="tabs">
+          <button class="tab on">Comments <span class="cnt">7</span></button>
+          <button class="tab">Leaderboard</button>
+          <button class="tab">Stats</button>
+          <button class="tab">History</button>
+        </div>
+        <div class="pad muted tiny" style="padding:18px 14px 22px;text-align:center">tab content …</div>
+      </div></div>
+    </div>
+    <div class="note">
+      <h3>What stays out of the tabs</h3>
+      <p>Video, identity, and your standing — the three things you want without a click. Everything else moved.</p>
+      <ul>
+        <li><b>The tab strip is sticky</b> inside the scroll container, so a tall header scrolls away underneath it rather than taking the tabs with it.</li>
+        <li><b>The comment count is the invitation.</b> Default tab is Leaderboard; last choice persists in a <code>ChartDetails__Tab</code> UiSetting. The badge is what makes anyone open Comments the first time.</li>
+        <li><b>Every tab is lazy</b> — no queries until selected. Nineteen call sites render this dialog; the board already gates on <code>Active="Visible"</code> and the rest now follow.</li>
+        <li><b>History hides when logged out.</b> It's your journal plus your score inputs; both are meaningless signed out.</li>
+      </ul>
+      <div class="flag"><b>Regression to cover:</b> recording a score is now two taps, and several call sites exist only to record — QuickRecordWidget, DailyStepWidget, Charts' quick record. Fix is an <code>InitialTab</code> parameter beside the existing <code>BoardScope</code>, so those callers open straight on History. Round&nbsp;11's "always-visible inputs" decision survives for the people it was made for.</div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════ -->
+<section>
+  <div class="sec-head"><span class="n">02</span><h2>Comments</h2><span class="eyebrow">the main event</span></div>
+  <div class="cols split" style="--w:424px">
+    <div class="frame narrow">
+      <div class="cap">Comments tab · public scope</div>
+      <div class="app"><div class="dlg">
+        <div class="tabs">
+          <button class="tab on">Comments <span class="cnt">7</span></button>
+          <button class="tab">Leaderboard</button>
+          <button class="tab">Stats</button>
+          <button class="tab">History</button>
+        </div>
+        <div class="rail">
+          <button class="chip on">Public</button>
+          <button class="chip">Murloc Lab</button>
+          <button class="chip">NYC Pump</button>
+        </div>
+        <div class="subbar">
+          <span>Sort</span>
+          <select class="select"><option>Top</option><option>Newest</option></select>
+          <span class="spacer" style="flex:1"></span>
+          <span>Read in</span>
+          <select class="select"><option>English</option><option>Original</option></select>
+        </div>
+
+        <div class="clist">
+          <!-- native language -->
+          <div class="cmt">
+            <div class="av">E</div>
+            <div>
+              <div class="chead">
+                <span class="cname">ERRLENA 🇺🇸</span>
+                <span class="cmeta">3 days ago</span>
+              </div>
+              <div class="cbody">
+                <p>The <strong>drill section at 2:01</strong> is the whole chart. If you can hold that you pass — everything after is recovery. Practice it at half speed first.</p>
+              </div>
+              <div class="cfoot">
+                <button class="act voted">▲ 14</button>
+                <button class="act">Reply</button>
+                <span class="spacer"></span>
+                <button class="act">⋯</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- reply -->
+          <div class="cmt reply">
+            <div class="av">T</div>
+            <div>
+              <div class="chead">
+                <span class="cname">TUSA 🇰🇷</span>
+                <span class="cmeta">2 days ago</span>
+                <span class="badge tr">Translated from 한국어</span>
+              </div>
+              <div class="cbody">
+                <p>Agreed, but watch your footing going <em>into</em> it — most people fail because they enter on the wrong foot, not because the drill is too fast.</p>
+              </div>
+              <div class="cfoot">
+                <button class="act">▲ 9</button>
+                <button class="act">Show original</button>
+                <span class="spacer"></span>
+                <button class="act">⋯</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- queued -->
+          <div class="cmt">
+            <div class="av">R</div>
+            <div>
+              <div class="chead">
+                <span class="cname">rafa_pump 🇧🇷</span>
+                <span class="cmeta">14 minutes ago</span>
+                <span class="badge q">Queued for translation</span>
+              </div>
+              <div class="cbody">
+                <p>Alguém sabe se o BPM muda no final? Senti que acelerou mas pode ser impressão minha kkkk</p>
+              </div>
+              <div class="cfoot">
+                <button class="act">▲ 1</button>
+                <button class="act">Reply</button>
+                <span class="spacer"></span>
+                <button class="act">⋯</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- links + edited -->
+          <div class="cmt">
+            <div class="av">D</div>
+            <div>
+              <div class="chead">
+                <span class="cname">DrMurloc 🇺🇸</span>
+                <span class="cmeta">1 week ago · (edited 6 days ago)</span>
+              </div>
+              <div class="cbody">
+                <p>Best reference run I've found is <a class="lnk" href="#">this one on YouTube</a>. The step data is on <a class="lnk" href="#">PIU Center</a> if you want the breakdown, and someone mirrored the pattern chart at <a class="lnk untrusted" href="#">stepcharts.example.net</a>.</p>
+              </div>
+              <div class="cfoot">
+                <button class="act voted">▲ 22</button>
+                <button class="act">Reply</button>
+                <span class="spacer"></span>
+                <button class="act shield">🛡</button>
+                <button class="act">⋯</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- unsupported source -->
+          <div class="cmt">
+            <div class="av">A</div>
+            <div>
+              <div class="chead">
+                <span class="cname">andhika 🇮🇩</span>
+                <span class="cmeta">5 days ago</span>
+                <span class="badge tr">Translated from Indonesian</span>
+              </div>
+              <div class="cbody">
+                <p>Passed this on my third try after two months stuck. Don't give up — the timing window is more forgiving than it looks.</p>
+              </div>
+              <div class="cfoot">
+                <button class="act">▲ 31</button>
+                <button class="act">Show original</button>
+                <span class="spacer"></span>
+                <button class="act">⋯</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- removed -->
+          <div class="cmt">
+            <div class="av" style="opacity:.35">?</div>
+            <div>
+              <div class="chead"><span class="removed">Removed by a community admin · 4 days ago</span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- composer -->
+        <div class="comp">
+          <div class="posting-as" style="margin-bottom:7px">Posting to <b>Public</b> as ERRLENA</div>
+          <div class="comp-tabs">
+            <button class="ct on">Write</button><button class="ct">Preview</button>
+          </div>
+          <div class="tools">
+            <button class="tbtn" title="Bold"><b>B</b></button>
+            <button class="tbtn" title="Italic"><i>I</i></button>
+            <button class="tbtn" title="Strikethrough"><s>S</s></button>
+            <button class="tbtn" title="Code">&lt;&gt;</button>
+            <button class="tbtn" title="Link">🔗</button>
+            <button class="tbtn" title="Bulleted list">☰</button>
+          </div>
+          <textarea class="ta" placeholder="Share what you know about this chart…">Hold the **drill at 2:01** and the rest is recovery.</textarea>
+          <div class="comp-foot">
+            <span class="count">51 / 500</span>
+            <span class="spacer"></span>
+            <button class="btn ghost">Cancel</button>
+            <button class="btn primary">Post</button>
+          </div>
+        </div>
+      </div></div>
+    </div>
+
+    <div class="note">
+      <h3>The scope rail is the audience picker</h3>
+      <p>Same <code>.cld-chip</code> vocabulary as the leaderboard's scopes, doing double duty: it filters what you read <em>and</em> decides what you post to. "Which community am I posting to" is answered by where you're standing, not by a second dropdown.</p>
+      <p>A reply inherits its root's audience as a <b>domain invariant on the aggregate</b> — it isn't a field the UI can set wrong. One level of replies; replying to a reply targets the root.</p>
+
+      <h3 style="margin-top:20px">Every language state on screen</h3>
+      <ul>
+        <li><b>Reader's own language</b> → no badge. Silence is the common case.</li>
+        <li><b>Translated</b> → <span class="badge tr" style="font-size:10px">Translated from 한국어</span> plus a per-comment <i>Show original</i>. Never rendered back into its own language — that round trip is a measured rewrite, not a no-op.</li>
+        <li><b>Pending</b> → the original text with <span class="badge q" style="font-size:10px">Queued for translation</span>. The comment already exists in <em>some</em> language; an empty box would be worse than the author's own words.</li>
+        <li><b>Unsupported source</b> (Indonesian) → detected by stage one, named from <code>CultureInfo.DisplayName</code>, translated normally.</li>
+      </ul>
+
+      <div class="flag"><b>Untrusted links are marked before you click</b>, not just on the way out — the orange <span class="lnk untrusted" style="font-size:13px">stepcharts.example.net</span> treatment. Trusted hosts (YouTube, Reddit, piugame, PIU Center, Pumpout, and every <em>public</em> Community Tool) open straight through.</div>
+
+      <h3 style="margin-top:18px">The shield is the permission</h3>
+      <p>A moderator sees 🛡 on comments they have power over — site admin on everything, a community admin only inside their own club. Its presence <em>is</em> the signal; nobody else renders it. Report lives in the ⋯ for everyone signed in.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════ -->
+<section>
+  <div class="sec-head"><span class="n">03</span><h2>First post</h2><span class="eyebrow">the rules card</span></div>
+  <div class="cols split" style="--w:520px">
+    <div class="frame" style="max-width:552px">
+      <div class="cap">Blocking modal · private profile posting publicly</div>
+      <div class="app"><div class="modal">
+        <div class="modal-h">DrMurloc's Rules for Comments</div>
+        <div class="modal-b">
+          <p style="color:var(--mix-ink-muted);font-size:12.5px;margin-bottom:12px">PIU Scores exists to bring the Pump It Up community together across distance and language. Comments are where you share what you know and help each other get better at the game.</p>
+          <ul class="rules">
+            <li><div><b>Your community moderates itself.</b><span>Community comments belong to that community, and its admins handle them. I stay out of it, except for hate, discrimination, or threats. The rule is "Don't Be An Asshole" — where exactly that line sits is your admins' call.</span></div></li>
+            <li><div><b>Public comments are mine.</b><span>I read generously; different cultures and different people communicate differently. But a public comment reported for bad faith, discrimination, or hate is very likely to come down.</span></div></li>
+            <li><div><b>Step artists and the PIU devs are community too.</b><span>They're players, same as us. Joking about someone's charting habits is fine. Insults and bad-faith accusations are not.</span></div></li>
+            <li><div><b>I'm one person.</b><span>I would far rather build features for you than investigate community drama. We play this game because it's fun. Keep it fun.</span></div></li>
+          </ul>
+        </div>
+        <div class="chk"><span class="box on">✓</span><span>I've read these, and I'll keep it fun.</span></div>
+        <div class="chk consent"><span class="box"></span><span>My profile is private. I understand my username, avatar, and country will be visible on public comments.</span></div>
+        <div class="modal-f">
+          <button class="btn ghost">Cancel</button>
+          <button class="btn primary" disabled>Post comment</button>
+        </div>
+      </div></div>
+    </div>
+    <div class="note">
+      <h3>Two consents, collected when they're true</h3>
+      <p>Follows <code>ToolRulesCard</code> exactly — bold lead, body, checkbox at the bottom, every string through <code>L[…]</code>.</p>
+      <ul>
+        <li><code>AgreedToTermsAt</code> + <code>TermsVersion</code> — once, on the first comment of any kind. Versioned so editing the rules re-prompts.</li>
+        <li><code>ConsentedToPublicIdentityAt</code> — the orange checkbox, fired the first time a <em>private-profile</em> user posts to <em>Public</em>. Post to a community first and you only see the one checkbox; the second appears later, when it's actually true.</li>
+      </ul>
+      <p>A real row rather than a UiSettings key: an agreement wants a timestamp and a version, and you'll want it auditable if a dispute ever lands.</p>
+      <div class="flag"><b>Build note:</b> the Murloc rendering exists to satisfy <code>LocalizationKeyTests</code> and <code>MurlocValuesUseOnlyTheMurlocAlphabet</code> — five bullets in <code>a b g l m o p r u</code>, with "DrMurloc" and "PIU Scores" riding the protected proper-noun exemption.</div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════ -->
+<section>
+  <div class="sec-head"><span class="n">04</span><h2>Link gate &amp; reports</h2></div>
+  <div class="cols" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr))">
+    <div class="frame">
+      <div class="cap">Untrusted link interstitial</div>
+      <div class="app"><div class="modal" style="max-width:100%">
+        <div class="modal-h">Leaving PIU Scores</div>
+        <div class="modal-b">
+          <p style="font-size:13px;color:var(--mix-ink-muted)">This link goes to a site I don't know anything about:</p>
+          <p style="font-family:var(--mono);font-size:14px;background:var(--mix-surface-muted);border:1px solid var(--mix-lines);border-radius:6px;padding:9px 11px;word-break:break-all;color:var(--mix-accent)">stepcharts.example.net</p>
+          <p style="font-size:12.5px;color:var(--mix-ink-muted)">Make sure you trust it before you go.</p>
+        </div>
+        <div class="modal-f">
+          <button class="btn ghost">Stay here</button>
+          <button class="btn primary">Open anyway</button>
+        </div>
+      </div></div>
+    </div>
+    <div class="frame">
+      <div class="cap">Report · closed reason list</div>
+      <div class="app"><div class="modal" style="max-width:100%">
+        <div class="modal-h">Report this comment</div>
+        <div class="modal-b">
+          <p style="font-size:12.5px;color:var(--mix-ink-muted)">Goes to the admins of <b style="color:var(--mix-ink)">Murloc Lab</b>.</p>
+          <div style="display:flex;flex-direction:column;gap:6px;margin:10px 0 4px">
+            <label class="chk" style="padding:0"><span class="box"></span><span>Spam or advertising</span></label>
+            <label class="chk" style="padding:0"><span class="box"></span><span>Off topic</span></label>
+            <label class="chk" style="padding:0"><span class="box"></span><span>Wrong information</span></label>
+            <label class="chk" style="padding:0"><span class="box on">✓</span><span>Hate or discrimination</span></label>
+            <label class="chk" style="padding:0"><span class="box"></span><span>Threats or harassment</span></label>
+          </div>
+        </div>
+        <div class="modal-f">
+          <button class="btn ghost">Cancel</button>
+          <button class="btn danger">Report</button>
+        </div>
+      </div></div>
+    </div>
+  </div>
+  <div class="note" style="margin-top:22px">
+    <div class="flag"><b>The report row stamps the rendering the reporter was reading.</b> Translation launders the thing being detected — and the language-asymmetry case (benign Korean, hostile Spanish) is <em>only</em> a moderation problem, because a moderator ever sees one language. So the moderation view shows the original <em>and</em> what the reporter saw. Without that, an admin reading ko-KR literally cannot evaluate a report filed against the es-ES rendering.</div>
+    <p>Only <code>http</code> and <code>https</code> parse. Fixed-list hosts match on a dot boundary so <code>youtube.com.evil.tld</code> can't slip through; tool URLs match <b>exact host only</b>, so a tool at <code>tools.example.com</code> doesn't bless <code>evil.example.com</code>. The interstitial always shows the parsed host, never the link text.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════ -->
+<section>
+  <div class="sec-head"><span class="n">05</span><h2>Stats &amp; History</h2></div>
+  <div class="cols" style="grid-template-columns:repeat(auto-fit,minmax(330px,1fr))">
+    <div class="frame narrow">
+      <div class="cap">Chart Stats</div>
+      <div class="app"><div class="dlg">
+        <div class="tabs">
+          <button class="tab">Comments <span class="cnt">7</span></button>
+          <button class="tab">Leaderboard</button>
+          <button class="tab on">Stats</button>
+          <button class="tab">History</button>
+        </div>
+        <div class="metagrid" style="padding-top:12px">
+          <div><span class="k">BPM</span><span class="v">142–190</span></div>
+          <div><span class="k">Notes</span><span class="v">1,204</span></div>
+          <div><span class="k">Notes / sec</span><span class="v">10.7</span></div>
+          <div><span class="k">Step artist</span><span class="v">SANJIYAN</span></div>
+          <div><span class="k">Popularity overall</span><span class="v">#417</span></div>
+          <div><span class="k">In Single 20</span><span class="v">#23</span></div>
+        </div>
+        <div class="tierchips">
+          <span class="tchip" style="color:#f0a13a">Pass Difficulty: Hard</span>
+          <span class="tchip" style="color:#e0563f">Score Difficulty: Very Hard</span>
+        </div>
+        <div class="ovr">Skills</div>
+        <div class="bars">
+          <div class="bar"><span>Drill</span><span class="track"><span class="fill" style="width:64%"></span></span><span class="p">64%</span></div>
+          <div class="bar"><span>Twist</span><span class="track"><span class="fill" style="width:41%"></span></span><span class="p">41%</span></div>
+          <div class="bar"><span>Run</span><span class="track"><span class="fill" style="width:22%"></span></span><span class="p">22%</span></div>
+        </div>
+        <div class="ovr">Charts like this</div>
+        <div class="simgrid">
+          <div class="simtile"><div class="jacket" style="background:linear-gradient(150deg,#5b2f6e,#20122b)">TRICKL4SH<br>220</div><span class="bub sm">S20</span><div class="nm">TRICKL4SH 220</div></div>
+          <div class="simtile"><div class="jacket" style="background:linear-gradient(150deg,#7a3520,#2a1109)">Slapstick<br>Parfait</div><span class="bub sm">S20</span><div class="nm">Slapstick Parfait</div></div>
+          <div class="simtile"><div class="jacket" style="background:linear-gradient(150deg,#1f4f6d,#0d1e2b)">Horang<br>Pungryuga</div><span class="bub sm">S21</span><div class="nm">Horang Pungryuga</div></div>
+          <div class="simtile"><div class="jacket" style="background:linear-gradient(150deg,#2d5c3a,#101f16)">Conflict</div><span class="bub sm">S20</span><div class="nm">Conflict</div></div>
+          <div class="simtile"><div class="jacket" style="background:linear-gradient(150deg,#6b2340,#28101c)">Viyella's<br>Nightmare</div><span class="bub sm">S21</span><div class="nm">Viyella's Nightmare</div></div>
+          <div class="simtile"><div class="jacket" style="background:linear-gradient(150deg,#4a4520,#1c1a0c)">Yoropiku<br>Pikuyoro</div><span class="bub d sm">D20</span><div class="nm">Yoropiku Pikuyoro</div></div>
+        </div>
+        <div class="pad tiny muted" style="padding-top:0">Tap a chart to open it here. Step analysis from PIU Center.</div>
+      </div></div>
+    </div>
+
+    <div class="frame narrow">
+      <div class="cap">Score History · manual edit at the bottom</div>
+      <div class="app"><div class="dlg">
+        <div class="tabs">
+          <button class="tab">Comments <span class="cnt">7</span></button>
+          <button class="tab">Leaderboard</button>
+          <button class="tab">Stats</button>
+          <button class="tab on">History</button>
+        </div>
+        <div style="padding-top:8px"></div>
+        <div class="hrow"><span class="d">2026-07-28</span><span class="mixchip">Phoenix 2</span><span class="s">964,102</span><span class="grade">AA+</span></div>
+        <div class="hrow"><span class="d">2026-06-11</span><span class="mixchip">Phoenix 2</span><span class="s">941,880</span><span class="grade" style="background:linear-gradient(160deg,#d8dee8,#96a2b4);color:#1b2230">AA</span></div>
+        <div class="hrow"><span class="d">2026-03-02</span><span class="mixchip">Phoenix</span><span class="s">918,447</span><span class="grade" style="background:linear-gradient(160deg,#d8dee8,#96a2b4);color:#1b2230">A+</span></div>
+        <div class="hrow"><span class="d">2025-11-19</span><span class="mixchip">Phoenix</span><span class="s">—</span><span class="badge">Broken</span></div>
+        <div class="ovr">Manual score edit</div>
+        <div class="editrow">
+          <span class="fld"><span class="k">Score</span><span class="v">964102</span></span>
+          <span class="fld"><span class="k">Plate</span><span class="v">Marvelous</span></span>
+          <label class="chk" style="padding:0;font-size:12px"><span class="box"></span><span>Broken</span></label>
+          <button class="btn primary">Save</button>
+        </div>
+      </div></div>
+    </div>
+  </div>
+  <div class="note" style="margin-top:22px">
+    <p><b>Similar charts stays deliberately dumb</b> — stored match order at the 0.55 floor, no re-sorting, no difficulty lens. Tapping one swaps the dialog in place via an internal chart override with a <i>← back to Baroque&nbsp;Virus</i> crumb, rather than pushing a chart-change callback out to nineteen hosts.</p>
+    <div class="flag"><b>Still owed:</b> trigger <code>recalculate-chart-similarity</code> once in <code>/hangfire</code>. Until then this grid is empty on every chart.</div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════ -->
+<section>
+  <div class="sec-head"><span class="n">06</span><h2>Moderation queue</h2><span class="eyebrow">community admin page &amp; /Admin</span></div>
+  <div class="frame">
+    <div class="cap">Renders only when that moderator has open reports</div>
+    <div class="app">
+      <div style="border:1px solid var(--mix-lines);border-radius:8px;overflow:hidden;background:var(--mix-surface)">
+        <div class="ovr" style="border-top:none">Reported comments · Murloc Lab</div>
+        <div class="qrow">
+          <span class="bub sm">S20</span>
+          <span class="jacket" style="width:44px;height:44px;margin:0;font-size:8px;background:linear-gradient(150deg,#7a3520,#2a1109)">Baroque<br>Virus</span>
+          <span class="who"><b>kimchi_stomper</b><span class="r"> — reported by ERRLENA · 2 hours ago</span></span>
+          <span style="display:flex;gap:8px;align-items:center"><span class="reason">Hate or discrimination</span><button class="btn ghost">Open</button></span>
+        </div>
+        <div class="qrow" style="border-bottom:none">
+          <span class="bub d sm">D22</span>
+          <span class="jacket" style="width:44px;height:44px;margin:0;font-size:8px;background:linear-gradient(150deg,#1f4f6d,#0d1e2b)">Horang<br>Pungryuga</span>
+          <span class="who"><b>bot_spam_9000</b><span class="r"> — reported by TUSA · yesterday</span></span>
+          <span style="display:flex;gap:8px;align-items:center"><span class="reason" style="border-color:var(--mix-ink-muted);color:var(--mix-ink-muted)">Spam</span><button class="btn ghost">Open</button></span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="note" style="margin-top:18px">
+    <p><b>Open</b> launches the chart details dialog with <code>InitialTab=Comments</code> and <code>FocusCommentId</code>, so moderation happens in the surface where the comment actually lives — no second console to build or maintain. Same row, same behaviour, on <code>/Admin</code> for anything that reaches your desk.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════ -->
+<section>
+  <div class="sec-head"><span class="n">07</span><h2>390&nbsp;px</h2><span class="eyebrow">where it gets tight</span></div>
+  <div class="cols split" style="--w:424px">
+    <div class="frame narrow">
+      <div class="cap">Mobile · four tabs</div>
+      <div class="app"><div class="dlg mobile">
+        <div class="video"><span class="play"></span></div>
+        <div class="title-row">
+          <span class="bub">S20</span>
+          <span class="song">Baroque Virus</span>
+          <button class="icon-btn on">★</button>
+        </div>
+        <div class="scoreline"><span class="grade">AA+</span><span class="score-v">964,102</span><span class="muted tiny">#84 of 2,317</span></div>
+        <div class="tabs">
+          <button class="tab on">Comments <span class="cnt">7</span></button>
+          <button class="tab">Leaderboard</button>
+          <button class="tab">Stats</button>
+          <button class="tab">History</button>
+        </div>
+        <div class="rail"><button class="chip on">Public</button><button class="chip">Murloc Lab</button><button class="chip">NYC Pump</button></div>
+        <div class="cmt" style="border-top:1px solid var(--mix-lines)">
+          <div class="av">E</div>
+          <div>
+            <div class="chead"><span class="cname">ERRLENA 🇺🇸</span><span class="cmeta">3d</span></div>
+            <div class="cbody"><p>The <strong>drill at 2:01</strong> is the whole chart…</p></div>
+            <div class="cfoot"><button class="act voted">▲ 14</button><button class="act">Reply</button><span class="spacer"></span><button class="act">⋯</button></div>
+          </div>
+        </div>
+      </div></div>
+    </div>
+    <div class="note">
+      <h3>The tab strip overflows, on purpose</h3>
+      <p>Four labels don't fit 390&nbsp;px. Rather than truncating to jargon ("Boards"), the strip scrolls horizontally and the fourth tab peeks — a standard, legible affordance that keeps every label a real word.</p>
+      <p>The header is 274&nbsp;px before the tabs. That's the argument for moving the record inputs out: with the old always-visible record row the first comment landed below the fold on every phone.</p>
+      <div class="flag"><b>To verify, not assume:</b> open at 390 and check <code>scrollWidth &gt; clientWidth</code> on the strip and nowhere else — the page body must never scroll sideways.</div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════ -->
+<section>
+  <div class="sec-head"><span class="n">08</span><h2>The editor question</h2><span class="eyebrow">own it vs. Froala</span></div>
+
+  <div class="callout" style="margin-bottom:24px">
+    <h3>The parser isn't optional, so a WYSIWYG library is additive — not a replacement.</h3>
+    <p style="margin-bottom:0">Comments render in five languages from machine-translated text. That rendering has to be safe, and it must never touch <code>MarkupString</code>. So a parser producing a token tree that Blazor renders as real elements exists <b>either way</b>. Once it exists, "the editor" is a textarea, six buttons that wrap the selection, and a preview piped through the renderer you already built.</p>
+  </div>
+
+  <div class="scroller">
+    <div class="vs">
+      <div class="r h"><div></div><div>Own it</div><div>Froala</div></div>
+      <div class="r"><div class="k">Display renderer</div><div>Needed. ~200 lines, pure, in the vertical's Domain.</div><div>Needed anyway — Froala is an input widget, not a renderer.</div></div>
+      <div class="r"><div class="k">Editor</div><div>Textarea + 6 buttons doing <code>wrapSelection('**')</code> + Write/Preview toggle. ~150 lines, no JS library.</div><div>~100&nbsp;KB of JS, a JS interop bridge, and a MudBlazor dialog host to fight.</div></div>
+      <div class="r"><div class="k">Stored format</div><div>Markdown. 500 characters.</div><div>HTML — or an HTML↔Markdown converter you now own.</div></div>
+      <div class="r"><div class="k">XSS surface</div><div><span class="yes">None by construction.</span> Tokens become elements; no raw string ever reaches the DOM.</div><div><span class="no">Arbitrary user HTML</span> that must be sanitized server-side before it's stored or re-rendered.</div></div>
+      <div class="r"><div class="k">Survives translation</div><div><span class="yes">Measured.</span> The corpus meme comment kept its <code>2:01</code>, its blank line, and its punchline across every arm.</div><div><span class="no">Unmeasured.</span> HTML tags round-tripping through an LLM in five languages.</div></div>
+      <div class="r"><div class="k">Testing</div><div><code>DomainTests</code>, no infrastructure. Link-trust rules unit-tested beside it.</div><div>Playwright, because the behaviour lives in JS.</div></div>
+      <div class="r"><div class="k">Package allowlist</div><div>Nothing new.</div><div>New dependency in <code>ScoreTracker.Web</code> + a CLAUDE.md amendment.</div></div>
+      <div class="r"><div class="k">Licence</div><div>—</div><div><span class="no">Commercial, per-domain</span>, on a free one-person community site.</div></div>
+    </div>
+  </div>
+
+  <div class="note" style="margin-top:22px">
+    <p><b>And the cap argues on its own.</b> 500 characters is a tweet and a half. A rich-text editor for a 500-character comment is a bigger control than the content it produces — every community that gets this right (GitHub, Reddit, Discord) ships a textarea with a formatting row and a preview toggle, and none of them ship WYSIWYG.</p>
+    <p style="margin-bottom:0">If the Write/Preview split still feels too raw once it's in front of you, the upgrade path is cheap and doesn't touch storage: keep markdown on the wire and swap the input widget for a markdown-native open-source editor (EasyMDE, MIT, ~40&nbsp;KB). What you must not do is store HTML — that's the door that doesn't close again.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════ -->
+<section>
+  <div class="sec-head"><span class="n">09</span><h2>Before build</h2></div>
+  <div class="scroller">
+    <table class="spec">
+      <thead><tr><th>Item</th><th>Where</th><th>Note</th></tr></thead>
+      <tbody>
+        <tr><td><code>ModerateComments = 1&nbsp;&lt;&lt;&nbsp;4</code></td><td>SharedKernel</td><td><code>All</code> 15&nbsp;→&nbsp;31, seed 13&nbsp;→&nbsp;29. Creators are computed by <code>PermissionsOf</code>, so they need nothing.</td></tr>
+        <tr><td>Permission backfill</td><td>EF migration</td><td>13&nbsp;→&nbsp;29 and 15&nbsp;→&nbsp;31 across <b>both</b> <code>CommunityMembership.Permissions</code> and <code>Community</code>'s stored default. Missing the second means future admins in existing clubs silently lack the power.</td></tr>
+        <tr><td><code>CommentRestriction</code></td><td>ChartComments</td><td>Two Guid <code>*UserId</code> columns → needs <code>[PurgeKey(nameof(UserId))]</code>, or account deletion purges the wrong person.</td></tr>
+        <tr><td>Purge manifest</td><td>ChartComments</td><td>Comments, votes and restrictions carry <code>UserId</code>. Revisions don't — that table needs an exemption row with its reason.</td></tr>
+        <tr><td>Re-translation cooldown</td><td>ChartComments</td><td>The $30 ceiling is a fuse against bugs. An edit loop is a <i>user-driven</i> cost amplifier the fuse can't see.</td></tr>
+        <tr><td>Regional communities excluded</td><td>domain rule</td><td>World and country boards are ownerless and carry no roles — a comment there would have no moderator. Audiences are Public + your non-regional clubs.</td></tr>
+        <tr><td class="num">recalculate-chart-similarity</td><td>/hangfire</td><td>Owner, post-deploy, once. Similar charts is empty until it runs.</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+</div>

--- a/docs/design/chart-comments/mock.html
+++ b/docs/design/chart-comments/mock.html
@@ -704,7 +704,7 @@ table.spec td.num { font-variant-numeric: tabular-nums; white-space: nowrap; }
   </div>
   <div class="note" style="margin-top:22px">
     <p><b>Similar charts stays deliberately dumb</b> — stored match order at the 0.55 floor, no re-sorting, no difficulty lens. Tapping one swaps the dialog in place via an internal chart override with a <i>← back to Baroque&nbsp;Virus</i> crumb, rather than pushing a chart-change callback out to nineteen hosts.</p>
-    <div class="flag"><b>Still owed:</b> trigger <code>recalculate-chart-similarity</code> once in <code>/hangfire</code>. Until then this grid is empty on every chart.</div>
+    <p><b>The graph is populated</b> — <code>recalculate-chart-similarity</code> runs on a daily cron. The empty state still matters: 139 of 4,426 charts have no piucenter coverage and show it.</p>
   </div>
 </section>
 
@@ -818,7 +818,7 @@ table.spec td.num { font-variant-numeric: tabular-nums; white-space: nowrap; }
         <tr><td>Purge manifest</td><td>ChartComments</td><td>Comments, votes and restrictions carry <code>UserId</code>. Revisions don't — that table needs an exemption row with its reason.</td></tr>
         <tr><td>Re-translation cooldown</td><td>ChartComments</td><td>The $30 ceiling is a fuse against bugs. An edit loop is a <i>user-driven</i> cost amplifier the fuse can't see.</td></tr>
         <tr><td>Regional communities excluded</td><td>domain rule</td><td>World and country boards are ownerless and carry no roles — a comment there would have no moderator. Audiences are Public + your non-regional clubs.</td></tr>
-        <tr><td class="num">recalculate-chart-similarity</td><td>/hangfire</td><td>Owner, post-deploy, once. Similar charts is empty until it runs.</td></tr>
+        <tr><td>Similar-charts empty state</td><td>ChartComments</td><td>Not a deploy step — the graph is live on a daily cron. 139 of 4,426 charts have no piucenter coverage, so the empty state is a real state.</td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/design/discord-overhaul.md
+++ b/docs/design/discord-overhaul.md
@@ -12,8 +12,9 @@ mirroring the `/Charts` page — the difficulty breakdown (scoring level + pass 
 `GetChartScoringLevelsQuery` + `GetTierListQuery("Pass Count")`), the skill fingerprint
 (`GetChartSkillChipsQuery`), and **similar charts by skill** (`GetSimilarChartsQuery`, the
 primary ask). Each section drops when its data is absent; a bare song name still falls back to
-the difficulty-list card. **Similar charts are empty until `recalculate-chart-similarity` runs
-once in `/hangfire`** — same trigger the chart-details page needs.
+the difficulty-list card. Similar charts were empty until `recalculate-chart-similarity` first
+ran; it is on a daily cron, so that resolved itself within a day of deploy and the graph has been
+populated since.
 
 **Iteration (F7, owner feedback):** the session-snapshot card now marks **cross-mix reclears**.
 A new pass on a chart the player already cleared (non-broken) in another mix trails an escaped

--- a/docs/design/seo-friendly-site.md
+++ b/docs/design/seo-friendly-site.md
@@ -263,9 +263,9 @@ MainLayout's video dialog, shrinking PR-3's blast radius before the flip exists.
   pattern live on HomeDashboard/ChartSkills/ChartRandomizer/RandomizerSpectate), and renders
   through `MudDialogProvider` — zero MainLayout involvement. Flipping a caller = host an
   instance + set two fields in the click handler.
-- **Port Report Video** into `ChartDetailsDialog`'s video block (the one feature the old dialog
-  has that the new one lacks — `IAdminNotificationClient.NotifyAdmin` + snackbar; the resx keys
-  exist in all locales). Every dialog surface gains reporting as a side effect.
+- ~~**Port Report Video** into `ChartDetailsDialog`'s video block~~ — done, then **deleted
+  2026-08-05**. The owner does not read the notification mail; wrong videos reach him as Discord
+  DMs instead. No surface offers video reporting now, and the resx keys are gone from all locales.
 - `Charts.razor` rows are `BestAttemptDto` (ChartId only) — that one call site needs a chart
   lookup on click; the other three hold full `Chart` records.
 - **Deletes**: `Components/ChartVideoDisplay.razor`, `Services/ChartVideoDisplayer.cs`, the


### PR DESCRIPTION
Slice 1 of the chart-comments work — the dialog re-shape, with no comments in it yet. Design and
UI reference land here too: [`docs/design/chart-comments/`](docs/design/chart-comments/README.md).
Part 1 of that README is the feature requirements and survives; Part 2 and `mock.html` are
scaffolding and get deleted when the feature ships.

## The dialog

**Three tabs — Leaderboard, Chart Stats, Score History** — under a header that keeps the video,
the title row and your score. Comments becomes a fourth tab in Slice 2; shipping it now would be a
dead control.

- **Opening the dialog costs one query instead of five.** A panel behind an unselected tab is
  gated on `Active` and fetches nothing. Nineteen call sites render this.
- Panels stay mounted and hide with CSS rather than unmounting — switching away and back would
  otherwise discard the board's scope selection and re-query.
- The strip is **sticky** against the scroll container, so a tall header scrolls away underneath
  it. It deliberately does not bleed to MudBlazor's content padding: matching that gutter by hand
  risks overflowing it, and a dialog that scrolls sideways is a worse bug than a 24px gutter.
- `InitialTab` and `FocusCommentId` are the new parameters. `MixChangesSongSheet` opens on Chart
  Stats — that sheet exists to answer what changed about a chart, and the meta grid is the answer.
- Score History hides when signed out; it is your journal plus your recording inputs.

## Similar charts

Stored match order at the shared 0.55 floor, rendered as jackets you tap. None of the shelf's
machinery — no ordering lens, no range filters, no least-similar mode. Those answer "what should I
play next", which the chart page exists for.

Tapping one **swaps the dialog in place** with a crumb back. The host owns `Visible`, so a second
dialog would mean teaching nineteen call sites a chart-change callback for one piece of internal
state. Score, To-Do and the popularity places stand down while drilled in — they describe the
chart the *host* passed and would be describing the wrong one.

Six columns on desktop, **three below 500px**. The jackets are landscape, so at six columns on a
phone a 22px bubble sat on a ~25px-tall image and the tile was all bubble.

## One real bug, found by field test

**The To-Do bookmark did nothing on ten of the thirteen hosts.** It was gated on "is someone signed
in", but only `Charts`, `ChartSkills` and `HomeDashboard` wire `OnToDo` — everywhere else the click
invoked an unbound `EventCallback` and silently succeeded. Now gated on `OnToDo.HasDelegate`, with
both directions asserted. Pre-existing, not introduced here.

## Removals

- **Report Video.** The mail went unread; wrong videos arrive as Discord DMs. No surface offers
  video reporting now.
- **Good Suggestion.** Unused, and on a phone it wrapped the action bar onto two lines. Took the
  `SuggestionCategory` parameter, the handler and the dashboard's plumbing with it.
  `SubmitFeedbackCommand` and the widget's own veto path are untouched.
- Four orphaned resx keys removed from all nine locales.

## Localization

Five new keys added, four removed, all nine locales, alphabetical position, spliced as text
rather than round-tripped through `XDocument` (which reformats escapes and adds a BOM these files
don't carry). Murloc reuses established glossary words; the eight function words it needed are
coined once and written into `docs/LOCALIZATION-en-ZW.md` as that document requires.

## A stale claim, corrected

Three docs — and an earlier version of this description — said similar charts stay empty until
`recalculate-chart-similarity` is manually triggered in `/hangfire`. **That was wrong.** The job
has always been on a `Daily 12:00` cron, so it self-serviced within a day of the chart-page
overhaul deploying; the graph has been populated for weeks. Nothing re-checks a "still owed" note,
so it propagated. Fixed in `6d9890a9`.

The grid's empty state still earns its place — 139 of 4,426 charts have no piucenter coverage —
but that is a data gap, not a pending deploy step.

## Verification

All five suites green on `0ce64347`:

| Suite | |
|---|---|
| ScoreTracker.Tests | 2,217 ✓ |
| ScoreTracker.Tests.Api | 148 ✓ |
| ScoreTracker.Tests.Components | 618 ✓ |
| ScoreTracker.Tests.Integration | 229 ✓ |
| ScoreTracker.Tests.E2E | 74 ✓ |

`TierListTests.ChartCardOpensTheDetailsDialogVideoFirst` failed four times mid-review. It is the
documented intermittent from `1bd38b3e`, not this branch — verified by restoring main's dialog and
reproducing the identical failure, then passing 74/74 on the final run.

## Not verified here

**The 390px layout.** Three tab labels should fit and the strip scrolls if they don't, but that
needs the running app rather than a test.

## Known, deliberate

- `ChartClickContext` still carries `SuggestionCategory` and nothing reads it. It is part of the
  render contract `WidgetRenderContractTests` ratchets, so pruning it is a contract change rather
  than a cleanup.
- Recording is two taps from Score History. A header shortcut existed for one commit and was cut
  on owner call; the remembered-tab preference covers frequent recorders.

## After deploy

Nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
