### PR TITLE
fix(tools): listing is a directory concern, not an access gate

### DIFF
--- a/ScoreTracker/ScoreTracker.CommunityTools/Contracts/ToolEnums.cs
+++ b/ScoreTracker/ScoreTracker.CommunityTools/Contracts/ToolEnums.cs
@@ -20,7 +20,14 @@ public enum ToolKind
     ListingOnly
 }
 
-/// <summary>Where a tool sits in the listing flow.</summary>
+/// <summary>
+///     Where a tool sits in the listing flow — a directory concern only.
+///     <para>
+///         None of these values gates who a tool may read. A private tool is eligible for the
+///         all-tools pool on exactly the same terms as a listed one: it accepts the pool, it is not
+///         in session mode, its source is published and checked, and its maker is not banned.
+///     </para>
+/// </summary>
 public enum ToolVisibility
 {
     /// <summary>Fully functional and reachable by invite. The starting state, and a valid resting one.</summary>
@@ -29,7 +36,7 @@ public enum ToolVisibility
     /// <summary>Listing requested, awaiting an admin decision. Still fully functional.</summary>
     PendingApproval,
 
-    /// <summary>In the directory, and eligible for players who share with all tools.</summary>
+    /// <summary>In the directory, so a player can find it without an invite link.</summary>
     Public,
 
     /// <summary>Listing refused with a reason. Still fully functional as a private tool.</summary>
@@ -68,7 +75,7 @@ public enum ShareSource
     /// <summary>The player connected to this tool specifically.</summary>
     Direct,
 
-    /// <summary>The player shares with every approved tool, and this one accepts that pool.</summary>
+    /// <summary>The player shares with every registered tool, and this one accepts that pool.</summary>
     AllTools
 }
 

--- a/ScoreTracker/ScoreTracker.CommunityTools/Infrastructure/EFToolRepository.cs
+++ b/ScoreTracker/ScoreTracker.CommunityTools/Infrastructure/EFToolRepository.cs
@@ -239,11 +239,11 @@ internal sealed class EFToolRepository : IToolRepository
             .Where(b => b.UserId == userId).Select(b => b.ToolId).ToArrayAsync(cancellationToken);
 
         // The source gate and the maker ban are resolved in memory against the same predicates the
-        // per-tool query uses. The candidate set is every listed pooled tool — tens of rows — and
-        // one rule expressed twice is one rule that can drift into disagreeing with itself about
-        // who may read a player's scores.
+        // per-tool query uses. The candidate set is every pooled tool — tens of rows — and one rule
+        // expressed twice is one rule that can drift into disagreeing with itself about who may read
+        // a player's scores.
         var candidates = await database.Set<ToolEntity>()
-            .Where(t => t.Visibility == nameof(ToolVisibility.Public) && t.AcceptsAllToolsShare)
+            .Where(t => t.AcceptsAllToolsShare)
             // Session mode never arrives by blanket consent — it needs a moment the player saw.
             .Where(t => t.WebhookMode != nameof(WebhookMode.PiuGameSession))
             .Select(t => new
@@ -280,14 +280,15 @@ internal sealed class EFToolRepository : IToolRepository
             .Select(s => s.UserId).ToArrayAsync(cancellationToken);
 
         // A tool without a readable source and a reachable maker is excluded from the blanket pool,
-        // exactly as a private or session-mode tool is. Deliberate grants already given survive it:
-        // the site's own rule is that going private blocks the blanket grant and never a named one
-        // (api-v2-community-tools.md §5), and cutting off players who chose a tool because its
-        // maker mistyped a URL would punish the wrong people.
-        if (tool.Visibility != nameof(ToolVisibility.Public) || !tool.AcceptsAllToolsShare
-                                                             || tool.WebhookMode == nameof(WebhookMode.PiuGameSession)
-                                                             || !Tool.Shareable(tool.Id, tool.RepositoryUrl,
-                                                                 tool.RepositoryCheckedAt, tool.DiscordHandle))
+        // exactly as a session-mode tool is. Deliberate grants already given survive it: cutting off
+        // players who chose a tool because its maker mistyped a URL would punish the wrong people.
+        //
+        // Visibility is deliberately NOT part of this. Listing is a directory concern — what protects
+        // a pooled player is the published source, the reachable maker, and the maker ban, all of
+        // which a private tool is held to identically.
+        if (!tool.AcceptsAllToolsShare
+            || tool.WebhookMode == nameof(WebhookMode.PiuGameSession)
+            || !Tool.Shareable(tool.Id, tool.RepositoryUrl, tool.RepositoryCheckedAt, tool.DiscordHandle))
             return direct.Distinct().ToArray();
 
         var blocked = await database.Set<ToolBlockEntity>()

--- a/ScoreTracker/ScoreTracker.CommunityTools/Infrastructure/Entities/CommunityToolEntities.cs
+++ b/ScoreTracker/ScoreTracker.CommunityTools/Infrastructure/Entities/CommunityToolEntities.cs
@@ -130,7 +130,7 @@ internal sealed class ToolBlockEntity
 }
 
 /// <summary>
-///     Whether a player shares with every approved tool.
+///     Whether a player shares with every registered tool.
 ///     <para>
 ///         Lives here rather than on the user row: it is authorization data this vertical owns, and
 ///         keeping it beside shares and blocks makes the effective-access check one local join

--- a/ScoreTracker/ScoreTracker.Tests.Integration/EFToolRepositoryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/EFToolRepositoryTests.cs
@@ -248,11 +248,39 @@ public sealed class EFToolRepositoryTests : IAsyncLifetime
     }
 
     /// <summary>
-    ///     A private tool is invite-only whatever a player's blanket preference says — approval is
-    ///     what puts a tool in front of everyone, and it hasn't happened.
+    ///     Listing is a directory concern and never an access one: a private tool that publishes its
+    ///     source and names a reachable maker is in the pool on the same terms as a listed one.
+    ///     <para>
+    ///         Asserted against a real query rather than a handler, because nothing routes through a
+    ///         handler to grant the pool — the predicate <i>is</i> the rule.
+    ///     </para>
     /// </summary>
     [Fact]
-    public async Task APrivateToolIsNotInThePoolEvenWhenItAcceptsIt()
+    public async Task APrivateToolIsInThePoolOnTheSameTermsAsAListedOne()
+    {
+        var repository = BuildRepository();
+        var player = Guid.NewGuid();
+        await repository.SetShareWithAllTools(player, true, Now);
+
+        var unlisted = await SaveTool(repository, "Unlisted", t =>
+        {
+            Sourced(t);
+            t.SetAcceptsAllToolsShare(true);
+        });
+
+        Assert.Equal(ToolVisibility.Private, unlisted.Visibility);
+        Assert.True(await repository.CanRead(unlisted.Id, player));
+        Assert.Contains(player, await repository.GetReadablePlayerIds(unlisted.Id));
+        Assert.Contains(unlisted.Id, await repository.GetToolIdsReading(player));
+    }
+
+    /// <summary>
+    ///     The other half, and the reason dropping the visibility gate is safe: what actually holds
+    ///     the line is the published source and the reachable maker, and an unlisted tool is held to
+    ///     it exactly as a listed one is.
+    /// </summary>
+    [Fact]
+    public async Task APrivateToolWithNoCheckedSourceIsStillNotInThePool()
     {
         var repository = BuildRepository();
         var player = Guid.NewGuid();
@@ -261,6 +289,7 @@ public sealed class EFToolRepositoryTests : IAsyncLifetime
         var tool = await SaveTool(repository, "Unlisted", t => t.SetAcceptsAllToolsShare(true));
 
         Assert.False(await repository.CanRead(tool.Id, player));
+        Assert.DoesNotContain(tool.Id, await repository.GetToolIdsReading(player));
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker/Components/Account/ProfilePanel.razor
+++ b/ScoreTracker/ScoreTracker/Components/Account/ProfilePanel.razor
@@ -70,7 +70,7 @@
                        ValueChanged="ToggleShareWithAllTools" Color="Color.Success"
                        Label=@L["Share my scores with community tools"]></MudSwitch>
             <MudText Typo="Typo.body2" Style="opacity:.75;" Class="ml-11">
-                @L["Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected."]
+                @L["Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected."]
             </MudText>
             <div class="d-flex align-center gap-2 ml-11 mt-2 flex-wrap">
                 <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info">
@@ -168,7 +168,7 @@
             <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Dense="true" Class="mt-3">
                 <MudText Typo="Typo.body2"><b>@L["This also turns on sharing with community tools."]</b></MudText>
                 <MudText Typo="Typo.body2">
-                    @L["Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page."]
+                    @L["Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page."]
                 </MudText>
             </MudAlert>
         }

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -612,14 +612,17 @@
   <data name="Any" xml:space="preserve">
     <value>Any</value>
   </data>
-  <data name="Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
-    <value>Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected.</value>
-  </data>
   <data name="Any level" xml:space="preserve">
     <value>Any level</value>
   </data>
   <data name="any moment now" xml:space="preserve">
     <value>any moment now</value>
+  </data>
+  <data name="Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
+    <value>Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected.</value>
+  </data>
+  <data name="Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
+    <value>Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page.</value>
   </data>
   <data name="Anyone with an invite link can connect, whether their profile is public or private." xml:space="preserve">
     <value>Anyone with an invite link can connect, whether their profile is public or private.</value>
@@ -662,9 +665,6 @@
   </data>
   <data name="Approved" xml:space="preserve">
     <value>Approved</value>
-  </data>
-  <data name="Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
-    <value>Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page.</value>
   </data>
   <data name="Approving a tool puts its name, description and link in front of every player. Everything else about it — webhooks, keys, who it can read — is the maker's business and is not reviewed here." xml:space="preserve">
     <value>Approving a tool puts its name, description and link in front of every player. Everything else about it — webhooks, keys, who it can read — is the maker's business and is not reviewed here.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -612,14 +612,17 @@
   <data name="Any" xml:space="preserve">
     <value>Ro</value>
   </data>
-  <data name="Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
-    <value>Argla Rorgl murp blurgl gromurp Mgrlgmrg. Ormo blu mgrlgmrg-rorgblub. Murgloo grorp mrpgrogl, blu Rorgl grabla morgmurm.</value>
-  </data>
   <data name="Any level" xml:space="preserve">
     <value>Ro grorpmurm</value>
   </data>
   <data name="any moment now" xml:space="preserve">
     <value>puluma</value>
+  </data>
+  <data name="Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
+    <value>Argla Rorgl murp Grolub Murgblub blurgl gromurp Mgrlgmrg. Ormo blu mgrlgmrg-rorgblub. Murgloo grorp mrpgrogl, blu Rorgl grabla morgmurm.</value>
+  </data>
+  <data name="Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
+    <value>Argla Rorgl murp Grolub Murgblub blurgl gromurp Mgrlgmrg — ormo blu mgrlgmrg-rorgblub. Amurmo murgargl, gromurp murp grorp murmarglmurp, blu blaromurp.</value>
   </data>
   <data name="Anyone with an invite link can connect, whether their profile is public or private." xml:space="preserve">
     <value>Argla morp murm murpgrogl grabla murp galm, mrpgrogl Mrglrgll arplo murmo.</value>
@@ -662,9 +665,6 @@
   </data>
   <data name="Approved" xml:space="preserve">
     <value>Marogl</value>
-  </data>
-  <data name="Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
-    <value>Argla Rorgl murp blurgl gromurp Mgrlgmrg — ormo blu mgrlgmrg-rorgblub. Amurmo murgargl, gromurp murp grorp murmarglmurp, blu blaromurp.</value>
   </data>
   <data name="Approving a tool puts its name, description and link in front of every player. Everything else about it — webhooks, keys, who it can read — is the maker's business and is not reviewed here." xml:space="preserve">
     <value>Marogl blurgl - alla plaruga glub burgla mo groblu, alla mogul. Bo grumbla, alla marogl: obbla, pragl, bloop groblu - alla blurgl mogla, opa marogl bo.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -609,14 +609,17 @@
   <data name="Any" xml:space="preserve">
     <value>Cualquiera</value>
   </data>
-  <data name="Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
-    <value>Cualquier herramienta aprobada puede leer tus puntuaciones. Sobre todo sirve para herramientas de análisis. Si lo desactivas se detiene el acceso nuevo, pero las herramientas pueden conservar lo que ya recopilaron.</value>
-  </data>
   <data name="Any level" xml:space="preserve">
     <value>Cualquier nivel</value>
   </data>
   <data name="any moment now" xml:space="preserve">
     <value>en cualquier momento</value>
+  </data>
+  <data name="Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
+    <value>Cualquier herramienta que publique su código fuente puede leer tus puntuaciones. Sobre todo sirve para herramientas de análisis. Si lo desactivas se detiene el acceso nuevo, pero las herramientas pueden conservar lo que ya recopilaron.</value>
+  </data>
+  <data name="Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
+    <value>Cualquier herramienta que publique su código fuente podrá leer tus puntuaciones — eso es lo que impulsa la mayoría de las herramientas de análisis. Es un ajuste aparte y puedes desactivarlo justo después, en esta página.</value>
   </data>
   <data name="Anyone with an invite link can connect, whether their profile is public or private." xml:space="preserve">
     <value>Cualquiera con un enlace de invitación puede conectarse, tenga el perfil público o privado.</value>
@@ -659,9 +662,6 @@
   </data>
   <data name="Approved" xml:space="preserve">
     <value>Aprobada</value>
-  </data>
-  <data name="Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
-    <value>Las herramientas aprobadas podrán leer tus puntuaciones — eso es lo que impulsa la mayoría de las herramientas de análisis. Es un ajuste aparte y puedes desactivarlo justo después, en esta página.</value>
   </data>
   <data name="Approving a tool puts its name, description and link in front of every player. Everything else about it — webhooks, keys, who it can read — is the maker's business and is not reviewed here." xml:space="preserve">
     <value>Aprobar una herramienta pone su nombre, descripción y enlace ante todos los jugadores. Todo lo demás — webhooks, claves, a quién puede leer — es asunto de quien la desarrolla y no se revisa aquí.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -609,14 +609,17 @@
   <data name="Any" xml:space="preserve">
     <value>Cualquiera</value>
   </data>
-  <data name="Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
-    <value>Cualquier herramienta aprobada puede leer tus puntuaciones. Sobre todo sirve para herramientas de análisis. Si lo desactivas se detiene el acceso nuevo, pero las herramientas pueden conservar lo que ya recopilaron.</value>
-  </data>
   <data name="Any level" xml:space="preserve">
     <value>Cualquier nivel</value>
   </data>
   <data name="any moment now" xml:space="preserve">
     <value>en cualquier momento</value>
+  </data>
+  <data name="Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
+    <value>Cualquier herramienta que publique su código fuente puede leer tus puntuaciones. Sobre todo sirve para herramientas de análisis. Si lo desactivas se detiene el acceso nuevo, pero las herramientas pueden conservar lo que ya recopilaron.</value>
+  </data>
+  <data name="Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
+    <value>Cualquier herramienta que publique su código fuente podrá leer tus puntuaciones — eso es lo que impulsa la mayoría de las herramientas de análisis. Es un ajuste aparte y puedes desactivarlo justo después, en esta página.</value>
   </data>
   <data name="Anyone with an invite link can connect, whether their profile is public or private." xml:space="preserve">
     <value>Cualquiera con un enlace de invitación puede conectarse, tenga el perfil público o privado.</value>
@@ -659,9 +662,6 @@
   </data>
   <data name="Approved" xml:space="preserve">
     <value>Aprobada</value>
-  </data>
-  <data name="Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
-    <value>Las herramientas aprobadas podrán leer tus puntuaciones — eso es lo que impulsa la mayoría de las herramientas de análisis. Es un ajuste aparte y puedes desactivarlo justo después, en esta página.</value>
   </data>
   <data name="Approving a tool puts its name, description and link in front of every player. Everything else about it — webhooks, keys, who it can read — is the maker's business and is not reviewed here." xml:space="preserve">
     <value>Aprobar una herramienta pone su nombre, descripción y enlace frente a todos los jugadores. Todo lo demás — webhooks, llaves, a quién puede leer — es asunto de quien la desarrolla y no se revisa aquí.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -612,14 +612,17 @@
   <data name="Any" xml:space="preserve">
     <value>Tous</value>
   </data>
-  <data name="Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
-    <value>Tout outil approuvé peut lire vos scores. Cela sert surtout aux outils d'analyse. Le désactiver arrête les nouveaux accès, mais les outils peuvent conserver ce qu'ils ont déjà collecté.</value>
-  </data>
   <data name="Any level" xml:space="preserve">
     <value>Tout niveau</value>
   </data>
   <data name="any moment now" xml:space="preserve">
     <value>d'un instant à l'autre</value>
+  </data>
+  <data name="Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
+    <value>Tout outil qui publie son code source peut lire vos scores. Cela sert surtout aux outils d'analyse. Le désactiver arrête les nouveaux accès, mais les outils peuvent conserver ce qu'ils ont déjà collecté.</value>
+  </data>
+  <data name="Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
+    <value>Tout outil qui publie son code source pourra lire vos scores — c'est ce qui alimente la plupart des outils d'analyse. C'est un réglage distinct et vous pouvez le désactiver juste après, sur cette page.</value>
   </data>
   <data name="Anyone with an invite link can connect, whether their profile is public or private." xml:space="preserve">
     <value>Toute personne disposant d'un lien d'invitation peut se connecter, que son profil soit public ou privé.</value>
@@ -662,9 +665,6 @@
   </data>
   <data name="Approved" xml:space="preserve">
     <value>Approuvé</value>
-  </data>
-  <data name="Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
-    <value>Les outils approuvés pourront lire vos scores — c'est ce qui alimente la plupart des outils d'analyse. C'est un réglage distinct et vous pouvez le désactiver juste après, sur cette page.</value>
   </data>
   <data name="Approving a tool puts its name, description and link in front of every player. Everything else about it — webhooks, keys, who it can read — is the maker's business and is not reviewed here." xml:space="preserve">
     <value>Approuver un outil place son nom, sa description et son lien devant tous les joueurs. Tout le reste — webhooks, clés, qui il peut lire — relève de son auteur et n'est pas examiné ici.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -612,14 +612,17 @@
   <data name="Any" xml:space="preserve">
     <value>Tutti</value>
   </data>
-  <data name="Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
-    <value>Qualsiasi strumento approvato può leggere i tuoi punteggi. Serve soprattutto agli strumenti di analisi. Disattivarlo blocca i nuovi accessi, ma gli strumenti possono conservare ciò che hanno già raccolto.</value>
-  </data>
   <data name="Any level" xml:space="preserve">
     <value>Qualsiasi livello</value>
   </data>
   <data name="any moment now" xml:space="preserve">
     <value>da un momento all'altro</value>
+  </data>
+  <data name="Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
+    <value>Qualsiasi strumento che pubblica il proprio codice sorgente può leggere i tuoi punteggi. Serve soprattutto agli strumenti di analisi. Disattivarlo blocca i nuovi accessi, ma gli strumenti possono conservare ciò che hanno già raccolto.</value>
+  </data>
+  <data name="Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
+    <value>Qualsiasi strumento che pubblica il proprio codice sorgente potrà leggere i tuoi punteggi — è ciò che alimenta la maggior parte degli strumenti di analisi. È un'impostazione separata e puoi disattivarla subito dopo, in questa pagina.</value>
   </data>
   <data name="Anyone with an invite link can connect, whether their profile is public or private." xml:space="preserve">
     <value>Chiunque abbia un link d'invito può collegarsi, con profilo pubblico o privato.</value>
@@ -662,9 +665,6 @@
   </data>
   <data name="Approved" xml:space="preserve">
     <value>Approvato</value>
-  </data>
-  <data name="Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
-    <value>Gli strumenti approvati potranno leggere i tuoi punteggi — è ciò che alimenta la maggior parte degli strumenti di analisi. È un'impostazione separata e puoi disattivarla subito dopo, in questa pagina.</value>
   </data>
   <data name="Approving a tool puts its name, description and link in front of every player. Everything else about it — webhooks, keys, who it can read — is the maker's business and is not reviewed here." xml:space="preserve">
     <value>Approvare uno strumento mette il suo nome, la descrizione e il link davanti a tutti i giocatori. Tutto il resto — webhook, chiavi, chi può leggere — riguarda chi lo sviluppa e non viene esaminato qui.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -612,14 +612,17 @@
   <data name="Any" xml:space="preserve">
     <value>すべて</value>
   </data>
-  <data name="Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
-    <value>承認されたツールがあなたのスコアを読み取れます。主にスコア分析ツールで使われます。オフにすると新しいアクセスは止まりますが、すでに取得されたデータはツール側に残る場合があります。</value>
-  </data>
   <data name="Any level" xml:space="preserve">
     <value>レベル指定なし</value>
   </data>
   <data name="any moment now" xml:space="preserve">
     <value>まもなく</value>
+  </data>
+  <data name="Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
+    <value>ソースコードを公開しているツールがあなたのスコアを読み取れます。主にスコア分析ツールで使われます。オフにすると新しいアクセスは止まりますが、すでに取得されたデータはツール側に残る場合があります。</value>
+  </data>
+  <data name="Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
+    <value>ソースコードを公開しているツールがあなたのスコアを読み取れるようになります。ほとんどのスコア分析ツールがこれを使っています。別の設定なので、このページですぐにオフにできます。</value>
   </data>
   <data name="Anyone with an invite link can connect, whether their profile is public or private." xml:space="preserve">
     <value>招待リンクがあれば、プロフィールが公開でも非公開でも接続できます。</value>
@@ -662,9 +665,6 @@
   </data>
   <data name="Approved" xml:space="preserve">
     <value>承認しました</value>
-  </data>
-  <data name="Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
-    <value>承認されたツールがあなたのスコアを読み取れるようになります。ほとんどのスコア分析ツールがこれを使っています。別の設定なので、このページですぐにオフにできます。</value>
   </data>
   <data name="Approving a tool puts its name, description and link in front of every player. Everything else about it — webhooks, keys, who it can read — is the maker's business and is not reviewed here." xml:space="preserve">
     <value>ツールを承認すると、その名前・説明・リンクがすべてのプレイヤーに表示されます。Webhook、キー、読み取り対象などそれ以外は作者の領分であり、ここでは審査しません。</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -609,14 +609,17 @@
   <data name="Any" xml:space="preserve">
     <value>전체</value>
   </data>
-  <data name="Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
-    <value>승인된 도구가 내 점수를 읽을 수 있습니다. 주로 점수 분석 도구에 사용됩니다. 끄면 새로운 접근이 중단되지만, 이미 수집한 데이터는 도구에 남아 있을 수 있습니다.</value>
-  </data>
   <data name="Any level" xml:space="preserve">
     <value>모든 레벨</value>
   </data>
   <data name="any moment now" xml:space="preserve">
     <value>곧</value>
+  </data>
+  <data name="Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
+    <value>소스 코드를 공개한 도구가 내 점수를 읽을 수 있습니다. 주로 점수 분석 도구에 사용됩니다. 끄면 새로운 접근이 중단되지만, 이미 수집한 데이터는 도구에 남아 있을 수 있습니다.</value>
+  </data>
+  <data name="Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
+    <value>소스 코드를 공개한 도구가 내 점수를 읽을 수 있게 됩니다. 대부분의 점수 분석 도구가 이 기능을 사용합니다. 별도의 설정이므로 이 페이지에서 바로 끌 수 있습니다.</value>
   </data>
   <data name="Anyone with an invite link can connect, whether their profile is public or private." xml:space="preserve">
     <value>초대 링크가 있으면 프로필이 공개든 비공개든 연결할 수 있습니다.</value>
@@ -659,9 +662,6 @@
   </data>
   <data name="Approved" xml:space="preserve">
     <value>승인됨</value>
-  </data>
-  <data name="Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
-    <value>승인된 도구가 내 점수를 읽을 수 있게 됩니다. 대부분의 점수 분석 도구가 이 기능을 사용합니다. 별도의 설정이므로 이 페이지에서 바로 끌 수 있습니다.</value>
   </data>
   <data name="Approving a tool puts its name, description and link in front of every player. Everything else about it — webhooks, keys, who it can read — is the maker's business and is not reviewed here." xml:space="preserve">
     <value>도구를 승인하면 이름, 설명, 링크가 모든 플레이어에게 표시됩니다. 웹훅, 키, 읽을 수 있는 대상 등 나머지는 제작자의 영역이며 여기서 검토하지 않습니다.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -609,14 +609,17 @@
   <data name="Any" xml:space="preserve">
     <value>Todos</value>
   </data>
-  <data name="Any approved tool can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
-    <value>Qualquer ferramenta aprovada pode ler suas pontuações. Isso serve principalmente para ferramentas de análise. Desativar interrompe novos acessos, mas as ferramentas podem manter o que já coletaram.</value>
-  </data>
   <data name="Any level" xml:space="preserve">
     <value>Qualquer nível</value>
   </data>
   <data name="any moment now" xml:space="preserve">
     <value>a qualquer momento</value>
+  </data>
+  <data name="Any tool that publishes its source code can read your scores. Mostly this powers score-analysis tools. Turning it off stops new access — tools may keep what they already collected." xml:space="preserve">
+    <value>Qualquer ferramenta que publique seu código-fonte pode ler suas pontuações. Isso serve principalmente para ferramentas de análise. Desativar interrompe novos acessos, mas as ferramentas podem manter o que já coletaram.</value>
+  </data>
+  <data name="Any tool that publishes its source code will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
+    <value>Qualquer ferramenta que publique seu código-fonte poderá ler suas pontuações — é isso que move a maioria das ferramentas de análise. É um ajuste separado e você pode desativá-lo logo em seguida, nesta página.</value>
   </data>
   <data name="Anyone with an invite link can connect, whether their profile is public or private." xml:space="preserve">
     <value>Qualquer pessoa com um link de convite pode conectar, com perfil público ou privado.</value>
@@ -659,9 +662,6 @@
   </data>
   <data name="Approved" xml:space="preserve">
     <value>Aprovada</value>
-  </data>
-  <data name="Approved tools will be able to read your scores — that's what powers most score-analysis tools. It's a separate switch and you can turn it off right after, on this page." xml:space="preserve">
-    <value>Ferramentas aprovadas poderão ler suas pontuações — é isso que move a maioria das ferramentas de análise. É um ajuste separado e você pode desativá-lo logo em seguida, nesta página.</value>
   </data>
   <data name="Approving a tool puts its name, description and link in front of every player. Everything else about it — webhooks, keys, who it can read — is the maker's business and is not reviewed here." xml:space="preserve">
     <value>Aprovar uma ferramenta coloca o nome, a descrição e o link dela diante de todos os jogadores. Todo o resto — webhooks, chaves, quem ela pode ler — é assunto de quem a desenvolve e não é revisado aqui.</value>

--- a/docs/LOCALIZATION-en-ZW.md
+++ b/docs/LOCALIZATION-en-ZW.md
@@ -104,6 +104,7 @@ file on 2026-07-28. **Reuse these; do not re-coin them.**
 | Hour / Hours | grogl | Coined 2026-08-03 for the console's `· 24 grogl` stat labels. |
 | GameTag | Grglmrg | `Grgl` (account) + `Mrg` (name). |
 | Code / Source | Murgblub | Already carried "Source & contact" (`Murgblub opa golba`); the Code tab reuses it. |
+| Publishes | Grolub | Coined 2026-08-06 for the sharing copy, which names publishing source as the gate. Not `Murpro` — that is already "Shared". |
 | Insights / Activity | Murgblarg | The console tab and the "recent activity" strings share one word. |
 
 ### PIU domain

--- a/docs/design/api-v2-community-tools.md
+++ b/docs/design/api-v2-community-tools.md
@@ -342,8 +342,17 @@ Effective read access for tool T over player P:
 
 ```
    explicit ToolShare(T, P)
-OR (P.ShareWithAllTools AND T.AcceptsAllToolsShare AND NOT ToolBlock(T, P))
+OR (P.ShareWithAllTools AND T.AcceptsAllToolsShare AND NOT ToolBlock(T, P)
+    AND T.WebhookMode <> PiuGameSession        -- never by blanket consent
+    AND T.RepositoryUrl is published and checked
+    AND T.DiscordHandle is set
+    AND T.OwnerUserId is not banned)
 ```
+
+**`T.Visibility` is not a term and must not become one.** Listing is a directory concern; the
+conditions above are the access ones. The `Visibility = Public` check that once sat in
+`GetReadablePlayerIds` was never in this formula — it made every unlisted tool read its own maker
+and nobody else, which reads to a toolmaker as "the API is broken".
 
 **Public and all-tools are separate concepts and must stay separate.** They are coupled in exactly
 two places, both deliberate:
@@ -610,9 +619,15 @@ Three, in order of value per unit of build:
 ## 9. State machines
 
 **Listing.** `Private → PendingApproval → Public | Rejected`. A private tool is fully functional —
-invite links work, keys work, webhooks fire. Approval buys the directory listing and eligibility for
-the all-tools pool, nothing else. Editing name, link or description on a public tool returns it to
-`PendingApproval` while it stays listed. Rejection carries a required reason, sent to the maker.
+invite links work, keys work, webhooks fire, and it is eligible for the all-tools pool on exactly
+the same terms as a listed one. **Approval buys the directory listing, nothing else.** Editing name,
+link or description on a public tool returns it to `PendingApproval` while it stays listed.
+Rejection carries a required reason, sent to the maker.
+
+Listing is deliberately not an access gate. What protects a pooled player is the published source,
+the reachable maker, and the maker ban (§5) — a private tool is held to all three identically, and
+registration is self-serve either way, so gating the pool on approval would have bought the
+appearance of review rather than review.
 
 **Webhook mode.** `None ↔ PlayerPing ↔ ScorePush` freely. `→ PiuGameSession` only when the tool has
 zero connected players. `PiuGameSession →` anything is always allowed (a de-escalation).


### PR DESCRIPTION
A tool maker reported that `GET /api/v2/players` returned only themselves — never the players who
have "share with all tools" turned on.

## The bug

`GetReadablePlayerIds` required `Visibility = Public` before it would union the all-tools pool. An
unlisted tool fell back to its direct grants, and the only direct grant a new tool has is the
auto-grant its own maker receives at registration. So the endpoint whose whole job is "who consented
to you" answered with a one-row list containing the caller, no error, and nothing on the console
explaining why.

**That check was never part of the access rule.** §5's formula is `ShareWithAllTools AND
AcceptsAllToolsShare AND NOT blocked`, later joined by session mode, the source gate and the maker
ban. Visibility is not among them, and it had quietly become the strictest term in the expression.

## The fix

Both resolution paths drop the check — the per-tool query and the per-player one, which have to
agree or they disagree about who may read a player's scores.

What still gates the pool, and what a private tool is held to identically:

- the tool accepts the pool (`AcceptsAllToolsShare`)
- it is not in PIUGame session mode — that never arrives by blanket consent
- its source repository is published **and checked**, and its maker has a Discord handle
- its maker is not banned

Registration is self-serve either way, so gating the pool on approval bought the appearance of
review rather than review. The published-source gate is the one doing real work.

## Consent copy

The Account page told players "Any approved tool can read your scores", which was only true because
of the bug. It now names the gate that actually protects them: **"Any tool that publishes its source
code…"**. Nine locales, inserted in alphabetical position, no BOM, CRLF intact. Murloc needed a
coinage for "publishes" — `Grolub`, recorded in the glossary; deliberately not `Murpro`, which is
already "Shared".

The admin-facing copy needed no change and now reads as intended: *"Approving a tool puts its name,
description and link in front of every player. Everything else about it — webhooks, keys, who it can
read — is the maker's business and is not reviewed here."*

## Tests

| Suite | Result |
|---|---|
| `ScoreTracker.Tests` | 2290 ✓ |
| `ScoreTracker.Tests.Api` | 148 ✓ |
| `ScoreTracker.Tests.Components` | 645 ✓ |
| `ScoreTracker.Tests.Integration` | 246 ✓ |
| `ScoreTracker.Tests.E2E` | 74 ✓ |

`APrivateToolIsNotInThePoolEvenWhenItAcceptsIt` is replaced by two tests: one proving a sourced
private tool **is** pooled, one proving an unsourced private tool still is **not** — so the safety
gate stays ratcheted exactly where the visibility gate used to sit. Asserted against a real database,
because nothing routes through a handler to grant the pool; the predicate *is* the rule.

## Two calls worth a second opinion

1. **`Rejected` tools are pooled too.** I dropped the visibility check entirely rather than carving
   out rejections. Rejection reasons can be mundane, the enum already describes a rejected tool as
   "fully functional as a private tool", and the real lever against a bad actor is the maker ban,
   which already reads nobody at all. One line to change if you'd rather an explicit refusal also cut
   off the pool.
2. **Session-mode entry gets harder for private tools.** A sourced private tool now reports its
   pooled players in `CountConnectedPlayers`, so it can no longer flip straight into PIUGame session
   mode — the maker turns the all-tools switch off first. I read that as the rule working (those
   players agreed to something else), but it is a behaviour change to a previously unblocked flow.

## Unrelated flake seen in passing

`ByLevelBreakdownConfigPanelTests.SaveEmitsTheDefaultConfig` failed once in a full Components run,
then passed in isolation and passed on a full re-run. Order-dependent, untouched by this change.

## Docs

- `api-v2-community-tools.md` §5 — the access formula in full, with `T.Visibility` called out as not
  a term and not to become one
- `api-v2-community-tools.md` §9 — approval buys the directory listing, nothing else
- `LOCALIZATION-en-ZW.md` — the `Grolub` coinage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
