### PR TITLE
Broken runs never count toward PUMBILITY, and carryover prices an upscore

### DIFF
--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PlayerRatingSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PlayerRatingSaga.cs
@@ -96,8 +96,10 @@ internal sealed class PlayerRatingSaga :
             .ToDictionary(c => c.Id);
         var scoring = ScoringConfiguration.PumbilityScoring(request.Mix, false);
 
-        // Phoenix 2 prices plates and stage breaks into the ranking; Phoenix keeps its
-        // historical plate-blind ordering byte-identical.
+        // Phoenix 2 prices plates into the ranking; Phoenix keeps its historical plate-blind
+        // ordering byte-identical. Stage breaks never reach here — the filter below drops
+        // them, which is why this may not pass IsBroken on the Phoenix branch: the argument
+        // is positional, so supplying it would drag the plate in with it.
         double Rank(RecordedPhoenixScore s)
         {
             return request.Mix == MixEnum.Phoenix2
@@ -106,10 +108,15 @@ internal sealed class PlayerRatingSaga :
                 : scoring.GetScore(charts[s.ChartId].Type, charts[s.ChartId].Level, s.Score!.Value);
         }
 
+        // A stage break is worth zero PUMBILITY, so a broken run in the pool holds a slot at
+        // no value. That is not merely wasteful: the PUMBILITY page measures every projected
+        // gain against the pool's MINIMUM, and one such row drives that floor to zero, which
+        // prints every suggestion's whole value as if it displaced nothing. Dropped here
+        // rather than at each call site, so the query means what its name says.
         return (await _scores.GetBestScores(request.Mix, request.UserId, cancellationToken))
             .Where(s => charts[s.ChartId].Type != ChartType.CoOp)
-            .Where(s => s.Score != null && (request.ChartType == null ||
-                                            charts[s.ChartId].Type == request.ChartType))
+            .Where(s => s.Score != null && !s.IsBroken && (request.ChartType == null ||
+                                                           charts[s.ChartId].Type == request.ChartType))
             .OrderByDescending(Rank)
             .Take(request.Count).ToArray();
     }
@@ -128,10 +135,14 @@ internal sealed class PlayerRatingSaga :
             (await _charts.GetCharts(request.Mix, cancellationToken: cancellationToken))
             .ToDictionary(c => c.Id);
         var count = request.ChartType == null ? 100 : 50;
+        // Broken attempts never rate, the same rule RecalculateCore applies when it computes
+        // the stored competitive level: a walkoff's partial score deflates small accounts'
+        // averages, and a deep partial on an overrated chart would farm competitive level
+        // without ever passing it. The query and the stored figure have to agree on that.
         return (await _scores.GetBestScores(request.Mix, request.UserId, cancellationToken))
             .Where(s => charts[s.ChartId].Type != ChartType.CoOp)
-            .Where(s => s.Score != null && (request.ChartType == null ||
-                                            charts[s.ChartId].Type == request.ChartType))
+            .Where(s => s.Score != null && !s.IsBroken && (request.ChartType == null ||
+                                                           charts[s.ChartId].Type == request.ChartType))
             .OrderByDescending(s =>
                 ScoringConfiguration.CalculateFungScore(charts[s.ChartId].Level, s.Score!.Value,
                     charts[s.ChartId].Type))

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityPageSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityPageSaga.cs
@@ -103,7 +103,7 @@ namespace ScoreTracker.PlayerProgress.Application
             // actually hit beats a quantile of what other people hit.
             if (mix == MixEnum.Phoenix2)
                 foreach (var carried in await CarryoverTargets(request.UserId, request.Pool, charts,
-                             bar, projection, mine, cancellationToken))
+                             bar, scoring, projection, mine, cancellationToken))
                     targets[carried.ChartId] = carried;
 
             // One ranked list of likely gains with two sources of evidence behind it, not two
@@ -122,22 +122,40 @@ namespace ScoreTracker.PlayerProgress.Application
         ///     Phoenix 1 scores worth playing here, as targets. The pool AND everything ranked
         ///     behind it: capping at the fiftieth hid the rows with the best evidence there is,
         ///     because against a thin Phoenix 2 pool a repriced #73 still clears the bar
-        ///     (owner, 2026-08-06). Excludes anything already scored here (done) and anything
-        ///     with no Phoenix 2 appearance (unplayable — the panel states those as a fact).
+        ///     (owner, 2026-08-06). Excludes anything with no Phoenix 2 appearance (unplayable —
+        ///     the panel states those as a fact).
+        ///     <para>
+        ///         A chart already scored here is NOT excluded. An 980k in Phoenix 1 against a
+        ///         900k here is a gain worth playing for, and the question is the same one the
+        ///         peer projection asks: how much does this beat what it would displace. So the
+        ///         floor is the same too — your standing value on the chart, or the pool's bar,
+        ///         whichever is higher — and both sources of evidence end up on one ranked list
+        ///         priced identically.
+        ///     </para>
         /// </summary>
         private async Task<IReadOnlyList<PumbilityTarget>> CarryoverTargets(Guid userId, ChartType? poolScope,
-            IReadOnlyDictionary<Guid, Chart> charts, int? bar, PumbilityProjection projection,
-            IReadOnlyDictionary<Guid, RecordedPhoenixScore> mine, CancellationToken cancellationToken)
+            IReadOnlyDictionary<Guid, Chart> charts, int? bar, ScoringConfiguration scoring,
+            PumbilityProjection projection, IReadOnlyDictionary<Guid, RecordedPhoenixScore> mine,
+            CancellationToken cancellationToken)
         {
             var carryover = await Handle(new ProjectPhoenix2CarryoverQuery(userId, poolScope), cancellationToken);
-            var floor = bar ?? 0;
+            var bottom = bar ?? 0;
+
+            // What the chart is worth to the player right now. A broken run is worth nothing,
+            // which is the same thing as never having played it.
+            double Standing(Guid chartId)
+            {
+                if (!mine.TryGetValue(chartId, out var held) || held.Score == null || held.IsBroken) return 0;
+                return scoring.GetScore(charts[chartId], held.Score.Value,
+                    held.Plate ?? PhoenixPlate.RoughGame, held.IsBroken);
+            }
 
             return carryover.Entries.Concat(carryover.Candidates)
-                .Where(e => e.Phoenix2Score == null && e.AvailableInPhoenix2 && charts.ContainsKey(e.ChartId))
+                .Where(e => e.AvailableInPhoenix2 && charts.ContainsKey(e.ChartId))
                 .Select(e => new
                 {
                     Entry = e,
-                    Gain = (int)Math.Round(e.Phoenix2Value - floor)
+                    Gain = (int)Math.Round(e.Phoenix2Value - Math.Max(Standing(e.ChartId), bottom))
                 })
                 .Where(x => x.Gain > 0)
                 .Select(x => new PumbilityTarget(x.Entry.ChartId,
@@ -172,8 +190,11 @@ namespace ScoreTracker.PlayerProgress.Application
                 .Where(s => s is { Score: not null, IsBroken: false } && phoenixCharts.ContainsKey(s.ChartId))
                 .Where(s => request.Pool == null || phoenixCharts[s.ChartId].Type == request.Pool)
                 .ToArray();
+            // A stage break here is not a score you hold — it rates zero, and a chart you broke
+            // on is precisely the chart your Phoenix 1 record has something to say about.
+            // Reading it as "already scored in Phoenix 2" is what hid those rows entirely.
             var phoenix2Scores = (await _scores.GetBestScores(MixEnum.Phoenix2, request.UserId, cancellationToken))
-                .Where(s => s.Score != null)
+                .Where(s => s is { Score: not null, IsBroken: false })
                 .ToDictionary(s => s.ChartId, s => s.Score!.Value);
 
             // The repricing: every Phoenix 1 score run through Phoenix 2's formula, which pays

--- a/ScoreTracker/ScoreTracker.Tests.Components/PumbilityComponentTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/PumbilityComponentTests.cs
@@ -163,6 +163,26 @@ public sealed class PumbilityComponentTests : ComponentTestBase
         Assert.Empty(cut.FindAll(".tier-chart-card-todo"));
     }
 
+    [Fact]
+    public void ABrokenRunGetsItsOwnBorderRatherThanReadingAsAnUpscore()
+    {
+        // A stage break is worth nothing, so the arithmetic prices the chart from the bar as
+        // though it had never been played. A solid "upscore" border would then be describing a
+        // score the page has just decided the player does not hold — and no border at all
+        // would claim they have never touched it.
+        var broke = NewChart(ChartType.Single, 22);
+        var targets = new[] { new PumbilityTarget(broke.Id, 980_000, 300, 640_000, true, null, null) };
+
+        var cut = RenderComponent<TargetList>(p => p
+            .Add(x => x.Targets, targets)
+            .Add(x => x.Charts, new Dictionary<Guid, Chart> { [broke.Id] = broke })
+            .Add(x => x.Density, UiDensity.Compact));
+
+        Assert.Single(cut.FindAll(".tier-card-grid .tier-chart-card-broken"));
+        Assert.Empty(cut.FindAll(".tier-card-grid .tier-chart-card-pass"));
+        Assert.Contains("Played, not passed", cut.Find(".pmb-legend").TextContent);
+    }
+
     /// <summary>One of each kind: carried from another mix, an upscore, and never played.</summary>
     private static PumbilityTarget[] ThreeKinds(out Dictionary<Guid, Chart> charts)
     {

--- a/ScoreTracker/ScoreTracker.Tests.Components/PumbilityComponentTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/PumbilityComponentTests.cs
@@ -140,7 +140,9 @@ public sealed class PumbilityComponentTests : ComponentTestBase
             .Add(x => x.Targets, ThreeKinds(out var charts)).Add(x => x.Charts, charts)
             .Add(x => x.Density, UiDensity.Compact));
 
-        var badges = cut.FindAll(".tier-card-grid .tier-chart-card-corner");
+        // Scoped to the end corner: the jacket carries two badges now, and they share the
+        // treatment on purpose — .tier-chart-card-corner alone would count both.
+        var badges = cut.FindAll(".tier-card-grid .tier-chart-card-compact-grade");
         Assert.Equal(3, badges.Count);
         Assert.All(badges, b => Assert.Contains("pmb-corner-gain", b.ClassName));
         Assert.Contains("+400", badges.Select(b => b.TextContent.Trim()).ToArray());
@@ -161,6 +163,24 @@ public sealed class PumbilityComponentTests : ComponentTestBase
         Assert.Empty(cut.FindAll(".tier-chart-card-pass"));
         Assert.Empty(cut.FindAll(".tier-chart-card-other-mix"));
         Assert.Empty(cut.FindAll(".tier-chart-card-todo"));
+    }
+
+    [Fact]
+    public void CompactPrintsTheGradeTheProjectionLandsOnOppositeTheGain()
+    {
+        // Two badges on the jacket's bottom edge, one treatment: how much on the right, what
+        // you would come away with on the left. The words for it ride the tooltip, which
+        // renders into the popover provider and so is not assertable from here.
+        var cut = RenderComponent<TargetList>(p => p
+            .Add(x => x.Targets, ThreeKinds(out var charts)).Add(x => x.Charts, charts)
+            .Add(x => x.Density, UiDensity.Compact));
+
+        var grades = cut.FindAll(".tier-card-grid .tier-chart-card-corner-start");
+        Assert.Equal(3, grades.Count);
+        Assert.All(grades, g => Assert.Contains("pmb-corner-gain", g.ClassName));
+        // The icon, not a specific letter: which grade a score earns is the scoring
+        // configuration's business and pinning one here would test that instead of this.
+        Assert.All(grades, g => Assert.Contains("/letters/", g.InnerHtml));
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerRatingSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerRatingSagaTests.cs
@@ -685,6 +685,55 @@ public sealed class PlayerRatingSagaTests
         Assert.Equal(rough.Id, result[1].ChartId);
     }
 
+    [Theory]
+    [InlineData(MixEnum.Phoenix)]
+    [InlineData(MixEnum.Phoenix2)]
+    public async Task Top50ForPlayerLeavesOutBrokenRuns(MixEnum mix)
+    {
+        // Both mixes, because the two get it wrong differently when the filter is missing:
+        // Phoenix 2 zeroes a stage break and Phoenix rates it as though it passed. Either way
+        // the run occupies a pool slot it has not earned.
+        var userId = Guid.NewGuid();
+        var passed = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var broke = new ChartBuilder().WithType(ChartType.Single).WithLevel(23).Build();
+        var saga = BuildSaga(
+            charts: ChartsMockReturning(new[] { passed, broke }, mix),
+            scores: ScoresMockReturning(userId, new[]
+            {
+                Score(passed.Id, 900000),
+                Score(broke.Id, 985000, isBroken: true)
+            }, mix));
+
+        var result = (await saga.Handle(
+            new GetTop50ForPlayerQuery(userId, ChartType: null, Mix: mix),
+            CancellationToken.None)).ToArray();
+
+        Assert.Equal(new[] { passed.Id }, result.Select(r => r.ChartId));
+    }
+
+    [Fact]
+    public async Task Top50CompetitiveLeavesOutBrokenRuns()
+    {
+        // A deep partial on a chart well above the player's level would otherwise farm
+        // competitive level without ever passing it.
+        var userId = Guid.NewGuid();
+        var passed = new ChartBuilder().WithType(ChartType.Single).WithLevel(18).Build();
+        var broke = new ChartBuilder().WithType(ChartType.Single).WithLevel(25).Build();
+        var saga = BuildSaga(
+            charts: ChartsMockReturning(new[] { passed, broke }),
+            scores: ScoresMockReturning(userId, new[]
+            {
+                Score(passed.Id, 900000),
+                Score(broke.Id, 950000, isBroken: true)
+            }));
+
+        var result = (await saga.Handle(
+            new GetTop50CompetitiveQuery(userId, ChartType: null),
+            CancellationToken.None)).ToArray();
+
+        Assert.Equal(new[] { passed.Id }, result.Select(r => r.ChartId));
+    }
+
     private static PlayerRatingSaga BuildSaga(
         Mock<IScoreReader>? scores = null,
         Mock<IChartRepository>? charts = null,

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityPageSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityPageSagaTests.cs
@@ -230,6 +230,46 @@ public sealed class PumbilityPageSagaTests
     }
 
     [Fact]
+    public async Task AChartYouDidBetterOnInPhoenix1IsATargetPricedAtTheDifference()
+    {
+        // 985k there against 900k here is a gain worth playing for. It used to be dropped
+        // outright for the sole reason that the chart already carried a Phoenix 2 score.
+        var ctx = new PageContext().WithPhoenixScores(ChartType.Single, 22, 55, 985_000);
+        var contested = ctx.FirstPhoenixChart();
+        ctx.WithPhoenix2Score(contested, 900_000);
+
+        var page = await ctx.Saga.Handle(new GetPumbilityPageQuery(ctx.UserId, MixEnum.Phoenix2),
+            CancellationToken.None);
+
+        var row = page.Targets.Single(t => t.ChartId == contested);
+        Assert.Equal(TargetSource.Phoenix1, row.Source);
+        Assert.True(row.Gain > 0);
+        // It holds the best Phoenix 1 score of the set, so nothing but the discount for what
+        // the chart is already worth could put another chart's gain above it.
+        Assert.True(row.Gain < page.Targets.Max(t => t.Gain),
+            "the gain was not reduced by what the chart already contributes");
+    }
+
+    [Fact]
+    public async Task ABrokenRunHereDoesNotCountAsHavingScoredTheChart()
+    {
+        // A stage break rates zero, so it displaces nothing — and a chart you broke on is
+        // precisely the one your Phoenix 1 record has something to say about.
+        var ctx = new PageContext().WithPhoenixScores(ChartType.Single, 22, 55, 985_000);
+        var broke = ctx.FirstPhoenixChart();
+        ctx.WithPhoenix2Score(broke, 900_000, true);
+
+        var page = await ctx.Saga.Handle(new GetPumbilityPageQuery(ctx.UserId, MixEnum.Phoenix2),
+            CancellationToken.None);
+        var carry = await ctx.Saga.Handle(new ProjectPhoenix2CarryoverQuery(ctx.UserId),
+            CancellationToken.None);
+
+        // Undiscounted, so the best Phoenix 1 score of the set still carries the best gain.
+        Assert.Equal(page.Targets.Max(t => t.Gain), page.Targets.Single(t => t.ChartId == broke).Gain);
+        Assert.Equal(0, carry.ScoredHere);
+    }
+
+    [Fact]
     public async Task TheCarryoverCountsWhatYouHaveNotScoredHereYet()
     {
         var ctx = new PageContext().WithPhoenixScores(ChartType.Single, 22, 55, 985_000);
@@ -329,6 +369,14 @@ public sealed class PumbilityPageSagaTests
 
         /// <summary>The first Phoenix 1 chart seeded — something for both sources to contest.</summary>
         public Guid FirstPhoenixChart() => _myBests.Keys.First();
+
+        /// <summary>What the player holds in Phoenix 2 on a chart they also played in Phoenix 1.</summary>
+        public PageContext WithPhoenix2Score(Guid chartId, int score, bool isBroken = false)
+        {
+            _phoenix2Scores[chartId] = new RecordedPhoenixScore(chartId, score, PhoenixPlate.TalentedGame,
+                isBroken, Now.AddDays(-10));
+            return this;
+        }
 
         /// <summary>Gives the peer estimator an opinion on a chart, so precedence is testable.</summary>
         public PageContext WithPeerProjection(Guid chartId, int projected, int gain)

--- a/ScoreTracker/ScoreTracker/Components/Pumbility/CornerLegend.razor
+++ b/ScoreTracker/ScoreTracker/Components/Pumbility/CornerLegend.razor
@@ -24,6 +24,12 @@
             <span class="border-legend-swatch tier-chart-card-other-mix"></span>@L["Carried from Phoenix 1"]
         </span>
     }
+    @if (HasBroke)
+    {
+        <span class="border-legend-item">
+            <span class="border-legend-swatch tier-chart-card-broken"></span>@L["Played, not passed"]
+        </span>
+    }
     @if (HasNew)
     {
         <span class="border-legend-item">
@@ -38,7 +44,12 @@
 
     private bool HasCarry => Targets.Any(t => t.Source == TargetSource.Phoenix1);
 
-    private bool HasUp => Targets.Any(t => t.Source != TargetSource.Phoenix1 && t.Current != null);
+    // A broken run holds no score for these purposes, so it is neither an upscore nor a chart
+    // the page has never seen you play. The four states stay disjoint on that reading.
+    private bool HasUp => Targets.Any(t => t.Source != TargetSource.Phoenix1
+                                           && t is { Current: not null, CurrentIsBroken: false });
+
+    private bool HasBroke => Targets.Any(t => t.Source != TargetSource.Phoenix1 && t.CurrentIsBroken);
 
     private bool HasNew => Targets.Any(t => t.Source != TargetSource.Phoenix1 && t.Current == null);
 }

--- a/ScoreTracker/ScoreTracker/Components/Pumbility/TargetList.razor
+++ b/ScoreTracker/ScoreTracker/Components/Pumbility/TargetList.razor
@@ -89,8 +89,9 @@ else if (Density == UiDensity.Compact)
             var chart = Charts[target.ChartId];
             <TierListChartCard Chart="chart" Density="UiDensity.Compact"
                                CornerBadge="@($"+{target.Gain:N0}")" CornerBadgeClass="pmb-corner-gain"
-                               Passed="target.Current != null"
+                               Passed="target.Current != null && !target.CurrentIsBroken"
                                PassedInAnotherMix="target.Source == TargetSource.Phoenix1"
+                               Broke="target.CurrentIsBroken"
                                TooltipNote="@CornerMeaning(target)"
                                ShowName="false" ShowToDo="false"
                                OnOpen="OpenById"></TierListChartCard>
@@ -186,6 +187,7 @@ else
     private string CornerMeaning(PumbilityTarget target) => target switch
     {
         { Source: TargetSource.Phoenix1 } => L["Carried from Phoenix 1"],
+        { CurrentIsBroken: true } => L["Played, not passed"],
         { Current: not null } => L["Upscore"],
         _ => L["Not yet played"]
     };

--- a/ScoreTracker/ScoreTracker/Components/Pumbility/TargetList.razor
+++ b/ScoreTracker/ScoreTracker/Components/Pumbility/TargetList.razor
@@ -89,10 +89,11 @@ else if (Density == UiDensity.Compact)
             var chart = Charts[target.ChartId];
             <TierListChartCard Chart="chart" Density="UiDensity.Compact"
                                CornerBadge="@($"+{target.Gain:N0}")" CornerBadgeClass="pmb-corner-gain"
+                               CornerBadgeStart="@ProjectedGrade(target)" CornerBadgeStartClass="pmb-corner-gain"
                                Passed="target.Current != null && !target.CurrentIsBroken"
                                PassedInAnotherMix="target.Source == TargetSource.Phoenix1"
                                Broke="target.CurrentIsBroken"
-                               TooltipNote="@CornerMeaning(target)"
+                               TooltipNote="@CompactNote(target)"
                                ShowName="false" ShowToDo="false"
                                OnOpen="OpenById"></TierListChartCard>
         }
@@ -181,6 +182,22 @@ else
     private Task OpenById(Guid chartId) => OnOpen.InvokeAsync(Charts[chartId]);
 
     private Task OnPlayById(Guid chartId) => OnPlay.InvokeAsync(Charts[chartId]);
+
+    // The grade the projection lands on, opposite the gain in the jacket's other bottom
+    // corner. Compact prints one number, and the number is how much — this says what you
+    // would come away with, which is the other half of deciding whether to go and play it.
+    private RenderFragment ProjectedGrade(PumbilityTarget target) => builder =>
+    {
+        builder.OpenComponent<LetterGradeIcon>(0);
+        builder.AddComponentParameter(1, nameof(LetterGradeIcon.Grade), target.Projected.LetterGradeFor(Mix));
+        builder.AddComponentParameter(2, nameof(LetterGradeIcon.Height), 14);
+        builder.CloseComponent();
+    };
+
+    // The jacket says it in pictures, so the tooltip says it in words — Compact has no body
+    // to carry either (rule 7).
+    private string CompactNote(PumbilityTarget target) =>
+        $"{CornerMeaning(target)} · {L["Projected"]} {target.Projected.LetterGradeFor(Mix).GetName()}";
 
     // Compact hides the body, so the words for the three kinds ride the tooltip and the
     // legend (rule 8: the border's colour never travels alone).

--- a/ScoreTracker/ScoreTracker/Components/TierListChartCard.razor
+++ b/ScoreTracker/ScoreTracker/Components/TierListChartCard.razor
@@ -28,6 +28,10 @@
                        prints the word so the hue never travels alone (rule 8). *@
                     <span class="tier-chart-card-lens-dot" style="background:@TierColor"></span>
                 }
+                @if (CornerBadgeStart != null)
+                {
+                    <div class="tier-chart-card-corner-start tier-chart-card-corner @CornerBadgeStartClass">@CornerBadgeStart</div>
+                }
                 @if (CornerBadge != null)
                 {
                     @* A printed value wins the corner over the grade icon: a caller that
@@ -182,6 +186,12 @@ else
     // A printed value in the jacket's bottom-right corner. Wins that slot over the grade
     // icon in Compact, and is the only thing a Compact card can say in words — so it is for
     // the number the list is RANKED by, not decoration.
+    // The jacket's other bottom corner. Content rather than text, because what goes here is a
+    // picture — the difficulty bubble owns the top edge, so the two badges share the bottom.
+    [Parameter] public RenderFragment? CornerBadgeStart { get; set; }
+
+    [Parameter] public string? CornerBadgeStartClass { get; set; }
+
     [Parameter] public string? CornerBadge { get; set; }
 
     /// <summary>A site.css modifier on the corner badge; the caller owns its meaning and its legend.</summary>

--- a/ScoreTracker/ScoreTracker/Components/TierListChartCard.razor
+++ b/ScoreTracker/ScoreTracker/Components/TierListChartCard.razor
@@ -204,14 +204,22 @@ else
     // on, so a To-Do ring there would be a fourth meaning competing with three.
     [Parameter] public bool ShowStateBorder { get; set; } = true;
 
+    // A run that broke. Ranked below the two pass states on purpose: where a chart is both
+    // attempted here and passed elsewhere, where the number came from is the more useful
+    // thing to say. It earns a state of its own because the alternative is no border at all,
+    // which reads as a chart nobody has ever seen the player touch.
+    [Parameter] public bool Broke { get; set; }
+
     private string StateClass => !ShowStateBorder ? string.Empty :
         Passed ? "tier-chart-card-pass" :
         IsToDo ? "tier-chart-card-todo" :
-        PassedInAnotherMix ? "tier-chart-card-other-mix" : string.Empty;
+        PassedInAnotherMix ? "tier-chart-card-other-mix" :
+        Broke ? "tier-chart-card-broken" : string.Empty;
 
     private string? StateTitle => Passed ? L["Passed"] :
         IsToDo ? L["To Do"] :
-        PassedInAnotherMix ? L["Passed in another mix"] : null;
+        PassedInAnotherMix ? L["Passed in another mix"] :
+        Broke ? L["Played, not passed"] : null;
 
     // Compact hides the name, so the tooltip carries the identity (rule 7: no
     // truncation without a tooltip) plus the state and lens-tier words (rule 8).

--- a/ScoreTracker/ScoreTracker/Pages/Progress/Pumbility.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Progress/Pumbility.razor
@@ -196,10 +196,11 @@ else
 
     private string MixName => _currentMix == MixEnum.Phoenix2 ? "Phoenix 2" : "Phoenix";
 
-    private string? HeroSubtitle => _currentMix == MixEnum.Phoenix2 && _carryover != null
-        ? string.Format(L["Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own."],
-            _carryover.ScoredHere)
-        : L["The sum of your 50 best-rated charts."];
+    // The hero number is this mix's own pool, in every mix. It was captioned as a Phoenix 1
+    // projection on Phoenix 2, which described the carryover panel further down the page
+    // instead — and at launch those two figures are far apart, so the caption read as the
+    // number being wrong. What Phoenix 1 is worth here is that panel's job to say.
+    private string? HeroSubtitle => L["The sum of your 50 best-rated charts."];
 
 
     protected override async Task OnInitializedAsync()

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -4719,9 +4719,6 @@
   <data name="projected Doubles PUMBILITY" xml:space="preserve">
     <value>projected Doubles PUMBILITY</value>
   </data>
-  <data name="Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own." xml:space="preserve">
-    <value>Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own.</value>
-  </data>
   <data name="projected Singles PUMBILITY" xml:space="preserve">
     <value>projected Singles PUMBILITY</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -4560,6 +4560,9 @@
   <data name="Played Not Counting" xml:space="preserve">
     <value>Played, not counting</value>
   </data>
+  <data name="Played, not passed" xml:space="preserve">
+    <value>Played, not passed</value>
+  </data>
   <data name="Player" xml:space="preserve">
 	  <value>Player</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -4719,9 +4719,6 @@
   <data name="projected Doubles PUMBILITY" xml:space="preserve">
     <value>mrglgrrglrgl Groggl PUMBILITY</value>
   </data>
-  <data name="Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own." xml:space="preserve">
-    <value>Mrglrgo blarg Phoenix 1 — morp mrgl {0} Phoenix 2 Mrglrgl.</value>
-  </data>
   <data name="projected Singles PUMBILITY" xml:space="preserve">
     <value>mrglgrrglrgl Mrglrlgl PUMBILITY</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -4560,6 +4560,9 @@
   <data name="Played Not Counting" xml:space="preserve">
     <value>Murpla, blub grogmrgl</value>
   </data>
+  <data name="Played, not passed" xml:space="preserve">
+    <value>Blubrgl, blub rglplgl</value>
+  </data>
   <data name="Player" xml:space="preserve">
 	  <value>Morp</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -4524,6 +4524,9 @@
   <data name="Played Not Counting" xml:space="preserve">
     <value>Jugada, no cuenta</value>
   </data>
+  <data name="Played, not passed" xml:space="preserve">
+    <value>Jugada, no superada</value>
+  </data>
   <data name="Player" xml:space="preserve">
     <value>Jugador/a</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -4683,9 +4683,6 @@
   <data name="projected Doubles PUMBILITY" xml:space="preserve">
     <value>PUMBILITY proyectado de Doubles</value>
   </data>
-  <data name="Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own." xml:space="preserve">
-    <value>Previsto a partir de Phoenix 1: tienes {0} puntuaciones propias en Phoenix 2.</value>
-  </data>
   <data name="projected Singles PUMBILITY" xml:space="preserve">
     <value>PUMBILITY proyectado de Singles</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -4524,6 +4524,9 @@
   <data name="Played Not Counting" xml:space="preserve">
     <value>Jugada, no cuenta</value>
   </data>
+  <data name="Played, not passed" xml:space="preserve">
+    <value>Jugada, no superada</value>
+  </data>
   <data name="Player" xml:space="preserve">
     <value>Jugador</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -4683,9 +4683,6 @@
   <data name="projected Doubles PUMBILITY" xml:space="preserve">
     <value>PUMBILITY Doubles proyectado</value>
   </data>
-  <data name="Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own." xml:space="preserve">
-    <value>Previsto a partir de Phoenix 1: tienes {0} puntuaciones propias en Phoenix 2.</value>
-  </data>
   <data name="projected Singles PUMBILITY" xml:space="preserve">
     <value>PUMBILITY Singles proyectado</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -4559,6 +4559,9 @@
   <data name="Played Not Counting" xml:space="preserve">
     <value>Jouée, non comptée</value>
   </data>
+  <data name="Played, not passed" xml:space="preserve">
+    <value>Jouée, non réussie</value>
+  </data>
   <data name="Player" xml:space="preserve">
     <value>Joueur</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -4718,9 +4718,6 @@
   <data name="projected Doubles PUMBILITY" xml:space="preserve">
     <value>PUMBILITY Doubles projeté</value>
   </data>
-  <data name="Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own." xml:space="preserve">
-    <value>Projeté depuis Phoenix 1 — tu as {0} scores à toi dans Phoenix 2.</value>
-  </data>
   <data name="projected Singles PUMBILITY" xml:space="preserve">
     <value>PUMBILITY Singles projeté</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -4719,9 +4719,6 @@
   <data name="projected Doubles PUMBILITY" xml:space="preserve">
     <value>PUMBILITY Doubles proiettato</value>
   </data>
-  <data name="Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own." xml:space="preserve">
-    <value>Previsto da Phoenix 1 — hai {0} punteggi tuoi in Phoenix 2.</value>
-  </data>
   <data name="projected Singles PUMBILITY" xml:space="preserve">
     <value>PUMBILITY Singles proiettato</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -4560,6 +4560,9 @@
   <data name="Played Not Counting" xml:space="preserve">
     <value>Giocata, non conta</value>
   </data>
+  <data name="Played, not passed" xml:space="preserve">
+    <value>Giocata, non superata</value>
+  </data>
   <data name="Player" xml:space="preserve">
     <value>Giocatore</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -4719,9 +4719,6 @@
   <data name="projected Doubles PUMBILITY" xml:space="preserve">
     <value>予測ダブルPUMBILITY</value>
   </data>
-  <data name="Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own." xml:space="preserve">
-    <value>Phoenix 1 からの予測です。Phoenix 2 での自分のスコアは {0} 件です。</value>
-  </data>
   <data name="projected Singles PUMBILITY" xml:space="preserve">
     <value>予測シングルPUMBILITY</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -4560,6 +4560,9 @@
   <data name="Played Not Counting" xml:space="preserve">
     <value>プレイ済み、対象外</value>
   </data>
+  <data name="Played, not passed" xml:space="preserve">
+    <value>プレイ済み、未クリア</value>
+  </data>
   <data name="Player" xml:space="preserve">
 	  <value>プレーヤー</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -4683,9 +4683,6 @@
   <data name="projected Doubles PUMBILITY" xml:space="preserve">
     <value>예상 더블 PUMBILITY</value>
   </data>
-  <data name="Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own." xml:space="preserve">
-    <value>Phoenix 1 기준 예상입니다 — Phoenix 2에는 본인 점수가 {0}개 있습니다.</value>
-  </data>
   <data name="projected Singles PUMBILITY" xml:space="preserve">
     <value>예상 싱글 PUMBILITY</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -4524,6 +4524,9 @@
   <data name="Played Not Counting" xml:space="preserve">
     <value>플레이함, 미반영</value>
   </data>
+  <data name="Played, not passed" xml:space="preserve">
+    <value>플레이함, 미클리어</value>
+  </data>
   <data name="Player" xml:space="preserve">
     <value>플레이어</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -4683,9 +4683,6 @@
   <data name="projected Doubles PUMBILITY" xml:space="preserve">
     <value>PUMBILITY Doubles projetado</value>
   </data>
-  <data name="Projected from Phoenix 1 — you have {0} Phoenix 2 scores of your own." xml:space="preserve">
-    <value>Previsto a partir do Phoenix 1 — você tem {0} pontuações próprias no Phoenix 2.</value>
-  </data>
   <data name="projected Singles PUMBILITY" xml:space="preserve">
     <value>PUMBILITY Singles projetado</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -4524,6 +4524,9 @@
   <data name="Played Not Counting" xml:space="preserve">
     <value>Jogada, não conta</value>
   </data>
+  <data name="Played, not passed" xml:space="preserve">
+    <value>Jogada, não passou</value>
+  </data>
   <data name="Player" xml:space="preserve">
     <value>Jogador</value>
   </data>

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -2218,6 +2218,15 @@ html.sheet-open .more-sheet-scrim {
     border-style: dashed;
 }
 
+/* Played and broke. Grey rather than the pass green because the run earned nothing, and
+   dotted rather than dashed so the three "we have seen you here" states stay separable at
+   a glance. The mix token rather than a Mud palette entry: this is the only one of the
+   four whose colour is a shade of the page rather than a semantic. */
+.tier-chart-card-broken {
+    border-color: color-mix(in srgb, var(--mix-ink-muted) 70%, transparent);
+    border-style: dotted;
+}
+
 /* Randomizer draw states join the same source-order contract: held = mix-primary ring
    (deliberately NOT the pass-green), vetoed = error red — both in every density, on
    top of the dim/strike second channels. */

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -1955,6 +1955,19 @@ html.sheet-open .more-sheet-scrim {
     border: 1px solid transparent;
 }
 
+/* The jacket's other bottom corner. Position only — the chrome rides .tier-chart-card-corner
+   alongside it, so the two badges cannot drift apart. Declared after it so the tighter
+   padding a picture wants beats the padding a printed value wants, on source order. */
+.tier-chart-card-corner-start {
+    position: absolute;
+    bottom: 3px;
+    left: 3px;
+    display: flex;
+    align-items: center;
+    border-radius: 4px;
+    padding: 1px 3px;
+}
+
 /* Play affordance on the jacket — .chart-card-play's treatment at card scale. Revealed on
    hover, always present for keyboard. */
 .tier-chart-card-play {
@@ -13006,14 +13019,16 @@ span.ct-console-pick { cursor: default; }
 
 
 /* --- targets, comfortable --- */
-/* One treatment for every gain badge: green on a green outline over the black backdrop.
-   The number says how MUCH, and nothing else — which KIND of row it is rides the card's
-   border (owner, 2026-08-06). Declared AFTER .tier-chart-card-corner so it wins that
-   rule's border shorthand on source order, the same contract the card border language runs
-   on. */
+/* One treatment for both jacket badges: the mix accent on the mix accent, over the black
+   backdrop. The number says how MUCH and nothing else, the grade says what you would come
+   away with — which KIND of row it is rides the card's border (owner, 2026-08-06).
+   Deliberately the mix accent rather than the pass green: the border language owns green,
+   and MixPalette.Success is one constant across every mix, so a badge painted with it says
+   nothing about where you are. Declared AFTER .tier-chart-card-corner so it wins that rule's
+   border shorthand on source order, the same contract the card border language runs on. */
 .pmb-corner-gain {
-    border-color: var(--mud-palette-success);
-    color: var(--mud-palette-success);
+    border-color: var(--mix-primary);
+    color: var(--mix-primary);
 }
 
 .pmb-legend {

--- a/docs/design/pumbility-overhaul.md
+++ b/docs/design/pumbility-overhaul.md
@@ -97,10 +97,18 @@ keep in sync, which is the drift the one-concept-one-component rule exists to pr
 The corner badge is the **gain**, because a Compact card is 72px tall and prints exactly one
 value — so it has to be the one the list is ranked by.
 
-**The border says which kind, the number says how much** (owner, 2026-08-06). Every gain badge
-is one treatment — green on a green outline over the black backdrop — and carries no meaning
-beyond its value. The kind rides the **card border**, in the tier list's own language rather
-than a second one invented here:
+**The jacket's other bottom corner is the grade the projection lands on** (owner, 2026-08-07).
+The difficulty bubble owns the top edge, so the two badges share the bottom: how much on the
+end, what you would come away with on the start. It is a picture rather than a second number,
+so "Compact prints one value" still holds — and the tooltip says it in words, because Compact
+has no body to put them in (rule 7).
+
+**The border says which kind, the number says how much** (owner, 2026-08-06). Both jacket
+badges are one treatment — the **mix accent** on the mix accent over the black backdrop — and
+carry no meaning beyond what they state. Deliberately not the pass green: the border language
+below owns green, and `MixPalette.Success` is one constant across every mix, so a badge painted
+with it says nothing about where you are. The kind rides the **card border**, in the tier list's
+own language rather than a second one invented here:
 
 | border | meaning |
 |---|---|

--- a/docs/design/pumbility-overhaul.md
+++ b/docs/design/pumbility-overhaul.md
@@ -45,6 +45,8 @@ Owner rulings, 2026-08-05. These bind; do not re-litigate them in the build.
 | D7 | **The top 50 is collapsed and below the fold.** It is a reference, not the answer |
 | D8 | **No world-rank chip.** Offered and declined |
 | D9 | **"Kind" is not a column.** It restated the cell beside it — see §3.3 |
+| D10 | **A broken run plays no part in this page** (owner, 2026-08-07). *"Failed shit should not show anywhere on here."* A stage break rates zero, so it is not a score the player holds: it cannot occupy a pool slot, cannot set the bar, and does not count as having scored a chart. Enforced at the two top-50 reads rather than per call site, so the queries mean what their names say |
+| D11 | **A carryover target is priced, not gated.** A chart already scored in Phoenix 2 stays a target when the Phoenix 1 repricing beats what it currently contributes — same floor as the peer projection, one ranked list, both sources priced identically |
 
 ## 3. The page
 
@@ -104,7 +106,15 @@ than a second one invented here:
 |---|---|
 | solid success (`.tier-chart-card-pass`) | you hold a score on this chart and would beat it |
 | dashed success (`.tier-chart-card-other-mix`) | you hold it in *another mix* (§5) |
+| dotted grey (`.tier-chart-card-broken`) | you played it here and broke |
 | none | nobody has seen you play it |
+
+The fourth state is what D10 costs. Once a stage break holds no score, a chart the player broke
+on falls through the first two — and *no* border would claim they had never touched it, on
+exactly the charts the rule changed. It ranks below both pass states on purpose: where a chart is
+attempted here and passed in Phoenix 1, where the number came from is the more useful thing to
+say. Grey rather than the pass green because the run earned nothing, dotted rather than dashed so
+the three "we have seen you here" states stay separable at 72px.
 
 Same classes as the tier list, so the two pages cannot drift apart. A "Kind" column restated
 what the card already says, and read the same value down every row on Phoenix 1.
@@ -409,6 +419,18 @@ Supporting facts the section renders, all real:
 
 **A chart with no Phoenix 2 appearance is a fact, not a target.** It is stated once in the fact
 tile and never appears in the target list — you cannot go and play it.
+
+**A chart already scored here is still a target** (D11). Carryover used to admit only charts with
+no Phoenix 2 score at all, which dropped 985k-there-against-900k-here — a real gain, resting on
+the best evidence the page has — for the sole reason that the chart had been touched. It now asks
+the projection's question with the projection's floor: `Phoenix2Value − max(what you already get
+from the chart, the bar)`, kept when positive. A stage break here contributes nothing and so reads
+as unscored, which was the compounding half of the same bug: a chart the player broke on was
+excluded for having been "scored" while adding nothing to the pool.
+
+Note what this does *not* change: `Entries`, `ScoredHere`, `NotYetScored` and every figure in the
+table above are still the pool's fifty. The repricing is the same arithmetic it always was — only
+which rows become suggestions moved.
 
 ## 6. Technical scope
 


### PR DESCRIPTION
Fixes what the owner hit on Phoenix 2 the moment his pool reached fifty charts: every projected suggestion printing its **whole** value instead of the difference it would make, and a bar reading **0**.

## The bug

A stage break is worth zero PUMBILITY (`StageBreakModifier = 0.0`), but neither top-50 read filtered broken runs — so they came back as pool members valued nothing.

`BuildPool` then counts them toward the fullness gate and takes the minimum of the fifty:

```csharp
var baseline = ratings.Count >= 50 ? top50.Min(kv => kv.Value) : 0;
```

Broken rows push the count over fifty, and the minimum is still zero. **That is why crossing fifty changed nothing** — the code moved off the deliberate `: 0` branch onto one that also evaluates to 0. Same defect in `PumbilityPageSaga.Handle`, so the hero's bar, the pool board and the carryover floor all read 0 too.

The corroborating detail: the carryover query in that same class already filtered `IsBroken: false`. One class, two paths, one filtering and one not.

## Also fixed

**Carryover skipped upscores.** It admitted a chart only when it had no Phoenix 2 score at all, so 985k in Phoenix 1 against 900k here — a real gain on the best evidence the page has — was dropped for the sole reason that the chart had been touched. It now asks the projection's question with the projection's floor. A broken Phoenix 2 run reads as unscored, which was the compounding half: a chart you broke on was excluded for having been "scored" while adding nothing to the pool.

**The hero number claimed to be a projection.** On Phoenix 2 the caption read "Projected from Phoenix 1 — you have N Phoenix 2 scores of your own" on every visit, over a number that is the player's own Phoenix 2 top-fifty sum. The caption was describing the carryover panel further down the page; at launch those two figures are far apart, so it read as the number itself being wrong.

## One thing that turned out not to be broken

Scoping flagged the stored rating as a third fix, on the grounds that `Rate()` does not pass `IsBroken` on its Phoenix branch. That reading was wrong about the consequence. `RecalculateCore` filters `!IsBroken` at **every** consumer — `top50`, both per-type pools, `coOps`, `TotalRating`, `HighestLevel`, `ClearCount` and the competitive arrays — so the value computed for a broken row is never used.

**No stored number moves, and no release note is needed.** Ratings, competitive levels and board positions are unchanged.

## Commits

| | |
|---|---|
| `fix(progress): a failed run never occupies a pool slot` | Both top-50 reads drop broken runs at the query |
| `fix(progress): carryover prices an upscore instead of skipping it` | Gain-positive rather than unscored-only |
| `feat(progress): a broken run gets its own border` | The fourth compact state the first commit costs |
| `docs: broken runs are out, and carryover measures gain` | D10, D11, and §3.3/§5 |
| `fix(progress): the hero number stops claiming to be a projection` | Every mix says what the number is |

## The border

Once a stage break holds no score, a chart you broke on falls through all three existing states — and no border at all would claim you had never touched it, on exactly the charts this PR changed. Dotted grey, ranked below both pass states, in the tier list's own class family.

| border | meaning |
|---|---|
| solid success | you hold a score here and would beat it |
| dashed success | you hold it in another mix |
| **dotted grey** | **you played it here and broke** |
| none | nobody has seen you play it |

## Field test

Phoenix 2 with fifty-plus charts: the bar should be a real number, suggestion gains should be differences, and any chart you broke on should carry a dotted grey outline on Compact and say "Played, not passed" in the legend and on Comfortable's why-line. A chart you scored better on in Phoenix 1 than here should now appear as a target. The hero caption should read "The sum of your 50 best-rated charts" on both mixes.

⚠ **One expectation.** If some of those fifty were broken runs, removing them can put you back *under* fifty real passes — and under fifty, `BuildPool` sets the baseline to 0 deliberately, because a pool that isn't full displaces nothing. Gains will still print whole, correctly this time. The tell is the bar: a real bar with whole-value gains is a bug; no bar at all means the pool isn't full yet.

## Not in here

The loading card and the projection cache work is PR 2, deliberately second — this PR changes what the projection outputs, so caching it for a day first would have banked wrong numbers.

## Suites

`ScoreTracker.Tests` 2304 · `Tests.Api` 148 · `Tests.Components` 645 — all green, 4 new facts. Integration and E2E untouched by these paths; CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
