### PR TITLE
fix(pumbility): the Phoenix 2 carryover repriced scores at the Phoenix 1 level

### DIFF
--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityPageSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityPageSaga.cs
@@ -154,12 +154,12 @@ namespace ScoreTracker.PlayerProgress.Application
         ///     </para>
         /// </summary>
         private static IReadOnlyList<ProjectedTitle> ProjectedTitles(
-            IReadOnlyList<RecordedPhoenixScore> everyScore, IReadOnlyDictionary<Guid, Chart> charts,
+            IReadOnlyList<RecordedPhoenixScore> everyScore, Func<Guid, Chart> priced,
             ScoringConfiguration p2Scoring)
         {
             var repriced = everyScore
-                .Select(s => (Chart: charts[s.ChartId],
-                    Value: p2Scoring.GetScore(charts[s.ChartId], s.Score!.Value,
+                .Select(s => (Chart: priced(s.ChartId),
+                    Value: p2Scoring.GetScore(priced(s.ChartId), s.Score!.Value,
                         s.Plate ?? PhoenixPlate.RoughGame, s.IsBroken)))
                 .Where(x => x.Value > 0)
                 .ToArray();
@@ -399,11 +399,21 @@ namespace ScoreTracker.PlayerProgress.Application
             var phoenixCharts = (await _mediator.Send(new GetChartsQuery(MixEnum.Phoenix), cancellationToken))
                 .ToDictionary(c => c.Id);
             var phoenix2Charts = (await _mediator.Send(new GetChartsQuery(MixEnum.Phoenix2), cancellationToken))
-                .Select(c => c.Id)
-                .ToHashSet();
+                .ToDictionary(c => c.Id);
 
             var p1Scoring = ScoringConfiguration.PumbilityScoring(MixEnum.Phoenix, false);
             var p2Scoring = ScoringConfiguration.PumbilityScoring(MixEnum.Phoenix2, false);
+
+            // Phoenix 2 RERATED the charts it inherited rather than restepping them, so one
+            // chart id carries a different level in each mix. The repricing has to read the
+            // level the chart carries HERE: priced from Phoenix 1, a downrated chart pays a
+            // base it no longer commands and an uprated one is short-changed by the same
+            // arithmetic. A chart with no Phoenix 2 row has no Phoenix 2 level to read, so it
+            // keeps its own — it still counts toward the pool, and it can never be a target.
+            Chart Priced(Guid chartId)
+            {
+                return phoenix2Charts.TryGetValue(chartId, out var here) ? here : phoenixCharts[chartId];
+            }
 
             var everyPhoenixScore =
                 (await _scores.GetBestScores(MixEnum.Phoenix, request.UserId, cancellationToken))
@@ -419,9 +429,10 @@ namespace ScoreTracker.PlayerProgress.Application
                 .Where(s => s is { Score: not null, IsBroken: false })
                 .ToDictionary(s => s.ChartId, s => s.Score!.Value);
 
-            // The repricing: every Phoenix 1 score run through Phoenix 2's formula, which pays
-            // a Singles chart one level up the base curve and zeroes anything under level 10.
-            // That rule alone can turn a doubles pool into a singles pool.
+            // The repricing: every Phoenix 1 score run through Phoenix 2's formula at the level
+            // the chart carries in Phoenix 2, which pays a Singles chart one level up the base
+            // curve and zeroes anything under level 10. The singles bump alone can turn a
+            // doubles pool into a singles pool.
             // Repriced to CandidateDepth, sliced at PoolSize. Every score was already being
             // repriced before the Take, so reading past the fiftieth costs nothing: the pool
             // figures below still come from the first fifty and mean exactly what they did.
@@ -433,8 +444,8 @@ namespace ScoreTracker.PlayerProgress.Application
             // fifty with zeros, which drives the bar this pool would set to zero and miscounts
             // the singles/doubles split the panel is built to show.
             var ranked = phoenixScores
-                .Select(s => (Score: s, Chart: phoenixCharts[s.ChartId],
-                    Value: p2Scoring.GetScore(phoenixCharts[s.ChartId], s.Score!.Value,
+                .Select(s => (Score: s, Chart: Priced(s.ChartId),
+                    Value: p2Scoring.GetScore(Priced(s.ChartId), s.Score!.Value,
                         s.Plate ?? PhoenixPlate.RoughGame, s.IsBroken)))
                 .Where(x => x.Value > 0)
                 .OrderByDescending(x => x.Value)
@@ -457,7 +468,7 @@ namespace ScoreTracker.PlayerProgress.Application
                     x.Score.Score!.Value.LetterGradeFor(MixEnum.Phoenix),
                     Math.Round(x.Value, 2),
                     phoenix2Scores.TryGetValue(x.Score.ChartId, out var here) ? here : null,
-                    phoenix2Charts.Contains(x.Score.ChartId));
+                    phoenix2Charts.ContainsKey(x.Score.ChartId));
             }
 
             var entries = repriced.Select(Entry).ToArray();
@@ -471,7 +482,7 @@ namespace ScoreTracker.PlayerProgress.Application
                 repriced.Length >= PoolSize ? Math.Round(repriced.Min(x => x.Value), 2) : 0,
                 phoenix2Scores.Count,
                 entries.Count(e => e.Phoenix2Score == null),
-                ProjectedTitles(everyPhoenixScore, phoenixCharts, p2Scoring),
+                ProjectedTitles(everyPhoenixScore, Priced, p2Scoring),
                 repriced.Count(x => x.Chart.Type == ChartType.Single),
                 repriced.Count(x => x.Chart.Type == ChartType.Double),
                 phoenix1Pool.Count(x => x.Chart.Type == ChartType.Single),

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityPageSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityPageSagaTests.cs
@@ -235,6 +235,29 @@ public sealed class PumbilityPageSagaTests
     }
 
     [Fact]
+    public async Task ARepricedScoreIsPricedAtThePhoenix2LevelNotThePhoenix1One()
+    {
+        // Phoenix 2 rerated the charts it inherited rather than restepping them, so the level
+        // a score was set against is not the level it is worth today. Priced from Phoenix 1, a
+        // downrated chart pays a base it no longer commands and floats up the suggestions on
+        // the strength of a rating the mix has taken away from it (owner, Spooky Macaron S23 →
+        // S22, reading +372 where the chart is worth +365).
+        var ctx = new PageContext().WithPhoenixScores(ChartType.Single, 23, 55, 985_000);
+        var downrated = ctx.FirstPhoenixChart();
+        ctx.WithPhoenix2Level(downrated, 22);
+
+        var carry = await ctx.Saga.Handle(new ProjectPhoenix2CarryoverQuery(ctx.UserId), CancellationToken.None);
+
+        var scoring = ScoringConfiguration.PumbilityScoring(MixEnum.Phoenix2, false);
+        var row = carry.Entries.Concat(carry.Candidates).Single(e => e.ChartId == downrated);
+        var here = scoring.GetScore(ChartType.Single, 22, row.Phoenix1Score, PhoenixPlate.MarvelousGame);
+        var there = scoring.GetScore(ChartType.Single, 23, row.Phoenix1Score, PhoenixPlate.MarvelousGame);
+
+        Assert.True(here < there, "the two levels must disagree or this asserts nothing");
+        Assert.Equal(here, row.Phoenix2Value, 2);
+    }
+
+    [Fact]
     public async Task TheCarryoverSaysWhereTheRecordWouldLandOnAllThreeLadders()
     {
         var ctx = new PageContext().WithPhoenixScores(ChartType.Single, 24, 55, 995_000);
@@ -509,6 +532,7 @@ public sealed class PumbilityPageSagaTests
         private readonly List<Chart> _charts = new();
         private readonly Dictionary<Guid, RecordedPhoenixScore> _myBests = new();
         private readonly HashSet<Guid> _phoenix2Charts = new();
+        private readonly Dictionary<Guid, int> _phoenix2Levels = new();
         private readonly Dictionary<Guid, RecordedPhoenixScore> _phoenix2Scores = new();
         private readonly Dictionary<Guid, PhoenixScore> _projected = new();
         private readonly Dictionary<Guid, int> _gains = new();
@@ -520,8 +544,15 @@ public sealed class PumbilityPageSagaTests
                 .ReturnsAsync((IRequest<IEnumerable<Chart>> request, CancellationToken _) =>
                 {
                     var mix = ((GetChartsQuery)request).Mix;
+                    // Phoenix 2 rerated charts rather than restepping them, so the same id can
+                    // come back at a different level per mix — which is the whole reason the
+                    // catalog is asked for per mix rather than once.
                     return mix == MixEnum.Phoenix2
-                        ? _charts.Where(c => _phoenix2Charts.Contains(c.Id)).ToArray()
+                        ? _charts.Where(c => _phoenix2Charts.Contains(c.Id))
+                            .Select(c => _phoenix2Levels.TryGetValue(c.Id, out var level)
+                                ? c with { Level = level, Mix = MixEnum.Phoenix2 }
+                                : c with { Mix = MixEnum.Phoenix2 })
+                            .ToArray()
                         : _charts.ToArray();
                 });
             Mediator.Setup(m => m.Send(It.IsAny<GetTop50ForPlayerQuery>(), It.IsAny<CancellationToken>()))
@@ -589,6 +620,13 @@ public sealed class PumbilityPageSagaTests
 
         /// <summary>The first Phoenix 1 chart seeded — something for both sources to contest.</summary>
         public Guid FirstPhoenixChart() => _myBests.Keys.First();
+
+        /// <summary>Rerates a chart for Phoenix 2, which is what Phoenix 2 did to 338 of them.</summary>
+        public PageContext WithPhoenix2Level(Guid chartId, int level)
+        {
+            _phoenix2Levels[chartId] = level;
+            return this;
+        }
 
         /// <summary>What the player holds in Phoenix 2 on a chart they also played in Phoenix 1.</summary>
         public PageContext WithPhoenix2Score(Guid chartId, int score, bool isBroken = false)

--- a/docs/design/pumbility-overhaul.md
+++ b/docs/design/pumbility-overhaul.md
@@ -552,6 +552,17 @@ Every Phoenix 1 score repriced under `Phoenix2PumbilityScoring` — singles pric
 base curve, sub-10 charts at zero, broken plays at zero — then the top 50 taken for each of All,
 Singles and Doubles.
 
+⚠ **Repriced means the Phoenix 2 level, not the level the score was set against.** Phoenix 2
+*rerated* the charts it inherited rather than restepping them: 338 of the 4,367 shared charts carry
+a different level here — 302 up, 36 down — so the same chart id resolves to a different `Chart` in
+each catalog and only the price moves, never the steps. Reading the Phoenix 1 level pays a
+downrated chart a base the mix has taken away from it, and short-changes the 302 uprates by the
+same arithmetic (found by the owner 2026-08-08 on Spooky Macaron S23 → S22, suggested at +372 where
+the chart is worth +365 — over the bar on a rating it no longer has). A chart with **no** Phoenix 2
+row has no Phoenix 2 level to read, so it keeps its own; it still counts toward the pool, and it can
+never become a target. `Phoenix2ProjectionCalculator` (the recap) always did this correctly and is
+the reference. The peer side handles the same fact separately — see `ReferenceLevelSlack` in §4.
+
 **The panel's fifty is the definition; the suggestions are not bound by it** (owner, 2026-08-06).
 PUMBILITY *is* the top fifty, so `Entries` and every figure in the table below come from exactly
 that. But capping *suggestions* at the pool hid the rows carrying the best evidence the site has:


### PR DESCRIPTION
**One actionable:** the Phoenix 2 carryover priced Phoenix 1 scores at the wrong mix's level.

## The bug

Phoenix 2 **rerated** the charts it inherited rather than restepping them, so a single `ChartId` resolves to a *different* `Chart` per mix — `Chart.Level` comes from `ChartMix.Level`, and it is the only field that moves. **338 of the 4,367 shared charts carry a different level in Phoenix 2: 302 up, 36 down.**

`ProjectPhoenix2CarryoverQuery` in `PumbilityPageSaga` ran every carried score through Phoenix 2's *formula* but against the Phoenix 1 *catalog*, so a rerated chart was priced on a rating the mix had taken away from it. It looks correct at every other seam — right scoring config, right chart id, right type, wrong number.

Reported by @DrMurloc from the "What to play next" list, and the arithmetic reproduces the screenshot exactly. **Spooky Macaron is S23 in Phoenix 1 and S22 in Phoenix 2:**

| priced at | base | × (SS+ 1.48 + Superb Game .008) | shown |
|---|---|---|---|
| Phoenix 1's level 23 (bug) | Base(24) = 250 | 372.0 | **+372** |
| Phoenix 2's level 22 (correct) | Base(23) = 245 | 364.6 | **+365** |

At its real value it ranks *below* Eternal Universe rather than tying Kokugen Kairou Labyrinth for the top of the list. The other two cards on that screenshot check out at their real levels, which is why only this one looked wrong.

**Blast radius is wider than one row.** The same repriced array feeds the carryover pool total, its bar, the singles/doubles split and the projected-title chips (`ProjectedTitles` had the same bug). And the visible half is the small half: the 36 downrates read *high*, while the 302 uprates read *low* and nobody notices.

## The fix

A `Priced(chartId)` resolver that reads the Phoenix 2 chart, falling back to the Phoenix 1 one only where the chart has **no** Phoenix 2 row — those have no level here to read, still count toward the pool, and can never become targets anyway.

Two places already did this correctly and are now cited as the references rather than treated as evidence the codebase was clean:

- `Phoenix2ProjectionCalculator` (the recap) takes the Phoenix 2 catalog outright and says so in its summary.
- `PumbilityProjectionSaga.BestAcrossMixes` widens its level-range scan by `ReferenceLevelSlack` for exactly this reason.

The peer-projection path was already correct — it prices against `GetChartsQuery(mix)`.

## Why nothing caught it

`PumbilityPageSagaTests.PageContext` returned **one `Chart` for both mixes**, so the harness could not express a rerate at all. It gains `WithPhoenix2Level`, and the `GetChartsQuery` stub now re-levels the Phoenix 2 catalog.

The regression test asserts the entry's value equals the shipped config's value **at the Phoenix 2 level**, and first asserts the two levels disagree — so it can't silently pass if the arithmetic ever stops distinguishing them.

## Docs

`docs/design/pumbility-overhaul.md` §5 defined the repricing (singles one level up, sub-10 at zero, broken at zero) without ever saying *which mix's level* it meant. It now does, with the counts and the reference implementations.

## Testing

| Suite | Result |
|---|---|
| `ScoreTracker.Tests` | ✅ 3,236 passed (incl. the new regression test) |
| `ScoreTracker.Tests.Api` | ✅ 148 passed |
| `ScoreTracker.Tests.Components` | ⚠️ not run locally — see below |
| Integration / E2E | not run locally (Docker); CI covers them |

`Tests.Components` could not build locally: a running Visual Studio held `ScoreTracker.Web`'s Debug bins locked in this worktree (`MSB3027`). It is unaffected by this change on inspection — `PumbilityComponentTests` constructs `PumbilityTarget` records by hand against a mocked mediator and never reaches this handler — but CI runs it.

## Reviewer notes

- **No post-deploy action.** The carryover is computed live per page load, not stored, so it corrects itself on the next read. The 24h `PumbilityProjectionCache` is the peer-projection path and is untouched.
- No schema, contract or wire-shape change. `Phoenix2CarryoverRecord` is unchanged; only the values in it move.
- Level counts were taken against the prod-synced local database, not inferred from code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
