### PR TITLE
fix(charts): the drag leaves the circuit, and the drawer fits the glass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Reader-facing docs live in `docs/` (README.md stays at the root). Keep them curr
 - [docs/HOW-TO-RUN.md](docs/HOW-TO-RUN.md) — prerequisites, Aspire local run, the /Dev/Populate harness, optional secrets
 - [docs/HOW-TO-TEST.md](docs/HOW-TO-TEST.md) — test philosophy + suite commands
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — update in the same PR that changes a structural pattern
-- [docs/UX-GUIDELINES.md](docs/UX-GUIDELINES.md) — the design system (per-mix themes, color tokens, the two semantic ramps) + the ten UX rules; update in the same PR that changes a UI pattern
+- [docs/UX-GUIDELINES.md](docs/UX-GUIDELINES.md) — the design system (per-mix themes, color tokens, the two semantic ramps) + the numbered UX rules; update in the same PR that changes a UI pattern
 - [docs/DATABASE-SCHEMA.md](docs/DATABASE-SCHEMA.md) — new tables get a row
 - [docs/API.md](docs/API.md) — the API surface map; Swagger is shape truth
 - [docs/SCHEDULED-JOBS.md](docs/SCHEDULED-JOBS.md) — new recurring jobs get a row

--- a/ScoreTracker/ScoreTracker.Tests.Components/RangeSliderTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/RangeSliderTests.cs
@@ -1,4 +1,6 @@
+using AngleSharp.Dom;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using ScoreTracker.Web.Components;
 using Xunit;
 
@@ -7,7 +9,8 @@ namespace ScoreTracker.Tests.Components;
 public sealed class RangeSliderTests : ComponentTestBase
 {
     private IRenderedComponent<RangeSlider> Render(int min = 10, int max = 26, int valueMin = 16,
-        int valueMax = 18, bool disabled = false, Action<int>? onMin = null, Action<int>? onMax = null)
+        int valueMax = 18, bool disabled = false, Action<int>? onMin = null, Action<int>? onMax = null,
+        Func<int, string>? format = null)
     {
         return RenderComponent<RangeSlider>(p => p
             .Add(x => x.Label, "Singles")
@@ -17,8 +20,14 @@ public sealed class RangeSliderTests : ComponentTestBase
             .Add(x => x.ValueMin, valueMin)
             .Add(x => x.ValueMax, valueMax)
             .Add(x => x.Disabled, disabled)
+            .Add(x => x.Format, format)
             .Add(x => x.ValueMinChanged, onMin ?? (_ => { }))
             .Add(x => x.ValueMaxChanged, onMax ?? (_ => { })));
+    }
+
+    private static IElement Thumb(IRenderedComponent<RangeSlider> cut, int index)
+    {
+        return cut.FindAll("input[type=range]")[index];
     }
 
     [Fact]
@@ -38,53 +47,124 @@ public sealed class RangeSliderTests : ComponentTestBase
     }
 
     [Fact]
-    public void ReleasingTheMinThumbRaisesValueMinChanged()
+    public async Task ReleasingTheMinThumbRaisesValueMinChanged()
     {
         int? changed = null;
         var cut = Render(onMin: v => changed = v);
 
-        cut.FindAll("input[type=range]")[0].Change("14");
+        await Thumb(cut, 0).ChangeAsync(new ChangeEventArgs { Value = "14" });
 
         Assert.Equal(14, changed);
     }
 
     [Fact]
-    public void TheDragItselfMovesTheReadoutButPublishesNothing()
+    public void TheDragNeverReachesTheServer()
     {
-        // A drag across a wide scale crosses hundreds of steps. Publishing each one re-runs
-        // whatever the caller does on change — for the SRP, the whole search — which fights
-        // the thumb. The readout still follows so the drag stays direct.
-        var published = 0;
-        var cut = Render(onMin: _ => published++);
+        // The thumb's position must not ride the circuit. Answering each input event means
+        // writing a value one latency old back onto the input, which drags the thumb backwards
+        // under the finger for as long as the gesture lasts — the whole reason js/range-slider.js
+        // exists. The server hears the release and nothing before it; the script paints the rest
+        // off these hooks.
+        var cut = Render();
 
-        cut.FindAll("input[type=range]")[0].Input("14");
-
-        Assert.Equal(0, published);
-        Assert.Equal("S14 – S18", cut.Find(".range-slider-value").TextContent);
-
-        cut.FindAll("input[type=range]")[0].Change("14");
-        Assert.Equal(1, published);
+        Assert.All(cut.FindAll("input[type=range]"),
+            input => Assert.False(input.HasAttribute("blazor:oninput")));
+        Assert.True(cut.Find(".range-slider").HasAttribute("data-range-slider"));
+        Assert.True(cut.Find(".range-slider-value").HasAttribute("data-range-readout"));
+        Assert.True(cut.Find(".range-slider-fill").HasAttribute("data-range-fill"));
     }
 
     [Fact]
-    public void MinThumbDraggedPastMaxClampsToMax()
+    public void TheThumbsSitWhereTheCommittedRangeIs()
     {
-        int? minChanged = null;
-        var cut = Render(onMin: v => minChanged = v);
+        var cut = Render();
 
-        cut.FindAll("input[type=range]")[0].Change("22");
+        Assert.Equal("16", Thumb(cut, 0).GetAttribute("value"));
+        Assert.Equal("18", Thumb(cut, 1).GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task MinThumbDraggedPastMaxSwapsTheEnds()
+    {
+        // Clamping mid-drag was the same yank the circuit round-trip caused, so the thumbs
+        // cross and the pair sorts itself on release.
+        int? minChanged = null;
+        int? maxChanged = null;
+        var cut = Render(onMin: v => minChanged = v, onMax: v => maxChanged = v);
+
+        await Thumb(cut, 0).ChangeAsync(new ChangeEventArgs { Value = "22" });
 
         Assert.Equal(18, minChanged);
+        Assert.Equal(22, maxChanged);
     }
 
     [Fact]
-    public void MaxThumbDraggedBelowMinClampsToMin()
+    public async Task MaxThumbDraggedBelowMinSwapsTheEnds()
     {
+        int? minChanged = null;
         int? maxChanged = null;
-        var cut = Render(onMax: v => maxChanged = v);
+        var cut = Render(onMin: v => minChanged = v, onMax: v => maxChanged = v);
 
-        cut.FindAll("input[type=range]")[1].Change("12");
+        await Thumb(cut, 1).ChangeAsync(new ChangeEventArgs { Value = "12" });
 
+        Assert.Equal(12, minChanged);
         Assert.Equal(16, maxChanged);
+    }
+
+    [Fact]
+    public async Task CoincidentThumbsAtTheTopCanStillBeSeparated()
+    {
+        // Both ends parked on the ceiling used to be a dead end: the max input is second in the
+        // DOM so it wins every overlap, and clamping it against a coincident min left it nowhere
+        // to go — Clear all was the only way out.
+        int? minChanged = null;
+        var cut = Render(valueMin: 26, valueMax: 26, onMin: v => minChanged = v);
+
+        await Thumb(cut, 1).ChangeAsync(new ChangeEventArgs { Value = "20" });
+
+        Assert.Equal(20, minChanged);
+    }
+
+    [Fact]
+    public async Task AReleaseOutsideTheScaleLandsOnTheScale()
+    {
+        int? changed = null;
+        var cut = Render(onMin: v => changed = v);
+
+        await Thumb(cut, 0).ChangeAsync(new ChangeEventArgs { Value = "3" });
+
+        Assert.Equal(10, changed);
+    }
+
+    [Fact]
+    public void TheFillMeasuresAgainstTheThumbInsetRatherThanTheBox()
+    {
+        // A thumb's centre never reaches the ends of its box, so a fill drawn in plain
+        // percentages ends up to half a thumb away from the thumb it is supposed to meet — and
+        // the gap changes as you drag. 16 and 18 of 10..26 are 0.375 and 0.5 along the travel.
+        var style = Render().Find(".range-slider-fill").GetAttribute("style") ?? string.Empty;
+
+        Assert.Contains("0.375 * (100% - var(--range-thumb))", style);
+        Assert.Contains("0.5 * (100% - var(--range-thumb))", style);
+    }
+
+    [Fact]
+    public void AScaleThatFormatsHandsDownItsWordingForEveryStop()
+    {
+        // The script paints the readout during a drag and must not re-implement a format, so
+        // C# ships the labels it would have rendered.
+        var cut = Render(min: 0, max: 3, format: v => $"{v}:00");
+
+        Assert.Equal("[\"0:00\",\"1:00\",\"2:00\",\"3:00\"]",
+            cut.Find(".range-slider").GetAttribute("data-range-labels"));
+    }
+
+    [Fact]
+    public void APlainScaleShipsItsPrefixInsteadOfATable()
+    {
+        var cut = Render();
+
+        Assert.False(cut.Find(".range-slider").HasAttribute("data-range-labels"));
+        Assert.Equal("S", cut.Find(".range-slider").GetAttribute("data-range-prefix"));
     }
 }

--- a/ScoreTracker/ScoreTracker.Tests.E2E/ChartsSrpTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.E2E/ChartsSrpTests.cs
@@ -143,6 +143,47 @@ public sealed class ChartsSrpTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task TheFilterDrawerAndItsSlidersFitOnAPhone()
+    {
+        // Field-test: on a folded Fold the range sliders ran off the left edge of the glass and
+        // the low end of every scale was under the bezel. MudBlazor sizes a temporary drawer
+        // `width: var(--mud-drawer-width)` and puts no max-width on it anywhere, so /Charts'
+        // 420px drawer hangs (420 - viewport)px past the edge it is anchored to — and a drawer
+        // scrolls vertically only, so nothing brings it back. Measured rather than eyeballed:
+        // a cap that silently fails to apply looks exactly like one that works.
+        await _page.SetViewportSizeAsync(390, 844);
+        await _page.GotoAsync("/Charts", new PageGotoOptions { Timeout = 60_000 });
+        await Expect(_page.Locator(".srp-card").First)
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 60_000 });
+
+        await _page.Locator("button[aria-label=Filters]").ClickAsync();
+        var drawer = _page.Locator(".mud-drawer.mud-drawer-temporary").First;
+        await Expect(drawer).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+
+        // The 225ms slide-in parks the drawer a full width off the anchored edge on its first
+        // frame, which measures exactly like a positioning bug and is not one. ToBeVisibleAsync
+        // returns immediately because a drawer is never display:none, so wait for the transition
+        // itself — after a beat, so a transition that has not started yet cannot read as done.
+        await _page.WaitForTimeoutAsync(300);
+        await _page.WaitForFunctionAsync(
+            "() => document.querySelector('.mud-drawer.mud-drawer-temporary')" +
+            "  .getAnimations().every(a => a.playState === 'finished')",
+            null, new PageWaitForFunctionOptions { Timeout = 10_000 });
+
+        var box = await drawer.BoundingBoxAsync();
+        Assert.True(box!.X >= 0,
+            $"the filter drawer starts {box.X:0}px off the left edge of a 390px phone");
+        Assert.True(box.X + box.Width <= 391,
+            $"the filter drawer ends {box.X + box.Width:0}px into a 390px phone");
+
+        // And the control the drawer exists for: a track whose low end is under the bezel
+        // cannot be dragged to its low end.
+        var track = await _page.Locator(".range-slider-track").First.BoundingBoxAsync();
+        Assert.True(track!.X >= 0,
+            $"the range slider's track starts {track.X:0}px off the glass");
+    }
+
+    [Fact]
     public async Task TheMoreFiltersListStaysPutWhenThePageBehindScrolls()
     {
         // Field-test round 4: the open pick list appeared to slide with the background. The

--- a/ScoreTracker/ScoreTracker.Tests/ArchitectureTests/BunitEventDispatchTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ArchitectureTests/BunitEventDispatchTests.cs
@@ -76,7 +76,6 @@ public sealed class BunitEventDispatchTests
         // QuickRecordWidgetTests burned its 8 — it was the loudest file left once the
         // warmup was in (three of its facts chain a grade tap into a save), so it went
         // first — entry removed, ratchet tightened.
-        ["RangeSliderTests.cs"] = 5,
         ["RivalsOfMeListTests.cs"] = 1,
         ["ScoreCheckPanelTests.cs"] = 2,
         ["SessionHeroTests.cs"] = 1,

--- a/ScoreTracker/ScoreTracker/Components/RangeSlider.razor
+++ b/ScoreTracker/ScoreTracker/Components/RangeSlider.razor
@@ -1,4 +1,6 @@
 @namespace ScoreTracker.Web.Components
+@implements IAsyncDisposable
+@inject IJSRuntime JSRuntime
 
 @* Dual-thumb range (docs/design/randomizer-overhaul.md): the primary way to say
    "S16–S18" — two drags instead of a wall of switches. The working range prints beside
@@ -10,32 +12,44 @@
    as an inert tag that looks right and does nothing. Anything wanting two thumbs comes
    here. Non-integer scales ride the track as integers and format back through Format.
 
-   The track moves on every input event but the value is only *published* on release: a
-   drag across a BPM range crosses two hundred steps, and telling the page about each one
-   re-runs the search two hundred times, which fights the thumb. The fill and readout still
-   track the drag, so it stays direct — the caller just hears the answer, not the journey. *@
-<div class="range-slider @(Disabled ? "range-slider-disabled" : string.Empty)">
+   **The drag belongs to the browser.** Blazor renders the *committed* range and hears one
+   change per release; range-slider.js paints the fill and the readout from the inputs' own
+   values in between. Rendering the live value instead put the thumb's position on the wire:
+   the server answers each input event with a value one latency old, Blazor writes it back
+   onto the input, and the thumb is yanked backwards under the finger for as long as the drag
+   lasts. Nothing on a circuit is fast enough to fix that — the drag has to leave the wire.
+
+   **Thumbs cross and swap ends** rather than stopping at each other. Clamping was the same
+   yank by another name, and two thumbs parked on the same value could not be separated at
+   all: the max input is second in the DOM so it wins every overlap, and clamping it against
+   a coincident min left it nowhere to go. Crossing, the pair sorts on release instead. *@
+<div class="range-slider @(Disabled ? "range-slider-disabled" : string.Empty)" @ref="_root"
+     data-range-slider data-range-min="@Min" data-range-max="@Max" data-range-step="@Step"
+     data-range-prefix="@Prefix" data-range-labels="@_labels">
     <div class="range-slider-head">
         <span class="range-slider-label">@Label</span>
-        <span class="range-slider-value">@Display</span>
+        <span class="range-slider-value" data-range-readout>@Display</span>
     </div>
     <div class="range-slider-track-wrap">
         <span class="range-slider-track"></span>
-        <span class="range-slider-fill" style="left:@(Percent(DraggedMin).ToString(System.Globalization.CultureInfo.InvariantCulture))%;right:@((100 - Percent(DraggedMax)).ToString(System.Globalization.CultureInfo.InvariantCulture))%"></span>
-        <input type="range" min="@Min" max="@Max" step="@Step" value="@DraggedMin" disabled="@Disabled"
-               aria-label="@($"{Label} {L["Minimum"]}")" @oninput="DragMin" @onchange="CommitMin"/>
-        <input type="range" min="@Min" max="@Max" step="@Step" value="@DraggedMax" disabled="@Disabled"
-               aria-label="@($"{Label} {L["Maximum"]}")" @oninput="DragMax" @onchange="CommitMax"/>
+        <span class="range-slider-fill" data-range-fill style="@FillStyle"></span>
+        <input type="range" min="@Min" max="@Max" step="@Step" value="@ValueMin" disabled="@Disabled"
+               aria-label="@($"{Label} {L["Minimum"]}")" @onchange="CommitMin"/>
+        <input type="range" min="@Min" max="@Max" step="@Step" value="@ValueMax" disabled="@Disabled"
+               aria-label="@($"{Label} {L["Maximum"]}")" @onchange="CommitMax"/>
     </div>
     <div class="range-slider-ticks">
         @foreach (var tick in Ticks)
         {
-            <span style="left:@(Percent(tick).ToString(System.Globalization.CultureInfo.InvariantCulture))%">@Text(tick)</span>
+            <span style="left:@(Percent(tick).ToString(Invariant))%">@Text(tick)</span>
         }
     </div>
 </div>
 
 @code {
+
+    private static readonly System.Globalization.CultureInfo Invariant =
+        System.Globalization.CultureInfo.InvariantCulture;
 
     [Parameter] public string Label { get; set; } = string.Empty;
 
@@ -75,21 +89,25 @@
     /// </summary>
     [Parameter] public string? ValueText { get; set; }
 
-    // Where the thumbs are right now. Null between drags, so a value pushed in from the
-    // outside (a cleared filter, a shared URL) still wins.
-    private int? _draggingMin;
-    private int? _draggingMax;
-
-    private int DraggedMin => _draggingMin ?? ValueMin;
-    private int DraggedMax => _draggingMax ?? ValueMax;
+    private ElementReference _root;
+    private IJSObjectReference? _module;
 
     private string Display => Disabled
         ? L["Off"]
-        // Mid-drag the readout follows the thumbs; the caller's ValueText only describes the
-        // committed filter, so it would sit frozen at "Any" while you drag.
-        : _draggingMin != null || _draggingMax != null
-            ? $"{Text(DraggedMin)} – {Text(DraggedMax)}"
-            : ValueText ?? $"{Text(ValueMin)} – {Text(ValueMax)}";
+        : ValueText ?? $"{Text(ValueMin)} – {Text(ValueMax)}";
+
+    // A thumb's centre travels between half a thumb in from each end, never the full box, so
+    // the fill measures against that inset too — otherwise its edge drifts up to half a thumb
+    // away from the thumb it is supposed to end at, and the drift changes as you drag. The
+    // tick rail already sits on the same inset (its margin is half a thumb).
+    private string FillStyle =>
+        $"left:calc(var(--range-thumb) / 2 + {Fraction(ValueMin)} * (100% - var(--range-thumb)));"
+        + $"right:calc(100% - var(--range-thumb) / 2 - {Fraction(ValueMax)} * (100% - var(--range-thumb)))";
+
+    private string Fraction(int value)
+    {
+        return (Max == Min ? 0 : (value - Min) / (double)(Max - Min)).ToString("0.######", Invariant);
+    }
 
     private double Percent(int value)
     {
@@ -106,44 +124,106 @@
         }
     }
 
-    // Thumbs never cross: each stops where the other stands.
-    private int ClampMin(ChangeEventArgs e)
+    // The readout's wording is C#'s, mid-drag included: a scale that formats (a clock, a
+    // grade, a tier name) hands down its label for every step it can stop on, so the script
+    // painting the drag never re-implements a format. Plain scales need no table — the script
+    // can put Prefix in front of a number itself.
+    private string? _labels;
+    private (int Min, int Max, int Step, bool Formatted) _labelKey;
+
+    protected override void OnParametersSet()
     {
-        return int.TryParse(e.Value?.ToString(), out var value)
-            ? Math.Clamp(value, Min, DraggedMax)
-            : DraggedMin;
+        var key = (Min, Max, Step, Format != null);
+        if (key == _labelKey) return;
+
+        _labelKey = key;
+        _labels = BuildLabels();
     }
 
-    private int ClampMax(ChangeEventArgs e)
+    private string? BuildLabels()
     {
-        return int.TryParse(e.Value?.ToString(), out var value)
-            ? Math.Clamp(value, DraggedMin, Max)
-            : DraggedMax;
+        if (Format == null) return null;
+
+        var step = Math.Max(1, Step);
+        var stops = (Max - Min) / step;
+        // A scale fine enough to need thousands of stops would cost more to send than the
+        // readout is worth; the script falls back to the bare number.
+        if (stops < 0 || stops > 2000) return null;
+
+        var labels = new string[stops + 1];
+        for (var i = 0; i <= stops; i++) labels[i] = Text(Min + i * step);
+
+        return System.Text.Json.JsonSerializer.Serialize(labels);
     }
 
-    private void DragMin(ChangeEventArgs e)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        _draggingMin = ClampMin(e);
+        if (!firstRender) return;
+
+        try
+        {
+            _module = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./js/range-slider.js");
+            await _module.InvokeVoidAsync("attach", _root);
+        }
+        catch (JSException)
+        {
+            // Without the script the fill and readout simply wait for the release instead of
+            // following the thumb. The control still filters; it is not worth a failed render.
+        }
     }
 
-    private void DragMax(ChangeEventArgs e)
+    private Task CommitMin(ChangeEventArgs e) => Commit(Parse(e, ValueMin), ValueMax);
+
+    private Task CommitMax(ChangeEventArgs e) => Commit(ValueMin, Parse(e, ValueMax));
+
+    private static int Parse(ChangeEventArgs e, int fallback)
     {
-        _draggingMax = ClampMax(e);
+        return int.TryParse(e.Value?.ToString(), System.Globalization.NumberStyles.Integer,
+            Invariant, out var value)
+            ? value
+            : fallback;
     }
 
-    private async Task CommitMin(ChangeEventArgs e)
+    private async Task Commit(int a, int b)
     {
-        var clamped = ClampMin(e);
-        _draggingMin = null;
-        ValueMin = clamped;
-        await ValueMinChanged.InvokeAsync(clamped);
+        var low = Math.Clamp(Math.Min(a, b), Min, Max);
+        var high = Math.Clamp(Math.Max(a, b), Min, Max);
+        var wasMin = ValueMin;
+        var wasMax = ValueMax;
+        ValueMin = low;
+        ValueMax = high;
+
+        // A crossed drag moves both ends, and each end is its own callback — so the caller
+        // holds half the new range for one round trip. Publish the widening end first: a
+        // moment of too many results reads better than a moment of none.
+        if (low < wasMin)
+        {
+            await Publish(ValueMinChanged, low, low != wasMin);
+            await Publish(ValueMaxChanged, high, high != wasMax);
+        }
+        else
+        {
+            await Publish(ValueMaxChanged, high, high != wasMax);
+            await Publish(ValueMinChanged, low, low != wasMin);
+        }
     }
 
-    private async Task CommitMax(ChangeEventArgs e)
+    private static Task Publish(EventCallback<int> callback, int value, bool changed)
     {
-        var clamped = ClampMax(e);
-        _draggingMax = null;
-        ValueMax = clamped;
-        await ValueMaxChanged.InvokeAsync(clamped);
+        return changed ? callback.InvokeAsync(value) : Task.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module == null) return;
+
+        try
+        {
+            await _module.DisposeAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+            // The circuit went first — the browser has already dropped the module with the page.
+        }
     }
 }

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -41,6 +41,17 @@ body {
     font-family: var(--font-body);
 }
 
+/* MudBlazor 8.15 sizes a temporary drawer `width: var(--mud-drawer-width)` and puts no
+   max-width on it anywhere, so a drawer declared wider than the glass hangs off the edge it
+   is anchored to and nothing brings it back — a drawer scrolls vertically only. /Charts'
+   filter drawer is 420px, which is past a folded Fold's cover screen. max-width beats width
+   whatever the specificity, and a fixed element resolves the percentage against the viewport,
+   so a declared width still applies wherever it fits and only an over-wide drawer is clamped.
+   Site-wide because /Titles' detail drawer (400px) loses the same strip at 360px. */
+.mud-drawer.mud-drawer-temporary {
+    max-width: 100%;
+}
+
 /* Big-number treatment for stats (rating, Pumbility, scores). tabular-nums keeps digit
    columns steady while values tick up live. */
 .stat-display {
@@ -1686,6 +1697,12 @@ html.sheet-open .more-sheet-scrim {
     display: flex;
     flex-direction: column;
     gap: 2px;
+    /* A thumb's centre travels between half a thumb in from each end, never the full box.
+       The fill and the tick rail both measure against that inset so all three agree; the
+       fill's calc lives in RangeSlider.razor because the script painting a drag writes the
+       same expression. One size across engines: Firefox's default thumb is smaller, and a
+       band that reads 20px on one browser and 14px on another is 14px to plan for. */
+    --range-thumb: 20px;
 }
 
 .range-slider-head {
@@ -1749,8 +1766,8 @@ html.sheet-open .more-sheet-scrim {
     -webkit-appearance: none;
     appearance: none;
     pointer-events: auto;
-    width: 20px;
-    height: 20px;
+    width: var(--range-thumb);
+    height: var(--range-thumb);
     border-radius: 50%;
     background: var(--mix-primary);
     border: 3px solid var(--mix-bg);
@@ -1761,8 +1778,9 @@ html.sheet-open .more-sheet-scrim {
 
 .range-slider-track-wrap input[type=range]::-moz-range-thumb {
     pointer-events: auto;
-    width: 14px;
-    height: 14px;
+    box-sizing: border-box;
+    width: var(--range-thumb);
+    height: var(--range-thumb);
     border-radius: 50%;
     background: var(--mix-primary);
     border: 3px solid var(--mix-bg);
@@ -1773,7 +1791,7 @@ html.sheet-open .more-sheet-scrim {
 .range-slider-ticks {
     position: relative;
     height: 14px;
-    margin: 0 10px;
+    margin: 0 calc(var(--range-thumb) / 2);
 }
 
 .range-slider-ticks span {

--- a/ScoreTracker/ScoreTracker/wwwroot/js/range-slider.js
+++ b/ScoreTracker/ScoreTracker/wwwroot/js/range-slider.js
@@ -1,0 +1,96 @@
+// The dual-thumb range control (Components/RangeSlider.razor, docs/design/charts-srp.md).
+//
+// Blazor renders the committed range and hears one `change` per release. Everything between
+// the first touch and that release is painted here, from the inputs' own values, because a
+// server round-trip per `input` event puts the thumb's position on the wire: the answer
+// carries a value one latency old, Blazor writes it back onto the input, and the thumb is
+// pulled backwards under the finger for as long as the drag lasts. A drag across a wide scale
+// is also hundreds of events, which is not something a phone on a slow link should be sending.
+//
+// Nothing here formats a value. A scale whose readout is not just a number (a clock, a grade,
+// a tier name) hands down data-range-labels — C#'s wording for every stop on the track.
+
+const DASH = ' – ';
+const TRAVEL = '(100% - var(--range-thumb))';
+const HALF = 'var(--range-thumb) / 2';
+
+export function attach(root) {
+    if (!root || root.dataset.rangeAttached) return;
+
+    const inputs = root.querySelectorAll('input[type=range]');
+    const fill = root.querySelector('[data-range-fill]');
+    const readout = root.querySelector('[data-range-readout]');
+    if (inputs.length !== 2 || !fill || !readout) return;
+
+    root.dataset.rangeAttached = '1';
+
+    // What Blazor last rendered into the readout, kept for a drag that nets out (see settle).
+    let resting = null;
+    let committed = true;
+    let labels = null;
+    let labelsRaw = null;
+
+    root.addEventListener('input', () => {
+        if (resting === null) resting = readout.textContent;
+        committed = false;
+        paint();
+    });
+
+    // A `change` means Blazor is about to re-render the readout in its own words.
+    root.addEventListener('change', () => {
+        committed = true;
+        resting = null;
+    });
+
+    root.addEventListener('pointerup', settle);
+    root.addEventListener('pointercancel', settle);
+    root.addEventListener('touchend', settle);
+
+    // A drag that ends where it started fires no `change`, so no render comes to take the
+    // live pair back down — and where the caller supplied its own wording ("Any"), the pair
+    // is not what belongs there.
+    function settle() {
+        setTimeout(() => {
+            if (!committed && resting !== null) readout.textContent = resting;
+            resting = null;
+        }, 0);
+    }
+
+    function paint() {
+        // Read the extents every time: a slider whose scale is fetched (the drawer's BPM and
+        // note-count ranges) is rendered before its Min and Max are known.
+        const min = Number(root.dataset.rangeMin);
+        const max = Number(root.dataset.rangeMax);
+        const span = max - min;
+
+        const a = Number(inputs[0].value);
+        const b = Number(inputs[1].value);
+        const low = Math.min(a, b);
+        const high = Math.max(a, b);
+
+        // Both ends measure along the thumb's travel rather than the box, because a thumb's
+        // centre never reaches either end of its own input. RangeSlider.razor writes the same
+        // expression for the resting state, so the two cannot disagree.
+        const along = (value) => (span > 0 ? (value - min) / span : 0);
+        fill.style.left = `calc(${HALF} + ${along(low)} * ${TRAVEL})`;
+        fill.style.right = `calc(100% - ${HALF} - ${along(high)} * ${TRAVEL})`;
+
+        readout.textContent = label(low, min) + DASH + label(high, min);
+    }
+
+    function label(value, min) {
+        const raw = root.dataset.rangeLabels;
+        if (raw) {
+            if (raw !== labelsRaw) {
+                labelsRaw = raw;
+                labels = JSON.parse(raw);
+            }
+
+            const step = Math.max(1, Number(root.dataset.rangeStep) || 1);
+            const word = labels[Math.round((value - min) / step)];
+            if (word !== undefined) return word;
+        }
+
+        return (root.dataset.rangePrefix || '') + value;
+    }
+}

--- a/docs/UX-GUIDELINES.md
+++ b/docs/UX-GUIDELINES.md
@@ -113,6 +113,20 @@ the other on Windows. Leave a margin, and never sit a rung directly on a device'
 circuit to re-render it, so anything that must survive an unfold has to be a media query —
 CSS, never Razor ([static-shell.md §11](design/static-shell.md)).
 
+⚠ **A fixed-width overlay has to fit the narrowest rung, and nothing checks that for you.**
+MudBlazor 8.15 sizes a temporary drawer `width: var(--mud-drawer-width)` and puts no `max-width`
+on it anywhere, so a drawer declared wider than the glass hangs off the edge it is anchored to —
+and a drawer scrolls vertically only, so nothing brings it back. `/Charts`' 420px filter drawer
+sat **30px** past the left edge of a 390px phone, taking the low end of every range slider's track
+with it; the same 420px fits a fold's *unfolded* screen exactly, which is how it read as a
+mobile-only slider bug. `site.css` now caps every temporary drawer at `max-width: 100%` sitewide
+(`max-width` beats `width` whatever the specificity, and a fixed element resolves the percentage
+against the viewport, so a declared width still applies wherever it fits). Measure any new overlay
+against the Mobile rung anyway — and note that **measuring a drawer the moment it opens reads its
+225ms slide-in's first frame**, which parks it a full width off the anchored edge and looks exactly
+like the bug. Wait for `getAnimations().every(a => a.playState === 'finished')` first; an empty
+list settles immediately, which is right under reduced motion.
+
 ---
 
 ## 2. The rules
@@ -151,6 +165,21 @@ what is about to happen — *Delete my Phoenix scores* — rather than *Confirm*
 scope outperform another acknowledgement checkbox, and they fix the failure mode where nobody can
 tell what a control is about to take. Derived values that are recomputed from what is being deleted
 are stated as a consequence, never offered as a checkbox.
+
+**12. A control the finger is holding never round-trips.** For the length of a gesture the
+browser owns the control's position; the circuit hears the release and nothing before it.
+Rendering the live value instead puts the thumb on the wire, and the failure is not slowness but
+*wrongness*: the server answers each `input` event with a value one latency old, Blazor writes it
+back onto the input, and the thumb is pulled backwards under the finger for as long as the drag
+lasts. Throttling cannot fix it — the stale write is the bug — and it is invisible on localhost,
+where the round trip is a millisecond, so it only ever shows up in a field test. `RangeSlider` is
+the worked example: Blazor renders the *committed* range, [range-slider.js](../ScoreTracker/ScoreTracker/wwwroot/js/range-slider.js)
+paints the fill and the readout from the inputs' own values in between, and C# ships its wording
+for every stop on the track so the script never re-implements a format. Its thumbs also **cross and
+swap ends** rather than clamping against each other, because clamping mid-drag was the same
+backwards yank by another name — and two thumbs parked on the same value could not be separated at
+all, the second input in the DOM winning every overlap and having nowhere to go. The rule
+generalizes to anything that follows a finger: a scrub bar, a reorder drag, a resize handle.
 
 ---
 


### PR DESCRIPTION
The `/Charts` range sliders "visually snap around a bit" while you slide — on a Z Fold 7 folded, but not unfolded. Two independent causes; the auto-apply logic turned out not to be either of them (the search already only re-ran on release).

## The snapping is the circuit

The component rendered `value="@DraggedMin"` with `@oninput`, so every input event went to the server and came back as a DOM write — and Blazor sets `.value` on an input, which **moves the thumb**. The write lands one RTT late, so it puts the thumb where it *was*, sixty times a second, while your finger keeps going. Throttling can't help: the stale write is the bug. It's invisible on localhost, where the round trip is a millisecond, which is why four rounds of field tests never pinned it.

So the drag leaves the wire. Blazor renders the **committed** range and hears one `change` per release; [`range-slider.js`](../blob/claude/chart-list-slider-mobile-392a20/ScoreTracker/ScoreTracker/wwwroot/js/range-slider.js) paints the fill and readout from the inputs' own values in between, off a table of C#'s own wording for every stop on the track — so the script never re-implements a format, and a drag across a wide scale costs zero messages instead of hundreds.

**Thumbs now cross and sort on release** rather than clamping. Clamping mid-drag was the same backwards yank by another name, and two thumbs parked on the same value couldn't be separated at all: the max input is second in the DOM so it wins every overlap, and clamping it against a coincident min left it nowhere to go. Clear all was the only way out of the top of a scale.

## The folded/unfolded split is geometric

The drawer is a fixed **420px at every width**, so the only thing that changes is whether it fits. MudBlazor 8.15 sizes a temporary drawer `width: var(--mud-drawer-width)` with **no `max-width` anywhere**, and a drawer scrolls vertically only — so on a 390px phone it sat **30px past the left edge**, with the low end of every track under the bezel. Capped sitewide; `/Titles`' 400px detail drawer loses the same strip at 360px.

## Also in here

- The fill measures along the thumb's **travel** rather than the box, so its edge meets the thumb it's meant to end at instead of drifting up to half a thumb away as you drag.
- Firefox's thumb 14px → 20px. A band that reads 20px on one engine and 14px on another is 14px to plan for.

## Testing

Both new guards were **verified to fail on the old code**, not merely to pass on the new — the drawer measures `-30px` uncapped, and the coincident-thumb fact reproduces the dead end.

| Suite | Result |
|---|---|
| `ScoreTracker.Tests` | 3346 passed |
| `ScoreTracker.Tests.Components` | 762 passed |
| `ScoreTracker.Tests.Api` | 156 passed |
| `ScoreTracker.Tests.E2E` | 75 passed |

`RangeSliderTests` converts to awaited dispatch and burns its `BunitEventDispatchTests` allowance. `docs/UX-GUIDELINES.md` gains rule 12 and a viewport-ladder note on fixed-width overlays.

## Not touched, deliberately

The vocabulary was never chosen, so this repairs the existing control's mechanics and nothing else. Still open: the **20px thumb in a 28px band** (the drawer's chips took 40px targets in round 3, the sliders never got that pass) and **tap-to-jump**. Both are option E's remaining half.

## Field test

Worth a thumb on the folded cover screen specifically — that's where the drawer cap changes what you see, and where the drag was worst. The snap fix needs real network latency to show its improvement; it will look identical on localhost either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
