### PR TITLE
fix(widgets): Breakdown graphs honor the Singles / Doubles scope

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/ByLevelAggregatorTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/ByLevelAggregatorTests.cs
@@ -420,6 +420,95 @@ public sealed class ByLevelAggregatorTests
         Assert.Equal(900_000, s.Values[0]); // the doubles chart is out of scope
     }
 
+    // A stacked Breakdown pools S and D into one stack per level, but a single-type scope is
+    // ALREADY one stack — pooling it too silently dropped the S/D filter, so every Breakdown
+    // preset (Grade / Plate / Clear Progress) rendered identically for Singles and Doubles.
+
+    [Theory]
+    [InlineData(BreakdownChartScope.Singles, ChartType.Single, 1, 2)]
+    [InlineData(BreakdownChartScope.Doubles, ChartType.Double, 3, 1)]
+    [InlineData(BreakdownChartScope.SinglesDoubles, null, 4, 3)]
+    public void BreakdownScopeFiltersChartType(
+        BreakdownChartScope scope, ChartType? expectedType, double expectedPassed, double expectedUnpassed)
+    {
+        var records = new[]
+        {
+            Passed(ChartType.Single, 20, 900_000, 5),
+            Failed(ChartType.Single, 20),
+            Unplayed(ChartType.Single, 20),
+            Passed(ChartType.Double, 20, 800_000, 4),
+            Passed(ChartType.Double, 20, 850_000, 4),
+            Passed(ChartType.Double, 20, 870_000, 4),
+            Failed(ChartType.Double, 20),
+            new BreakdownRecord(ChartType.CoOp, 20, true, true, 900_000, 5, 5) // never in an S/D scope
+        };
+        var config = new ByLevelBreakdownConfig
+        {
+            Scope = scope,
+            Metric = BreakdownMetric.Pass,
+            Aggregation = BreakdownAggregation.Breakdown,
+            MinLevel = 20, MaxLevel = 20
+        };
+
+        var result = ByLevelAggregator.Aggregate(config, records, Scales);
+
+        Assert.Equal(expectedPassed, Value(result, "Passed"));
+        Assert.Equal(expectedUnpassed, Value(result, "Unpassed")); // fails + unplayed
+        // One stack per level either way — the scope narrows the population, never the grouping.
+        Assert.False(result.SeparateTypes);
+        Assert.All(result.Series, s => Assert.Equal(expectedType, s.Type));
+    }
+
+    [Fact]
+    public void BreakdownGradeSegmentsHonorTheDoublesScope()
+    {
+        var records = new[]
+        {
+            Passed(ChartType.Single, 20, 900_000, 5),
+            Passed(ChartType.Single, 20, 950_000, 6),
+            Passed(ChartType.Double, 20, 800_000, 5)
+        };
+        var config = new ByLevelBreakdownConfig
+        {
+            Scope = BreakdownChartScope.Doubles,
+            Metric = BreakdownMetric.LetterGrade,
+            Aggregation = BreakdownAggregation.Breakdown,
+            Normalize = false, IncludeUnplayed = true,
+            MinLevel = 20, MaxLevel = 20
+        };
+
+        var result = ByLevelAggregator.Aggregate(config, records, Scales);
+
+        Assert.Equal(1, Value(result, "S")); // rank 5, the one doubles chart
+        Assert.Equal(0, Value(result, "SS")); // rank 6 is singles-only — out of scope
+        Assert.Equal(0, Value(result, "Not cleared"));
+    }
+
+    [Fact]
+    public void BreakdownCoOpScopeStillCoversOnlyCoOp()
+    {
+        var records = new[]
+        {
+            new BreakdownRecord(ChartType.CoOp, 2, true, true, 900_000, 5, 5),
+            new BreakdownRecord(ChartType.CoOp, 2, true, false, null, null, null),
+            Passed(ChartType.Single, 2, 900_000, 5) // a level-2 single is not a 2-player co-op
+        };
+        var config = new ByLevelBreakdownConfig
+        {
+            Scope = BreakdownChartScope.CoOp,
+            Metric = BreakdownMetric.Pass,
+            Aggregation = BreakdownAggregation.Breakdown,
+            MinPlayers = 2, MaxPlayers = 2
+        };
+
+        var result = ByLevelAggregator.Aggregate(config, records, Scales);
+
+        Assert.Equal("Players", result.XAxisTitle);
+        Assert.Equal(1, Value(result, "Passed"));
+        Assert.Equal(1, Value(result, "Unpassed"));
+        Assert.All(result.Series, s => Assert.Equal(ChartType.CoOp, s.Type));
+    }
+
     [Fact]
     public void SeparateMinMaxRangeEmitsOneBandPerType()
     {

--- a/ScoreTracker/ScoreTracker/Services/HomeDashboard/ByLevelAggregator.cs
+++ b/ScoreTracker/ScoreTracker/Services/HomeDashboard/ByLevelAggregator.cs
@@ -444,16 +444,15 @@ public static class ByLevelAggregator
     {
         if (config.Metric is BreakdownMetric.Score) return BreakdownResult.Empty; // grades ARE the score bands
 
-        // Breakdown renders one stack per level (grouped stacked bars are a later UX
-        // iteration); S/D separation lives in the line aggregations.
-        draws = new[]
+        // One stack per level: grouped stacked bars render as duplicate-labelled overlaps
+        // (ApexCharts ignores series Group), so a separated S/D config pools to a single draw.
+        // A single-type scope is already one stack and keeps its type — and with it its filter.
+        if (draws.Length > 1)
         {
-            config.Scope == BreakdownChartScope.CoOp
-                ? new Draw(ChartType.CoOp, "Co-Op", 'C', false)
-                : new Draw(null, "S + D", ' ', false)
-        };
-        separate = false;
-        legendNote = null;
+            draws = new[] { new Draw(null, "S + D", ' ', false) };
+            separate = false;
+            legendNote = null;
+        }
 
         var series = new List<BreakdownSeries>();
 

--- a/docs/design/HomePageWidgets/by-level-breakdown.md
+++ b/docs/design/HomePageWidgets/by-level-breakdown.md
@@ -7,10 +7,16 @@ decisions (D1–D19), the widget registry contract, and the widget index. **Stat
 **Render notes:** the shaded distribution band draws as a native `ApexRangeAreaSeries`
 (Blazor-ApexCharts 6.1.0 `Top`/`Bottom`), muted and translucent behind the stat lines. **Separate
 S/D is a Distribution-only opt-in** — Blazor-ApexCharts 6.1.0 ignores `ApexBaseSeries.Group`, so
-grouped S/D bars render as duplicate-labelled overlaps; the stacked aggregations (Breakdown,
-Completion) therefore stay combined ("S + D") and S/D separation lives only in the line
-distributions. When separated, each type reads by **color** (red Singles / green Doubles), showing
-one stat line or a shaded range per type (§ UX iterations).
+grouped S/D bars render as duplicate-labelled overlaps; a stacked aggregation therefore draws one
+stack per level, and drawing *both* types at once lives only in the line distributions. When
+separated, each type reads by **color** (red Singles / green Doubles), showing one stat line or a
+shaded range per type (§ UX iterations).
+
+That limit is about drawing **two** groups side by side, and it is not the chart **scope**. A
+Singles-only or Doubles-only scope is one stack either way, so every aggregation — Distribution,
+Breakdown and Completion alike — narrows to the chosen type. Conflating the two is what made the
+Breakdown presets (Grade / Plate / Clear Progress) ignore the Charts dropdown and render Singles,
+Doubles and Singles + Doubles identically; Co-Op escaped only because it was special-cased.
 
 Mock (interactive config flow, fake data): https://claude.ai/code/artifact/77692444-46e8-451c-ac17-f3f5e2ba6604
 
@@ -219,9 +225,10 @@ Field-test rounds after the C0–C7 build; the owner runs, these are the ratifie
   IQR / Min–Max / ±1σ, with dotted min/max outside a range band); **Chart Age** metric added, then given
   **Completion** parity with Score (recency tiers); four-option Charts dropdown.
 - **Grouped S/D bars: shelved.** Blazor-ApexCharts 6.1.0 ignores `ApexBaseSeries.Group`, so a grouped
-  stacked bar renders as duplicate-labelled overlaps. Stacked aggregations stay combined; the
-  "separate data" toggle is Distribution-only and self-hides elsewhere. Revisit if the wrapper gains real
-  grouped-bar support.
+  stacked bar renders as duplicate-labelled overlaps. A stacked aggregation under the Singles + Doubles
+  scope therefore pools into one stack; the "separate data" toggle is Distribution-only and self-hides
+  elsewhere. This never applied to the single-type scopes — see the render note. Revisit if the wrapper
+  gains real grouped-bar support.
 - **Round 3 (V1 lock)** — preset roster trimmed to the six above: Score Completion dropped (it overlaps a
   normalized Grade Distribution), Chart Age dropped as a *suggested* graph (kept configurable); added
   **Singles vs Doubles** (separated Score, IQR shaded) and **Co-Op Completion** (Co-Op Pass breakdown).


### PR DESCRIPTION
The Charts dropdown did nothing on four home-page widgets: **Grade Distribution**, **Plate
Distribution**, **Clear Progress** and **Clear Progress by Grade** rendered the same graph
whether you picked Singles, Doubles, or Singles + Doubles. Co-Op worked.

## Cause

`ByLevelAggregator.Aggregate` builds a draw set from the configured scope, then the `Breakdown`
branch threw it away and rebuilt one:

```csharp
draws = new[]
{
    config.Scope == BreakdownChartScope.CoOp
        ? new Draw(ChartType.CoOp, "Co-Op", 'C', false)
        : new Draw(null, "S + D", ' ', false)   // Singles and Doubles land here too
};
```

That ternary only asks whether the scope is Co-Op. Everything else collapses to `Draw(null, …)`,
and a null type is the *pooled* draw — `Matches` reads it as `r.Type is Single or Double`, i.e.
both. Co-Op was fine precisely because it is the one case the ternary names.

Every affected widget is a **Breakdown** aggregation; Distribution and Completion use the draw set
the scope already produced, so `Score Distribution`, `Singles vs Doubles` and `Co-Op Completion`
were never affected. The config side was innocent throughout — the panel saves `Scope` and reads it
back correctly, and the widget passes it straight through. The setting was stored, then discarded
at aggregation time.

## Fix

The rebuild was guarding something real, just too broadly. Blazor-ApexCharts 6.1.0 ignores
`ApexBaseSeries.Group`, so two stacks per level render as duplicate-labelled overlaps — but that
constraint is about drawing **both** types at once. A single-type scope is one stack either way.

The guard now fires only when there is more than one draw to pool:

```csharp
if (draws.Length > 1)
{
    draws = new[] { new Draw(null, "S + D", ' ', false) };
    separate = false;
    legendNote = null;
}
```

Singles and Doubles keep their typed draw, and with it their filter. Grouped S/D bars stay shelved.

Nothing downstream changes for the pooled or Co-Op cases: bar grouping is gated on
`result.SeparateTypes` (still false), and Breakdown segments resolve color from their role
(Muted / Pass / Grade / Plate), never from `Type`.

## Tests

The gap was a whole untested cell — the existing scope tests cross with the wrong aggregations
(`SinglesScopeCoversOnlySingles` runs under Distribution, the Co-Op one under Completion), and every
Breakdown test left `Scope` at its default. Added scope × Breakdown coverage:

- `BreakdownScopeFiltersChartType` — a theory over Singles / Doubles / Singles + Doubles, asserting
  the pass and unpass counts per scope, that the result stays ungrouped, and that the series carry
  the expected type.
- `BreakdownGradeSegmentsHonorTheDoublesScope` — a grade stack whose singles-only rung must read 0.
- `BreakdownCoOpScopeStillCoversOnlyCoOp` — pins the case that already worked, so the special-case
  removal can't silently regress it.

Verified red before the fix and green after: reverting the source change fails exactly the Singles
and Doubles cases and the grade test, while the pooled and Co-Op cases stay green. Full
`ScoreTracker.Tests.Components` suite passes (845).

Docs: the design doc's render note claimed the stacked aggregations "stay combined," which conflated
the grouped-bar limit with the scope filter (and was wrong about Completion, which never had the
bug). Corrected in `docs/design/HomePageWidgets/by-level-breakdown.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
