### PR TITLE
PUMBILITY: cut the projection's query cost, and move the evidence rule to the card border

### DIFF
--- a/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IScoreReader.cs
+++ b/ScoreTracker/ScoreTracker.Domain/SecondaryPorts/IScoreReader.cs
@@ -46,6 +46,19 @@ public interface IScoreReader
     Task<IEnumerable<UserPhoenixScore>> GetPlayerScores(MixEnum mix, IEnumerable<Guid> userIds,
         IEnumerable<Guid> chartIds, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    ///     Named best attempts for a set of players across a mix's level range and chart type.
+    ///     <para>
+    ///         The chart-id overload above takes the same shape as a list of GUIDs, which for a
+    ///         cohort read is several hundred of them — a parameter list SQL Server plans badly.
+    ///         A caller whose chart set IS a level band should ask for the band and narrow in
+    ///         memory: one indexed range scan instead of a second giant IN.
+    ///     </para>
+    /// </summary>
+    Task<IEnumerable<UserPhoenixScore>> GetPlayerScoresInLevelRange(MixEnum mix, IEnumerable<Guid> userIds,
+        ChartType chartType, DifficultyLevel minimumLevel, DifficultyLevel maximumLevel,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Named best attempts for a set of players on one chart in a mix.</summary>
     Task<IEnumerable<UserPhoenixScore>> GetPhoenixScores(MixEnum mix, IEnumerable<Guid> userIds, Guid chartId,
         CancellationToken cancellationToken = default);

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityPageSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityPageSaga.cs
@@ -26,6 +26,20 @@ namespace ScoreTracker.PlayerProgress.Application
         /// <summary>How many charts just outside the pool the curve ghosts in.</summary>
         private const int WaitingRoomSize = 6;
 
+        /// <summary>
+        ///     How deep the Phoenix 1 repricing is kept. The pool is the first fifty; the rest
+        ///     are suggestion candidates, and the depth only has to outrun the target cap after
+        ///     already-scored and unavailable charts are filtered out.
+        /// </summary>
+        private const int CandidateDepth = 200;
+
+        /// <summary>
+        ///     How long the suggestion list runs, per source and again after the merge (owner,
+        ///     2026-08-06). Nobody plans past the first hundred, and the tail is payload and
+        ///     scrolling for rows no one reads.
+        /// </summary>
+        private const int MaxTargets = 100;
+
         private readonly IMediator _mediator;
         private readonly IScoreReader _scores;
 
@@ -92,14 +106,24 @@ namespace ScoreTracker.PlayerProgress.Application
                              bar, projection, mine, cancellationToken))
                     targets[carried.ChartId] = carried;
 
+            // One ranked list of likely gains with two sources of evidence behind it, not two
+            // lists stapled together. The cut happens AFTER the merge so a chart both sources
+            // named cannot spend two of the hundred slots.
+            var top = targets.Values
+                .OrderByDescending(t => t.Gain)
+                .Take(MaxTargets)
+                .ToArray();
+
             return new PumbilityPageRecord(mix, request.Pool, pool.Sum(p => p.Value), bar, barChart,
-                pool, waiting, targets.Values.OrderByDescending(t => t.Gain).ToArray());
+                pool, waiting, top);
         }
 
         /// <summary>
-        ///     Phoenix 1 scores that would land in the requested Phoenix 2 pool, as targets.
-        ///     Excludes anything already scored here (done) and anything with no Phoenix 2
-        ///     appearance (unplayable — the carryover panel states those as a fact instead).
+        ///     Phoenix 1 scores worth playing here, as targets. The pool AND everything ranked
+        ///     behind it: capping at the fiftieth hid the rows with the best evidence there is,
+        ///     because against a thin Phoenix 2 pool a repriced #73 still clears the bar
+        ///     (owner, 2026-08-06). Excludes anything already scored here (done) and anything
+        ///     with no Phoenix 2 appearance (unplayable — the panel states those as a fact).
         /// </summary>
         private async Task<IReadOnlyList<PumbilityTarget>> CarryoverTargets(Guid userId, ChartType? poolScope,
             IReadOnlyDictionary<Guid, Chart> charts, int? bar, PumbilityProjection projection,
@@ -108,7 +132,7 @@ namespace ScoreTracker.PlayerProgress.Application
             var carryover = await Handle(new ProjectPhoenix2CarryoverQuery(userId, poolScope), cancellationToken);
             var floor = bar ?? 0;
 
-            return carryover.Entries
+            return carryover.Entries.Concat(carryover.Candidates)
                 .Where(e => e.Phoenix2Score == null && e.AvailableInPhoenix2 && charts.ContainsKey(e.ChartId))
                 .Select(e => new
                 {
@@ -127,6 +151,8 @@ namespace ScoreTracker.PlayerProgress.Application
                     // report about how many people were heard from.
                     null,
                     TargetSource.Phoenix1))
+                .OrderByDescending(t => t.Gain)
+                .Take(MaxTargets)
                 .ToArray();
         }
 
@@ -153,13 +179,17 @@ namespace ScoreTracker.PlayerProgress.Application
             // The repricing: every Phoenix 1 score run through Phoenix 2's formula, which pays
             // a Singles chart one level up the base curve and zeroes anything under level 10.
             // That rule alone can turn a doubles pool into a singles pool.
-            var repriced = phoenixScores
+            // Repriced to CandidateDepth, sliced at PoolSize. Every score was already being
+            // repriced before the Take, so reading past the fiftieth costs nothing: the pool
+            // figures below still come from the first fifty and mean exactly what they did.
+            var ranked = phoenixScores
                 .Select(s => (Score: s, Chart: phoenixCharts[s.ChartId],
                     Value: p2Scoring.GetScore(phoenixCharts[s.ChartId], s.Score!.Value,
                         s.Plate ?? PhoenixPlate.RoughGame, s.IsBroken)))
                 .OrderByDescending(x => x.Value)
-                .Take(PoolSize)
+                .Take(CandidateDepth)
                 .ToArray();
+            var repriced = ranked.Take(PoolSize).ToArray();
 
             var phoenix1Pool = phoenixScores
                 .Select(s => (Chart: phoenixCharts[s.ChartId],
@@ -169,12 +199,19 @@ namespace ScoreTracker.PlayerProgress.Application
                 .Take(PoolSize)
                 .ToArray();
 
-            var entries = repriced
-                .Select((x, i) => new CarryoverEntry(i + 1, x.Score.ChartId, x.Score.Score!.Value,
+            CarryoverEntry Entry((RecordedPhoenixScore Score, Chart Chart, double Value) x, int index)
+            {
+                return new CarryoverEntry(index + 1, x.Score.ChartId, x.Score.Score!.Value,
                     x.Score.Score!.Value.LetterGradeFor(MixEnum.Phoenix),
                     Math.Round(x.Value, 2),
                     phoenix2Scores.TryGetValue(x.Score.ChartId, out var here) ? here : null,
-                    phoenix2Charts.Contains(x.Score.ChartId)))
+                    phoenix2Charts.Contains(x.Score.ChartId));
+            }
+
+            var entries = repriced.Select(Entry).ToArray();
+            // Place keeps counting past the pool, so a candidate can say it was your #73.
+            var candidates = ranked.Skip(PoolSize)
+                .Select((x, i) => Entry(x, PoolSize + i))
                 .ToArray();
 
             return new Phoenix2CarryoverRecord(
@@ -187,7 +224,8 @@ namespace ScoreTracker.PlayerProgress.Application
                 repriced.Count(x => x.Chart.Type == ChartType.Double),
                 phoenix1Pool.Count(x => x.Chart.Type == ChartType.Single),
                 phoenix1Pool.Count(x => x.Chart.Type == ChartType.Double),
-                entries);
+                entries,
+                candidates);
         }
     }
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionCache.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionCache.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Caching.Memory;
+using ScoreTracker.PlayerProgress.Contracts;
+using ScoreTracker.SharedKernel.Enums;
+
+namespace ScoreTracker.PlayerProgress.Application
+{
+    /// <summary>
+    ///     Holds a player's Pumbility projection between visits.
+    ///     <para>
+    ///         The projection is the expensive read on the page by an order of magnitude — a
+    ///         cohort sweep plus a level-history read, both sized by the player population
+    ///         rather than by the viewer. Its inputs change only when somebody's scores do,
+    ///         so recomputing it per visit and per pool switch bought nothing.
+    ///     </para>
+    ///     <para>
+    ///         Eviction is by the viewer's own score changes (owner, 2026-08-06: an import
+    ///         busts it). Peers' scores moving does NOT evict — a projection that is a few
+    ///         hours behind on other people's play is indistinguishable from one that is not,
+    ///         and watching every player's imports would evict continuously and cache nothing.
+    ///         <see cref="Lifetime" /> is the backstop that bounds that drift.
+    ///     </para>
+    /// </summary>
+    internal sealed class PumbilityProjectionCache
+    {
+        /// <summary>Bounds how far behind peers' play a cached projection can drift.</summary>
+        public static readonly TimeSpan Lifetime = TimeSpan.FromHours(6);
+
+        private readonly IMemoryCache _cache;
+
+        public PumbilityProjectionCache(IMemoryCache cache)
+        {
+            _cache = cache;
+        }
+
+        public bool TryGet(Guid userId, MixEnum mix, ChartType? pool, out PumbilityProjection? projection)
+        {
+            return _cache.TryGetValue(Key(userId, mix, pool), out projection);
+        }
+
+        public void Set(Guid userId, MixEnum mix, ChartType? pool, PumbilityProjection projection)
+        {
+            _cache.Set(Key(userId, mix, pool), projection, Lifetime);
+        }
+
+        /// <summary>
+        ///     Drops every pool a player could be looking at. A null mix drops every mix — a
+        ///     score wipe does not say which one it took.
+        /// </summary>
+        public void Evict(Guid userId, MixEnum? mix)
+        {
+            var mixes = mix is { } one ? new[] { one } : Enum.GetValues<MixEnum>();
+            foreach (var m in mixes)
+            foreach (var pool in new ChartType?[] { null, ChartType.Single, ChartType.Double })
+                _cache.Remove(Key(userId, m, pool));
+        }
+
+        // Enumerated rather than prefix-scanned: IMemoryCache cannot evict by prefix, and the
+        // key space per player is small and fixed (mixes x the three pools).
+        private static string Key(Guid userId, MixEnum mix, ChartType? pool)
+        {
+            return $"pumbility:projection:{userId}:{mix}:{pool?.ToString() ?? "all"}";
+        }
+    }
+}

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionCacheConsumer.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionCacheConsumer.cs
@@ -1,0 +1,38 @@
+using MassTransit;
+using ScoreTracker.Domain.Events;
+
+namespace ScoreTracker.PlayerProgress.Application
+{
+    /// <summary>
+    ///     Drops a player's cached Pumbility projection when their own scores move.
+    ///     <para>
+    ///         Both directions matter: an import can add a chart worth suggesting, and a
+    ///         deletion can take one away — a projection that still recommends a chart the
+    ///         player just cleared reads as the page being broken rather than stale.
+    ///     </para>
+    /// </summary>
+    internal sealed class PumbilityProjectionCacheConsumer :
+        IConsumer<PlayerScoresUpdatedEvent>,
+        IConsumer<PlayerScoreDataDeletedEvent>
+    {
+        private readonly PumbilityProjectionCache _cache;
+
+        public PumbilityProjectionCacheConsumer(PumbilityProjectionCache cache)
+        {
+            _cache = cache;
+        }
+
+        public Task Consume(ConsumeContext<PlayerScoreDataDeletedEvent> context)
+        {
+            // A null mix is an every-mix wipe, which Evict already reads as "all of them".
+            _cache.Evict(context.Message.UserId, context.Message.Mix);
+            return Task.CompletedTask;
+        }
+
+        public Task Consume(ConsumeContext<PlayerScoresUpdatedEvent> context)
+        {
+            _cache.Evict(context.Message.UserId, context.Message.Mix);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
@@ -32,6 +32,9 @@ namespace ScoreTracker.PlayerProgress.Application
         /// </summary>
         private const double ScoringLevelWindow = 2.0;
 
+        /// <summary>How many suggestions per chart type survive to the page (owner, 2026-08-06).</summary>
+        private const int MaxTargetsPerType = 100;
+
         private readonly IPlayerHistoryRepository _history;
         private readonly IMediator _mediator;
         private readonly IScoreReader _scores;
@@ -68,7 +71,7 @@ namespace ScoreTracker.PlayerProgress.Application
                 ? new[] { only }
                 : new[] { ChartType.Single, ChartType.Double };
 
-            var scope = new ProjectionScope(mix, charts, scoringLevels, myStats);
+            var scope = new ProjectionScope(mix, charts, scoringLevels, myStats, scoring, pool.Baseline);
             var into = new ProjectionResults(expectedScore, evidence);
 
             foreach (var chartType in types)
@@ -99,12 +102,29 @@ namespace ScoreTracker.PlayerProgress.Application
                 projectedGains[kv.Key] = (int)gain;
             }
 
-            return new PumbilityProjection(expectedScore, projectedGains, chartDifficulty, evidence);
+            // Ranked advice, not an inventory. A full window clears the bar on well over a
+            // thousand charts, and nobody plans past the first hundred — the tail is payload,
+            // render and scrolling for suggestions no one reads.
+            //
+            // Per TYPE, not overall: capping the merged list would let a singles-heavy top
+            // hundred empty out the Doubles filter, which is the one place a doubles player
+            // looks.
+            var ranked = projectedGains
+                .GroupBy(kv => charts[kv.Key].Type)
+                .SelectMany(g => g.OrderByDescending(kv => kv.Value).Take(MaxTargetsPerType))
+                .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+            return new PumbilityProjection(
+                expectedScore.Where(kv => ranked.ContainsKey(kv.Key)).ToDictionary(kv => kv.Key, kv => kv.Value),
+                ranked,
+                chartDifficulty,
+                evidence.Where(kv => ranked.ContainsKey(kv.Key)).ToDictionary(kv => kv.Key, kv => kv.Value));
         }
 
         /// <summary>What a projection run reads: the same for every chart type in the run.</summary>
         private sealed record ProjectionScope(MixEnum Mix, IReadOnlyDictionary<Guid, Chart> Charts,
-            IDictionary<Guid, double> ScoringLevels, PlayerStatsRecord MyStats);
+            IDictionary<Guid, double> ScoringLevels, PlayerStatsRecord MyStats,
+            ScoringConfiguration Scoring, int Baseline);
 
         /// <summary>What it writes. Both types accumulate into one pair, which is why they are passed in.</summary>
         private sealed record ProjectionResults(IDictionary<Guid, PhoenixScore> ExpectedScore,
@@ -113,7 +133,7 @@ namespace ScoreTracker.PlayerProgress.Application
         private async Task ProjectType(ChartType chartType, Guid userId, ProjectionScope scope,
             ProjectionResults into, CancellationToken cancellationToken)
         {
-            var (mix, charts, scoringLevels, myStats) = scope;
+            var (mix, charts, scoringLevels, myStats, scoring, baseline) = scope;
 
             // The player is measured in the mix they are looking at: their pool, their bar and
             // their level all come from this mix and nowhere else. The reference mix is a
@@ -133,6 +153,11 @@ namespace ScoreTracker.PlayerProgress.Application
             var scoped = charts.Values
                 .Where(c => c.Type == chartType)
                 .Where(c => Math.Abs(ScoringLevelOf(c, scoringLevels) - myLevel) <= ScoringLevelWindow)
+                // A chart whose value at a PERFECT game still sits under the bar can never pay,
+                // so nothing downstream would keep it. Dropping it here costs nothing and is
+                // exact — but it is the difference between asking the database for every peer's
+                // scores on ~600 charts and asking for the couple hundred that could matter.
+                .Where(c => scoring.GetScore(c, PhoenixScore.Max, PhoenixPlate.PerfectGame, false) > baseline)
                 .Select(c => c.Id)
                 .ToArray();
             if (scoped.Length == 0) return;

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
@@ -35,21 +35,43 @@ namespace ScoreTracker.PlayerProgress.Application
         /// <summary>How many suggestions per chart type survive to the page (owner, 2026-08-06).</summary>
         private const int MaxTargetsPerType = 100;
 
+        /// <summary>
+        ///     Levels of slack when reading the reference mix, which rerated these charts — a
+        ///     chart sitting at 21 here may sit at 22 or 20 there.
+        /// </summary>
+        private const int ReferenceLevelSlack = 2;
+
+        private readonly PumbilityProjectionCache _cache;
         private readonly IPlayerHistoryRepository _history;
         private readonly IMediator _mediator;
         private readonly IScoreReader _scores;
         private readonly IPlayerStatsReader _stats;
 
         public PumbilityProjectionSaga(IMediator mediator, IPlayerStatsReader stats, IScoreReader scores,
-            IPlayerHistoryRepository history)
+            IPlayerHistoryRepository history, PumbilityProjectionCache cache)
         {
             _mediator = mediator;
             _stats = stats;
             _scores = scores;
             _history = history;
+            _cache = cache;
         }
 
         public async Task<PumbilityProjection> Handle(ProjectPumbilityGainsQuery request,
+            CancellationToken cancellationToken)
+        {
+            // Held between visits and dropped when this player's scores move
+            // (PumbilityProjectionCacheConsumer). Everything below is sized by the player
+            // population, not by the viewer, so a repeat visit should not pay for it again.
+            if (_cache.TryGet(request.UserId, request.Mix, request.ChartType, out var cached) && cached != null)
+                return cached;
+
+            var projection = await Project(request, cancellationToken);
+            _cache.Set(request.UserId, request.Mix, request.ChartType, projection);
+            return projection;
+        }
+
+        private async Task<PumbilityProjection> Project(ProjectPumbilityGainsQuery request,
             CancellationToken cancellationToken)
         {
             var mix = request.Mix;
@@ -170,22 +192,30 @@ namespace ScoreTracker.PlayerProgress.Application
             cohort.Remove(userId);
             if (cohort.Count == 0) return;
 
-            // Their level NOW, and their whole level history, so a score can be dated against
-            // the player they were when they set it. One read each for the cohort (§6.3).
-            // Both come from the reference mix, which is where the level series actually runs;
-            // a peer the reference mix has never seen falls back to this one.
-            var levelNow = (await _stats.GetStats(reference, cohort, cancellationToken))
+            var peerScores = await BestAcrossMixes(mix, reference, cohort, scoped, charts, chartType,
+                cancellationToken);
+
+            // Their level NOW, and their level history, so a score can be dated against the
+            // player they were when they set it. Both come from the reference mix, which is
+            // where the level series actually runs; a peer the reference mix has never seen
+            // falls back to this one.
+            //
+            // History is read for the peers who ACTUALLY turned up in the sweep, not for the
+            // whole cohort — a cohort is several hundred players and each carries a full
+            // timeline, so the ones who never played a chart in the window were pure freight.
+            var voices = peerScores.Select(s => s.UserId).Distinct().ToArray();
+            if (voices.Length == 0) return;
+
+            var levelNow = (await _stats.GetStats(reference, voices, cancellationToken))
                 .ToDictionary(s => s.UserId, s => CompetitiveLevelFor(s, chartType));
             if (reference != mix)
-                foreach (var stats in await _stats.GetStats(mix, cohort, cancellationToken))
+                foreach (var stats in await _stats.GetStats(mix, voices, cancellationToken))
                     if (!levelNow.ContainsKey(stats.UserId))
                         levelNow[stats.UserId] = CompetitiveLevelFor(stats, chartType);
 
-            var history = (await _history.GetHistory(reference, cohort, cancellationToken))
+            var history = (await _history.GetHistory(reference, voices, cancellationToken))
                 .GroupBy(h => h.UserId)
                 .ToDictionary(g => g.Key, g => g.OrderBy(h => h.Date).ToArray());
-
-            var peerScores = await BestAcrossMixes(mix, reference, cohort, scoped, cancellationToken);
 
             foreach (var group in peerScores.GroupBy(s => s.ChartId))
             {
@@ -228,13 +258,29 @@ namespace ScoreTracker.PlayerProgress.Application
         /// </summary>
         private async Task<IReadOnlyCollection<UserPhoenixScore>> BestAcrossMixes(MixEnum mix, MixEnum reference,
             IReadOnlyCollection<Guid> cohort, IReadOnlyCollection<Guid> chartIds,
-            CancellationToken cancellationToken)
+            IReadOnlyDictionary<Guid, Chart> charts, ChartType chartType, CancellationToken cancellationToken)
         {
-            var scores = (await _scores.GetPlayerScores(mix, cohort, chartIds, cancellationToken)).ToList();
+            var wanted = chartIds.ToHashSet();
+            // The scoped set IS a level band, so it is asked for as one: a range scan the
+            // index can serve, rather than several hundred chart GUIDs in an IN list. The
+            // exact set is applied in memory below, so the result is identical either way.
+            var levels = chartIds.Select(id => (int)charts[id].Level).ToArray();
+            var min = levels.Min();
+            var max = levels.Max();
+
+            var scores = (await _scores.GetPlayerScoresInLevelRange(mix, cohort, chartType, min, max,
+                cancellationToken)).ToList();
+
             if (reference != mix)
-                scores.AddRange(await _scores.GetPlayerScores(reference, cohort, chartIds, cancellationToken));
+                // Widened, because the reference mix rerated these charts and a chart's level
+                // there is not necessarily its level here. Over-fetching costs a few rows; the
+                // wanted-set filter below makes it exact.
+                scores.AddRange(await _scores.GetPlayerScoresInLevelRange(reference, cohort, chartType,
+                    Math.Max(1, min - ReferenceLevelSlack), Math.Min(DifficultyLevel.Max, max + ReferenceLevelSlack),
+                    cancellationToken));
 
             return scores
+                .Where(s => wanted.Contains(s.ChartId))
                 .GroupBy(s => (s.UserId, s.ChartId))
                 .Select(g => g.OrderByDescending(s => (int)s.Score).First())
                 .ToArray();

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityProjectionSaga.cs
@@ -32,8 +32,8 @@ namespace ScoreTracker.PlayerProgress.Application
         /// </summary>
         private const double ScoringLevelWindow = 2.0;
 
-        /// <summary>How many suggestions per chart type survive to the page (owner, 2026-08-06).</summary>
-        private const int MaxTargetsPerType = 100;
+        /// <summary>How many peer-estimated suggestions survive to the merge (owner, 2026-08-06).</summary>
+        private const int MaxTargets = 100;
 
         /// <summary>
         ///     Levels of slack when reading the reference mix, which rerated these charts — a
@@ -125,15 +125,14 @@ namespace ScoreTracker.PlayerProgress.Application
             }
 
             // Ranked advice, not an inventory. A full window clears the bar on well over a
-            // thousand charts, and nobody plans past the first hundred — the tail is payload,
-            // render and scrolling for suggestions no one reads.
+            // thousand charts, and nobody plans past the first hundred.
             //
-            // Per TYPE, not overall: capping the merged list would let a singles-heavy top
-            // hundred empty out the Doubles filter, which is the one place a doubles player
-            // looks.
+            // Flat, not per chart type: the request itself carries the type now (the page's
+            // pool selector scopes the whole query), so a per-type split would be counting
+            // groups that only ever have one member.
             var ranked = projectedGains
-                .GroupBy(kv => charts[kv.Key].Type)
-                .SelectMany(g => g.OrderByDescending(kv => kv.Value).Take(MaxTargetsPerType))
+                .OrderByDescending(kv => kv.Value)
+                .Take(MaxTargets)
                 .ToDictionary(kv => kv.Key, kv => kv.Value);
 
             return new PumbilityProjection(

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/Phoenix2CarryoverRecord.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/Phoenix2CarryoverRecord.cs
@@ -23,6 +23,13 @@ namespace ScoreTracker.PlayerProgress.Contracts;
 ///     Singles chart one level up, so a doubles pool can become a singles pool and the player's
 ///     whole grind priority inverts.
 /// </param>
+/// <param name="Entries">The repriced pool — the top fifty, which is what PUMBILITY means.</param>
+/// <param name="Candidates">
+///     Repriced scores ranked past the fiftieth. They are NOT the pool and never count toward
+///     its figures, but they are still scores the player has actually hit: against an empty
+///     Phoenix 2 pool a repriced #73 can beat the bar comfortably. Capping suggestions at the
+///     pool hid exactly the rows carrying the best evidence there is (owner, 2026-08-06).
+/// </param>
 [ExcludeFromCodeCoverage]
 public sealed record Phoenix2CarryoverRecord(
     double Projected,
@@ -34,7 +41,8 @@ public sealed record Phoenix2CarryoverRecord(
     int DoublesInPool,
     int Phoenix1SinglesInPool,
     int Phoenix1DoublesInPool,
-    IReadOnlyList<CarryoverEntry> Entries);
+    IReadOnlyList<CarryoverEntry> Entries,
+    IReadOnlyList<CarryoverEntry> Candidates);
 
 /// <summary>
 ///     One Phoenix 1 score repriced for Phoenix 2, with what it would be worth and whether the

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Wiring/PlayerProgressRegistrationExtensions.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Wiring/PlayerProgressRegistrationExtensions.cs
@@ -34,6 +34,9 @@ public static class PlayerProgressRegistrationExtensions
         services.AddTransient<IPlayerHighlightRepository, EFPlayerHighlightRepository>();
         services.AddTransient<IPlayerHighlightCapturer, PlayerHighlightCapturer>();
         services.AddTransient<CohortScoreProvider>();
+        // Singleton: the projection outlives the request that built it, which is the
+        // entire point, and its eviction consumer has to see the same instance.
+        services.AddSingleton<PumbilityProjectionCache>();
         services.AddSingleton<IDbModelContribution, PlayerProgressModelContribution>();
         return services;
     }
@@ -66,5 +69,9 @@ public static class PlayerProgressRegistrationExtensions
         // community-scoped (docs/design/rivals.md D32).
         configurator.AddConsumer<PlayerHighlightSaga>();
         configurator.AddConsumer<PlayerHighlightPurgeConsumer>();
+        // Drops a player's cached Pumbility projection when their own scores move.
+        // If this registration goes, the page serves a projection up to six hours
+        // stale after an import and looks like it ignored the scores.
+        configurator.AddConsumer<PumbilityProjectionCacheConsumer>();
     }
 }

--- a/ScoreTracker/ScoreTracker.ScoreLedger/Infrastructure/EFPhoenixRecordsRepository.cs
+++ b/ScoreTracker/ScoreTracker.ScoreLedger/Infrastructure/EFPhoenixRecordsRepository.cs
@@ -76,6 +76,14 @@ internal sealed class EFPhoenixRecordsRepository : IPhoenixRecordRepository,
         return GetPlayerScores(mix, userIds, chartIds, cancellationToken);
     }
 
+    Task<IEnumerable<UserPhoenixScore>> IScoreReader.GetPlayerScoresInLevelRange(MixEnum mix,
+        IEnumerable<Guid> userIds, ChartType chartType, DifficultyLevel minimumLevel,
+        DifficultyLevel maximumLevel, CancellationToken cancellationToken)
+    {
+        return GetPlayerScoresInLevelRange(mix, userIds, chartType, minimumLevel, maximumLevel,
+            cancellationToken);
+    }
+
     Task<IEnumerable<UserPhoenixScore>> IScoreReader.GetPhoenixScores(MixEnum mix, IEnumerable<Guid> userIds,
         Guid chartId,
         CancellationToken cancellationToken)
@@ -420,6 +428,32 @@ internal sealed class EFPhoenixRecordsRepository : IPhoenixRecordRepository,
                 select new UserPhoenixScore(pba.UserId, pba.ChartId, u.IsPublic ? u.Name : "Anonymous",
                     pba.Score!.Value,
                     PhoenixPlateHelperMethods.TryParse(pba.Plate), pba.IsBroken, u.IsPublic, pba.RecordedDate))
+            .ToArrayAsync(cancellationToken);
+    }
+
+    public async Task<IEnumerable<UserPhoenixScore>> GetPlayerScoresInLevelRange(MixEnum mix,
+        IEnumerable<Guid> userIds, ChartType chartType, DifficultyLevel minimumLevel,
+        DifficultyLevel maximumLevel, CancellationToken cancellationToken = default)
+    {
+        var userIdArray = userIds.Distinct().ToArray();
+        var mixId = MixIds.For(mix);
+        var min = (int)minimumLevel;
+        var max = (int)maximumLevel;
+        var chartTypeString = chartType.ToString();
+        await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+        // Same cohort-only contract as the other cohort reads: a broken row is a walkoff in
+        // the distribution and never enters.
+        return await (from cm in database.ChartMix
+                join c in database.Chart on cm.ChartId equals c.Id
+                join pba in database.Set<PhoenixRecordEntity>() on c.Id equals pba.ChartId
+                join u in database.User on pba.UserId equals u.Id
+                where cm.MixId == mixId && pba.MixId == mixId
+                      && cm.Level >= min && cm.Level <= max && c.Type == chartTypeString
+                      && pba.Score != null && !pba.IsBroken
+                      && userIdArray.Contains(pba.UserId)
+                select new UserPhoenixScore(pba.UserId, pba.ChartId, u.IsPublic ? u.Name : "Anonymous",
+                    pba.Score!.Value, PhoenixPlateHelperMethods.TryParse(pba.Plate), pba.IsBroken, u.IsPublic,
+                    pba.RecordedDate))
             .ToArrayAsync(cancellationToken);
     }
 

--- a/ScoreTracker/ScoreTracker.Tests.Components/PumbilityComponentTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/PumbilityComponentTests.cs
@@ -263,7 +263,7 @@ public sealed class PumbilityComponentTests : ComponentTestBase
     public void TheCarryoverNamesTheFlipOnlyWhenThePoolActuallyChangedHands()
     {
         var flipped = new Phoenix2CarryoverRecord(18041, 358, 15, 49, Array.Empty<Guid>(),
-            32, 18, 4, 46, Array.Empty<CarryoverEntry>());
+            32, 18, 4, 46, Array.Empty<CarryoverEntry>(), Array.Empty<CarryoverEntry>());
         var steady = flipped with { SinglesInPool = 4, DoublesInPool = 46 };
 
         var withFlip = RenderComponent<CarryoverPanel>(p => p
@@ -280,7 +280,7 @@ public sealed class PumbilityComponentTests : ComponentTestBase
     {
         var lost = NewChart(ChartType.Single, 22);
         var carry = new Phoenix2CarryoverRecord(18041, 358, 15, 49, new[] { lost.Id },
-            32, 18, 4, 46, Array.Empty<CarryoverEntry>());
+            32, 18, 4, 46, Array.Empty<CarryoverEntry>(), Array.Empty<CarryoverEntry>());
 
         var cut = RenderComponent<CarryoverPanel>(p => p
             .Add(x => x.Carryover, carry)

--- a/ScoreTracker/ScoreTracker.Tests.Components/PumbilityComponentTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/PumbilityComponentTests.cs
@@ -116,35 +116,67 @@ public sealed class PumbilityComponentTests : ComponentTestBase
     }
 
     [Fact]
-    public void TheGainBadgeSaysWhichOfTheThreeKindsOfRowThisIs()
+    public void TheCompactBorderSaysWhichOfTheThreeKindsOfRowThisIs()
     {
-        // The whole reason there is no "kind" column: the card already says it. A Compact
-        // card prints one number and nothing else, so that number's treatment carries it.
+        // A Compact card prints one number and no words, so the BORDER carries the kind — in
+        // the tier list's own language, reused rather than reinvented so the two pages cannot
+        // drift apart.
+        var cut = RenderComponent<TargetList>(p => p
+            .Add(x => x.Targets, ThreeKinds(out var charts)).Add(x => x.Charts, charts)
+            .Add(x => x.Density, UiDensity.Compact));
+
+        // Scoped to the grid: the legend wears the same classes on purpose, so a swatch is a
+        // second match for every kind the grid contains.
+        Assert.Single(cut.FindAll(".tier-card-grid .tier-chart-card-pass"));
+        Assert.Single(cut.FindAll(".tier-card-grid .tier-chart-card-other-mix"));
+        // The third kind is the absence of a border, so it is counted by what it is NOT.
+        Assert.Equal(3, cut.FindAll(".tier-card-grid .tier-chart-card").Count);
+    }
+
+    [Fact]
+    public void TheGainBadgeIsOneTreatmentAndOnlySaysHowMuch()
+    {
+        var cut = RenderComponent<TargetList>(p => p
+            .Add(x => x.Targets, ThreeKinds(out var charts)).Add(x => x.Charts, charts)
+            .Add(x => x.Density, UiDensity.Compact));
+
+        var badges = cut.FindAll(".tier-card-grid .tier-chart-card-corner");
+        Assert.Equal(3, badges.Count);
+        Assert.All(badges, b => Assert.Contains("pmb-corner-gain", b.ClassName));
+        Assert.Contains("+400", badges.Select(b => b.TextContent.Trim()).ToArray());
+    }
+
+    [Fact]
+    public void ComfortableNeverPaintsAStateBorder()
+    {
+        // Comfortable says the kind in words on every card's why-line, and the To-Do bookmark
+        // would otherwise paint a fourth ring competing with the three that mean something.
+        var targets = ThreeKinds(out var charts);
+        var cut = RenderComponent<TargetList>(p => p
+            .Add(x => x.Targets, targets).Add(x => x.Charts, charts)
+            .Add(x => x.Density, UiDensity.Comfortable)
+            .Add(x => x.ShowToDo, true)
+            .Add(x => x.ToDos, (ISet<Guid>)targets.Select(t => t.ChartId).ToHashSet()));
+
+        Assert.Empty(cut.FindAll(".tier-chart-card-pass"));
+        Assert.Empty(cut.FindAll(".tier-chart-card-other-mix"));
+        Assert.Empty(cut.FindAll(".tier-chart-card-todo"));
+    }
+
+    /// <summary>One of each kind: carried from another mix, an upscore, and never played.</summary>
+    private static PumbilityTarget[] ThreeKinds(out Dictionary<Guid, Chart> charts)
+    {
         var carried = NewChart(ChartType.Single, 22);
         var upscore = NewChart(ChartType.Single, 22);
         var unplayed = NewChart(ChartType.Single, 22);
-        var targets = new[]
+        charts = new Dictionary<Guid, Chart>
+            { [carried.Id] = carried, [upscore.Id] = upscore, [unplayed.Id] = unplayed };
+        return new[]
         {
             new PumbilityTarget(carried.Id, 985_000, 400, null, false, null, null, TargetSource.Phoenix1),
             new PumbilityTarget(upscore.Id, 980_000, 200, 930_000, false, null, null),
             new PumbilityTarget(unplayed.Id, 970_000, 300, null, false, null, null)
         };
-        var charts = new Dictionary<Guid, Chart>
-            { [carried.Id] = carried, [upscore.Id] = upscore, [unplayed.Id] = unplayed };
-
-        foreach (var density in new[] { UiDensity.Comfortable, UiDensity.Compact })
-        {
-            var cut = RenderComponent<TargetList>(p => p
-                .Add(x => x.Targets, targets).Add(x => x.Charts, charts)
-                .Add(x => x.Density, density));
-
-            // Scoped to the grid: Compact's legend wears the same classes on purpose, so a
-            // swatch is a second match for every kind the grid contains.
-            Assert.Single(cut.FindAll(".tier-card-grid .pmb-corner-carry"));
-            Assert.Single(cut.FindAll(".tier-card-grid .pmb-corner-up"));
-            Assert.Single(cut.FindAll(".tier-card-grid .pmb-corner-new"));
-            Assert.Contains("400", cut.Find(".tier-card-grid .pmb-corner-carry").TextContent);
-        }
     }
 
     [Fact]
@@ -321,83 +353,25 @@ public sealed class PumbilityComponentTests : ComponentTestBase
     }
 
     [Fact]
-    public void TheTypeFilterNarrowsCarriedPhoenix1RowsToo()
+    public void AShorterListCannotStrandTheReaderOnAPageThatIsGone()
     {
-        // The point of the parenthetical in the owner's ask: a carried row is a suggestion in
-        // the same list, so an unfiltered block among filtered ones would read as a bug.
-        var single = NewChart(ChartType.Single, 21);
-        var doubleCarried = NewChart(ChartType.Double, 21);
-        var targets = new[]
-        {
-            new PumbilityTarget(single.Id, 970_000, 300, null, false, null, null),
-            new PumbilityTarget(doubleCarried.Id, 985_000, 400, null, false, null, null, TargetSource.Phoenix1)
-        };
-        var charts = new Dictionary<Guid, Chart> { [single.Id] = single, [doubleCarried.Id] = doubleCarried };
-
+        // Page 3 exists at 70 targets. Switching pool re-runs the query and can come back with
+        // far fewer, and a stale page number renders an empty slice off the end rather than an
+        // empty state.
+        var many = Page(poolSize: 50, targets: 70);
         var cut = RenderComponent<TargetList>(p => p
-            .Add(x => x.Targets, targets).Add(x => x.Charts, charts)
-            .Add(x => x.Density, UiDensity.Comfortable)
-            .Add(x => x.TypeFilter, ChartType.Single));
-
-        Assert.Single(cut.FindAll(".tier-chart-card"));
-        Assert.Empty(cut.FindAll(".pmb-corner-carry"));
-    }
-
-    [Fact]
-    public void TheLevelCeilingDropsAnythingAboveIt()
-    {
-        var low = NewChart(ChartType.Single, 19);
-        var high = NewChart(ChartType.Single, 23);
-        var targets = new[]
-        {
-            new PumbilityTarget(high.Id, 970_000, 400, null, false, null, null),
-            new PumbilityTarget(low.Id, 960_000, 300, null, false, null, null)
-        };
-        var charts = new Dictionary<Guid, Chart> { [low.Id] = low, [high.Id] = high };
-
-        var cut = RenderComponent<TargetList>(p => p
-            .Add(x => x.Targets, targets).Add(x => x.Charts, charts)
-            .Add(x => x.Density, UiDensity.Comfortable)
-            .Add(x => x.MaxLevel, 20));
-
-        Assert.Single(cut.FindAll(".tier-chart-card"));
-        Assert.Contains("+300", cut.Find(".tier-chart-card .pmb-corner-new").TextContent);
-    }
-
-    [Fact]
-    public void FilteringToNothingSaysSoRatherThanShowingTheEmptyStateForNoTargets()
-    {
-        // Two different nothings: "you have no suggestions" is a state of your account,
-        // "nothing matched" is a state of the controls, and only one of them is your fault.
-        var chart = NewChart(ChartType.Single, 23);
-        var targets = new[] { new PumbilityTarget(chart.Id, 970_000, 300, null, false, null, null) };
-
-        var cut = RenderComponent<TargetList>(p => p
-            .Add(x => x.Targets, targets)
-            .Add(x => x.Charts, new Dictionary<Guid, Chart> { [chart.Id] = chart })
-            .Add(x => x.Density, UiDensity.Comfortable)
-            .Add(x => x.MaxLevel, 20));
-
-        Assert.Contains("No suggestions match", cut.Find(".pmb-empty").TextContent);
-    }
-
-    [Fact]
-    public void ANarrowedFilterCannotStrandTheReaderOnAPageThatIsGone()
-    {
-        var page = Page(poolSize: 50, targets: 70);
-        var charts = page.Charts();
-
-        var cut = RenderComponent<TargetList>(p => p
-            .Add(x => x.Targets, page.Targets).Add(x => x.Charts, charts)
+            .Add(x => x.Targets, many.Targets).Add(x => x.Charts, many.Charts())
             .Add(x => x.Density, UiDensity.Comfortable));
+        // Driven through the pager's callback, not a DOM click: MudPagination's items carry
+        // no onclick bUnit can dispatch.
+        var pager = cut.FindComponent<MudBlazor.MudPagination>();
+        cut.InvokeAsync(() => pager.Instance.SelectedChanged.InvokeAsync(3)).Wait();
 
-        // Page 3 exists at 70 targets; filtering down to a handful must not leave the list
-        // rendering an empty slice off the end of the new, shorter result.
-        cut.SetParametersAndRender(p => p.Add(x => x.MaxLevel, 1));
-        Assert.Contains("No suggestions match", cut.Find(".pmb-empty").TextContent);
+        var few = Page(poolSize: 50, targets: 3);
+        cut.SetParametersAndRender(p => p
+            .Add(x => x.Targets, few.Targets).Add(x => x.Charts, few.Charts()));
 
-        cut.SetParametersAndRender(p => p.Add(x => x.MaxLevel, (int?)null));
-        Assert.NotEmpty(cut.FindAll(".tier-chart-card"));
+        Assert.Equal(3, cut.FindAll(".tier-chart-card").Count);
     }
 
     private static Chart NewChart(ChartType type, int level) =>

--- a/ScoreTracker/ScoreTracker.Tests.Integration/PhoenixRecordsRepositoryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/PhoenixRecordsRepositoryTests.cs
@@ -43,6 +43,53 @@ public sealed class PhoenixRecordsRepositoryTests : IAsyncLifetime
             Mock.Of<IMediator>(), Mock.Of<IPlayerStatsReader>());
 
     [Fact]
+    public async Task GetPlayerScoresInLevelRangeReadsTheBandAndNothingOutsideIt()
+    {
+        // The read that replaced a several-hundred-GUID IN list on the Pumbility cohort
+        // sweep. Its whole value is that the level band is a range the index can serve, so
+        // the band's edges and the type filter are what has to hold against real SQL.
+        var userId = await _seed.SeedUserAsync();
+        var stranger = await _seed.SeedUserAsync();
+        var below = await _seed.SeedPhoenixChartAsync(18);
+        var low = await _seed.SeedPhoenixChartAsync(19);
+        var high = await _seed.SeedPhoenixChartAsync(21);
+        var above = await _seed.SeedPhoenixChartAsync(22);
+        var doubles = await _seed.SeedPhoenixChartAsync(20, "Double");
+
+        var writer = BuildRepository();
+        foreach (var chartId in new[] { below, low, high, above, doubles })
+            await writer.UpdateBestAttempt(MixEnum.Phoenix, userId, new RecordedPhoenixScore(chartId,
+                PhoenixScore.From(950000), PhoenixPlate.SuperbGame, IsBroken: false, RecordedAt));
+        await writer.UpdateBestAttempt(MixEnum.Phoenix, stranger, new RecordedPhoenixScore(low,
+            PhoenixScore.From(910000), PhoenixPlate.SuperbGame, IsBroken: false, RecordedAt));
+
+        var read = (await BuildRepository().GetPlayerScoresInLevelRange(MixEnum.Phoenix, new[] { userId },
+            ChartType.Single, 19, 21)).ToArray();
+
+        // Inclusive at both ends, exclusive of 18 and 22, and never the doubles chart sitting
+        // inside the band — a type mismatch is the failure that would look like a level bug.
+        Assert.Equal(new[] { low, high }.OrderBy(g => g), read.Select(r => r.ChartId).OrderBy(g => g));
+        Assert.All(read, r => Assert.Equal(userId, r.UserId));
+    }
+
+    [Fact]
+    public async Task GetPlayerScoresInLevelRangeLeavesOutBrokenRuns()
+    {
+        // Cohort-only contract, same as every other cohort read: a broken row is a walkoff in
+        // the distribution and would drag the quantile the projection is built on.
+        var userId = await _seed.SeedUserAsync();
+        var chartId = await _seed.SeedPhoenixChartAsync(20);
+
+        await BuildRepository().UpdateBestAttempt(MixEnum.Phoenix, userId, new RecordedPhoenixScore(chartId,
+            PhoenixScore.From(880000), PhoenixPlate.SuperbGame, IsBroken: true, RecordedAt));
+
+        var read = await BuildRepository().GetPlayerScoresInLevelRange(MixEnum.Phoenix, new[] { userId },
+            ChartType.Single, 19, 21);
+
+        Assert.Empty(read);
+    }
+
+    [Fact]
     public async Task UpdateBestAttemptInsertsANewRecordReadableViaGetRecordedScore()
     {
         var userId = await _seed.SeedUserAsync();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityPageSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityPageSagaTests.cs
@@ -131,6 +131,67 @@ public sealed class PumbilityPageSagaTests
     }
 
     [Fact]
+    public async Task CarryoverSuggestionsReachPastTheFiftiethScore()
+    {
+        // The gap this closes: capping suggestions at the pool hid rows carrying the best
+        // evidence there is. Against an empty Phoenix 2 pool the bar is zero, so a repriced
+        // #73 clears it as surely as a #3 does — and it is still a score actually hit.
+        var ctx = new PageContext().WithPhoenixScores(ChartType.Single, 22, 120, 985_000);
+
+        var page = await ctx.Saga.Handle(new GetPumbilityPageQuery(ctx.UserId, MixEnum.Phoenix2),
+            CancellationToken.None);
+
+        Assert.True(page.Targets.Count > 50,
+            $"only {page.Targets.Count} suggestions — the pool cap is still in the way");
+        Assert.All(page.Targets, t => Assert.Equal(TargetSource.Phoenix1, t.Source));
+    }
+
+    [Fact]
+    public async Task ThePoolFiguresStillMeanTheTopFiftyAfterReadingDeeper()
+    {
+        // Reading past the fiftieth is for suggestions only. PUMBILITY IS the top fifty, so
+        // the panel's projected total and bar must not move when the candidate list grows.
+        var ctx = new PageContext().WithPhoenixScores(ChartType.Single, 22, 120, 985_000);
+
+        var carry = await ctx.Saga.Handle(new ProjectPhoenix2CarryoverQuery(ctx.UserId),
+            CancellationToken.None);
+
+        Assert.Equal(50, carry.Entries.Count);
+        Assert.Equal(50, carry.SinglesInPool + carry.DoublesInPool);
+        Assert.NotEmpty(carry.Candidates);
+        // Candidates rank behind the pool and say so.
+        Assert.All(carry.Candidates, c => Assert.True(c.Place > 50));
+    }
+
+    [Fact]
+    public async Task TheListIsOneRankedHundredAcrossBothSources()
+    {
+        var ctx = new PageContext().WithPhoenixScores(ChartType.Single, 22, 160, 985_000);
+
+        var page = await ctx.Saga.Handle(new GetPumbilityPageQuery(ctx.UserId, MixEnum.Phoenix2),
+            CancellationToken.None);
+
+        Assert.Equal(100, page.Targets.Count);
+        Assert.True(page.Targets.Select(t => t.Gain).SequenceEqual(
+            page.Targets.Select(t => t.Gain).OrderByDescending(g => g)));
+    }
+
+    [Fact]
+    public async Task AChartBothSourcesNameSpendsOneSlotNotTwo()
+    {
+        // The merge dedups by chart before the cut. A duplicate would eat one of the hundred
+        // and push a real suggestion off the end.
+        var ctx = new PageContext().WithPhoenixScores(ChartType.Single, 22, 55, 985_000);
+        var contested = ctx.FirstPhoenixChart();
+        ctx.WithPeerProjection(contested, projected: 910_000, gain: 999);
+
+        var page = await ctx.Saga.Handle(new GetPumbilityPageQuery(ctx.UserId, MixEnum.Phoenix2),
+            CancellationToken.None);
+
+        Assert.Single(page.Targets, t => t.ChartId == contested);
+    }
+
+    [Fact]
     public async Task OnPhoenix1NothingClaimsToBeCarriedOver()
     {
         var ctx = new PageContext().WithPool(55, ChartType.Single, 20);

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using Microsoft.Extensions.Caching.Memory;
 using Moq;
 using ScoreTracker.Catalog.Contracts.Queries;
 using ScoreTracker.ChartIntelligence.Contracts.Queries;
@@ -210,6 +211,73 @@ public sealed class PumbilityProjectionSagaTests
     }
 
     [Fact]
+    public async Task ARepeatVisitDoesNotSweepTheCohortAgain()
+    {
+        // The cohort sweep and the history read are sized by the player population, not by
+        // the viewer, so a second visit must not pay for them twice.
+        var ctx = new ProjectionContext().WithChart(out var chart, ChartType.Single, 20);
+        ctx.WithPeerScores(chart, 950_000, 955_000, 960_000, 965_000);
+
+        await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+        await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+
+        // Once, not twice: the fixture holds singles only, so the doubles pass finds nothing
+        // in scope and returns before it reads anything. The point is the SECOND visit adds
+        // nothing at all.
+        ctx.Scores.Verify(s => s.GetPlayerScoresInLevelRange(It.IsAny<MixEnum>(), It.IsAny<IEnumerable<Guid>>(),
+            It.IsAny<ChartType>(), It.IsAny<DifficultyLevel>(), It.IsAny<DifficultyLevel>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        ctx.History.Verify(h => h.GetHistory(It.IsAny<MixEnum>(), It.IsAny<IEnumerable<Guid>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AnImportDropsTheCachedProjection()
+    {
+        // Serving a projection that predates your own import reads as the page ignoring the
+        // scores you just uploaded, which is worse than being slow.
+        var ctx = new ProjectionContext().WithChart(out var chart, ChartType.Single, 20);
+        ctx.WithPeerScores(chart, 950_000, 955_000, 960_000, 965_000);
+        await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+
+        ctx.Cache.Evict(ctx.UserId, MixEnum.Phoenix);
+        await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+
+        // Twice over: the eviction sent the second visit back to the database, which is the
+        // whole contract — an import must not be able to serve you a projection older than it.
+        ctx.Scores.Verify(s => s.GetPlayerScoresInLevelRange(It.IsAny<MixEnum>(), It.IsAny<IEnumerable<Guid>>(),
+            It.IsAny<ChartType>(), It.IsAny<DifficultyLevel>(), It.IsAny<DifficultyLevel>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task AWipeWithNoNamedMixDropsEveryMix()
+    {
+        // PlayerScoreDataDeletedEvent carries a null mix for an all-mixes wipe, and a
+        // projection surviving that would keep recommending scores that no longer exist.
+        var ctx = new ProjectionContext().WithChart(out var chart, ChartType.Single, 20);
+        ctx.WithPeerScores(chart, 950_000, 955_000, 960_000, 965_000);
+        await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+
+        ctx.Cache.Evict(ctx.UserId, null);
+
+        Assert.False(ctx.Cache.TryGet(ctx.UserId, MixEnum.Phoenix, null, out _));
+        Assert.False(ctx.Cache.TryGet(ctx.UserId, MixEnum.Phoenix2, null, out _));
+    }
+
+    [Fact]
+    public async Task OnePlayersImportLeavesAnotherPlayersProjectionAlone()
+    {
+        var ctx = new ProjectionContext().WithChart(out var chart, ChartType.Single, 20);
+        ctx.WithPeerScores(chart, 950_000, 955_000, 960_000, 965_000);
+        await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+
+        ctx.Cache.Evict(Guid.NewGuid(), MixEnum.Phoenix);
+
+        Assert.True(ctx.Cache.TryGet(ctx.UserId, MixEnum.Phoenix, null, out _));
+    }
+
+    [Fact]
     public async Task APlayerWithNoCompetitiveLevelGetsNothingRatherThanNonsense()
     {
         var ctx = new ProjectionContext(1, 1).WithChart(out var chart, ChartType.Single, 20);
@@ -322,6 +390,26 @@ public sealed class PumbilityProjectionSagaTests
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => _peerHistory.ToArray().AsEnumerable());
 
+            // The level-band read the saga actually uses: a range scan rather than several
+            // hundred chart GUIDs in an IN list.
+            Scores.Setup(s => s.GetPlayerScoresInLevelRange(It.IsAny<MixEnum>(), It.IsAny<IEnumerable<Guid>>(),
+                    It.IsAny<ChartType>(), It.IsAny<DifficultyLevel>(), It.IsAny<DifficultyLevel>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((MixEnum mix, IEnumerable<Guid> userIds, ChartType type, DifficultyLevel min,
+                    DifficultyLevel max, CancellationToken _) =>
+                {
+                    var asked = userIds.ToHashSet();
+                    return _peerScores
+                        .Where(p => p.Mix == mix && asked.Contains(p.Score.UserId))
+                        .Where(p =>
+                        {
+                            var chart = _charts.FirstOrDefault(c => c.Id == p.Score.ChartId);
+                            return chart != null && chart.Type == type
+                                                 && (int)chart.Level >= (int)min && (int)chart.Level <= (int)max;
+                        })
+                        .Select(p => p.Score).ToArray().AsEnumerable();
+                });
+
             Scores.Setup(s => s.GetPlayerScores(It.IsAny<MixEnum>(), It.IsAny<IEnumerable<Guid>>(),
                     It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((MixEnum mix, IEnumerable<Guid> userIds, IEnumerable<Guid> chartIds,
@@ -348,7 +436,10 @@ public sealed class PumbilityProjectionSagaTests
             Mediator.Setup(m => m.Send(It.IsAny<GetTierListQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => Array.Empty<SongTierListEntry>().AsEnumerable());
 
-            Saga = new PumbilityProjectionSaga(Mediator.Object, Stats.Object, Scores.Object, History.Object);
+            // A cache per context, so one test's projection can never answer another's.
+            Cache = new PumbilityProjectionCache(new MemoryCache(new MemoryCacheOptions()));
+            Saga = new PumbilityProjectionSaga(Mediator.Object, Stats.Object, Scores.Object,
+                History.Object, Cache);
         }
 
         public Guid UserId { get; } = Guid.NewGuid();
@@ -357,6 +448,8 @@ public sealed class PumbilityProjectionSagaTests
         public Mock<IScoreReader> Scores { get; } = new();
         public Mock<IPlayerHistoryRepository> History { get; } = new();
         public PumbilityProjectionSaga Saga { get; }
+
+        public PumbilityProjectionCache Cache { get; }
 
         public ProjectionContext WithChart(out Chart chart, ChartType type, int level, double? scoringLevel = null)
         {

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
@@ -170,15 +170,43 @@ public sealed class PumbilityProjectionSagaTests
     [Fact]
     public async Task AChartThatCannotClearTheBarIsNotOffered()
     {
-        // A weak 15 against a pool of 22s: the projection exists, the gain does not.
+        // A weak 15 against a pool of 22s. Its value at a PERFECT game is still under the bar,
+        // so it is dropped before anyone's scores are read — not estimated and then discarded.
+        // That is the cheap half of the projection: the database is never asked about it.
         var ctx = new ProjectionContext(17).WithChart(out var weak, ChartType.Single, 15);
         ctx.WithPeerScores(weak, 910_000, 915_000, 920_000, 925_000);
         ctx.WithFullPoolAt(990_000, ChartType.Single, 22);
 
         var result = await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
 
-        Assert.Contains(weak.Id, result.ExpectedScores.Keys);
         Assert.DoesNotContain(weak.Id, result.ProjectedGains.Keys);
+        Assert.DoesNotContain(weak.Id, result.ExpectedScores.Keys);
+    }
+
+    [Fact]
+    public async Task TheAdviceStopsAtAHundredPerTypeAndKeepsTheBestOnes()
+    {
+        // A full window clears the bar on well over a thousand charts. Nobody plans past the
+        // first hundred, so the tail is payload and scrolling for suggestions no one reads.
+        var ctx = new ProjectionContext();
+        for (var i = 0; i < 130; i++)
+        {
+            ctx.WithChart(out var single, ChartType.Single, 20);
+            ctx.WithPeerScores(single, 900_000 + i * 500, 905_000 + i * 500, 910_000 + i * 500);
+            ctx.WithChart(out var doubles, ChartType.Double, 20);
+            ctx.WithPeerScores(doubles, 900_000 + i * 500, 905_000 + i * 500, 910_000 + i * 500);
+        }
+
+        var result = await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+
+        // Per type, so a singles-heavy top hundred cannot empty out the Doubles filter.
+        var perType = result.ProjectedGains.Keys.GroupBy(id => ctx.TypeOf(id)).ToArray();
+        Assert.All(perType, g => Assert.Equal(100, g.Count()));
+
+        // And it keeps the top of the ranking, not an arbitrary hundred.
+        var kept = result.ProjectedGains.Values.OrderByDescending(v => v).ToArray();
+        Assert.Equal(kept, result.ProjectedGains.Values.OrderByDescending(v => v).Take(kept.Length));
+        Assert.True(kept.Min() > 0);
     }
 
     [Fact]
@@ -385,6 +413,8 @@ public sealed class PumbilityProjectionSagaTests
             _myMissingMixes.Add(mix);
             return this;
         }
+
+        public ChartType TypeOf(Guid chartId) => _charts.First(c => c.Id == chartId).Type;
 
         private bool KnownIn(Guid peer, MixEnum mix)
         {

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityProjectionSagaTests.cs
@@ -185,29 +185,30 @@ public sealed class PumbilityProjectionSagaTests
     }
 
     [Fact]
-    public async Task TheAdviceStopsAtAHundredPerTypeAndKeepsTheBestOnes()
+    public async Task TheAdviceStopsAtAHundredAndKeepsTheBestOnes()
     {
         // A full window clears the bar on well over a thousand charts. Nobody plans past the
         // first hundred, so the tail is payload and scrolling for suggestions no one reads.
+        // Flat rather than per type: the query itself is type-scoped by the pool selector.
         var ctx = new ProjectionContext();
+        var offered = new List<int>();
         for (var i = 0; i < 130; i++)
         {
             ctx.WithChart(out var single, ChartType.Single, 20);
             ctx.WithPeerScores(single, 900_000 + i * 500, 905_000 + i * 500, 910_000 + i * 500);
-            ctx.WithChart(out var doubles, ChartType.Double, 20);
-            ctx.WithPeerScores(doubles, 900_000 + i * 500, 905_000 + i * 500, 910_000 + i * 500);
+            offered.Add(910_000 + i * 500);
         }
 
-        var result = await ctx.Saga.Handle(new ProjectPumbilityGainsQuery(ctx.UserId), CancellationToken.None);
+        var result = await ctx.Saga.Handle(
+            new ProjectPumbilityGainsQuery(ctx.UserId, MixEnum.Phoenix, ChartType.Single),
+            CancellationToken.None);
 
-        // Per type, so a singles-heavy top hundred cannot empty out the Doubles filter.
-        var perType = result.ProjectedGains.Keys.GroupBy(id => ctx.TypeOf(id)).ToArray();
-        Assert.All(perType, g => Assert.Equal(100, g.Count()));
-
-        // And it keeps the top of the ranking, not an arbitrary hundred.
-        var kept = result.ProjectedGains.Values.OrderByDescending(v => v).ToArray();
-        Assert.Equal(kept, result.ProjectedGains.Values.OrderByDescending(v => v).Take(kept.Length));
-        Assert.True(kept.Min() > 0);
+        Assert.Equal(100, result.ProjectedGains.Count);
+        // The best hundred, not an arbitrary hundred: the weakest survivor still out-gains
+        // everything that was dropped.
+        Assert.True(result.ProjectedGains.Values.Min() > 0);
+        Assert.Equal(100, result.ExpectedScores.Count);
+        Assert.Equal(100, result.Evidence.Count);
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker/Components/Pumbility/CornerLegend.razor
+++ b/ScoreTracker/ScoreTracker/Components/Pumbility/CornerLegend.razor
@@ -1,30 +1,33 @@
 @using ScoreTracker.PlayerProgress.Contracts
 @namespace ScoreTracker.Web.Components
 
-@* Compact prints one number per card and nothing else, so the treatment of that number is
-   the only thing separating "you already scored this" from "we think you would". A colour
-   carrying meaning has to be printed somewhere (UX rule 8) and Compact has no room, so the
-   legend carries it for the whole grid.
+@* Compact prints one number per card and no words at all, so the card's BORDER is what
+   separates "you already scored this" from "we think you would". A colour carrying meaning
+   has to be printed somewhere (UX rule 8) and a 72px sticker has no room, so the legend
+   carries it for the whole grid.
 
-   Each item only appears when the grid actually contains that kind — a legend row for a
-   state no card is in reads as a state you failed to find. *@
+   The border language is the tier list's, reused rather than reinvented — same classes, so
+   the two pages cannot drift apart.
+
+   Each item only appears when the grid actually contains that kind: a swatch for a state no
+   card is in reads as a state you failed to find. *@
 <div class="border-legend pmb-legend">
-    @if (HasCarry)
-    {
-        <span class="border-legend-item">
-            <span class="pmb-legend-swatch pmb-corner-carry">+000</span>@L["Carried from Phoenix 1"]
-        </span>
-    }
     @if (HasUp)
     {
         <span class="border-legend-item">
-            <span class="pmb-legend-swatch pmb-corner-up">+000</span>@L["Upscore"]
+            <span class="border-legend-swatch tier-chart-card-pass"></span>@L["Upscore"]
+        </span>
+    }
+    @if (HasCarry)
+    {
+        <span class="border-legend-item">
+            <span class="border-legend-swatch tier-chart-card-other-mix"></span>@L["Carried from Phoenix 1"]
         </span>
     }
     @if (HasNew)
     {
         <span class="border-legend-item">
-            <span class="pmb-legend-swatch pmb-corner-new">+000</span>@L["Not yet played"]
+            <span class="border-legend-swatch"></span>@L["Not yet played"]
         </span>
     }
 </div>

--- a/ScoreTracker/ScoreTracker/Components/Pumbility/TargetList.razor
+++ b/ScoreTracker/ScoreTracker/Components/Pumbility/TargetList.razor
@@ -24,10 +24,6 @@
 {
     <p class="pmb-empty">@L["Nothing here clears your bar yet — play a few more charts and check back."]</p>
 }
-else if (Shown.Count == 0)
-{
-    <p class="pmb-empty">@L["No suggestions match those filters."]</p>
-}
 else if (Density == UiDensity.Table)
 {
     <div class="tier-table-wrap">
@@ -80,16 +76,21 @@ else if (Density == UiDensity.Compact)
        printed value. The value here is the gain, since that is what the list is ranked
        by — nothing else on a 72px card would earn its space.
 
-       The legend reads the whole filtered set, not the page: paging to a slice that
-       happens to hold no carryover row should not retire the word for it mid-browse. *@
-    <CornerLegend Targets="Filtered"></CornerLegend>
+       The BORDER says which kind of row it is, in the tier list's own language: solid you
+       hold a score here, dashed you hold it in another mix, bare nobody has seen you play
+       it. The number stays one treatment throughout and means only "how much".
+
+       The legend reads the whole list, not the page: paging to a slice that happens to hold
+       no carryover row should not retire the word for it mid-browse. *@
+    <CornerLegend Targets="Targets"></CornerLegend>
     <div class="tier-card-grid tier-card-grid-compact">
         @foreach (var target in Shown)
         {
             var chart = Charts[target.ChartId];
             <TierListChartCard Chart="chart" Density="UiDensity.Compact"
-                               CornerBadge="@($"+{target.Gain:N0}")"
-                               CornerBadgeClass="@CornerClass(target)"
+                               CornerBadge="@($"+{target.Gain:N0}")" CornerBadgeClass="pmb-corner-gain"
+                               Passed="target.Current != null"
+                               PassedInAnotherMix="target.Source == TargetSource.Phoenix1"
                                TooltipNote="@CornerMeaning(target)"
                                ShowName="false" ShowToDo="false"
                                OnOpen="OpenById"></TierListChartCard>
@@ -98,13 +99,16 @@ else if (Density == UiDensity.Compact)
 }
 else
 {
+    @* No border here: Comfortable says which kind it is in words, on the why-line under
+       every card, and the To-Do bookmark would otherwise paint a fourth ring nobody asked
+       for. *@
     <div class="tier-card-grid">
         @foreach (var target in Shown)
         {
             var chart = Charts[target.ChartId];
             <TierListChartCard Chart="chart" Density="UiDensity.Comfortable"
-                               CornerBadge="@($"+{target.Gain:N0}")"
-                               CornerBadgeClass="@CornerClass(target)"
+                               CornerBadge="@($"+{target.Gain:N0}")" CornerBadgeClass="pmb-corner-gain"
+                               ShowStateBorder="false"
                                ShowPlay="true" OnPlay="OnPlayById"
                                ShowToDo="ShowToDo" IsToDo="ToDos.Contains(target.ChartId)" OnToDo="OnToDo"
                                OnOpen="OpenById"
@@ -142,16 +146,8 @@ else
 
     [Parameter] public EventCallback<Guid> OnToDo { get; set; }
 
-    /// <summary>Null shows both. Applies to carried Phoenix 1 rows exactly as it does to estimates.</summary>
-    [Parameter] public ChartType? TypeFilter { get; set; }
-
-    /// <summary>Printed difficulty ceiling — the number on the bubble, which is what a player filters by.</summary>
-    [Parameter] public int? MaxLevel { get; set; }
-
-    /// <summary>Reports how much of the list survived the filters, so the page can print it.</summary>
-    [Parameter] public EventCallback<int> OnFilteredCountChanged { get; set; }
-
-    // A full projection runs to hundreds of charts and the page is a plan, not an archive.
+    // The list arrives already scoped and already ranked: the hero's pool selector re-runs the
+    // whole query per chart type, so there is nothing left for the component to narrow.
     // Compact fits far more per screen than Comfortable does, so the page size follows the
     // density rather than forcing one number to be wrong at two of the three.
     private int PageSize => Density switch
@@ -162,63 +158,31 @@ else
     };
 
     private int _page = 1;
-    private int _lastFilteredCount = -1;
-
-    // Filtered once per parameter set, not once per read: Shown, PageCount, HasCarryover and
-    // the render itself all want it, and re-running the Where each time is four sweeps of a
-    // list that can run to several hundred.
-    private IReadOnlyList<PumbilityTarget> _filtered = Array.Empty<PumbilityTarget>();
-
-    private IReadOnlyList<PumbilityTarget> Filtered => _filtered;
 
     private IReadOnlyList<PumbilityTarget> Shown =>
-        _filtered.Skip((_page - 1) * PageSize).Take(PageSize).ToArray();
+        Targets.Skip((_page - 1) * PageSize).Take(PageSize).ToArray();
 
-    private int PageCount => (_filtered.Count + PageSize - 1) / PageSize;
+    private int PageCount => (Targets.Count + PageSize - 1) / PageSize;
 
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
-        _filtered = Filter();
-
-        // A narrowed filter can leave the reader stranded on a page that no longer exists,
-        // which renders as an empty list rather than as "no matches" — so clamp rather than
-        // reset: a density flip changes the page size and should keep you roughly in place.
+        // A shorter list can leave the reader stranded on a page that no longer exists, which
+        // renders as an empty list rather than as an empty state — so clamp rather than reset:
+        // a density flip changes the page size and should keep you roughly in place.
         if (_page > Math.Max(1, PageCount)) _page = Math.Max(1, PageCount);
-
-        if (_filtered.Count != _lastFilteredCount)
-        {
-            _lastFilteredCount = _filtered.Count;
-            await OnFilteredCountChanged.InvokeAsync(_filtered.Count);
-        }
-    }
-
-    private IReadOnlyList<PumbilityTarget> Filter()
-    {
-        if (TypeFilter == null && MaxLevel == null) return Targets;
-        return Targets.Where(t => Charts.TryGetValue(t.ChartId, out var chart)
-                                  && (TypeFilter == null || chart.Type == TypeFilter)
-                                  && (MaxLevel == null || (int)chart.Level <= MaxLevel)).ToArray();
     }
 
     private void GoToPage(int page) => _page = page;
 
     /// <summary>Only worth a column when the list actually mixes evidence.</summary>
-    private bool HasCarryover => _filtered.Any(t => t.Source == TargetSource.Phoenix1);
+    private bool HasCarryover => Targets.Any(t => t.Source == TargetSource.Phoenix1);
 
     private Task OpenById(Guid chartId) => OnOpen.InvokeAsync(Charts[chartId]);
 
     private Task OnPlayById(Guid chartId) => OnPlay.InvokeAsync(Charts[chartId]);
 
-    // Three kinds of row, and the corner is the only place a Compact card can say which:
-    // a score you already hold elsewhere, a score you hold here and would beat, and one
-    // nobody has seen you play. The legend prints all three (rule 8).
-    private static string CornerClass(PumbilityTarget target) => target switch
-    {
-        { Source: TargetSource.Phoenix1 } => "pmb-corner-carry",
-        { Current: not null } => "pmb-corner-up",
-        _ => "pmb-corner-new"
-    };
-
+    // Compact hides the body, so the words for the three kinds ride the tooltip and the
+    // legend (rule 8: the border's colour never travels alone).
     private string CornerMeaning(PumbilityTarget target) => target switch
     {
         { Source: TargetSource.Phoenix1 } => L["Carried from Phoenix 1"],

--- a/ScoreTracker/ScoreTracker/Components/TierListChartCard.razor
+++ b/ScoreTracker/ScoreTracker/Components/TierListChartCard.razor
@@ -199,7 +199,13 @@ else
     // only in Comfortable has to be reachable here or it is lost (rule 7).
     [Parameter] public string? TooltipNote { get; set; }
 
-    private string StateClass => Passed ? "tier-chart-card-pass" :
+    // A page that means something else by a border turns this off and paints nothing, rather
+    // than fighting the class: PUMBILITY reads a border as which evidence a suggestion rests
+    // on, so a To-Do ring there would be a fourth meaning competing with three.
+    [Parameter] public bool ShowStateBorder { get; set; } = true;
+
+    private string StateClass => !ShowStateBorder ? string.Empty :
+        Passed ? "tier-chart-card-pass" :
         IsToDo ? "tier-chart-card-todo" :
         PassedInAnotherMix ? "tier-chart-card-other-mix" : string.Empty;
 

--- a/ScoreTracker/ScoreTracker/Pages/Progress/Pumbility.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/Pumbility.razor
@@ -79,51 +79,6 @@ else
             @L["Ranked by what each would add if you played it to the standard players at your level reach. Everything here clears your bar."]
         </p>
 
-        @* Narrowing controls, not a second pool selector: these change what the list SHOWS,
-           never what your PUMBILITY is measured against. The type filter renders only where
-           the list actually holds both — on a Phoenix 2 Singles board it would be a control
-           with one reachable state. Carried Phoenix 1 rows obey both filters, because they
-           are suggestions in the same list and an unfiltered block among filtered ones reads
-           as a bug. *@
-        <div class="pmb-filters">
-            @if (HasBothTypes)
-            {
-                @* Variant rides each button, not the group: OverrideStyles="false" means the
-                   group propagates nothing, so a Variant on it is inert and the buttons render
-                   flat. Filled-when-selected against Outlined is the tier list's segmented
-                   control exactly. *@
-                <MudButtonGroup OverrideStyles="false">
-                    <MudButton Variant="@(_typeFilter == null ? Variant.Filled : Variant.Outlined)"
-                               Color="Color.Primary" Size="Size.Small"
-                               OnClick="() => SetTypeFilter(null)">@L["All"]</MudButton>
-                    <MudButton Variant="@(_typeFilter == ChartType.Single ? Variant.Filled : Variant.Outlined)"
-                               Color="Color.Primary" Size="Size.Small"
-                               OnClick="() => SetTypeFilter(ChartType.Single)">@L["Singles"]</MudButton>
-                    <MudButton Variant="@(_typeFilter == ChartType.Double ? Variant.Filled : Variant.Outlined)"
-                               Color="Color.Primary" Size="Size.Small"
-                               OnClick="() => SetTypeFilter(ChartType.Double)">@L["Doubles"]</MudButton>
-                </MudButtonGroup>
-            }
-            @if (TargetLevels.Count > 1)
-            {
-                <div class="pmb-field pmb-field-inline">
-                    <label for="pmb-maxlevel">@L["Max Level"]</label>
-                    <MudSelect id="pmb-maxlevel" T="int?" Value="_maxLevel" ValueChanged="SetMaxLevel"
-                               Dense="true" Margin="Margin.Dense">
-                        <MudSelectItem T="int?" Value="@((int?)null)">@L["Any"]</MudSelectItem>
-                        @foreach (var level in TargetLevels)
-                        {
-                            <MudSelectItem T="int?" Value="@((int?)level)">@level</MudSelectItem>
-                        }
-                    </MudSelect>
-                </div>
-            }
-            <span class="pmb-filter-count pmb-muted">
-                @(_filteredCount == _page.Targets.Count
-                    ? string.Format(L["{0} suggestions"], _page.Targets.Count)
-                    : string.Format(L["{0} of {1} suggestions"], _filteredCount, _page.Targets.Count))
-            </span>
-        </div>
 
         @if (_projecting)
         {
@@ -132,8 +87,6 @@ else
         else
         {
             <TargetList Targets="_page.Targets" Charts="_charts" Density="_density" Mix="_currentMix"
-                        TypeFilter="_typeFilter" MaxLevel="_maxLevel"
-                        OnFilteredCountChanged="c => _filteredCount = c"
                         ShowToDo="true" ToDos="_todos" OnToDo="ToggleToDo"
                         OnOpen="ShowChartDetails" OnPlay="PlayChart"></TargetList>
         }
@@ -229,10 +182,6 @@ else
     private UiDensity _density = UiDensity.Comfortable;
     private bool _projecting;
 
-    private ChartType? _typeFilter;
-    private int? _maxLevel;
-    private int _filteredCount;
-
     private Chart? _detailsChart;
     private bool _detailsOpen;
     private bool _detailsAutoPlay;
@@ -252,35 +201,6 @@ else
             _carryover.ScoredHere)
         : L["The sum of your 50 best-rated charts."];
 
-    // A control that can only reach one state is not a choice. On a Phoenix 2 Singles or
-    // Doubles board the projection is already scoped to that type, so the filter would be
-    // three buttons where two do nothing.
-    private bool HasBothTypes => _page != null
-                                 && _page.Targets.Any(t => TypeOf(t) == ChartType.Single)
-                                 && _page.Targets.Any(t => TypeOf(t) == ChartType.Double);
-
-    /// <summary>
-    ///     Printed levels present in the suggestions, so the ceiling can only pick a real one.
-    ///     Rebuilt when the targets are, not on every render — the select re-reads it each time.
-    /// </summary>
-    private IReadOnlyList<int> TargetLevels { get; set; } = Array.Empty<int>();
-
-    private void IndexTargetLevels()
-    {
-        TargetLevels = _page == null
-            ? Array.Empty<int>()
-            : _page.Targets
-                .Where(t => _charts.ContainsKey(t.ChartId))
-                .Select(t => (int)_charts[t.ChartId].Level)
-                .Distinct().OrderBy(l => l).ToArray();
-    }
-
-    private ChartType? TypeOf(PumbilityTarget target) =>
-        _charts.TryGetValue(target.ChartId, out var chart) ? chart.Type : null;
-
-    private void SetTypeFilter(ChartType? type) => _typeFilter = type;
-
-    private void SetMaxLevel(int? level) => _maxLevel = level;
 
     protected override async Task OnInitializedAsync()
     {
@@ -308,7 +228,6 @@ else
         _projecting = true;
         _page = await Mediator.Send(new GetPumbilityPageQuery(CurrentUser.User.Id, _currentMix, _pool));
         _projecting = false;
-        IndexTargetLevels();
 
         // Phoenix 2 keeps Singles and Doubles as independent pools alongside the merged one,
         // so the selector is real there and would invent a stat on Phoenix 1.

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -3234,9 +3234,6 @@
 	  <value>Max Letter Grade</value>
 	  <comment>Max Letter Grade</comment>
   </data>
-  <data name="Max Level" xml:space="preserve">
-    <value>Max Level</value>
-  </data>
   <data name="Max Note Count" xml:space="preserve">
 	  <value>Max Note Count</value>
 	  <comment>Max Note Count</comment>
@@ -3722,9 +3719,6 @@
   </data>
   <data name="No source published" xml:space="preserve">
     <value>No source published</value>
-  </data>
-  <data name="No suggestions match those filters." xml:space="preserve">
-    <value>No suggestions match those filters.</value>
   </data>
   <data name="No suggestions right now — try a different goal, or import more scores first." xml:space="preserve">
     <value>No suggestions right now — try a different goal, or import more scores first.</value>
@@ -7866,9 +7860,6 @@
   <data name="{0} of {1} scores identical" xml:space="preserve">
     <value>{0} of {1} scores identical</value>
   </data>
-  <data name="{0} of {1} suggestions" xml:space="preserve">
-    <value>{0} of {1} suggestions</value>
-  </data>
   <data name="{0} of {1} tracked players" xml:space="preserve">
     <value>{0} of {1} tracked players</value>
   </data>
@@ -7940,9 +7931,6 @@
   </data>
   <data name="{0} songs left the catalog, taking {1} charts with them. Your scores on them stay on your profile." xml:space="preserve">
     <value>{0} songs left the catalog, taking {1} charts with them. Your scores on them stay on your profile.</value>
-  </data>
-  <data name="{0} suggestions" xml:space="preserve">
-    <value>{0} suggestions</value>
   </data>
   <data name="{0} titles" xml:space="preserve">
     <value>{0} titles</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -3234,9 +3234,6 @@
 	  <value>Gro Mrlurg Rorgl</value>
 	  <comment>Max Letter Grade</comment>
   </data>
-  <data name="Max Level" xml:space="preserve">
-    <value>Gro Grorpmurm</value>
-  </data>
   <data name="Max Note Count" xml:space="preserve">
 	  <value>Gro Grogrgl Glorgmurp</value>
 	  <comment>Max Note Count</comment>
@@ -3722,9 +3719,6 @@
   </data>
   <data name="No source published" xml:space="preserve">
     <value>Bam murgblub grumba</value>
-  </data>
-  <data name="No suggestions match those filters." xml:space="preserve">
-    <value>Mrp glrglmurpmrp murgrgl argl glrglmurg.</value>
   </data>
   <data name="No suggestions right now — try a different goal, or import more scores first." xml:space="preserve">
     <value>Mrp glrglmurpmrp rogro magl — lurg gro roplglblgrl mrpmrp, argl glorggl mrrgl mgrlgmrg murpargl.</value>
@@ -7866,9 +7860,6 @@
   <data name="{0} of {1} scores identical" xml:space="preserve">
     <value>{0} pu {1} magrub romagl</value>
   </data>
-  <data name="{0} of {1} suggestions" xml:space="preserve">
-    <value>{0} mrgl {1} glrglmurpmrp</value>
-  </data>
   <data name="{0} of {1} tracked players" xml:space="preserve">
     <value>{0} mrgl {1} mrplglmagl morp</value>
   </data>
@@ -7940,9 +7931,6 @@
   </data>
   <data name="{0} songs left the catalog, taking {1} charts with them. Your scores on them stay on your profile." xml:space="preserve">
     <value>{0} mrgl rolurg mrp blgrlroglorg, blargblgrl {1} murgl glgrgl gllurg. Gromurp mgrlgmrg lurg gllurg mrpro lurg gromurp mrglarglrgl.</value>
-  </data>
-  <data name="{0} suggestions" xml:space="preserve">
-    <value>{0} glrglmurpmrp</value>
   </data>
   <data name="{0} titles" xml:space="preserve">
     <value>{0} mrgl</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -3210,9 +3210,6 @@
   <data name="Max Letter Grade" xml:space="preserve">
     <value>Nota máxima</value>
   </data>
-  <data name="Max Level" xml:space="preserve">
-    <value>Nivel máximo</value>
-  </data>
   <data name="Max Note Count" xml:space="preserve">
     <value>Recuento de notas máx.</value>
   </data>
@@ -3692,9 +3689,6 @@
   </data>
   <data name="No source published" xml:space="preserve">
     <value>Sin código publicado</value>
-  </data>
-  <data name="No suggestions match those filters." xml:space="preserve">
-    <value>Ninguna sugerencia coincide con esos filtros.</value>
   </data>
   <data name="No suggestions right now — try a different goal, or import more scores first." xml:space="preserve">
     <value>No hay sugerencias ahora mismo — prueba otro objetivo o importa más scores primero.</value>
@@ -7794,9 +7788,6 @@
   <data name="{0} of {1} scores identical" xml:space="preserve">
     <value>{0} de {1} scores idénticos</value>
   </data>
-  <data name="{0} of {1} suggestions" xml:space="preserve">
-    <value>{0} de {1} sugerencias</value>
-  </data>
   <data name="{0} of {1} tracked players" xml:space="preserve">
     <value>{0} de {1} jugadores registrados</value>
   </data>
@@ -7868,9 +7859,6 @@
   </data>
   <data name="{0} songs left the catalog, taking {1} charts with them. Your scores on them stay on your profile." xml:space="preserve">
     <value>{0} canciones salieron del catálogo, llevándose {1} charts. Tus scores siguen en tu perfil.</value>
-  </data>
-  <data name="{0} suggestions" xml:space="preserve">
-    <value>{0} sugerencias</value>
   </data>
   <data name="{0} titles" xml:space="preserve">
     <value>{0} títulos</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -3210,9 +3210,6 @@
   <data name="Max Letter Grade" xml:space="preserve">
     <value>Grado de letra máx</value>
   </data>
-  <data name="Max Level" xml:space="preserve">
-    <value>Nivel máximo</value>
-  </data>
   <data name="Max Note Count" xml:space="preserve">
     <value>Conteo de notas máx</value>
   </data>
@@ -3692,9 +3689,6 @@
   </data>
   <data name="No source published" xml:space="preserve">
     <value>Sin código publicado</value>
-  </data>
-  <data name="No suggestions match those filters." xml:space="preserve">
-    <value>Ninguna sugerencia coincide con esos filtros.</value>
   </data>
   <data name="No suggestions right now — try a different goal, or import more scores first." xml:space="preserve">
     <value>No hay sugerencias por ahora — prueba otra meta o importa más puntajes primero.</value>
@@ -7796,9 +7790,6 @@
   <data name="{0} of {1} scores identical" xml:space="preserve">
     <value>{0} de {1} scores idénticos</value>
   </data>
-  <data name="{0} of {1} suggestions" xml:space="preserve">
-    <value>{0} de {1} sugerencias</value>
-  </data>
   <data name="{0} of {1} tracked players" xml:space="preserve">
     <value>{0} de {1} jugadores registrados</value>
   </data>
@@ -7870,9 +7861,6 @@
   </data>
   <data name="{0} songs left the catalog, taking {1} charts with them. Your scores on them stay on your profile." xml:space="preserve">
     <value>{0} canciones salieron del catálogo, llevándose {1} charts. Tus puntajes siguen en tu perfil.</value>
-  </data>
-  <data name="{0} suggestions" xml:space="preserve">
-    <value>{0} sugerencias</value>
   </data>
   <data name="{0} titles" xml:space="preserve">
     <value>{0} títulos</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -3233,9 +3233,6 @@
 	  <value>Rang Max (lettres)</value>
 	  <comment>Rang Max (lettres)</comment>
   </data>
-  <data name="Max Level" xml:space="preserve">
-    <value>Niveau Max</value>
-  </data>
   <data name="Max Note Count" xml:space="preserve">
 	  <value>Nombre de Notes Max</value>
 	  <comment>Nombre de Notes Max</comment>
@@ -3721,9 +3718,6 @@
   </data>
   <data name="No source published" xml:space="preserve">
     <value>Aucun code publié</value>
-  </data>
-  <data name="No suggestions match those filters." xml:space="preserve">
-    <value>Aucune suggestion ne correspond à ces filtres.</value>
   </data>
   <data name="No suggestions right now — try a different goal, or import more scores first." xml:space="preserve">
     <value>Pas de suggestions pour le moment — essayez un autre objectif ou importez d'abord plus de scores.</value>
@@ -7865,9 +7859,6 @@
   <data name="{0} of {1} scores identical" xml:space="preserve">
     <value>{0} scores identiques sur {1}</value>
   </data>
-  <data name="{0} of {1} suggestions" xml:space="preserve">
-    <value>{0} suggestions sur {1}</value>
-  </data>
   <data name="{0} of {1} tracked players" xml:space="preserve">
     <value>{0} joueurs suivis sur {1}</value>
   </data>
@@ -7939,9 +7930,6 @@
   </data>
   <data name="{0} songs left the catalog, taking {1} charts with them. Your scores on them stay on your profile." xml:space="preserve">
     <value>{0} chansons ont quitté le catalogue, emportant {1} charts. Vos scores restent sur votre profil.</value>
-  </data>
-  <data name="{0} suggestions" xml:space="preserve">
-    <value>{0} suggestions</value>
   </data>
   <data name="{0} titles" xml:space="preserve">
     <value>{0} titres</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -3234,9 +3234,6 @@
     <value>Voto in lettere max</value>
     <comment>Max Letter Grade</comment>
   </data>
-  <data name="Max Level" xml:space="preserve">
-    <value>Livello max</value>
-  </data>
   <data name="Max Note Count" xml:space="preserve">
     <value>Conteggio note max</value>
     <comment>Max Note Count</comment>
@@ -3722,9 +3719,6 @@
   </data>
   <data name="No source published" xml:space="preserve">
     <value>Nessun codice pubblicato</value>
-  </data>
-  <data name="No suggestions match those filters." xml:space="preserve">
-    <value>Nessun suggerimento corrisponde a quei filtri.</value>
   </data>
   <data name="No suggestions right now — try a different goal, or import more scores first." xml:space="preserve">
     <value>Nessun suggerimento al momento — prova un altro obiettivo o importa prima più punteggi.</value>
@@ -7866,9 +7860,6 @@
   <data name="{0} of {1} scores identical" xml:space="preserve">
     <value>{0} di {1} punteggi identici</value>
   </data>
-  <data name="{0} of {1} suggestions" xml:space="preserve">
-    <value>{0} di {1} suggerimenti</value>
-  </data>
   <data name="{0} of {1} tracked players" xml:space="preserve">
     <value>{0} di {1} giocatori registrati</value>
   </data>
@@ -7940,9 +7931,6 @@
   </data>
   <data name="{0} songs left the catalog, taking {1} charts with them. Your scores on them stay on your profile." xml:space="preserve">
     <value>{0} canzoni sono uscite dal catalogo, portando via {1} chart. I tuoi punteggi restano sul profilo.</value>
-  </data>
-  <data name="{0} suggestions" xml:space="preserve">
-    <value>{0} suggerimenti</value>
   </data>
   <data name="{0} titles" xml:space="preserve">
     <value>{0} titoli</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -3234,9 +3234,6 @@
 	  <value>最高ランク</value>
 	  
   <comment>Max Letter Grade</comment></data>
-  <data name="Max Level" xml:space="preserve">
-    <value>最高レベル</value>
-  </data>
   <data name="Max Note Count" xml:space="preserve">
 	  <value>最高ノーツ数</value>
 	  
@@ -3722,9 +3719,6 @@
   </data>
   <data name="No source published" xml:space="preserve">
     <value>ソース未公開</value>
-  </data>
-  <data name="No suggestions match those filters." xml:space="preserve">
-    <value>そのフィルターに一致する候補はありません。</value>
   </data>
   <data name="No suggestions right now — try a different goal, or import more scores first." xml:space="preserve">
     <value>現在提案はありません。別の目標を試すか、先にスコアをインポートしてください。</value>
@@ -7866,9 +7860,6 @@
   <data name="{0} of {1} scores identical" xml:space="preserve">
     <value>{1}件中{0}件のスコアが一致</value>
   </data>
-  <data name="{0} of {1} suggestions" xml:space="preserve">
-    <value>{1} 件中 {0} 件の候補</value>
-  </data>
   <data name="{0} of {1} tracked players" xml:space="preserve">
     <value>記録のあるプレイヤー {1} 人中 {0} 人</value>
   </data>
@@ -7940,9 +7931,6 @@
   </data>
   <data name="{0} songs left the catalog, taking {1} charts with them. Your scores on them stay on your profile." xml:space="preserve">
     <value>{0} 曲がカタログから削除され、{1} 譜面がなくなりました。記録はプロフィールに残ります。</value>
-  </data>
-  <data name="{0} suggestions" xml:space="preserve">
-    <value>{0} 件の候補</value>
   </data>
   <data name="{0} titles" xml:space="preserve">
     <value>タイトル {0} 件</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -3210,9 +3210,6 @@
   <data name="Max Letter Grade" xml:space="preserve">
     <value>최고 랭크</value>
   </data>
-  <data name="Max Level" xml:space="preserve">
-    <value>최고 레벨</value>
-  </data>
   <data name="Max Note Count" xml:space="preserve">
     <value>최대 노트 수</value>
   </data>
@@ -3692,9 +3689,6 @@
   </data>
   <data name="No source published" xml:space="preserve">
     <value>소스 미공개</value>
-  </data>
-  <data name="No suggestions match those filters." xml:space="preserve">
-    <value>해당 필터와 일치하는 추천이 없습니다.</value>
   </data>
   <data name="No suggestions right now — try a different goal, or import more scores first." xml:space="preserve">
     <value>지금은 추천할 채보가 없습니다. 다른 목표를 선택하거나 먼저 점수를 가져와주세요.</value>
@@ -7796,9 +7790,6 @@
   <data name="{0} of {1} scores identical" xml:space="preserve">
     <value>{1}개 중 {0}개 점수 일치</value>
   </data>
-  <data name="{0} of {1} suggestions" xml:space="preserve">
-    <value>추천 {1}개 중 {0}개</value>
-  </data>
   <data name="{0} of {1} tracked players" xml:space="preserve">
     <value>기록된 유저 {1}명 중 {0}명</value>
   </data>
@@ -7870,9 +7861,6 @@
   </data>
   <data name="{0} songs left the catalog, taking {1} charts with them. Your scores on them stay on your profile." xml:space="preserve">
     <value>노래 {0}곡이 목록에서 빠지면서 채보 {1}개가 사라졌습니다. 기록은 프로필에 그대로 남습니다.</value>
-  </data>
-  <data name="{0} suggestions" xml:space="preserve">
-    <value>추천 {0}개</value>
   </data>
   <data name="{0} titles" xml:space="preserve">
     <value>타이틀 {0}개</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -3210,9 +3210,6 @@
   <data name="Max Letter Grade" xml:space="preserve">
     <value>Letra de nota máx.</value>
   </data>
-  <data name="Max Level" xml:space="preserve">
-    <value>Nível máximo</value>
-  </data>
   <data name="Max Note Count" xml:space="preserve">
     <value>Contagem máx. de notas</value>
   </data>
@@ -3692,9 +3689,6 @@
   </data>
   <data name="No source published" xml:space="preserve">
     <value>Sem código publicado</value>
-  </data>
-  <data name="No suggestions match those filters." xml:space="preserve">
-    <value>Nenhuma sugestão corresponde a esses filtros.</value>
   </data>
   <data name="No suggestions right now — try a different goal, or import more scores first." xml:space="preserve">
     <value>Sem sugestões no momento — tente outra meta ou importe mais pontuações primeiro.</value>
@@ -7796,9 +7790,6 @@
   <data name="{0} of {1} scores identical" xml:space="preserve">
     <value>{0} de {1} pontuações idênticas</value>
   </data>
-  <data name="{0} of {1} suggestions" xml:space="preserve">
-    <value>{0} de {1} sugestões</value>
-  </data>
   <data name="{0} of {1} tracked players" xml:space="preserve">
     <value>{0} de {1} jogadores registrados</value>
   </data>
@@ -7870,9 +7861,6 @@
   </data>
   <data name="{0} songs left the catalog, taking {1} charts with them. Your scores on them stay on your profile." xml:space="preserve">
     <value>{0} músicas saíram do catálogo, levando {1} charts. Suas pontuações continuam no seu perfil.</value>
-  </data>
-  <data name="{0} suggestions" xml:space="preserve">
-    <value>{0} sugestões</value>
   </data>
   <data name="{0} titles" xml:space="preserve">
     <value>{0} títulos</value>

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -12995,72 +12995,20 @@ span.ct-console-pick { cursor: default; }
     margin: 2px 0 14px;
 }
 
-/* Narrowing controls for the suggestion list. Wraps rather than scrolls: on a phone the
-   count drops under the controls instead of pushing them off the edge. */
-.pmb-filters {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    flex-wrap: wrap;
-    margin: 8px 0 10px;
-}
-
-.pmb-field-inline {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    min-width: 150px;
-}
-
-.pmb-field-inline label {
-    white-space: nowrap;
-    font-size: 12px;
-    color: var(--mix-ink-muted);
-}
-
-.pmb-filter-count {
-    font-size: 12px;
-    font-variant-numeric: tabular-nums;
-    margin-left: auto;
-}
 
 /* --- targets, comfortable --- */
-/* The gain badge's three states. Declared AFTER .tier-chart-card-corner so these win its
-   background and border shorthands on source order, the same contract the card border
-   language runs on. The words live in the Compact legend and in every Comfortable card's
-   why-line, so the colour never travels alone (rule 8).
-
-   Green fills when you already hold a score here and would beat it; green outlines when
-   the score is one you hold in another mix; neither when nobody has seen you play it. */
-.pmb-corner-up {
-    background: var(--mud-palette-success);
-    border-color: var(--mud-palette-success);
-    color: var(--mud-palette-black);
-}
-
-.pmb-corner-carry {
+/* One treatment for every gain badge: green on a green outline over the black backdrop.
+   The number says how MUCH, and nothing else — which KIND of row it is rides the card's
+   border (owner, 2026-08-06). Declared AFTER .tier-chart-card-corner so it wins that
+   rule's border shorthand on source order, the same contract the card border language runs
+   on. */
+.pmb-corner-gain {
     border-color: var(--mud-palette-success);
     color: var(--mud-palette-success);
 }
 
-.pmb-corner-new {
-    color: var(--mix-ink);
-}
-
 .pmb-legend {
     margin-top: 0;
-}
-
-.pmb-legend-swatch {
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 10px;
-    line-height: 1.3;
-    font-variant-numeric: tabular-nums;
-    background: rgba(0, 0, 0, .82);
-    padding: 0 4px;
-    border: 1px solid transparent;
-    border-radius: 4px;
 }
 
 .pmb-tcard-meta {

--- a/docs/design/pumbility-overhaul.md
+++ b/docs/design/pumbility-overhaul.md
@@ -95,23 +95,41 @@ keep in sync, which is the drift the one-concept-one-component rule exists to pr
 The corner badge is the **gain**, because a Compact card is 72px tall and prints exactly one
 value — so it has to be the one the list is ranked by.
 
-**Three kinds of row, said by the badge and never by a column.** Green-filled = you hold a score
-here and would beat it. Green-outlined = you hold it in *another mix* (§5). Neither = nobody has
-seen you play it. A "Kind" column restated what the card already says, and read the same value
-down every row on Phoenix 1.
+**The border says which kind, the number says how much** (owner, 2026-08-06). Every gain badge
+is one treatment — green on a green outline over the black backdrop — and carries no meaning
+beyond its value. The kind rides the **card border**, in the tier list's own language rather
+than a second one invented here:
 
-Compact has no room for a word on the card, so the **legend prints all three** — and only the
-kinds the grid actually contains, since a swatch for an absent state reads as one you failed to
-find. Comfortable needs no legend: every card's why-line says its kind in words. That is rule 8
-satisfied at both densities without a colour travelling alone at either.
+| border | meaning |
+|---|---|
+| solid success (`.tier-chart-card-pass`) | you hold a score on this chart and would beat it |
+| dashed success (`.tier-chart-card-other-mix`) | you hold it in *another mix* (§5) |
+| none | nobody has seen you play it |
 
-**In Phoenix 2 the list mixes two kinds of evidence, and says which is which.** A chart from
-the player's Phoenix 1 pool that they have not scored here is not estimated — the score is on
-record and repricing it is arithmetic. Those rows **replace** any peer estimate for the same
-chart (owner, 2026-08-06: *"there is no better data than the actual scores you had before"*)
-and are the only signal that works at a mix launch. Table density keeps a **Based on** column
-with the word spelled out, because a table cell can hold a word where a 72px card cannot; it
-renders only where the list actually mixes sources.
+Same classes as the tier list, so the two pages cannot drift apart. A "Kind" column restated
+what the card already says, and read the same value down every row on Phoenix 1.
+
+**Compact only.** Comfortable says the kind in words on every card's why-line, and its To-Do
+bookmark would otherwise paint a fourth ring competing with the three that mean something — so
+it turns the state border off (`ShowStateBorder="false"`, a flag that defaults *on* so the tier
+list is unaffected). Compact has no room for a word, so the **legend prints every kind the grid
+contains** — and only those, since a swatch for an absent state reads as one you failed to find.
+Rule 8 is satisfied at both densities without a colour travelling alone at either.
+
+**One ranked list, two sources of evidence.** Not two lists stapled together: up to 100 peer
+estimates and up to 100 carried Phoenix 1 scores, merged and cut to 100. The cut happens *after*
+the merge, so a chart both sources name cannot spend two slots.
+
+A chart from the player's Phoenix 1 record that they have not scored here is not estimated — the
+score is on record and repricing it is arithmetic. Those rows **replace** any peer estimate for
+the same chart (owner: *"there is no better data than the actual scores you had before"*) and are
+the only signal that works at a mix launch. Table density keeps a **Based on** column with the
+word spelled out, because a table cell can hold a word where a 72px card cannot; it renders only
+where the list actually mixes sources.
+
+**No filters on the list.** A filter that re-runs the query is what the hero's pool selector
+already is, and two controls driving one piece of state is one too many. The max-level filter
+was dropped outright — narrow use case, and it cost a control on every visit.
 
 ⚠ **The "why" line is OPEN, and the mock's version is now dishonest.** The mock renders badge
 chips ("▲ Anchor Runs · ▼ Twists") as the explanation for each target. That was drawn when the
@@ -128,26 +146,10 @@ Density trio via `Density__Pumbility`, governing the targets only, using the sit
 control — a `MudButtonGroup` of `ViewComfy` / `GridView` / `TableRows` icon buttons, the same
 one the tier list carries.
 
-**The list narrows and pages.** A full projection runs to hundreds of charts, and the page is a
-plan rather than an archive:
-
-- **Type** — All / Singles / Doubles, rendered only where the list actually holds both. On a
-  Phoenix 2 Singles board the projection is already scoped to one type, so the control would
-  have two states that do nothing.
-- **Max level** — the printed level on the bubble, offering only levels the suggestions actually
-  contain, so the ceiling can never select an empty result by accident.
-- **Pagination** sized by density (Comfortable 24, Compact 60, Table 50) — one page size would
-  be wrong at two of the three. Narrowing the filter **clamps** the current page rather than
-  resetting it, so a density flip keeps you roughly where you were.
-
-Both filters are **view** concerns: they change what the list shows, never what your PUMBILITY
-is measured against, and they apply to carried Phoenix 1 rows exactly as they do to estimates
-(owner, 2026-08-06). A carried row is a suggestion in the same list — an unfiltered block among
-filtered ones reads as a bug.
-
-Two empty states, deliberately distinct: *nothing clears your bar yet* is a fact about the
-account; *nothing matched those filters* is a fact about the controls, and only one of them is
-the player's to fix.
+**Pagination** sized by density (Comfortable 24, Compact 60, Table 50) — one page size would be
+wrong at two of the three. A shorter list **clamps** the current page rather than resetting it,
+so a density flip or a pool switch keeps you roughly where you were instead of throwing you back
+to the top.
 
 ### 3.4 The pool board
 
@@ -376,6 +378,19 @@ there would invent a stat.
 Every Phoenix 1 score repriced under `Phoenix2PumbilityScoring` — singles priced one level up the
 base curve, sub-10 charts at zero, broken plays at zero — then the top 50 taken for each of All,
 Singles and Doubles.
+
+**The panel's fifty is the definition; the suggestions are not bound by it** (owner, 2026-08-06).
+PUMBILITY *is* the top fifty, so `Entries` and every figure in the table below come from exactly
+that. But capping *suggestions* at the pool hid the rows carrying the best evidence the site has:
+against a thin Phoenix 2 pool a repriced **#73** clears the bar as surely as a #3 does, and it is
+still a score the player has actually hit. So the repricing is kept to `CandidateDepth` (200) and
+split — `Entries` is the pool, `Candidates` is what ranks behind it, each carrying its real place
+so a row can say it was your #73. This costs nothing: every score was already being repriced
+before the `Take(50)`.
+
+Under 50 Phoenix 2 scores the bar is **zero**, so every candidate qualifies and the 100-target cap
+is what actually limits the list. That is the launch case and it is correct — *"50 scores takes 3
+play sessions."*
 
 **The finding this section exists for.** On the owner's account the Phoenix 1 top 50 is **46
 Doubles / 4 Singles**. The same fifty scores under Phoenix 2's rules are **18 Doubles / 32


### PR DESCRIPTION
Follow-up to #229, which is merged. Two things: the page was **absurdly slow in production**, and
the evidence rule on the cards was on the wrong element.

---

## The page was slow, and it was querying far too much

Measured against the prod-synced database for a level-21 singles account:

| | |
|---|---|
| cohort (peers ±1 competitive level) | **359** |
| charts in window (singles 19–23) | **605** |
| **peer score rows swept** | **72,770** — singles alone |
| history rows loaded | **11,636** |

Double it for doubles, and double again on Phoenix 2 (which reads both mixes) — **~290k rows per
page load**, on every visit and every pool switch. The filters existed, they were just far too
loose, which is also why the owner's account returned **1,200 suggestions**.

Four fixes, none of which move a number on the page:

1. **Charts that cannot pay are dropped before any peer read.** If a chart's value at a *perfect
   game* is still under your bar it could never contribute, so nothing downstream would have kept
   it — this just stops asking the database about it. Exact, not heuristic.
2. **The 605-GUID `IN` list is gone.** The scoped set *is* a level band, so it's queried as one
   (`GetPlayerScoresInLevelRange`, an indexed range scan) with the exact chart set applied in
   memory. The reference-mix read widens by 2 levels because Phoenix 2 rerated these charts.
3. **History is read only for peers who turned up in the sweep**, not the whole cohort. It was
   loading 359 full timelines to use whichever ones had a score in the window.
4. **The projection is cached** per (user, mix, pool), evicted when *that player's* scores move —
   import and deletion both, since a projection still recommending a chart you just cleared reads
   as broken rather than stale.

**One judgement call inside #4:** peers' scores moving does *not* evict. Watching every player's
imports would evict continuously and cache nothing, so a **6-hour lifetime** bounds that drift
instead. Your own imports bust it immediately.

## The list is now one ranked hundred from two sources

The gap the owner hit: *"scores you already had in Phoenix that'd be in your top 50"* stopped at
**50**, so everything ranked behind it was invisible — and those rows carry the best evidence the
site has, because they're scores actually hit. Against a thin Phoenix 2 pool a repriced **#73**
clears the bar as surely as a #3 does.

The fifty was never a display cap — it's what PUMBILITY *means*. So the panel keeps it: `Entries`
is still the top fifty and its projected total, bar and singles/doubles split are untouched.
`Candidates` is what ranks behind, carrying its real place. This costs nothing — every score was
already being repriced before the `Take(50)`.

The page is then **one ordered list of likely gains with two sources behind it**: up to 100 from
each, merged, cut to 100. The cut happens *after* the merge, so a chart both sources name can't
spend two slots.

## The border says which kind, the number says how much

The outline rule was on the wrong element — I'd put it on the gain number; it belongs on the card.

Every gain badge is now one treatment (green on a green outline over black) meaning only *how
much*. The kind rides the **card border**, in the tier list's own language rather than a second
one invented here — solid = you hold a score here and would beat it, dashed = you hold it in
another mix, bare = nobody has seen you play it. Same classes, so the two pages can't drift apart.

**Compact only.** Comfortable says the kind in words on every card's why-line, and its To-Do
bookmark would otherwise paint a fourth ring competing with the three that mean something — so it
turns the state border off via a new `ShowStateBorder` flag that defaults *on*, leaving the tier
list unchanged.

**The targets filters are deleted.** Once a filter re-runs the query, "Singles" is what the hero's
pool selector already means, and two controls driving one piece of state is one too many. Max
level went too — narrow use case, and it cost a control on every visit. Four resx keys became
unreferenced and are removed from all nine locales.

## Testing

All five suites green locally against the rebased main: **2,299 / 148 / 644** fast, **247**
integration, **74** E2E. New coverage for the level-range query against real SQL (band edges,
type filter, broken-row exclusion), the cache and its invalidation, the merge dedup, and the
border language.

## Still open, carried over from #229

- **C3** — the exploration harness is still in `Downloads/pumbility-harness/`, not ported to
  `ScoreTracker.ExplorationTests/Pumbility/`.
- **C4** — the p65 quantile is fitted to a **one-year** truth horizon, so projections read high.
  Refitting needs a call on what horizon the page is claiming.
- The before/after page timing hasn't been measured directly. The row counts above say the
  improvement should be large, but that's inference — two loads of `/Pumbility` after an import
  would confirm it, the second being the one that should be near-instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
