### PR TITLE
The setup step stops handing new accounts other people's news

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/CommunityToolsAnnouncementTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/CommunityToolsAnnouncementTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using Bunit;
+using Bunit.TestDoubles;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -14,10 +15,15 @@ using Xunit;
 namespace ScoreTracker.Tests.Components;
 
 /// <summary>
-///     The Community Tools rollout notice is modal, so where it is allowed to fire matters as
-///     much as who sees it. It must stay quiet for an account that has not finished
-///     <c>/Setup</c> — that player's first screen is the setup card, and a scrim over it makes
-///     the one thing they have to do unclickable.
+///     The Community Tools rollout notice reports a change the rollout made to a profile that
+///     already existed, so it is addressed to accounts that predate it and to nobody else. A new
+///     account is recognised by its arrival on <c>/Setup</c>, where the notice retires itself: it
+///     is modal, and a scrim there covers the one screen a first-run player has to use.
+///     <para>
+///         An account that predates <c>/Setup</c> has no completion flag either, so the audience
+///         test cannot be "has this account finished setup?" — that question reads every
+///         long-standing player as brand new, which is the whole point of the pair of facts below.
+///     </para>
 ///     <para>
 ///         Rendered markup is NOT the observable here: an inline MudDialog portals through
 ///         MudDialogProvider, which a component-under-test's tree does not have, so the markup is
@@ -46,19 +52,17 @@ public sealed class CommunityToolsAnnouncementTests : ComponentTestBase
         Services.AddSingleton(_uiSettings.Object);
     }
 
-    private void SetupCompleted(bool completed) =>
-        _uiSettings.Setup(u => u.GetSetting(IUiSettingsAccessor.SetupCompletedSettingKey,
-                It.IsAny<CancellationToken>(), null))
-            .ReturnsAsync(completed ? "true" : null);
+    private void ArriveAt(string url) =>
+        Services.GetRequiredService<FakeNavigationManager>().NavigateTo(url);
 
     private void AssertConsidered(Times times) =>
         _mediator.Verify(m => m.Send(It.IsAny<GetShareWithAllToolsQuery>(), It.IsAny<CancellationToken>()),
             times);
 
     [Fact]
-    public void StaysQuietWhileAnAccountIsStillInSetup()
+    public void StaysQuietForANewAccountOnTheSetupPage()
     {
-        SetupCompleted(false);
+        ArriveAt("/Setup?from=Discord");
 
         RenderComponent<CommunityToolsAnnouncement>();
 
@@ -66,24 +70,29 @@ public sealed class CommunityToolsAnnouncementTests : ComponentTestBase
     }
 
     /// <summary>
-    ///     …and is not marked seen while suppressed, so the notice is deferred rather than
-    ///     burned: the player meets it on the dashboard, which is where it always fired.
+    ///     …and retires it there rather than deferring it, so finishing setup does not hand the
+    ///     player a rollout notice about a change that was never made to their account.
     /// </summary>
     [Fact]
-    public void DoesNotBurnTheNoticeItSuppressed()
+    public void RetiresTheNoticeForANewAccount()
     {
-        SetupCompleted(false);
+        ArriveAt("/Setup?from=Discord");
 
         RenderComponent<CommunityToolsAnnouncement>();
 
-        _uiSettings.Verify(u => u.SetSetting(SeenKey, It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        _uiSettings.Verify(u => u.SetSetting(SeenKey, "true", It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    /// <summary>
+    ///     The audience test, stated directly: an account old enough to have never seen <c>/Setup</c>
+    ///     carries no completion flag, and still gets the notice.
+    /// </summary>
     [Fact]
-    public void ConsidersTheNoticeOnceSetupIsDone()
+    public void ConsidersTheNoticeForAnAccountThatNeverWalkedSetup()
     {
-        SetupCompleted(true);
+        _uiSettings.Setup(u => u.GetSetting(IUiSettingsAccessor.SetupCompletedSettingKey,
+                It.IsAny<CancellationToken>(), null))
+            .ReturnsAsync((string?)null);
 
         RenderComponent<CommunityToolsAnnouncement>();
 
@@ -93,7 +102,6 @@ public sealed class CommunityToolsAnnouncementTests : ComponentTestBase
     [Fact]
     public void StaysQuietForAnAccountThatAlreadySawIt()
     {
-        SetupCompleted(true);
         _uiSettings.Setup(u => u.GetSetting(SeenKey, It.IsAny<CancellationToken>(), null))
             .ReturnsAsync("true");
 
@@ -106,7 +114,6 @@ public sealed class CommunityToolsAnnouncementTests : ComponentTestBase
     public void StaysQuietForAnAnonymousVisitor()
     {
         CurrentUser.Setup(c => c.IsLoggedIn).Returns(false);
-        SetupCompleted(true);
 
         RenderComponent<CommunityToolsAnnouncement>();
 

--- a/ScoreTracker/ScoreTracker.Tests.Components/CommunityToolsAnnouncementTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/CommunityToolsAnnouncementTests.cs
@@ -84,19 +84,19 @@ public sealed class CommunityToolsAnnouncementTests : ComponentTestBase
     }
 
     /// <summary>
-    ///     The audience test, stated directly: an account old enough to have never seen <c>/Setup</c>
-    ///     carries no completion flag, and still gets the notice.
+    ///     The audience test, stated directly: an account old enough to have never seen
+    ///     <c>/Setup</c> still gets the notice. Its completion flag is deliberately left unstubbed
+    ///     — the component must reach this conclusion without consulting it, because every account
+    ///     that predates the page is missing that flag exactly as a brand-new one is.
     /// </summary>
     [Fact]
     public void ConsidersTheNoticeForAnAccountThatNeverWalkedSetup()
     {
-        _uiSettings.Setup(u => u.GetSetting(IUiSettingsAccessor.SetupCompletedSettingKey,
-                It.IsAny<CancellationToken>(), null))
-            .ReturnsAsync((string?)null);
-
         RenderComponent<CommunityToolsAnnouncement>();
 
         AssertConsidered(Times.Once());
+        _uiSettings.Verify(u => u.GetSetting(IUiSettingsAccessor.SetupCompletedSettingKey,
+            It.IsAny<CancellationToken>(), It.IsAny<Guid?>()), Times.Never);
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests.Components/SetupPageTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/SetupPageTests.cs
@@ -9,6 +9,7 @@ using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using ScoreTracker.CommunityTools.Contracts.Commands;
+using ScoreTracker.Domain.Exceptions;
 using ScoreTracker.Domain.Models;
 using ScoreTracker.Domain.Records;
 using ScoreTracker.Domain.SecondaryPorts;
@@ -287,6 +288,63 @@ public sealed class SetupPageTests : ComponentTestBase
 
         Assert.Contains("ERRLENA", page.Markup);
         Assert.DoesNotContain("Cassandra Vex", page.Markup);
+    }
+
+    /// <summary>
+    ///     The way back carries the provider, or the wizard would strip the "filled in from
+    ///     PIUGAME" chip off the username field — and PIUGAME is the only sign-in that sets a game
+    ///     tag, so every player who uses this banner arrived through it.
+    /// </summary>
+    [Fact]
+    public void TheWayBackFromTheWizardKeepsTheProvider()
+    {
+        Services.GetRequiredService<FakeNavigationManager>().NavigateTo("/Setup?from=PiuGame");
+        var page = RenderCarryingGameTag("ERRLENA", AccountNamed("Cassandra Vex"));
+
+        var href = page.Find(".setup-merge-link").GetAttribute("href")!;
+        Assert.Contains("returnUrl=%2FSetup%3Ffrom%3DPiuGame", href);
+    }
+
+    /// <summary>
+    ///     The lookup materializes other people's rows, so a single unusable name or profile-image
+    ///     URL among them throws. This is the one page a new account has to finish and nothing
+    ///     catches a circuit-killing throw here, so the invitation gives up rather than stranding
+    ///     them on a dead screen over a stranger's bad data.
+    /// </summary>
+    [Fact]
+    public void AFailingLookupCostsTheInvitationAndNothingElse()
+    {
+        CurrentUser.Setup(c => c.User).Returns(new User(UserId, Name.From("Jordan Alvarez"), false,
+            Name.From("ERRLENA"), new Uri("https://example.invalid/a.png"), null));
+        _mediator.Setup(m => m.Send(It.IsAny<GetUsersByGameTagQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidNameException("A name cannot be empty."));
+
+        var page = Render();
+
+        Assert.Empty(page.FindAll(".setup-merge"));
+        Assert.NotNull(page.Find("button.setup-continue"));
+    }
+
+    /// <summary>
+    ///     A shared tag can match several accounts and the query imposes no order, so the pick is
+    ///     made deterministic here — the language picker reloads this page, and an unordered pick
+    ///     could name a different stranger on the way back.
+    /// </summary>
+    [Fact]
+    public void TheSameTagOffersTheSameAccountEveryRender()
+    {
+        var accounts = new[]
+        {
+            AccountNamed("Cassandra Vex"), AccountNamed("Bo Ryu"), AccountNamed("Ada Quill")
+        };
+        var first = RenderCarryingGameTag("ERRLENA", accounts)
+            .Find(".setup-merge-link").GetAttribute("href");
+
+        // The same set, handed back in a different order — as an unordered query legitimately may.
+        var second = RenderCarryingGameTag("ERRLENA", accounts.Reverse().ToArray())
+            .Find(".setup-merge-link").GetAttribute("href");
+
+        Assert.Equal(first, second);
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests.Components/SetupPageTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/SetupPageTests.cs
@@ -13,6 +13,7 @@ using ScoreTracker.Domain.Models;
 using ScoreTracker.Domain.Records;
 using ScoreTracker.Domain.SecondaryPorts;
 using ScoreTracker.Identity.Contracts.Commands;
+using ScoreTracker.Identity.Contracts.Queries;
 using ScoreTracker.SharedKernel.Enums;
 using ScoreTracker.SharedKernel.ValueTypes;
 using ScoreTracker.Web.Pages;
@@ -54,6 +55,24 @@ public sealed class SetupPageTests : ComponentTestBase
     }
 
     private IRenderedComponent<Setup> Render() => RenderComponent<Setup>();
+
+    /// <summary>
+    ///     Puts a game tag on the account and answers the doorway lookup with
+    ///     <paramref name="tagIsAlsoCarriedBy" /> — the accounts a self-reported tag collides with.
+    /// </summary>
+    private IRenderedComponent<Setup> RenderCarryingGameTag(string tag,
+        params User[] tagIsAlsoCarriedBy)
+    {
+        CurrentUser.Setup(c => c.User).Returns(new User(UserId, Name.From("Jordan Alvarez"), false,
+            Name.From(tag), new Uri("https://example.invalid/a.png"), null));
+        _mediator.Setup(m => m.Send(It.IsAny<GetUsersByGameTagQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tagIsAlsoCarriedBy);
+        return Render();
+    }
+
+    private static User AccountNamed(string name) =>
+        new(Guid.NewGuid(), Name.From(name), true, Name.From(name),
+            new Uri("https://example.invalid/b.png"), null);
 
     /// <summary>
     ///     [SupplyParameterFromQuery] only binds from the address, so the provider has to arrive
@@ -237,6 +256,59 @@ public sealed class SetupPageTests : ComponentTestBase
         Assert.Contains("--mix-primary: #FF2FA0", page.Markup);
         Assert.DoesNotContain("--mix-primary: #4FE33F", page.Markup);
         Assert.Equal(before, NavigationCount);
+    }
+
+    /// <summary>
+    ///     The game-tag doorway asks on the way past instead of intercepting the sign-in
+    ///     (docs/design/login-overhaul-spec.md C6), and hands the wizard both the account to
+    ///     compare against and the way back to setup.
+    /// </summary>
+    [Fact]
+    public void AGameTagAnotherAccountCarriesOffersTheMerge()
+    {
+        var other = AccountNamed("Cassandra Vex");
+
+        var page = RenderCarryingGameTag("ERRLENA", other);
+
+        var href = page.Find(".setup-merge-link").GetAttribute("href")!;
+        Assert.Contains($"with={other.Id}", href);
+        Assert.Contains("returnUrl=%2FSetup", href);
+    }
+
+    /// <summary>
+    ///     …and never names what it matched. A game tag is self-reported and non-unique, so the
+    ///     invitation reaches strangers who share a nickname; naming the account would tell them
+    ///     it exists and who it belongs to.
+    /// </summary>
+    [Fact]
+    public void TheInvitationNeverNamesTheMatchedAccount()
+    {
+        var page = RenderCarryingGameTag("ERRLENA", AccountNamed("Cassandra Vex"));
+
+        Assert.Contains("ERRLENA", page.Markup);
+        Assert.DoesNotContain("Cassandra Vex", page.Markup);
+    }
+
+    [Fact]
+    public void AGameTagNobodyElseCarriesAsksNothing()
+    {
+        var page = RenderCarryingGameTag("ERRLENA");
+
+        Assert.Empty(page.FindAll(".setup-merge"));
+    }
+
+    /// <summary>
+    ///     An OAuth sign-in creates an account with no game tag, so there is nothing to collide
+    ///     with and the lookup never runs.
+    /// </summary>
+    [Fact]
+    public void AnAccountWithNoGameTagIsNeverAsked()
+    {
+        var page = Render();
+
+        Assert.Empty(page.FindAll(".setup-merge"));
+        _mediator.Verify(m => m.Send(It.IsAny<GetUsersByGameTagQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker.Tests.Components/SetupPageTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/SetupPageTests.cs
@@ -8,6 +8,7 @@ using Bunit.TestDoubles;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using ScoreTracker.CommunityTools.Contracts.Commands;
 using ScoreTracker.Domain.Models;
 using ScoreTracker.Domain.Records;
 using ScoreTracker.Domain.SecondaryPorts;
@@ -236,6 +237,36 @@ public sealed class SetupPageTests : ComponentTestBase
         Assert.Contains("--mix-primary: #FF2FA0", page.Markup);
         Assert.DoesNotContain("--mix-primary: #4FE33F", page.Markup);
         Assert.Equal(before, NavigationCount);
+    }
+
+    /// <summary>
+    ///     Sharing follows privacy here as it does on /Account. A public profile with no share
+    ///     preference reads as "not shared", so an account that opens up during setup would
+    ///     otherwise sit outside the pool every other public account belongs to.
+    /// </summary>
+    [Fact]
+    public async Task OpeningTheProfileGrantsTheAllToolsShare()
+    {
+        var page = Render();
+
+        await page.Find("button.setup-switch").ClickAsync(new());
+
+        _mediator.Verify(m => m.Send(It.Is<SetShareWithAllToolsCommand>(c => c.Share),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>…and closing it again withdraws the grant, so the two never disagree.</summary>
+    [Fact]
+    public async Task ClosingTheProfileWithdrawsTheAllToolsShare()
+    {
+        CurrentUser.Setup(c => c.User).Returns(new User(UserId, Name.From("Jordan Alvarez"), true, null,
+            new Uri("https://example.invalid/a.png"), null));
+        var page = Render();
+
+        await page.Find("button.setup-switch").ClickAsync(new());
+
+        _mediator.Verify(m => m.Send(It.Is<SetShareWithAllToolsCommand>(c => !c.Share),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker/Components/CommunityTools/CommunityToolsAnnouncement.razor
+++ b/ScoreTracker/ScoreTracker/Components/CommunityTools/CommunityToolsAnnouncement.razor
@@ -4,7 +4,9 @@
 @using ScoreTracker.Domain.SecondaryPorts
 @using ScoreTracker.Web.Services.Contracts
 
-@* The one-time rollout notice, shown once per signed-in player.
+@* The one-time rollout notice, shown once to each player who already had an account when the
+   rollout ran. It is addressed to them alone: it reports a change made to a profile that existed
+   before it, which is not something a new account has.
 
    The public-profile branch has to confess a setting that was turned on FOR them — the only
    sentence in this feature that could read as a bait-and-switch — so it leads with that and links
@@ -80,17 +82,33 @@
     private bool _show;
     private bool _isPublic;
 
+    /// <summary>
+    ///     Whether this render is happening on the new-account setup step. Every navigation is a
+    ///     full document load, so the island re-initializes per page and the address is current.
+    /// </summary>
+    private bool IsSetupPage =>
+        new Uri(NavManager.Uri).AbsolutePath.TrimEnd('/')
+            .Equals("/Setup", StringComparison.OrdinalIgnoreCase);
+
     protected override async Task OnInitializedAsync()
     {
         if (!CurrentUser.IsLoggedIn) return;
 
         if (await UiSettings.GetSetting(SeenKey) is not null) return;
 
-        // Not while they are still setting the account up. This is a "what's new" notice, and a
-        // brand-new player has no "before" to compare it to — meanwhile it is a modal, so on
-        // /Setup it covers the one screen they have to use. Deliberately not marked seen: they
-        // meet it on the dashboard a moment later, which is where it always used to fire.
-        if (await UiSettings.GetSetting(IUiSettingsAccessor.SetupCompletedSettingKey) is null) return;
+        // A brand-new account is one that lands on /Setup, and the notice is not addressed to it:
+        // it reports that the rollout switched sharing on for a profile that already existed, and
+        // an account created afterwards was never switched. So arriving here retires the notice
+        // outright rather than deferring it to the dashboard a moment later.
+        //
+        // Keyed on the page rather than on whether setup is finished: an account that predates
+        // /Setup carries no completion flag either, so reading a missing flag as "brand new" takes
+        // every long-standing player for one and silences the notice for its entire audience.
+        if (IsSetupPage)
+        {
+            await UiSettings.SetSetting(SeenKey, "true");
+            return;
+        }
 
         _isPublic = CurrentUser.User.IsPublic;
         // Reading the preference rather than assuming it: a player who already found the toggle

--- a/ScoreTracker/ScoreTracker/Controllers/LoginController.cs
+++ b/ScoreTracker/ScoreTracker/Controllers/LoginController.cs
@@ -186,18 +186,10 @@ public sealed class LoginController : Controller
                 _proofs.RecordProof(resolution.User.Id, aliasOwner.Id);
         }
 
-        // Game-tag doorway: a fresh piugame account whose tag another account already carries
-        // gets the merge invitation (invitation only — the wizard's prove step is the gate).
-        if (resolution.IsNew)
-        {
-            var tagMatch =
-                (await _mediator.Send(new GetUsersByGameTagQuery(identity.GameTag), HttpContext.RequestAborted))
-                .FirstOrDefault(u => u.Id != resolution.User.Id);
-            if (tagMatch != null)
-                return LocalRedirect(
-                    $"/Account/Merge?with={tagMatch.Id}&returnUrl={Uri.EscapeDataString(SetupUrl(PiuGameProvider))}");
-        }
-
+        // The game-tag doorway lives on the setup step itself, as an invitation the player can
+        // walk past. A tag is self-reported and non-unique, so a match cannot be allowed to
+        // decide where a brand-new account lands — every new account goes to setup, and setup
+        // asks the question.
         if (resolution.IsNew) return LocalRedirect(SetupUrl(PiuGameProvider));
 
         return LocalRedirect(string.IsNullOrWhiteSpace(returnUrl) ? "/" : returnUrl);

--- a/ScoreTracker/ScoreTracker/Pages/Setup.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Setup.razor
@@ -1,6 +1,7 @@
 @page "/Setup"
 @rendermode RenderModes.Interactive
 @using MediatR
+@using ScoreTracker.CommunityTools.Contracts.Commands
 @using ScoreTracker.Domain.Records
 @using ScoreTracker.Domain.SecondaryPorts
 @using ScoreTracker.SharedKernel.Enums
@@ -645,10 +646,23 @@
             : L["Country saved"], Severity.Success);
     }
 
+    /// <summary>
+    ///     Sharing follows privacy in both directions, the same rule the Account page carries:
+    ///     going public turns the all-tools grant on, going private turns it off. Without it a
+    ///     brand-new account that opens its profile here is public but carries no share
+    ///     preference, which reads as "off" — so it sits outside the pool that every account
+    ///     going public from /Account joins.
+    ///     <para>
+    ///         Visibility commits first. The pool is not joined on IsPublic, so writing the
+    ///         preference first would leave the account shared-with-everyone while still private
+    ///         for as long as the second call takes — and permanently if it throws.
+    ///     </para>
+    /// </summary>
     private async Task TogglePublic()
     {
         _isPublic = !_isPublic;
         await SaveProfile();
+        await Mediator.Send(new SetShareWithAllToolsCommand(_isPublic));
         Snackbar.Add(_isPublic
             ? L["Your profile is public"]
             : L["Your profile is private"], Severity.Success);

--- a/ScoreTracker/ScoreTracker/Pages/Setup.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Setup.razor
@@ -609,6 +609,7 @@
 @inject NavigationManager NavManager
 @inject ISnackbar Snackbar
 @inject IJSRuntime JS
+@inject ILogger<Setup> Logger
 
 @code {
 
@@ -652,12 +653,22 @@
     private string _mergeInviteTag = string.Empty;
 
     /// <summary>
+    ///     This page's own address, carrying the provider through so anything that leaves and comes
+    ///     back keeps the "filled in from PIUGAME" chip. Rebuilt from the whitelisted label rather
+    ///     than echoing the query string, which the player controls.
+    /// </summary>
+    private string SelfUrl =>
+        ProviderLabel == null || From == null
+            ? "/Setup"
+            : $"/Setup?from={Uri.EscapeDataString(From)}";
+
+    /// <summary>
     ///     Back here afterwards: keeping the new account leaves setup unfinished, so the wizard
     ///     returns to it. Keeping the other one retires this account and the wizard forces a
     ///     sign-out instead, which is why this is only ever the survivor's path.
     /// </summary>
     private string MergeUrl =>
-        $"/Account/Merge?with={_mergeInviteUserId}&returnUrl={Uri.EscapeDataString("/Setup")}";
+        $"/Account/Merge?with={_mergeInviteUserId}&returnUrl={Uri.EscapeDataString(SelfUrl)}";
 
     protected override async Task OnInitializedAsync()
     {
@@ -697,12 +708,28 @@
     {
         if (CurrentUser.User.GameTag is not { } tag) return;
 
-        var match = (await Mediator.Send(new GetUsersByGameTagQuery(tag)))
-            .FirstOrDefault(u => u.Id != CurrentUser.User.Id);
-        if (match == null) return;
+        try
+        {
+            // Ordered so the answer is stable. A shared tag can match several accounts and the
+            // query imposes no order, so an unordered pick can name one stranger on arrival and a
+            // different one after the language reload re-runs it.
+            var match = (await Mediator.Send(new GetUsersByGameTagQuery(tag)))
+                .OrderBy(u => u.Id)
+                .FirstOrDefault(u => u.Id != CurrentUser.User.Id);
+            if (match == null) return;
 
-        _mergeInviteUserId = match.Id;
-        _mergeInviteTag = tag;
+            _mergeInviteUserId = match.Id;
+            _mergeInviteTag = tag;
+        }
+        catch (Exception e)
+        {
+            // The lookup materializes other people's rows, and one unusable name or profile-image
+            // URL among them throws while building them. This is an optional invitation on the one
+            // page a new account has to finish, and nothing here catches a circuit-killing throw —
+            // so a stranger's bad row would leave a new player on a dead screen with no way
+            // forward. An invitation that cannot be offered is simply not offered.
+            Logger.LogWarning(e, "Game-tag merge invitation lookup failed for {GameTag}", tag);
+        }
     }
 
     private async Task OnNameChanged(ChangeEventArgs args)
@@ -795,12 +822,8 @@
         _culture = SupportedCultures.Normalize(value);
         await UiSettings.SetSetting("Culture", _culture);
 
-        var from = From;
-        var returnTo = ProviderLabel == null || from == null
-            ? "/Setup"
-            : $"/Setup?from={Uri.EscapeDataString(from)}";
         NavManager.NavigateTo(
-            $"/Culture/Set?culture={_culture}&redirectUrl={Uri.EscapeDataString(returnTo)}",
+            $"/Culture/Set?culture={_culture}&redirectUrl={Uri.EscapeDataString(SelfUrl)}",
             true);
     }
 

--- a/ScoreTracker/ScoreTracker/Pages/Setup.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Setup.razor
@@ -4,6 +4,7 @@
 @using ScoreTracker.CommunityTools.Contracts.Commands
 @using ScoreTracker.Domain.Records
 @using ScoreTracker.Domain.SecondaryPorts
+@using ScoreTracker.Identity.Contracts.Queries
 @using ScoreTracker.SharedKernel.Enums
 @using ScoreTracker.SharedKernel.ValueTypes
 @using ScoreTracker.Web.Services.Contracts
@@ -153,6 +154,44 @@
     .setup-lede b {
         color: var(--mix-ink);
         font-weight: 600;
+    }
+
+    /* The game-tag invitation. Sits above the fields and reads as a question, not a warning —
+       a self-reported tag match is a guess, and the mix primary carries that better than an
+       alert colour would. */
+    .setup-merge {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 10px 14px;
+        margin: 0 0 26px;
+        padding: 14px 16px;
+        border: 1px solid color-mix(in srgb, var(--mix-primary) 40%, transparent);
+        border-radius: 11px;
+        background: color-mix(in srgb, var(--mix-primary) 8%, transparent);
+    }
+
+    .setup-merge-text {
+        flex: 1 1 260px;
+        margin: 0;
+        font-size: 14.5px;
+        color: var(--mix-ink);
+    }
+
+    .setup-merge-link {
+        flex: 0 0 auto;
+        padding: 8px 15px;
+        border-radius: 999px;
+        font-size: 13.5px;
+        font-weight: 700;
+        text-decoration: none;
+        color: var(--mix-primary-contrast);
+        background: var(--mix-primary);
+        transition: filter .15s ease;
+    }
+
+    .setup-merge-link:hover {
+        filter: brightness(1.12);
     }
 
     .setup-fields {
@@ -451,6 +490,20 @@
             <b>@L["All of it is changeable later in your account."]</b>
         </p>
 
+        @if (_mergeInviteUserId != null)
+        {
+            @* The game-tag doorway (login-overhaul-spec C6). It asks rather than asserts, because
+               a game tag is self-reported and non-unique, and it never names the account it
+               matched: a shared nickname would otherwise tell a stranger that account exists and
+               who it is. The wizard's prove step is the security gate. *@
+            <div class="setup-merge">
+                <p class="setup-merge-text">
+                    @L["An account with game tag {0} already exists, is that you?", _mergeInviteTag]
+                </p>
+                <a class="setup-merge-link" href="@MergeUrl">@L["Review and merge"]</a>
+            </div>
+        }
+
         <div class="setup-fields">
 
             <div class="setup-field">
@@ -589,6 +642,23 @@
     private bool _isSaving;
     private bool _isFinishing;
 
+    /// <summary>
+    ///     The account this player may already have, matched on game tag, and the tag that matched.
+    ///     Null unless another account carries it — an OAuth sign-in creates an account with no
+    ///     game tag at all, so those never ask.
+    /// </summary>
+    private Guid? _mergeInviteUserId;
+
+    private string _mergeInviteTag = string.Empty;
+
+    /// <summary>
+    ///     Back here afterwards: keeping the new account leaves setup unfinished, so the wizard
+    ///     returns to it. Keeping the other one retires this account and the wizard forces a
+    ///     sign-out instead, which is why this is only ever the survivor's path.
+    /// </summary>
+    private string MergeUrl =>
+        $"/Account/Merge?with={_mergeInviteUserId}&returnUrl={Uri.EscapeDataString("/Setup")}";
+
     protected override async Task OnInitializedAsync()
     {
         if (!CurrentUser.IsLoggedIn)
@@ -612,6 +682,27 @@
             : MixEnum.Phoenix2;
 
         _countries = (await Users.GetCountries()).OrderBy(c => c.Name).ToArray();
+
+        await CheckMergeInvite();
+    }
+
+    /// <summary>
+    ///     Invitation only — the merge wizard's prove step is the security gate
+    ///     (docs/design/login-overhaul-spec.md C6). A game tag is self-reported and non-unique, so
+    ///     a match is a question asked on the way past, never a redirect: intercepting onboarding
+    ///     to demand a merge decision spends a brand-new player's first screen on a guess that is
+    ///     sometimes about somebody else entirely.
+    /// </summary>
+    private async Task CheckMergeInvite()
+    {
+        if (CurrentUser.User.GameTag is not { } tag) return;
+
+        var match = (await Mediator.Send(new GetUsersByGameTagQuery(tag)))
+            .FirstOrDefault(u => u.Id != CurrentUser.User.Id);
+        if (match == null) return;
+
+        _mergeInviteUserId = match.Id;
+        _mergeInviteTag = tag;
     }
 
     private async Task OnNameChanged(ChangeEventArgs args)

--- a/ScoreTracker/ScoreTracker/Services/Contracts/IUiSettingsAccessor.cs
+++ b/ScoreTracker/ScoreTracker/Services/Contracts/IUiSettingsAccessor.cs
@@ -12,9 +12,19 @@ public interface IUiSettingsAccessor
     const string MixSettingKey = "Universal__CurrentMix";
 
     /// <summary>
-    ///     Set when a new account finishes <c>/Setup</c>. Its presence is the whole "this account
-    ///     is past onboarding" test — <c>LoginController</c> reads it to stop sending them back,
-    ///     and anything that would interrupt a first-run player reads it to stay quiet.
+    ///     Set when a new account finishes <c>/Setup</c>, and read by nothing today.
+    ///     <para>
+    ///         Do not reach for it as a "is this account new?" test. It answers the opposite
+    ///         question and only for accounts that postdate the page: every account created before
+    ///         <c>/Setup</c> existed lacks the key permanently, so absence means "brand new" and
+    ///         "signed up years ago" at the same time. <c>LoginController</c> decides where to send
+    ///         a sign-in from whether the account was just created; the one feature that has to
+    ///         stay quiet for a first-run player recognises them by their arrival on the page.
+    ///     </para>
+    ///     <para>
+    ///         Kept written because it is the only durable record that an account finished
+    ///         onboarding, which is a real question even though nothing asks it yet.
+    ///     </para>
     /// </summary>
     const string SetupCompletedSettingKey = "Universal__SetupCompleted";
 

--- a/docs/design/api-v2-community-tools.md
+++ b/docs/design/api-v2-community-tools.md
@@ -362,7 +362,10 @@ two places, both deliberate:
   sharing is what going public unlocks — a lot of players do not know public is an option.
 - **Going public turns all-tools on, every time.** Not "only if never set" — the owner's call, on
   the grounds that people do not flip privacy back and forth and remembering a prior choice is the
-  more confusing behaviour.
+  more confusing behaviour. This binds **every** surface that flips visibility, not just
+  `/Account`: the rule lives in the pages, so a page that forgets it silently keeps its players
+  out of the pool. `/Setup` did exactly that from 2026-08-03 until it was fixed on 2026-08-10 —
+  public on the site, no preference row, invisible to tools.
 
 Consequences that must ship with it:
 

--- a/docs/design/login-overhaul-spec.md
+++ b/docs/design/login-overhaul-spec.md
@@ -163,7 +163,14 @@ and dropped" below.)
   2. **Game-tag match**: `GetUsersByGameTagQuery` (Identity contracts + `IUserRepository`
      method); after a PIUGAME login or import completes, a match on another account prompts
      "An account with game tag X already exists. Is that you?" → deep link, `returnUrl` back to
-     the import. Invitation only — the wizard's prove step is the security gate.
+     where it was asked. Invitation only — the wizard's prove step is the security gate.
+
+     **A doorway never redirects, it only offers** (2026-08-10). The login path originally sent a
+     new account straight to the wizard, which spent a brand-new player's first screen on a merge
+     decision. Tags are self-reported and non-unique, so the match is a guess and is sometimes
+     about a stranger; it may prompt, never navigate. The invitation now renders on `/Setup`
+     itself and on the import page, and it never names the matched account — naming it tells
+     someone who merely shares a nickname that the account exists.
   3. **Manual**: "Merge another account" button in the settings panel.
 - **Tests**: query handler test; prompt logic covered at handler level.
 

--- a/docs/design/new-user-setup.md
+++ b/docs/design/new-user-setup.md
@@ -164,6 +164,30 @@ sign-in into a returning user.
   This is independent of the rest of the design and shipped first — the language picker on
   `/Setup` should be a preference, not a workaround for a front door the visitor could not read.
 
+- **D11 — nothing intercepts a new account on its way here, and the page asks the questions
+  instead.** A fresh PIUGAME account whose game tag another account already carries used to be
+  redirected into the merge wizard *before* setup, so a brand-new player's first screen was a
+  merge decision. A game tag is self-reported and non-unique — `GetUsersByGameTagQuery` says so
+  in its own doc comment — so the match is a guess, and it is sometimes about a stranger who
+  shares a nickname. A guess cannot be allowed to decide where an account lands.
+
+  The doorway is a banner at the top of the card instead (`setup-merge`), reusing the copy the
+  import page already carries in all nine locales. It **asks** ("is that you?") rather than
+  telling, it **never names the account it matched** — naming it would tell a stranger that
+  account exists and who it belongs to — and it links to the wizard, whose prove step remains
+  the security gate. An OAuth account has no game tag, so the lookup never runs for one.
+
+  The consequence beyond this page: `/Setup` is now the unconditional first screen of every new
+  account, which makes "is on `/Setup`" the one reliable signal that an account is brand new.
+  The Community Tools rollout notice keys on exactly that to stay out of their way.
+
+- **D12 — sharing follows privacy here, the same as on `/Account`.** The visibility toggle sends
+  `SetShareWithAllToolsCommand` alongside `UpdateUserCommand`. The all-tools pool is not joined
+  on `IsPublic`; it reads a share preference, so a page that flips visibility without writing one
+  leaves the account public on the site and invisible to community tools. Visibility commits
+  first — the reverse order would put an account that is still private into the pool for as long
+  as the second call takes, and permanently if it throws.
+
 ## Technical scope
 
 **Presentation only.** Every new line lands in `ScoreTracker.Web`. No vertical gains a type, no
@@ -203,7 +227,7 @@ manifest already covers it — `AccountPurgeCoverageTests` needs nothing.
 | File | Change |
 |---|---|
 | `Pages/Setup.razor` | **new.** `@page "/Setup"`, `@rendermode RenderModes.Interactive`, hand-styled against `--mix-*` (D9), page-scoped `<style>` block |
-| `Controllers/LoginController.cs` | three redirects: OAuth `isNewUser` → `/Setup`; PIUGAME `resolution.IsNew` → `/Setup`; the PIUGAME tag-match merge's `returnUrl` → `/Setup`. Plus `DevLoginBootstrap`, so the dev path exercises the real flow |
+| `Controllers/LoginController.cs` | two redirects: OAuth `isNewUser` → `/Setup`; PIUGAME `resolution.IsNew` → `/Setup`. Plus `DevLoginBootstrap`, so the dev path exercises the real flow. **Nothing else may intercept a new account** — see D11 |
 | `Resources/App.*.resx` | new keys in **all nine** locales, inserted in alphabetical position (`ResxKeysAreStoredAlphabetically`), per-locale glossaries, Murloc from its own alphabet |
 | `Services/Theming/MixThemes.cs` | one line: `SuccessContrastText`, see Open questions |
 


### PR DESCRIPTION
Three defects around the new-account path, all found while answering "are new users getting the community tools dialog?" — they were, and the rest fell out of the same gate.

## The rollout notice was reaching exactly the wrong people

`CommunityToolsAnnouncement` reports that the rollout switched sharing on for a profile that already existed. It was suppressed by asking whether the account had finished `/Setup` — the wrong question twice over:

- An account created **before** `/Setup` existed carries no completion flag either, so a missing flag took every long-standing player for a brand-new one. Since 2026-08-03 the notice has been silenced for its entire intended audience.
- The suppression **deferred** rather than retired, so finishing setup handed the notice straight to the one account it does not address.

It now recognises a new account by its arrival on `/Setup` and retires itself there. Pre-existing players who never dismissed it will see it — intended, per the owner.

## Public accounts created at setup were invisible to community tools

"Going public turns all-tools sharing on" is a rule the *pages* carry. `/Account` sends `SetShareWithAllToolsCommand` alongside the visibility change; `/Setup` did not. An account that opened its profile during setup was public everywhere on the site with no share preference row at all — and a missing row reads as "off".

`/Setup` now sends the same command, visibility first: the reverse order would put a still-private account into the pool for as long as the second call takes, and permanently if it throws.

**A hand-run backfill covers the accounts already in that state** — it is not in this PR and not a migration.

## A game-tag guess decided where a new account landed

A fresh PIUGAME account whose tag another account already carries was redirected into the merge wizard *before* setup, so a brand-new player's first screen was a merge decision — about a match that is often somebody else. Game tags are self-reported and non-unique, which `GetUsersByGameTagQuery` says in its own doc comment.

The doorway is a banner on the setup card now. It asks rather than tells, never names the account it matched (naming it tells someone who merely shares a nickname that the account exists), and links to the wizard, whose prove step is still the gate. Both strings already existed for the import page's copy of this doorway, so no new localization keys.

Consequence beyond the banner: every new account now lands on `/Setup` unconditionally, which is what makes that page a reliable "this account is new" signal.

## Scope

Presentation only — no vertical, port, entity or migration. `Setup.razor`, `LoginController.cs`, `CommunityToolsAnnouncement.razor`, plus design docs.

Hand-rolled against `--mix-*`: a MudBlazor alert on `/Setup` would hold the previous mix's colours when the mix picker re-themes the page live (D9).

## Tests

32 in `SetupPageTests` + `CommunityToolsAnnouncementTests`, six of them new — the banner's presence, absence and privacy; both directions of the sharing rule; and the audience test stated directly, that an account too old to have walked setup still gets the notice. 75 architecture ratchets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)