### PR TITLE
fix(import): the card list comes from the mix being imported

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/UploadPhoenixScoresPageTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/UploadPhoenixScoresPageTests.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Bunit;
 using MediatR;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using ScoreTracker.Catalog.Contracts.Queries;
@@ -190,6 +192,36 @@ public sealed class UploadPhoenixScoresPageTests : ComponentTestBase
             Assert.NotEmpty(cut.FindAll(".mud-skeleton"));
         });
         _mediator.Verify(m => m.Send(It.IsAny<StartOfficialImportCommand>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(MixEnum.Phoenix)]
+    [InlineData(MixEnum.Phoenix2)]
+    public async Task ChangeCardListsTheSelectedMixesCards(MixEnum mix)
+    {
+        // Each official site lists only the cards registered in its own game, so asking Phoenix 1
+        // for a Phoenix 2 player's cards returns their old card and nothing else — which is what
+        // "Change Card only shows my first card" looked like from a Phoenix 2 import.
+        _uiSettings.Setup(u => u.GetSelectedMix(It.IsAny<CancellationToken>())).ReturnsAsync(mix);
+        // A remembered card with no loaded list is the state that offers the button.
+        _uiSettings.Setup(u => u.GetSetting("PhoenixScoreUpload__LastGameId", It.IsAny<CancellationToken>(),
+            It.IsAny<Guid?>())).ReturnsAsync("9990001");
+        _uiSettings.Setup(u => u.GetSetting("PhoenixScoreUpload__LastGameTag", It.IsAny<CancellationToken>(),
+            It.IsAny<Guid?>())).ReturnsAsync("OLDCARD");
+        _mediator.Setup(m => m.Send(It.IsAny<GetGameCardsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new GameCardRecord("NEWCARD", "9990002", true) });
+
+        var cut = RenderComponent<UploadPhoenixScores>();
+        cut.WaitForAssertion(() => Assert.Contains("Change Card", cut.Markup));
+        // The button gates on typed credentials. MudTextField binds on change, not input.
+        await cut.Find("input[type=text]").ChangeAsync(new ChangeEventArgs { Value = "player" });
+        await cut.Find("input[type=password]").ChangeAsync(new ChangeEventArgs { Value = "hunter2" });
+
+        await cut.FindAll("button").First(b => b.TextContent.Contains("Change Card"))
+            .ClickAsync(new MouseEventArgs());
+
+        _mediator.Verify(m => m.Send(It.Is<GetGameCardsQuery>(q => q.Mix == mix), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/ScoreTracker/ScoreTracker/Pages/UploadPhoenixScores.razor
+++ b/ScoreTracker/ScoreTracker/Pages/UploadPhoenixScores.razor
@@ -533,7 +533,10 @@
 
         try
         {
-            _cards = (await Mediator.Send(new GetGameCardsQuery(_username, _password))).ToArray();
+            // Cards are listed per mix — each official site knows only the cards registered in
+            // its own game. Omitting the mix reads Phoenix 1's list, so a card that exists only
+            // on Phoenix 2 can never be picked.
+            _cards = (await Mediator.Send(new GetGameCardsQuery(_username, _password, _currentMix))).ToArray();
         }
         catch (InvalidCredentialException)
         {
@@ -568,7 +571,9 @@
         {
             if (string.IsNullOrWhiteSpace(_selectedId))
             {
-                _cards = (await Mediator.Send(new GetGameCardsQuery(_username, _password))).ToArray();
+                // Per mix, for the same reason as LoadCards: the card being imported has to come
+                // from the site being imported.
+                _cards = (await Mediator.Send(new GetGameCardsQuery(_username, _password, _currentMix))).ToArray();
                 if (_cards.Count() > 1)
                 {
                     _selectedId = _cards.First(c => c.IsActive).Id;


### PR DESCRIPTION
Reported on Discord: a player importing Phoenix 2 scores with a new Phoenix 2 card pressed **Change Card** and saw only their Phoenix 1 card, with no way to reach the new one.

## The bug

Each official site lists only the cards registered in its own game — `game_id_information.php` is fetched from `PiuGameConfiguration.BaseUrlFor(mix)`, which is `phoenix.piugame.com` for Phoenix 1 and `piugame.com` for Phoenix 2. Two call sites on `/UploadPhoenixScores` fetched that list without saying which mix they meant:

- `LoadCards()` — the Change Card button
- the first-import branch of `ImportScores()`

`GetGameCardsQuery` takes the mix as a **trailing optional parameter defaulting to `MixEnum.Phoenix`**, so both compiled clean, ran clean, logged nothing, and always read Phoenix 1's list. A card that exists only on Phoenix 2 could not be picked at all.

The mix was threaded through these contracts in `ef129194` (the July 4 Phoenix 2 import backend) with a default so existing call sites kept compiling; these two were never revisited. `SaveCredentials()` passes `_currentMix` correctly because it was written afterwards — which is why pressing "Remember my password" was an accidental workaround for the reported symptom.

## The fix

Both call sites pass `_currentMix`.

## Tests

`+2` fast in `Tests.Components` — a `[Theory]` over both mixes asserting the button's `GetGameCardsQuery` carries the page's mix. Verified as a real guard rather than a passing tautology: with the fix reverted the Phoenix 2 case fails and the Phoenix 1 case still passes, since it happens to match the default.

`UploadPhoenixScoresPageTests` 9/9 green; `BunitEventDispatchTests` green.

## Not in scope — flagged to the owner separately

Three neighbours found while tracing this, each needing a decision rather than a patch:

1. `PhoenixScoreUpload__LastGameId` / `LastGameTag` carry no mix in the key, so one remembered card serves both mixes — and `SetCard` only checks the HTTP status, so an unknown card id silently no-ops and the import reads whatever card is active.
2. `OfficialLeaderboardSaga.cs:134` has an empty `if (accountData.AccountName != expectedGameTag) { }` — the guard that would catch (1), currently detecting the mismatch and discarding it.
3. Change Card is hidden entirely for saved-credential users, so switching cards means Forget → retype → switch → re-save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
