### PR TITLE
fix(communities): a missing community is an empty board, not a dead circuit

### DIFF
--- a/ScoreTracker/ScoreTracker.Catalog/Infrastructure/EFChartRepository.cs
+++ b/ScoreTracker/ScoreTracker.Catalog/Infrastructure/EFChartRepository.cs
@@ -60,15 +60,24 @@ internal sealed class EFChartRepository : IChartRepository
     public async Task<IEnumerable<ChartVideoInformation>> GetChartVideoInformation(
         IEnumerable<Guid>? chartIds = default, CancellationToken cancellationToken = default)
     {
-        var chartVideos = await _cache.GetOrCreateAsync<IDictionary<Guid, ChartVideoInformation>>(VideoCacheKey,
-            async entry =>
-            {
-                entry.AbsoluteExpiration = DateTimeOffset.Now + TimeSpan.FromDays(14);
-                await using var database = await _factory.CreateDbContextAsync(cancellationToken);
-                return await database.Set<ChartVideoEntity>()
-                    .Select(c => new ChartVideoInformation(c.ChartId, new Uri(c.VideoUrl), c.ChannelName))
-                    .ToDictionaryAsync(c => c.ChartId, cancellationToken);
-            });
+        if (!_cache.TryGetValue<IDictionary<Guid, ChartVideoInformation>>(VideoCacheKey, out var chartVideos)
+            || chartVideos == null)
+        {
+            await using var database = await _factory.CreateDbContextAsync(cancellationToken);
+            chartVideos = await database.Set<ChartVideoEntity>()
+                .Select(c => new ChartVideoInformation(c.ChartId, new Uri(c.VideoUrl), c.ChannelName))
+                .ToDictionaryAsync(c => c.ChartId, cancellationToken);
+
+            // One key holds the whole table, so an empty read asserts "no chart anywhere has a
+            // video" — true only of a database still being filled, and a fortnight's expiry
+            // outlasts the filling: every chart then reports no video until an admin edit evicts
+            // the key. An empty result is therefore left uncached and re-asked on the next call.
+            if (chartVideos.Count > 0)
+                _cache.Set(VideoCacheKey, chartVideos, new MemoryCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(14)
+                });
+        }
 
         return chartIds != null
             ? chartIds.Where(id => chartVideos.ContainsKey(id)).Select(id => chartVideos[id])

--- a/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs
@@ -962,10 +962,19 @@ internal sealed class CommunitySaga : IRequestHandler<CreateCommunityCommand>, I
         return await _communities.GetPublicCommunities(cancellationToken);
     }
 
+    /// <summary>
+    ///     A community nobody has created yet is an empty board, not a fault. System communities
+    ///     seed themselves on first join (see <see cref="JoinSystemCommunity" />), so "World" does
+    ///     not exist on a fresh database — and the chart leaderboard reads World on every open,
+    ///     from inside a Blazor render, where a throw tears down the whole circuit rather than
+    ///     leaving one panel empty.
+    /// </summary>
     public async Task<IEnumerable<UserPhoenixScore>> Handle(GetPhoenixRecordsForCommunityQuery request,
         CancellationToken cancellationToken)
     {
-        var community = await GetCommunity(request.CommuityName, cancellationToken);
+        var community = await _communities.GetCommunityByName(request.CommuityName, cancellationToken);
+        if (community == null) return Array.Empty<UserPhoenixScore>();
+
         return await _scores.GetPhoenixScores(request.Mix, community.MemberIds, request.ChartId,
             cancellationToken);
     }

--- a/ScoreTracker/ScoreTracker.Tests.E2E/Support/E2EAppFixture.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/Support/E2EAppFixture.cs
@@ -138,16 +138,10 @@ public sealed class E2EAppFixture : IAsyncLifetime
     ///     Drops every in-memory cache the running app holds.
     ///     <para>
     ///         Call it AFTER seeding as well as before. The app is live while a test seeds, and
-    ///         several catalog reads cache a whole table under one key for days — chart videos are
-    ///         the sharpest: one global key, a 14-day expiry, and production only evicts it when a
-    ///         video is edited through the admin path. Anything that reads that table between the
-    ///         reset and the seed pins an EMPTY dictionary for the rest of the run, and no amount
-    ///         of waiting brings the row back. Seeding through raw SQL bypasses the eviction the
-    ///         real write path performs, so the test has to do it.
-    ///     </para>
-    ///     <para>
-    ///         Added while chasing TierListTests' intermittent video assertion. It is correct on
-    ///         its own terms and did not fix that — see the note there.
+    ///         several catalog reads cache a whole table under one key for days (charts a
+    ///         fortnight, tier lists a day), evicted in production only by the write path that a
+    ///         raw-SQL seed goes around. Without the second call, a read landing between the reset
+    ///         and the seed serves the previous test's world for the rest of the run.
     ///     </para>
     /// </summary>
     public void ClearCaches()

--- a/ScoreTracker/ScoreTracker.Tests.E2E/TierListTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/TierListTests.cs
@@ -38,10 +38,9 @@ public sealed class TierListTests : IAsyncLifetime
         // The details dialog leads with the video (C6) — give every folder chart one.
         foreach (var chartId in new[] { easy1, easy2, hard, overrated })
             await _fixture.Seed.SeedChartVideoAsync(chartId, "https://e2e-files.invalid/video");
-        // Raw-SQL seeding bypasses the eviction the real write path performs, and chart videos
-        // cache as one whole-table dictionary for fourteen days — so anything that read the table
-        // between the reset and this line would pin an empty one for the rest of the run.
-        // Hygiene, not a fix: it did NOT resolve the intermittent failure below.
+        // Raw-SQL seeding goes around the eviction the real write path performs, and the catalog
+        // caches whole tables under one key for days — so a read landing between the reset and
+        // this line serves the previous test's world for the rest of the run.
         _fixture.ClearCaches();
 
         _browser = await _fixture.NewBrowserContextAsync();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/CommunitySagaTests.cs
@@ -1481,6 +1481,51 @@ public sealed class CommunitySagaTests
     }
 
     [Fact]
+    public async Task PhoenixRecordsForACommunityThatDoesNotExistIsAnEmptyBoard()
+    {
+        // The chart leaderboard reads the World community on every open, and World seeds itself
+        // on first join rather than in a migration — so it is absent on a fresh database. Throwing
+        // there kills the Blazor circuit the read happens inside, taking the whole page with it
+        // instead of leaving one empty panel.
+        var ctx = new HandlerContext();
+        ctx.Communities.Setup(c => c.GetCommunityByName(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Community?)null);
+
+        var result = await ctx.Saga.Handle(
+            new GetPhoenixRecordsForCommunityQuery("World", Guid.NewGuid(), MixEnum.Phoenix),
+            CancellationToken.None);
+
+        Assert.Empty(result);
+        ctx.Scores.Verify(s => s.GetPhoenixScores(It.IsAny<MixEnum>(), It.IsAny<IEnumerable<Guid>>(),
+            It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PhoenixRecordsForACommunityReadsItsMembersScores()
+    {
+        // The other half of the pair: a community that IS there still reaches the ledger, so the
+        // null guard above cannot pass by returning empty for everyone.
+        var ctx = new HandlerContext();
+        var member = Guid.NewGuid();
+        var chartId = Guid.NewGuid();
+        var community = new Community(Name.From("Murlocs"), Guid.Empty, CommunityPrivacyType.Public,
+            new[] { member }, Array.Empty<Community.ChannelConfiguration>(),
+            new Dictionary<Guid, DateOnly?>(), false);
+        ctx.Communities.Setup(c => c.GetCommunityByName(It.Is<Name>(n => (string)n == "Murlocs"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(community);
+        ctx.Scores.Setup(s => s.GetPhoenixScores(MixEnum.Phoenix, It.IsAny<IEnumerable<Guid>>(), chartId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new UserPhoenixScore(member, chartId, Name.From("MURLOC"), 994_000, null, false) });
+
+        var result = await ctx.Saga.Handle(
+            new GetPhoenixRecordsForCommunityQuery("Murlocs", chartId, MixEnum.Phoenix),
+            CancellationToken.None);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
     public async Task CommunityCountReturnsTheNonRegionalCount()
     {
         var ctx = new HandlerContext();


### PR DESCRIPTION
## What broke

`ChartLeaderboardScopes` threw an unhandled `CommunityNotFoundException` that killed the Blazor circuit — the page died with "An unhandled exception has occurred" instead of the panel degrading to an empty state.

```
CommunitySaga.GetCommunity(Name, CancellationToken) CommunitySaga.cs:1162
CommunitySaga.Handle(GetPhoenixRecordsForCommunityQuery, ...) CommunitySaga.cs:968
ChartLeaderboardScopes.LoadChartAsync() ChartLeaderboardScopes.razor:213
```

## One correction to the reported diagnosis

Line 213 is the unconditional **World** read, not a disabled scope. It feeds World, Competitive Peers and the "your score" row in Rivals, and fires on every chart-details open, signed in or not.

So "skip the scope the viewer has no community for" needed no change — the Community scope was already guarded three ways (`SelectScope` checks `IsAvailable`, the `Community` arm returns empty when `_community == null`, and `LoadChartAsync` falls back to World when `InitialScope` is unavailable), and `_myCommunities` comes from `GetMyCommunitiesQuery`, so a picked community always exists. World was the only unguarded read, and it can't be skipped: it is the panel's baseline data.

## Why World was missing

[`CommunitySaga.cs:862`](https://github.com/DrMurloc/PumpItUpScoreTracker/blob/main/ScoreTracker/ScoreTracker.Communities/Application/CommunitySaga.cs#L862) already said it — system communities have no seed anywhere; they create themselves on first join. A database with no public user yet has no `World` row. That is a fresh deploy, and it is **every E2E test**, since Respawn wipes `scores` between them.

## Changes

- **`CommunitySaga.Handle(GetPhoenixRecordsForCommunityQuery)`** — returns empty for a community that isn't there. This was the option that keeps the panel showing an empty state, and it fixes both call sites at once. Mutating handlers keep `GetCommunity`'s throw (still used by five of them).
- **`EFChartRepository.GetChartVideoInformation`** — an empty whole-table read is no longer cached for a fortnight. One key holds the whole table, so an empty result asserts "no chart anywhere has a video", and holding that outlasts a database still filling up.
- **Two saga tests** — the null case and its inverse, so the guard can't pass by returning empty for everyone.
- **Comments** in `TierListTests` and `E2EAppFixture` rewritten; the "Hygiene, not a fix: it did NOT resolve the intermittent failure" note is gone.

## The E2E flake

This crash — not the video cache — is the long-standing intermittent `TierListTests.ChartCardOpensTheDetailsDialogVideoFirst` failure.

`ChartDetailsDialog` has no video tab: the `<iframe>` is unconditional and **Leaderboard is always the opening tab**, so the board renders on every open regardless of whether a video exists. The race was the iframe landing in the DOM before the exception tore the circuit down — win it and the assertion passes, lose it and it doesn't. That is the pass/fail/fail.

Isolated rather than assumed: reverting **only** the cache change still gives 3/3 green. The cache change is insurance against a documented hazard, not the fix — separable if you'd rather not take a production behaviour change for something I couldn't demonstrate firing.

## Verification

| Suite | Result |
|---|---|
| `dotnet build -c Debug` | 0 errors |
| `ScoreTracker.Tests` | 2307 ✓ |
| `ScoreTracker.Tests.Components` | 649 ✓ |
| `ScoreTracker.Tests.Api` | 148 ✓ |
| `Tests.E2E` `TierListTests` | **6/6 on 6 consecutive runs** (3 with both fixes, 3 with the circuit fix alone) |

## Reviewer note

`Tests.Components` failed once on `ChartsPageTests.ASongNameFilterBecomesAChipCountsOnTheFunnelAndRequeries` during the first full run, then passed alone and in two later full runs. A bUnit timing flake under load, unrelated to these files — component tests mock `IMediator`, so neither changed class is constructed. Flagging rather than silently swallowing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
