### PR TITLE
PUMBILITY gains: truncate in decimal, not in doubles

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/PumbilityDeltaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/PumbilityDeltaTests.cs
@@ -39,6 +39,28 @@ public sealed class PumbilityDeltaTests : ComponentTestBase
         Assert.Equal("430", PumbilityFormat.Gain(429.99999999999994));
     }
 
+    [Theory]
+    // Cleaning the noise cannot be the whole answer, because these values ARE clean and the
+    // error lands after: the nearest double to 0.29 times 100 is 28.999999999999996, so a
+    // truncation done in doubles printed "0.28". The scaling happens in decimal for exactly
+    // these three, which are every value under one that the old arithmetic got wrong.
+    [InlineData(0.29, "0.29")]
+    [InlineData(0.57, "0.57")]
+    [InlineData(0.58, "0.58")]
+    public void ScalingToARungDoesNotReintroduceTheNoiseItJustRemoved(double value, string expected)
+    {
+        Assert.Equal(expected, PumbilityFormat.Gain(value));
+    }
+
+    [Fact]
+    public void AnOfficialDecimalIsNotRoundTrippedThroughADouble()
+    {
+        // The board quotes two places already. Nothing has to be cleaned off one, and going
+        // via double to find that out is the one way to damage it.
+        Assert.Equal("0.29", PumbilityFormat.Gain(0.29m));
+        Assert.Equal("1,255", PumbilityFormat.Gain(1255.87m));
+    }
+
     [Fact]
     public void TruncationIsAppliedToTheMagnitudeSoALossIsNotOverstated()
     {

--- a/ScoreTracker/ScoreTracker/Services/PumbilityFormat.cs
+++ b/ScoreTracker/ScoreTracker/Services/PumbilityFormat.cs
@@ -37,29 +37,50 @@ public static class PumbilityFormat
     private const int NoiseFloor = 6;
 
     /// <summary>
+    ///     One per rung, so the scale a magnitude is truncated against is a literal rather than
+    ///     a <see cref="Math.Pow" /> result. See <see cref="Truncated" /> for why that matters.
+    /// </summary>
+    private static readonly decimal[] Scales = { 1m, 10m, 100m };
+
+    /// <summary>
     ///     A gain's magnitude, unsigned. Callers own the sign or the arrow — they do not agree
     ///     on which ("+137" on a badge, "▲137" on a board), and that is a presentation choice
     ///     per surface rather than part of the number.
+    ///     <para>
+    ///         The noise comes off in <c>double</c>, where it was created, and the rung is chosen
+    ///         and applied in <c>decimal</c>. Converting after the round is lossless for what
+    ///         survives it: double-to-decimal is itself a round to fifteen significant digits, and
+    ///         a six-place value is well inside that.
+    ///     </para>
     /// </summary>
     public static string Gain(double value)
     {
-        var magnitude = Math.Round(Math.Abs(value), NoiseFloor, MidpointRounding.AwayFromZero);
+        return Gain((decimal)Math.Round(Math.Abs(value), NoiseFloor, MidpointRounding.AwayFromZero));
+    }
+
+    /// <summary>
+    ///     The mirrored official surfaces carry decimals, because the board they quote does. Those
+    ///     arrive already exact at two places, so they skip the noise floor rather than round-trip
+    ///     through a double that could only lose to it.
+    /// </summary>
+    public static string Gain(decimal value)
+    {
+        var magnitude = Math.Abs(value);
         return magnitude >= 10 ? Truncated(magnitude, 0)
             : magnitude >= 1 ? Truncated(magnitude, 1)
             : Truncated(magnitude, 2);
     }
 
     /// <summary>
-    ///     The mirrored official surfaces carry decimals, because the board they quote does.
+    ///     Truncation happens in decimal because scaling by a power of ten is exact there and is
+    ///     not in binary floating point. The same step in doubles read a gain of 0.29 as "0.28":
+    ///     the nearest double to 0.29 times 100 is 28.999999999999996, and truncating that loses
+    ///     the hundredth the rung exists to show. Cleaning the noise first does not save it —
+    ///     0.29 IS the cleaned value, and the error is reintroduced by the multiply after.
     /// </summary>
-    public static string Gain(decimal value)
+    private static string Truncated(decimal magnitude, int decimals)
     {
-        return Gain((double)value);
-    }
-
-    private static string Truncated(double magnitude, int decimals)
-    {
-        var scale = Math.Pow(10, decimals);
+        var scale = Scales[decimals];
         return (Math.Truncate(magnitude * scale) / scale).ToString("N" + decimals);
     }
 }


### PR DESCRIPTION
Follow-up from the release scan of this morning's merges. Minor display defect in the gain formatter that landed with #245.

## The bug

`PumbilityFormat.Gain` picks a rung, then scales by a power of ten to truncate to it. That scaling is exact in `decimal` and is **not** in binary floating point — the nearest double to `0.29` times 100 is `28.999999999999996`, so truncating gave `0.28`. A gain of 0.29 rendered as `+0.28`.

`0.29`, `0.57` and `0.58` are every value under one that the old arithmetic got wrong. Rare in practice — a gain has to land on one of those hundredths after the noise-floor round — but it's the same class of wrongness the formatter exists to prevent, and it reads on a badge.

The existing noise floor could never have caught it. That step cleans a value arriving from a chain of double arithmetic; `0.29` is already clean, and the error is introduced *after* it, by the multiply.

## The fix

Choose and apply the rung in `decimal`. The noise still comes off in `double`, where it was created — converting after that round is lossless for what survives it, since double-to-decimal is itself a round to fifteen significant digits and a six-place value sits well inside that.

The `decimal` overload also stops round-tripping through a `double`. An official board figure arrives already exact at two places, so the only thing that trip could do to one is damage it.

## Verification

- Swept ~11,000 values across all three rungs against the new arithmetic: **0 mismatches**. The same sweep finds 3 on `main`.
- New tests: the three regression values, plus the decimal overload's direct path.
- `ScoreTracker.Tests.Components` 756 passed (was 752), PUMBILITY filter in `ScoreTracker.Tests` 181 passed — including the `PumbilityPrecisionTests` ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)