### PR TITLE
March of Murlocs Slice 1: the six surfaces, mocked and settled

### DIFF
--- a/docs/design/march-of-murlocs-mocks/1-season.html
+++ b/docs/design/march-of-murlocs-mocks/1-season.html
@@ -1,0 +1,375 @@
+<title>MoM — Season page mock</title>
+<style>
+  /* Phoenix mix palette, verbatim from Services/Theming/MixThemes.cs. Dark-only, as the site is. */
+  :root {
+    --mix-bg:#070B15; --mix-surface:#161E2C; --mix-raised:#1E2A3D; --mix-nav:#0D1626;
+    --mix-primary:#3FA9F5; --mix-secondary:#FF6B35; --mix-accent:#FFD24A;
+    --mix-ink:#E9EFF7; --mix-muted:#93A3B8;
+    --chart-single:#FF6B35; --chart-double:#38B6FF;
+    --rar-gold:#FFD24A; --rar-silver:#CBD5E1;
+    /* Row-highlight tokens, verbatim from site.css: mix-invariant, because a rival reads as a
+       rival in every theme. --daily-rival is deliberately not MixPalette.Error. */
+    --daily-you:#4bb8ff; --daily-community:#43dc86; --daily-rival:#FF3B5C;
+    --line:rgba(233,239,247,.12); --line-strong:rgba(233,239,247,.22);
+    --display:"Barlow Condensed","Oswald","Roboto Condensed","Arial Narrow",system-ui,sans-serif;
+    --body:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"], :root[data-theme="dark"] { color-scheme: dark; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--mix-bg); color:var(--mix-ink); font-family:var(--body);
+         font-size:15px; line-height:1.5; -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:1060px; margin:0 auto; padding:16px 16px 80px; }
+  .num { font-variant-numeric:tabular-nums; }
+  h1,h2,h3 { font-family:var(--display); font-weight:600; margin:0; text-wrap:balance; }
+
+  .mockbar { background:#12203a; border-bottom:1px solid var(--line); padding:9px 16px;
+             font-size:12.5px; color:var(--mix-muted); display:flex; flex-wrap:wrap; gap:6px 14px; align-items:center; }
+  .mockbar b { color:var(--mix-ink); font-weight:600; }
+  .mockbar button { background:var(--mix-raised); color:var(--mix-ink); border:1px solid var(--line-strong);
+                    border-radius:5px; font:inherit; font-size:12px; padding:4px 10px; cursor:pointer; }
+  .mockbar button:hover { border-color:var(--mix-primary); }
+  .note { border-left:2px solid var(--mix-accent); background:rgba(255,210,74,.06);
+          padding:9px 13px; margin:0; border-radius:0 5px 5px 0; font-size:13px; color:#E4D9BC; }
+  .note b { color:var(--mix-accent); font-weight:600; }
+
+  /* ---------- section frame ---------- */
+  .frame-head { display:flex; align-items:flex-end; gap:14px; flex-wrap:wrap;
+                border-bottom:1px solid var(--line); padding-bottom:11px; }
+  .frame-title { font-family:var(--display); font-size:34px; font-weight:700; line-height:1; }
+  .frame-nav { display:flex; gap:4px; margin-left:auto; flex-wrap:wrap; }
+  .frame-nav a { color:var(--mix-muted); text-decoration:none; font-size:13px; padding:5px 10px; border-radius:5px; }
+  .frame-nav a:hover { color:var(--mix-ink); background:var(--mix-raised); }
+  .frame-nav a[aria-current] { color:var(--mix-ink); background:var(--mix-raised); }
+
+  /* ---------- season strip ---------- */
+  .season { display:flex; align-items:center; gap:14px 20px; flex-wrap:wrap; margin-top:16px; }
+  .season-name { font-family:var(--display); font-size:26px; font-weight:600; line-height:1; }
+  .season-dates { font-size:13px; color:var(--mix-muted); }
+  .countdown { margin-left:auto; text-align:right; min-width:150px; }
+  .countdown .n { font-family:var(--display); font-size:26px; font-weight:700; line-height:1; color:var(--mix-accent); }
+  .countdown .l { font-size:11px; letter-spacing:.11em; text-transform:uppercase; color:var(--mix-muted); }
+  .seasonbar { height:4px; border-radius:2px; background:var(--mix-raised); margin-top:11px; overflow:hidden; }
+  .seasonbar i { display:block; height:100%; background:linear-gradient(90deg,var(--mix-primary),var(--mix-accent)); }
+
+  /* ---------- your standing ---------- */
+  .standing { display:grid; grid-template-columns:repeat(2,1fr); gap:12px; margin-top:18px; }
+  .stand { background:var(--mix-surface); border:1px solid var(--line); border-radius:8px; padding:13px 15px;
+           display:flex; align-items:center; gap:14px; text-decoration:none; color:inherit;
+           cursor:pointer; font:inherit; text-align:left; width:100%; }
+  .stand:hover { border-color:var(--line-strong); }
+  .stand:focus-visible { outline:2px solid var(--mix-primary); outline-offset:2px; }
+  .stand.entered { border-color:rgba(63,169,245,.42); }
+  .stand.showing { box-shadow:0 0 0 1px var(--mix-primary) inset; }
+  .stand-place { font-family:var(--display); line-height:1; color:var(--mix-accent); display:flex; align-items:baseline; gap:3px; }
+  .stand-place .n { font-size:40px; font-weight:700; }
+  .stand-place .o { font-size:16px; font-weight:600; }
+  .stand-main { min-width:0; flex:1; display:flex; flex-direction:column; gap:1px; }
+  .stand-type { font-size:11px; letter-spacing:.11em; text-transform:uppercase; color:var(--mix-muted); }
+  .stand-score { font-family:var(--display); font-size:27px; font-weight:700; line-height:1.05; }
+  .stand-sub { font-size:12px; color:var(--mix-muted); }
+  .stand-cta { font-size:13.5px; color:var(--mix-primary); font-weight:600; }
+  .stand.empty { border-style:dashed; }
+
+  /* ---------- board toolbar ---------- */
+  .boardbar { display:flex; align-items:center; gap:10px 14px; flex-wrap:wrap; margin:26px 0 10px; }
+  /* The tier lists' view group: joined buttons, active filled, inactive outlined. */
+  .typegroup { display:inline-flex; }
+  .typegroup button {
+    background:transparent; color:var(--mix-primary); border:1px solid var(--mix-primary);
+    font:inherit; font-size:13px; font-weight:600; padding:5px 15px; cursor:pointer;
+    display:inline-flex; align-items:center; gap:6px; letter-spacing:.02em;
+  }
+  .typegroup button:first-child { border-radius:5px 0 0 5px; }
+  .typegroup button:last-child { border-radius:0 5px 5px 0; margin-left:-1px; }
+  .typegroup button[aria-pressed="true"] { background:var(--mix-primary); color:#06101C; }
+  .typegroup button:focus-visible { outline:2px solid var(--mix-ink); outline-offset:-2px; z-index:1; }
+  .boardcount { font-size:12.5px; color:var(--mix-muted); }
+  .legend { display:flex; gap:12px; flex-wrap:wrap; margin-left:auto; font-size:11.5px; color:var(--mix-muted); }
+  .legend span { display:inline-flex; align-items:center; gap:5px; }
+  .legend i { width:9px; height:9px; border-radius:2px; display:inline-block; }
+
+  /* ---------- board rows ---------- */
+  .rows { display:flex; flex-direction:column; gap:3px; }
+  .row { display:grid; grid-template-columns:42px 1fr auto; align-items:center; gap:12px;
+         padding:6px 10px; border-radius:6px; background:var(--mix-surface);
+         border:1px solid transparent; text-decoration:none; color:inherit; }
+  .row:hover { border-color:var(--line-strong); }
+  .row:focus-visible { outline:2px solid var(--mix-primary); outline-offset:1px; }
+
+  /* ONE GEOMETRY for every relationship state: a tint plus a bar down each edge, colour the
+     only variable. Lifted from site.css so a MoM board wears the standard rather than
+     re-deriving it. Precedence is you → both → rival → community. */
+  .is-me { background:color-mix(in srgb, var(--daily-you) 15%, transparent);
+           box-shadow:inset 3px 0 0 var(--daily-you), inset -3px 0 0 var(--daily-you), 0 0 12px -4px var(--daily-you); }
+  .is-rival { background:color-mix(in srgb, var(--daily-rival) 13%, transparent);
+              box-shadow:inset 3px 0 0 var(--daily-rival), inset -3px 0 0 var(--daily-rival); }
+  .is-community { background:color-mix(in srgb, var(--daily-community) 13%, transparent);
+                  box-shadow:inset 3px 0 0 var(--daily-community), inset -3px 0 0 var(--daily-community); }
+  .is-both { background:linear-gradient(90deg,
+               color-mix(in srgb, var(--daily-rival) 14%, transparent) 0 50%,
+               color-mix(in srgb, var(--daily-community) 14%, transparent) 50% 100%);
+             box-shadow:inset 3px 0 0 var(--daily-rival), inset -3px 0 0 var(--daily-community); }
+
+  .rowplace { font-family:var(--display); font-size:22px; font-weight:700; text-align:center;
+              color:var(--mix-muted); font-variant-numeric:tabular-nums; }
+  .row.p1 .rowplace { color:var(--rar-gold); }
+  .row.p2 .rowplace { color:var(--rar-silver); }
+  .row.p3 .rowplace { color:#C58A5B; }
+
+  .rowid { min-width:0; display:flex; align-items:center; gap:8px; }
+  /* Avatar art is external and blocked here; the disc holds the real 30px budget. */
+  .avatar { width:30px; height:30px; border-radius:50%; flex:none; display:grid; place-items:center;
+            font-family:var(--display); font-weight:700; font-size:14px; color:#0B0F17; }
+  .userlabel { display:flex; align-items:center; gap:5px; min-width:0; }
+  .flag { font-size:14px; line-height:1; flex:none; }
+  .rowname { font-size:14.5px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width:20ch; }
+  .runchip { font-size:10.5px; letter-spacing:.04em; text-transform:uppercase; color:var(--mix-muted);
+             border:1px solid var(--line-strong); border-radius:3px; padding:0 5px; white-space:nowrap; flex:none; }
+
+  .rowtail { display:flex; align-items:center; gap:14px; justify-self:end; font-variant-numeric:tabular-nums; }
+  .stat { text-align:right; }
+  .stat .v { font-size:14px; }
+  .stat .k { font-size:10px; letter-spacing:.08em; text-transform:uppercase; color:var(--mix-muted); }
+  .rowdate { font-size:12px; color:var(--mix-muted); white-space:nowrap; }
+  .vid { display:grid; place-items:center; width:26px; height:26px; border-radius:5px;
+         color:var(--mix-muted); border:1px solid var(--line-strong); flex:none; }
+  .vid:hover { color:var(--mix-ink); border-color:var(--mix-primary); }
+  .vid svg { width:14px; height:14px; fill:currentColor; }
+  .vid.none { opacity:0; pointer-events:none; }
+  .rowtotal { font-family:var(--display); font-size:24px; font-weight:700; min-width:78px; text-align:right; }
+
+  .empty-board { border:1px dashed var(--line-strong); border-radius:8px; padding:22px 18px;
+                 text-align:center; background:rgba(22,30,44,.5); }
+  .empty-board .big { font-family:var(--display); font-size:21px; font-weight:600; }
+  .empty-board p { color:var(--mix-muted); font-size:13.5px; margin:5px 0 13px; }
+  .btn { background:var(--mix-primary); color:#06101C; border:0; border-radius:6px; font:inherit;
+         font-size:13.5px; font-weight:600; padding:8px 16px; cursor:pointer; text-decoration:none; display:inline-block; }
+  .btn.ghost { background:transparent; color:var(--mix-ink); border:1px solid var(--line-strong); }
+  .btn:focus-visible { outline:2px solid var(--mix-primary); outline-offset:2px; }
+
+  .gated { border:1px solid var(--line); border-radius:8px; padding:18px; background:var(--mix-surface); margin-top:26px; }
+  .gated .big { font-family:var(--display); font-size:19px; font-weight:600; }
+  .gated p { color:var(--mix-muted); font-size:13.5px; margin:5px 0 0; max-width:64ch; }
+  .footlinks { display:flex; gap:10px; flex-wrap:wrap; margin-top:26px; }
+
+  @media (max-width:859.98px) { .standing { grid-template-columns:1fr; } }
+  @media (max-width:699.98px) {
+    .row { grid-template-columns:38px 1fr; row-gap:5px; }
+    .rowtail { grid-column:2; justify-self:start; gap:12px; flex-wrap:wrap; }
+    .rowtotal { min-width:0; }
+    .frame-nav { margin-left:0; width:100%; }
+    .countdown { margin-left:0; text-align:left; }
+    .legend { margin-left:0; width:100%; }
+  }
+  @media (max-width:499.98px) {
+    .frame-title { font-size:28px; }
+    .season-name { font-size:22px; }
+    .stat.diff { display:none; }
+    .rowname { max-width:11ch; }
+    .rowtotal { font-size:20px; }
+    .rowplace { font-size:18px; }
+    .avatar { width:26px; height:26px; font-size:12px; }
+  }
+</style>
+
+<div class="mockbar">
+  <b>Slice 1 mock 1 of 6 — Season</b>
+  <span>/MarchOfMurlocs</span>
+  <span>Real Winter 2025 boards · real communities · real rivals</span>
+  <button type="button" id="flip">Show opening week</button>
+</div>
+
+<div class="wrap">
+
+  <div class="frame-head">
+    <div>
+      <div class="frame-title">March of Murlocs</div>
+      <div class="season-dates" style="margin-top:3px">1 hour 45 minutes. Bank as many points as you can.</div>
+    </div>
+    <nav class="frame-nav">
+      <a href="#" aria-current="page">This season</a>
+      <a href="#">Planner</a>
+      <a href="#">Past seasons</a>
+      <a href="#">Rules</a>
+    </nav>
+  </div>
+
+  <div class="season">
+    <div>
+      <div class="season-name" id="seasonname">Winter 2025</div>
+      <div class="season-dates" id="seasondates">2 February – 31 March 2025</div>
+    </div>
+    <div class="countdown">
+      <div class="n num" id="cdn">27</div>
+      <div class="l">days left</div>
+    </div>
+  </div>
+  <div class="seasonbar"><i id="seasonbar" style="width:53%"></i></div>
+
+  <div class="standing" id="standing"></div>
+
+  <div class="boardbar">
+    <div class="typegroup" role="group" aria-label="Chart type">
+      <button type="button" data-type="D" aria-pressed="true">Doubles</button>
+      <button type="button" data-type="S" aria-pressed="false">Singles</button>
+    </div>
+    <span class="boardcount" id="boardcount"></span>
+    <div class="legend">
+      <span><i style="background:var(--daily-you)"></i>You</span>
+      <span><i style="background:var(--daily-rival)"></i>Rival</span>
+      <span><i style="background:var(--daily-community)"></i>Your communities</span>
+    </div>
+  </div>
+  <div id="board"></div>
+
+  <div class="gated">
+    <div class="big">Phoenix 2 scoring is still being tuned.</div>
+    <p>Phoenix 2 gets its own Doubles and Singles boards, on Phoenix 2’s own rating system.
+       They open once the scoring is settled — this season runs on Phoenix.</p>
+  </div>
+
+  <div class="footlinks">
+    <a class="btn ghost" href="#">Past seasons</a>
+    <a class="btn ghost" href="#">Plan a session</a>
+  </div>
+
+  <p class="note" style="margin-top:26px">
+    <b>The highlights are real, not staged.</b> DrMurloc’s actual rivals include <b>Elixir</b> and
+    <b>uhtreyu</b>, and he really does share <em>When the north is eastern pump</em> with 김재현,
+    Litenang, uhtreyu, Cherry, ddrlevelasian and GODDISH — so uhtreyu lands on <b>is-both</b>, the
+    split-fill case, without anything being invented. Two things still are staged: the season runs
+    <b>mid-flight</b> (it ended 31 March 2025), and <b>tieny’s second Doubles session</b> is his real
+    March of Murlocs 2 session moved here, since multiple sessions per season postdate all real data.
+    Avatars are external images the sandbox blocks, so each disc holds the real 30px budget.
+  </p>
+</div>
+
+<script>
+  // [name, total, charts, avgDifficulty, restSecs, dateISO, videoUrl, runIndex, country, rel]
+  // rel: "me" | "rival" | "community" | "both" | null — all from the live database.
+  var DOUBLES = [
+    ["김재현",59319,39,24.22,1324,"2025-02-14",null,0,null,"community"],
+    ["yimmythe42",57325,36,23.96,1619,"2025-02-22",null,0,null,null],
+    ["tieny",52979,31,24.18,2105,"2025-02-09",null,0,null,null],
+    ["tieny",49757,31,23.02,1884,"2025-03-01",null,1,null,null],
+    ["Redviper",47940,31,23.41,2235,"2025-02-18",null,0,null,null],
+    ["Elixir",38788,36,22.76,2195,"2025-02-11",null,0,"KR","rival"],
+    ["Litenang",37495,36,23.17,1577,"2025-02-25",null,0,null,"community"],
+    ["uhtreyu",37035,30,23.78,2611,"2025-02-16",null,0,null,"both"],
+    ["Selofeals",31399,27,22.86,2207,"2025-03-02",null,0,null,null],
+    ["Badkitty",26954,35,21.02,1985,"2025-02-08",null,0,"MY",null],
+    ["Tink",25191,35,19.89,1844,"2025-02-20",null,0,null,null],
+    ["Cherry",12688,32,18.43,2130,"2025-02-27",null,0,null,"community"]
+  ];
+  var SINGLES = [
+    ["ddrlevelasian",54431,32,24.1,2161,"2025-02-19","https://www.youtube.com/watch?v=c_79DBGN_WA",0,"US","community"],
+    ["DrMurloc",42596,36,22.32,1486,"2025-02-06","https://youtu.be/f16o-yGc_S8",0,"US","me"],
+    ["GODDISH",36684,36,23.51,2282,"2025-02-23","https://www.twitch.tv/videos/2382236206",0,null,"community"],
+    ["Badkitty",34158,35,22.17,1507,"2025-02-12","https://www.youtube.com/watch?v=OY-woXx9U_E",0,"MY",null],
+    ["DrMurloc - Random Step",24435,35,21.12,1917,"2025-03-03",null,0,null,null]
+  ];
+  var YOU = "DrMurloc";
+  var FLAGS = { KR:"🇰🇷", MY:"🇲🇾", US:"🇺🇸" };
+  var AVCOLORS = ["#7FB2E5","#E5A87F","#9BE5A0","#E5D77F","#C79BE5","#7FE5D9","#E58FA6","#B5C77F"];
+
+  function n(v){ return v.toLocaleString("en-US"); }
+  function esc(s){ return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/"/g,"&quot;"); }
+  function mmss(s){ var m=Math.floor(s/60), r=Math.round(s%60); return m+":"+(r<10?"0":"")+r; }
+  function ord(i){ return i + (["th","st","nd","rd"][(i%100-i%10!=10)*(i%10<4)*i%10] || "th"); }
+  function niceDate(iso){
+    var p=iso.split("-"), mo=["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+    return parseInt(p[2],10)+" "+mo[parseInt(p[1],10)-1];
+  }
+  function avatarFor(name){
+    var h=0; for (var i=0;i<name.length;i++) h=(h*31+name.charCodeAt(i))>>>0;
+    var ch = name.trim().charAt(0).toUpperCase();
+    return '<span class="avatar" style="background:'+AVCOLORS[h%AVCOLORS.length]+'" aria-hidden="true">'+esc(ch)+'</span>';
+  }
+  var VIDICON = '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>';
+  var RELWORD = { me:"You", rival:"Your rival", community:"In your communities", both:"Your rival, and in your communities" };
+
+  function boardHtml(list){
+    return '<div class="rows">' + list.map(function(r,i){
+      var rel = r[9];
+      var cls = "row p"+(i+1<=3?(i+1):0) + (rel ? " is-"+rel : "");
+      var relTitle = rel ? " — "+RELWORD[rel] : "";
+      return '<a class="'+cls+'" href="#" title="'+esc(r[0])+relTitle+'" aria-label="'+esc(r[0])+', '+ord(i+1)+', '+n(r[1])+' points'+relTitle+'">'
+        + '<span class="rowplace num">'+(i+1)+'</span>'
+        + '<span class="rowid">'+avatarFor(r[0])
+          + '<span class="userlabel">'
+            + (r[8] ? '<span class="flag" title="'+r[8]+'">'+FLAGS[r[8]]+'</span>' : '')
+            + '<span class="rowname">'+esc(r[0])+'</span></span>'
+          + (r[7] ? '<span class="runchip">'+ord(r[7]+1)+' session</span>' : '')
+          + '</span>'
+        + '<span class="rowtail">'
+          + '<span class="stat"><span class="v num">'+r[2]+'</span><span class="k">charts</span></span>'
+          + '<span class="stat diff" title="Average balanced level — the season\'s frozen scoring '
+            + 'difficulty, which is what actually priced each chart."><span class="v num">'
+            + r[3].toFixed(2)+'</span><span class="k">avg lvl</span></span>'
+          + '<span class="stat"><span class="v num">'+mmss(r[4])+'</span><span class="k">downtime</span></span>'
+          + '<span class="rowdate">'+niceDate(r[5])+'</span>'
+          + (r[6] ? '<span class="vid" title="Watch this session">'+VIDICON+'</span>' : '<span class="vid none">'+VIDICON+'</span>')
+          + '<span class="rowtotal num">'+n(r[1])+'</span>'
+        + '</span></a>';
+    }).join("") + '</div>';
+  }
+
+  function emptyBoardHtml(type){
+    return '<div class="empty-board"><div class="big">Nobody has played '+type+' yet this season.'</div>'
+      + '<p>Be the first. One session, one hour forty-five, as many points as you can bank.</p>'
+      + '<a class="btn" href="#">Record a session</a></div>';
+  }
+
+  function standHtml(type, key, list, showing){
+    var mine = list.map(function(r,i){ return {r:r,place:i+1}; }).filter(function(x){ return x.r[0]===YOU; });
+    var sel = showing===key ? " showing" : "";
+    if (!mine.length){
+      return '<button type="button" class="stand empty'+sel+'" data-type="'+key+'"><span class="stand-main">'
+        + '<span class="stand-type">'+type+'</span>'
+        + '<span class="stand-cta">Record your first session →</span>'
+        + '<span class="stand-sub">You have not played this board this season.</span></span></button>';
+    }
+    var best = mine[0];
+    return '<button type="button" class="stand entered'+sel+'" data-type="'+key+'">'
+      + '<span class="stand-place"><span class="n num">'+best.place+'</span>'
+        + '<span class="o">'+ord(best.place).replace(/^\d+/,"")+'</span></span>'
+      + '<span class="stand-main"><span class="stand-type">'+type+'</span>'
+      + '<span class="stand-score num">'+n(best.r[1])+'</span>'
+      + '<span class="stand-sub">'+best.r[2]+' charts · '+mmss(best.r[4])+' downtime · '
+        + (mine.length>1 ? 'your best of '+mine.length+' sessions' : 'your only session this season')+'</span></span></button>';
+  }
+
+  var opening = false, showing = "D";
+
+  function render(){
+    var dbl = opening ? DOUBLES.slice(0,1) : DOUBLES;
+    var sgl = opening ? [] : SINGLES;
+    var list = showing==="D" ? dbl : sgl;
+
+    document.getElementById("standing").innerHTML =
+      standHtml("Doubles","D",dbl,showing) + standHtml("Singles","S",sgl,showing);
+    document.getElementById("board").innerHTML =
+      list.length ? boardHtml(list) : emptyBoardHtml(showing==="D"?"Doubles":"Singles");
+    document.getElementById("boardcount").textContent =
+      list.length ? list.length+(list.length===1?" session":" sessions") : "no sessions yet";
+
+    Array.prototype.forEach.call(document.querySelectorAll(".typegroup button"), function(b){
+      b.setAttribute("aria-pressed", String(b.dataset.type===showing));
+    });
+    document.getElementById("seasonname").textContent = opening ? "Summer 2026" : "Winter 2025";
+    document.getElementById("seasondates").textContent = opening ? "1 July – 30 September 2026" : "2 February – 31 March 2025";
+    document.getElementById("cdn").textContent = opening ? "51" : "27";
+    document.getElementById("seasonbar").style.width = opening ? "44%" : "53%";
+    document.getElementById("flip").textContent = opening ? "Show mid-season" : "Show opening week";
+  }
+
+  // One delegated listener: the type group and the standing cards both select a board, and the
+  // standing cards are re-rendered on every switch so direct binding would go stale.
+  document.addEventListener("click", function(e){
+    var t = e.target.closest ? e.target.closest("[data-type]") : null;
+    if (!t) return;
+    showing = t.dataset.type; render();
+  });
+  document.getElementById("flip").addEventListener("click", function(){ opening = !opening; render(); });
+  render();
+</script>

--- a/docs/design/march-of-murlocs-mocks/2-session-breakdown.html
+++ b/docs/design/march-of-murlocs-mocks/2-session-breakdown.html
@@ -1,0 +1,1117 @@
+<title>MoM — Session Breakdown mock</title>
+<style>
+  /* ------------------------------------------------------------------
+     Phoenix mix palette, lifted verbatim from Services/Theming/MixThemes.cs
+     so this mock can be judged as if it were already on the site.
+     Dark-only on purpose: the site's two Mud palettes are deliberately identical.
+     ------------------------------------------------------------------ */
+  :root {
+    --mix-bg:        #070B15;
+    --mix-surface:   #161E2C;
+    --mix-raised:    #1E2A3D;
+    --mix-nav:       #0D1626;
+    --mix-primary:   #3FA9F5;
+    --mix-secondary: #FF6B35;
+    --mix-accent:    #FFD24A;
+    --mix-ink:       #E9EFF7;
+    --mix-muted:     #93A3B8;
+    --chart-double:  #38B6FF;
+
+    --rar-common:   #8B98A9;
+    --rar-silver:   #CBD5E1;
+    --rar-emerald:  #3FD35A;
+    --rar-gold:     #FFD24A;
+    --rar-sapphire: #38B6FF;
+
+    --diff-easy:     #7CB342;
+    --diff-medium:   #FDD835;
+    --diff-hard:     #FB8C00;
+    --diff-veryhard: #E53935;
+
+    /* plate metals, per the Play Data ladder: copper RG/FG, silver TG/MG, gold EG, ice UG/PG */
+    --plate-copper: #B87333;
+    --plate-silver: #CBD5E1;
+    --plate-gold:   #FFD24A;
+    --plate-ice:    #9BE9FF;
+
+    --line: rgba(233,239,247,.12);
+    --line-strong: rgba(233,239,247,.22);
+
+    --display: "Barlow Condensed", "Oswald", "Roboto Condensed", "Arial Narrow", system-ui, sans-serif;
+    --body: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  :root[data-theme="light"], :root[data-theme="dark"] { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--mix-bg); color: var(--mix-ink);
+    font-family: var(--body); font-size: 15px; line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1060px; margin: 0 auto; padding: 16px 16px 80px; }
+  .num { font-variant-numeric: tabular-nums; }
+  h1,h2,h3 { font-family: var(--display); font-weight: 600; margin: 0; text-wrap: balance; }
+
+  .mockbar {
+    background: #12203a; border-bottom: 1px solid var(--line); padding: 9px 16px;
+    font-size: 12.5px; color: var(--mix-muted);
+    display: flex; flex-wrap: wrap; gap: 6px 14px; align-items: baseline;
+  }
+  .mockbar b { color: var(--mix-ink); font-weight: 600; }
+  .note {
+    border-left: 2px solid var(--mix-accent); background: rgba(255,210,74,.06);
+    padding: 9px 13px; margin: 0; border-radius: 0 5px 5px 0;
+    font-size: 13px; color: #E4D9BC;
+  }
+  .note b { color: var(--mix-accent); font-weight: 600; }
+
+  h2.sec {
+    font-size: 13px; letter-spacing: .14em; text-transform: uppercase; color: var(--mix-muted);
+    font-family: var(--body); font-weight: 600; margin: 30px 0 12px;
+    display: flex; align-items: center; gap: 10px;
+  }
+  h2.sec::after { content: ""; flex: 1; height: 1px; background: var(--line); }
+
+  /* ---------------- board identity + result ---------------- */
+  .board-id {
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+    padding: 0 0 10px; border-bottom: 1px solid var(--line); margin-bottom: 14px;
+  }
+  .crumb { color: var(--mix-muted); font-size: 13px; text-decoration: none; }
+  .crumb:hover { color: var(--mix-primary); }
+  .typechip {
+    display: inline-flex; align-items: center; gap: 6px; font-family: var(--display);
+    font-size: 14px; font-weight: 600; letter-spacing: .06em; text-transform: uppercase;
+    padding: 3px 9px; border-radius: 4px; color: var(--chart-double);
+    border: 1px solid rgba(56,182,255,.45); background: rgba(56,182,255,.10);
+  }
+  .result { display: grid; grid-template-columns: auto 1fr auto; gap: 8px 20px; align-items: end; }
+  .placebox { font-family: var(--display); line-height: 1; display: flex; align-items: baseline; gap: 4px; color: var(--mix-accent); }
+  .placebox .n { font-size: 58px; font-weight: 700; }
+  .placebox .o { font-size: 22px; font-weight: 600; }
+  .whoami .name { font-family: var(--display); font-size: 30px; font-weight: 600; line-height: 1.1; }
+  .whoami .meta { color: var(--mix-muted); font-size: 13px; margin-top: 3px; }
+  .totalbox { text-align: right; font-family: var(--display); line-height: 1; }
+  .totalbox .n { font-size: 46px; font-weight: 700; }
+  .totalbox .l { font-family: var(--body); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--mix-muted); margin-top: 5px; }
+
+  .equation {
+    display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+    background: var(--mix-surface); border: 1px solid var(--line);
+    border-radius: 8px; padding: 13px 16px; margin: 16px 0 0;
+  }
+  .eq-term { display: flex; flex-direction: column; gap: 1px; }
+  .eq-term .v { font-family: var(--display); font-size: 26px; font-weight: 600; line-height: 1; }
+  .eq-term .k { font-size: 11px; letter-spacing: .1em; text-transform: uppercase; color: var(--mix-muted); }
+  .eq-op { font-family: var(--display); font-size: 24px; color: var(--mix-muted); }
+  .eq-note { margin-left: auto; font-size: 12.5px; color: var(--mix-muted); max-width: 30ch; }
+
+  /* ---------------- point-source tiles ---------------- */
+  .levers { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+  .lever {
+    background: var(--mix-surface); border: 1px solid var(--line); border-radius: 8px;
+    padding: 13px 14px 15px; display: flex; flex-direction: column; gap: 9px;
+  }
+  .lever.lead { border-color: rgba(255,210,74,.42); background: linear-gradient(180deg, rgba(255,210,74,.055), var(--mix-surface) 60%); }
+  .lever .k { font-size: 11px; letter-spacing: .11em; text-transform: uppercase; color: var(--mix-muted); }
+  .lever .v { font-family: var(--display); font-size: 38px; font-weight: 700; line-height: .95; }
+  .lever .vsub { font-size: 12.5px; color: var(--mix-muted); margin-top: -4px; font-variant-numeric: tabular-nums; }
+  .lever .rank { font-size: 12px; color: var(--mix-muted); }
+  .lever .rank b { color: var(--mix-ink); font-weight: 600; }
+  .lever.lead .rank b { color: var(--mix-accent); }
+  .rail .track { position: relative; height: 5px; border-radius: 3px; background: var(--mix-raised); margin: 9px 0 5px; }
+  .rail .med { position: absolute; top: -3px; width: 1px; height: 11px; background: var(--line-strong); }
+  .rail .you {
+    position: absolute; top: 50%; width: 11px; height: 11px; border-radius: 50%;
+    transform: translate(-50%,-50%); background: var(--mix-accent); box-shadow: 0 0 0 3px rgba(255,210,74,.18);
+  }
+  .lever:not(.lead) .rail .you { background: var(--mix-primary); box-shadow: 0 0 0 3px rgba(63,169,245,.18); }
+  .rail .ends { display: flex; justify-content: space-between; font-size: 10.5px; color: var(--mix-muted); font-variant-numeric: tabular-nums; }
+
+  /* ---------------- shared controls ---------------- */
+  .segmented { display: inline-flex; border: 1px solid var(--line-strong); border-radius: 6px; overflow: hidden; }
+  .segmented button {
+    background: transparent; border: 0; color: var(--mix-muted); font: inherit; font-size: 12.5px;
+    padding: 6px 12px; cursor: pointer; display: inline-flex; align-items: center; gap: 5px;
+  }
+  .segmented button[aria-pressed="true"] { background: var(--mix-raised); color: var(--mix-ink); }
+  .segmented button:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: -2px; }
+  .segmented button svg { width: 15px; height: 15px; fill: currentColor; }
+  select {
+    background: var(--mix-raised); color: var(--mix-ink); border: 1px solid var(--line-strong);
+    border-radius: 5px; padding: 6px 9px; font: inherit; font-size: 13px;
+  }
+  select:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: 1px; }
+
+  /* ---------------- compare ---------------- */
+  .cmp { background: var(--mix-surface); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+  .cmp-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; padding: 11px 14px; border-bottom: 1px solid var(--line); background: var(--mix-nav); }
+  .cmp-grid { display: grid; grid-template-columns: repeat(4, 1fr); }
+  .cmp-cell { padding: 13px 14px; border-right: 1px solid var(--line); }
+  .cmp-cell:last-child { border-right: 0; }
+  .cmp-cell .k { font-size: 11px; letter-spacing: .11em; text-transform: uppercase; color: var(--mix-muted); }
+  .cmp-row { display: flex; align-items: baseline; gap: 8px; margin-top: 7px; font-variant-numeric: tabular-nums; }
+  .cmp-row .who { font-size: 11.5px; color: var(--mix-muted); width: 62px; flex: none; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .cmp-row .val { font-family: var(--display); font-size: 21px; font-weight: 600; line-height: 1; }
+  .delta { font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .up { color: var(--rar-emerald); } .down { color: var(--mix-secondary); } .flat { color: var(--mix-muted); }
+  .cmp-verdict { padding: 11px 14px; border-top: 1px solid var(--line); font-size: 13.5px; color: #C6D3E2; background: rgba(63,169,245,.05); }
+  .cmp-verdict b { color: var(--mix-ink); font-weight: 600; }
+
+  /* head-to-head on the charts both sessions contain */
+  .h2h { border-top: 1px solid var(--line); padding: 12px 14px 14px; }
+  .h2h h3 { font-size: 12px; letter-spacing: .11em; text-transform: uppercase; font-family: var(--body); color: var(--mix-muted); }
+  .h2h .lede { font-size: 12.5px; color: var(--mix-muted); margin: 3px 0 10px; }
+  .h2hrow {
+    display: grid; grid-template-columns: 34px 1fr 96px 96px 62px; gap: 10px; align-items: center;
+    padding: 5px 0; border-bottom: 1px solid var(--line); font-variant-numeric: tabular-nums; font-size: 13px;
+  }
+  .h2hrow:last-child { border-bottom: 0; }
+  .h2hrow .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .h2hrow .sc { text-align: right; }
+  .h2hrow .sc small { color: var(--mix-muted); font-size: 11px; display: block; }
+  .h2hrow .win { font-weight: 700; text-align: right; }
+  .h2h-tally { margin-top: 10px; font-size: 13px; color: #C6D3E2; }
+  .h2h-tally b { color: var(--mix-ink); }
+
+  /* ---------------- rebasing ledger ---------------- */
+  .ledger { border-top: 1px solid var(--line); padding: 13px 14px 14px; }
+  .ledger h3 { font-size: 12px; letter-spacing: .11em; text-transform: uppercase; font-family: var(--body); color: var(--mix-muted); }
+  .ledger .why { font-size: 12.5px; color: var(--mix-muted); margin: 4px 0 12px; max-width: 72ch; }
+  .lrow { display: grid; grid-template-columns: 1fr auto 132px; gap: 6px 14px; align-items: baseline; padding: 7px 0; border-bottom: 1px dashed var(--line); font-variant-numeric: tabular-nums; }
+  .lrow.sub { padding: 3px 0 3px 16px; border-bottom: 0; color: var(--mix-muted); font-size: 13px; }
+  .lrow.sub .amt { font-family: var(--body); font-size: 13px; font-weight: 400; }
+  .lrow .lbl { font-size: 13.5px; }
+  .lrow .lbl small { display: block; font-size: 11.5px; color: var(--mix-muted); }
+  .lrow .amt { font-family: var(--display); font-size: 22px; font-weight: 600; }
+  .lrow .chg { font-size: 12.5px; font-weight: 600; text-align: right; }
+  .lrow.total .amt { color: var(--mix-accent); }
+  details.disc { margin-top: 11px; }
+  details.disc summary { cursor: pointer; font-size: 12.5px; color: var(--mix-primary); list-style: none; display: inline-flex; align-items: center; gap: 5px; }
+  details.disc summary::-webkit-details-marker { display: none; }
+  details.disc summary::before { content: "▸"; font-size: 10px; }
+  details.disc[open] summary::before { content: "▾"; }
+  details.disc summary:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: 2px; }
+  .rrow { display: grid; grid-template-columns: 1fr auto 66px; gap: 10px; align-items: baseline; padding: 4px 0; font-size: 12.5px; font-variant-numeric: tabular-nums; border-bottom: 1px solid var(--line); }
+  .rrow .mv { color: var(--mix-muted); }
+  .rrow .mv b { color: var(--rar-emerald); font-weight: 600; }
+  .rrow .gain { text-align: right; font-weight: 600; }
+
+  /* ---------------- the session: toolbar ---------------- */
+  .runbar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 11px; }
+  .denbtns { display: inline-flex; gap: 2px; }
+  .denbtns button {
+    background: transparent; border: 0; border-radius: 5px; padding: 5px;
+    color: var(--mix-muted); cursor: pointer; display: grid; place-items: center;
+  }
+  .denbtns button svg { width: 19px; height: 19px; fill: currentColor; }
+  .denbtns button:hover { color: var(--mix-ink); }
+  .denbtns button[aria-pressed="true"] { color: var(--mix-primary); }
+  .denbtns button:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: 1px; }
+  .sortwrap { position: relative; }
+  .sortbtn {
+    display: inline-flex; align-items: center; gap: 6px; background: transparent;
+    border: 1px solid var(--line-strong); border-radius: 6px; color: var(--mix-ink);
+    font: inherit; font-size: 12.5px; padding: 6px 11px; cursor: pointer;
+  }
+  .sortbtn:hover { border-color: var(--mix-primary); }
+  .sortbtn:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: 1px; }
+  .sortbtn svg { width: 15px; height: 15px; fill: currentColor; }
+  .sortbtn .cur { color: var(--mix-muted); }
+  .sortmenu {
+    position: absolute; z-index: 40; top: calc(100% + 5px); left: 0; min-width: 218px;
+    background: var(--mix-raised); border: 1px solid var(--line-strong); border-radius: 7px;
+    padding: 5px; box-shadow: 0 10px 26px rgba(0,0,0,.5);
+  }
+  .sortmenu[hidden] { display: none; }
+  .sortmenu button {
+    display: flex; width: 100%; align-items: center; gap: 8px; background: transparent;
+    border: 0; color: var(--mix-ink); font: inherit; font-size: 13px; text-align: left;
+    padding: 7px 9px; border-radius: 5px; cursor: pointer;
+  }
+  .sortmenu button:hover { background: rgba(63,169,245,.14); }
+  .sortmenu button:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: -2px; }
+  .sortmenu button .tick { width: 12px; color: var(--mix-primary); }
+  .runnote { font-size: 12.5px; color: var(--mix-muted); flex: 1 1 240px; min-width: 0; }
+
+  /* ---------------- shared chart bits ---------------- */
+  .jacket {
+    background: repeating-linear-gradient(135deg, #1B2637 0 6px, #16202F 6px 12px);
+    border: 1px solid var(--line); display: grid; place-items: center;
+    font-size: 8px; color: #4E6076; letter-spacing: .04em; border-radius: 4px; flex: none;
+  }
+  .bub {
+    border-radius: 4px; display: grid; place-items: center; font-family: var(--display);
+    font-weight: 700; color: #0B0F17; letter-spacing: .02em; flex: none;
+  }
+  .gradeicon { font-family: var(--display); font-weight: 700; line-height: 1; }
+  .plate {
+    font-family: var(--display); font-weight: 700; font-size: 11px; line-height: 1;
+    border: 1px solid currentColor; border-radius: 3px; padding: 1px 3px; letter-spacing: .04em;
+  }
+
+  /* ---------------- comfortable ---------------- */
+  .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(178px, 1fr)); gap: 12px; }
+  .ccard {
+    background: var(--mix-surface); border: 1px solid var(--line); border-radius: 8px;
+    overflow: hidden; display: flex; flex-direction: column;
+  }
+  .ccard-jacket { position: relative; aspect-ratio: 1; width: 100%; }
+  .ccard-jacket .jacket { width: 100%; height: 100%; border: 0; border-radius: 0; }
+  .ccard-jacket .bub { position: absolute; top: 5px; left: 5px; width: 38px; height: 25px; font-size: 14px; }
+  .ccard-ord {
+    position: absolute; top: 5px; right: 6px; font-family: var(--display); font-weight: 700;
+    font-size: 12px; color: var(--mix-muted); background: rgba(0,0,0,.7); border-radius: 3px; padding: 0 5px;
+  }
+  /* The play affordance: same dialog as the jacket, only autoplaying. Always present for
+     keyboard; the jacket brightens on hover to say the whole tile is a target. */
+  .playbtn {
+    position: absolute; inset: 0; margin: auto; width: 42px; height: 42px; border-radius: 50%;
+    background: rgba(0,0,0,.62); border: 1px solid rgba(233,239,247,.5); color: var(--mix-ink);
+    display: grid; place-items: center; cursor: pointer; opacity: 0; transition: opacity .12s;
+  }
+  .ccard-jacket:hover .playbtn, .playbtn:focus-visible { opacity: 1; }
+  .playbtn:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: 2px; }
+  .playbtn svg { width: 17px; height: 17px; fill: currentColor; margin-left: 2px; }
+  .ccard-body { padding: 8px 10px 10px; display: flex; flex-direction: column; gap: 5px; }
+  .ccard-name { font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ccard-meta { display: flex; align-items: center; gap: 6px; font-variant-numeric: tabular-nums; font-size: 13px; flex-wrap: wrap; }
+  .ccard-pts { font-family: var(--display); font-size: 21px; font-weight: 700; line-height: 1; }
+  .ccard-sub { font-size: 11.5px; color: var(--mix-muted); font-variant-numeric: tabular-nums; }
+
+  /* ---------------- compact (the sticker sheet) ---------------- */
+  .stickers { display: grid; grid-template-columns: repeat(auto-fill, minmax(78px, 1fr)); gap: 7px; }
+  .sticker { position: relative; aspect-ratio: 1; cursor: pointer; border: 0; padding: 0; background: none; }
+  .sticker:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: 2px; }
+  .sticker .jacket { width: 100%; height: 100%; }
+  .sticker .bub { position: absolute; top: 3px; left: 3px; width: 30px; height: 20px; font-size: 12px; }
+  /* The corner badge, exactly .tier-chart-card-corner + .pmb-corner-gain from site.css:
+     opaque black backdrop so it stays legible over any album art, outlined in the mix
+     primary. One printed value, and the value is the score. */
+  .corner {
+    position: absolute; bottom: 3px; right: 3px; font-family: var(--display); font-weight: 700;
+    font-size: 12px; line-height: 1.25; font-variant-numeric: tabular-nums;
+    background: rgba(0,0,0,.82); padding: 1px 5px; border-radius: 4px;
+    border: 1px solid var(--mix-primary); color: var(--mix-primary);
+  }
+  .corner-start {
+    position: absolute; bottom: 3px; left: 3px; display: flex; align-items: center; gap: 3px;
+    background: rgba(0,0,0,.82); border: 1px solid var(--mix-primary); border-radius: 4px; padding: 1px 3px;
+  }
+  /* Only present when the active sort is on a value the sticker does not otherwise print. */
+  .corner-2 { display: block; font-size: 9.5px; opacity: .72; font-weight: 600; }
+
+  /* ---------------- table ---------------- */
+  .tablewrap { overflow-x: auto; }
+  table.run { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+  table.run th {
+    text-align: left; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--mix-muted); font-weight: 600; padding: 6px 10px 6px 0; border-bottom: 1px solid var(--line-strong);
+    white-space: nowrap;
+  }
+  table.run th button {
+    background: none; border: 0; color: inherit; font: inherit; letter-spacing: inherit;
+    text-transform: inherit; cursor: pointer; padding: 0; display: inline-flex; align-items: center; gap: 4px;
+  }
+  table.run th button:hover { color: var(--mix-ink); }
+  table.run th button:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: 2px; }
+  table.run th[aria-sort] button { color: var(--mix-ink); }
+  table.run td { padding: 4px 10px 4px 0; border-bottom: 1px solid var(--line); font-size: 13.5px; }
+  table.run tbody tr { cursor: pointer; }
+  table.run tbody tr:hover td { background: rgba(63,169,245,.07); }
+  .t-ident { display: flex; align-items: center; gap: 8px; min-width: 0; }
+  .t-ident .jacket { width: 30px; height: 30px; }
+  .t-ident .bub { width: 34px; height: 22px; font-size: 12.5px; }
+  .t-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .t-r { text-align: right; }
+  /* Grade art and plate ride side by side while there is room, and stack when there is not
+     — the pumbility table's own ladder (site.css @499.98). */
+  .t-grade { display: flex; align-items: center; gap: 5px; }
+  .t-score { color: var(--mix-muted); font-size: 12.5px; }
+
+  /* ---------------- timeline ---------------- */
+  .tl { background: var(--mix-surface); border: 1px solid var(--line); border-radius: 8px; padding: 14px; }
+  .tl-legend { display: flex; gap: 16px; flex-wrap: wrap; font-size: 12px; color: var(--mix-muted); margin-bottom: 8px; }
+  .tl-legend i { display: inline-block; width: 14px; height: 2px; vertical-align: middle; margin-right: 5px; }
+  .tl-scroll { overflow-x: auto; }
+  svg { display: block; }
+
+  /* ---------------- dialog ---------------- */
+  dialog.chart {
+    background: var(--mix-surface); color: var(--mix-ink); border: 1px solid var(--line-strong);
+    border-radius: 10px; padding: 0; max-width: 560px; width: calc(100% - 32px);
+  }
+  dialog.chart::backdrop { background: rgba(3,6,12,.72); }
+  .dlg-head { display: flex; align-items: center; gap: 10px; padding: 13px 15px; border-bottom: 1px solid var(--line); }
+  .dlg-head .bub { width: 42px; height: 27px; font-size: 15px; }
+  .dlg-title { font-family: var(--display); font-size: 21px; font-weight: 600; line-height: 1.15; min-width: 0; }
+  .dlg-body { padding: 14px 15px; display: flex; flex-direction: column; gap: 13px; }
+  .dlg-video {
+    aspect-ratio: 16/9; border-radius: 6px; display: grid; place-items: center; text-align: center;
+    background: repeating-linear-gradient(135deg, #101A28 0 8px, #0D1522 8px 16px);
+    border: 1px solid var(--line); color: var(--mix-muted); font-size: 12.5px; padding: 12px;
+  }
+  .dlg-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(96px, 1fr)); gap: 10px; }
+  .dlg-stat .k { font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; color: var(--mix-muted); }
+  .dlg-stat .v { font-family: var(--display); font-size: 20px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .dlg-actions { display: flex; justify-content: flex-end; gap: 8px; padding: 0 15px 14px; }
+  .btn {
+    background: var(--mix-primary); color: #06101C; border: 0; border-radius: 6px;
+    font: inherit; font-size: 13px; font-weight: 600; padding: 7px 14px; cursor: pointer;
+  }
+  .btn.ghost { background: transparent; color: var(--mix-ink); border: 1px solid var(--line-strong); }
+  .btn:focus-visible { outline: 2px solid var(--mix-primary); outline-offset: 2px; }
+
+  /* ---------------- width ladder ---------------- */
+  @media (max-width: 899.98px) {
+    .levers { grid-template-columns: repeat(2, 1fr); }
+    .cmp-grid { grid-template-columns: repeat(2, 1fr); }
+    .cmp-cell:nth-child(2) { border-right: 0; }
+    .cmp-cell:nth-child(1), .cmp-cell:nth-child(2) { border-bottom: 1px solid var(--line); }
+    /* first column to go: points-per-second, least information per pixel */
+    .col-pps { display: none; }
+  }
+  @media (max-width: 699.98px) {
+    /* the jacket and the bubble already say which chart it is */
+    .t-name, .ccard-name { display: none; }
+    .h2hrow { grid-template-columns: 30px 1fr 78px 78px; }
+    .h2hrow .win { display: none; }
+  }
+  @media (max-width: 619.98px) {
+    .result { grid-template-columns: auto 1fr; }
+    .totalbox { grid-column: 1 / -1; text-align: left; margin-top: 4px; }
+    .totalbox .n { font-size: 38px; }
+    .placebox .n { font-size: 44px; }
+    .whoami .name { font-size: 24px; }
+    .eq-note { margin-left: 0; }
+    .lrow { grid-template-columns: 1fr auto; }
+    .lrow .chg { grid-column: 2; font-size: 11.5px; }
+  }
+  @media (max-width: 499.98px) {
+    /* Scores drop to grade art alone; the number rides the row's tooltip. Grade and plate
+       stack rather than shrink, so neither becomes unreadable. */
+    .t-score { display: none; }
+    .t-grade { flex-direction: column; align-items: flex-start; gap: 2px; }
+    .stickers { grid-template-columns: repeat(auto-fill, minmax(70px, 1fr)); }
+    .cards { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
+  }
+</style>
+
+<div class="mockbar">
+  <b>Slice 1 mock 2 of 6 — Session Breakdown</b>
+  <span>/MarchOfMurlocs/Session/{id}</span>
+  <span>Real data: 김재현, Winter 2025 · Doubles, 1st of 11</span>
+</div>
+
+<div class="wrap">
+
+  <div class="board-id">
+    <a class="crumb" href="#">March of Murlocs</a>
+    <span style="color:var(--mix-muted)">/</span>
+    <a class="crumb" href="#">Winter 2025</a>
+    <span style="color:var(--mix-muted)">/</span>
+    <span class="typechip">D Doubles · Phoenix</span>
+  </div>
+
+  <div class="result">
+    <div class="placebox"><span class="n num">1</span><span class="o">st</span></div>
+    <div class="whoami">
+      <div class="name">김재현</div>
+      <div class="meta">Recorded 14 February 2025 · 39 charts · 1:45:00 window</div>
+    </div>
+    <div class="totalbox"><div class="n num">59,319</div><div class="l">Total points</div></div>
+  </div>
+
+  <div class="equation">
+    <div class="eq-term"><span class="v num">39</span><span class="k">charts</span></div>
+    <span class="eq-op">×</span>
+    <div class="eq-term"><span class="v num">1,521</span><span class="k">avg per chart</span></div>
+    <span class="eq-op">=</span>
+    <div class="eq-term"><span class="v num" style="color:var(--mix-accent)">59,319</span><span class="k">total</span></div>
+    <p class="eq-note">Volume and value are the only two things a session is. The four numbers below set each one.</p>
+  </div>
+
+  <h2 class="sec">Where the points came from</h2>
+  <div class="levers" id="levers"></div>
+
+  <p class="note" style="margin-top:14px">
+    <b>This is why the page exists.</b> 김재현 won this board with the <b>6th-best average score on it</b>.
+    Redviper played the cleanest session of anyone here — averaged an S — and finished <b>4th</b>, because he
+    played 8 fewer charts, nearly a level easier, and left 15 more minutes on the floor. Flip the compare
+    below to him.
+  </p>
+
+  <h2 class="sec">Compare</h2>
+  <div class="cmp">
+    <div class="cmp-head">
+      <div class="segmented" role="group" aria-label="Comparison source">
+        <button type="button" data-mode="board" aria-pressed="true">This board</button>
+        <button type="button" data-mode="season" aria-pressed="false">My past seasons</button>
+      </div>
+      <select id="cmpsel" aria-label="Session to compare against"></select>
+      <span style="font-size:12px;color:var(--mix-muted)" id="cmpscope"></span>
+    </div>
+    <div class="cmp-grid" id="cmpgrid"></div>
+    <div class="cmp-verdict" id="cmpverdict"></div>
+    <div id="h2h"></div>
+    <div id="rebase"></div>
+  </div>
+
+  <h2 class="sec">The session</h2>
+  <div class="runbar">
+    <!-- Bare icon buttons, the way /Pumbility does it: no segmented chrome, the active one
+       carries the mix primary, and the name lives in the tooltip and the aria-label.
+       Icons match its MudIconButtons — ViewComfy, GridView, TableRows. -->
+    <div class="denbtns" role="group" aria-label="Density">
+      <button type="button" data-den="Comfortable" aria-pressed="false" title="Comfortable" aria-label="Comfortable">
+        <svg viewBox="0 0 24 24"><path d="M3 9h4V5H3v4zm0 5h4v-4H3v4zm5 0h4v-4H8v4zm5 0h4v-4h-4v4zM8 9h4V5H8v4zm5-4v4h4V5h-4zm5 9h3v-4h-3v4zm0-9v4h3V5h-3z"/></svg></button>
+      <button type="button" data-den="Compact" aria-pressed="true" title="Compact" aria-label="Compact">
+        <svg viewBox="0 0 24 24"><path d="M3 3h8v8H3zm10 0h8v8h-8zM3 13h8v8H3zm10 0h8v8h-8z"/></svg></button>
+      <button type="button" data-den="Table" aria-pressed="false" title="Table" aria-label="Table">
+        <svg viewBox="0 0 24 24"><path d="M21 8H3V4h18v4zm0 2H3v4h18v-4zm0 6H3v4h18v-4z"/></svg></button>
+    </div>
+    <div class="sortwrap" id="sortwrap">
+      <button type="button" class="sortbtn" id="sortbtn" aria-haspopup="true" aria-expanded="false">
+        <svg viewBox="0 0 24 24"><path d="M3 6h12v2H3zm0 5h9v2H3zm0 5h6v2H3zm15-9v9.2l3-3 1.4 1.4-5.4 5.4-5.4-5.4L13 12.2l3 3V7z"/></svg>
+        Sort by <span class="cur" id="sortcur">play order</span>
+      </button>
+      <div class="sortmenu" id="sortmenu" hidden role="menu"></div>
+    </div>
+    <span class="runnote" id="runnote"></span>
+  </div>
+  <div id="run"></div>
+
+  <h2 class="sec">Pace</h2>
+  <div class="tl">
+    <div class="tl-legend">
+      <span><i style="background:var(--mix-primary)"></i>Points per second</span>
+      <span><i style="background:var(--mix-accent)"></i>Session average</span>
+      <span style="color:var(--mix-muted)">Gaps are rest between charts</span>
+    </div>
+    <div class="tl-scroll"><svg id="tl" viewBox="0 0 1000 220" width="100%" height="220" role="img"
+      aria-label="Points per second across the 1 hour 45 minute session, with rest gaps between charts."></svg></div>
+  </div>
+
+  <p class="note" style="margin-top:22px">
+    <b>Two things this mock cannot show, by design.</b> Jacket art is served from an external host the
+    artifact sandbox blocks, so every jacket is a placeholder holding the real layout budget — on the site
+    the jacket is the identifier. And <b>downtime is derived, not measured</b>: today it is
+    <span class="num">1:45:00</span> minus how long your songs ran, which is why 82:56 of play and 22:04 of
+    rest add up to exactly the window. Slice 5's timestamps make it an observation instead.
+  </p>
+</div>
+
+<dialog class="chart" id="dlg" aria-labelledby="dlgtitle">
+  <div class="dlg-head" id="dlghead"></div>
+  <div class="dlg-body" id="dlgbody"></div>
+  <div class="dlg-actions"><button type="button" class="btn ghost" id="dlgclose">Close</button></div>
+</dialog>
+
+<script>
+  /* ==================================================================
+     All figures below are real, pulled from the local prod-synced SQL.
+     ================================================================== */
+
+  // 김재현's Winter 2025 Doubles session. [title, level, seconds, score, points, bonus, plate]
+  var RAW = [
+    ["Love is a Danger Zone pt. 2 - SHORT CUT -",23,58,973872,698,0,"FG"],
+    ["Slam",24,99,976489,1528,0,"FG"],
+    ["DUEL",24,111,955044,1442,0,"FG"],
+    ["Adrenaline Blaster",23,119,976959,1653,176,"TG"],
+    ["Queencard",22,102,991718,1154,0,"MG"],
+    ["Telling Fortune Flower",23,113,979705,1438,0,"MG"],
+    ["8 6 - FULL SONG -",23,266,962566,2990,0,"RG"],
+    ["FLVSH OUT",23,127,979784,1617,0,"TG"],
+    ["Pop Sequence",23,119,960218,1324,0,"RG"],
+    ["Final Audition Ep. 2-X",24,104,927315,1393,250,"RG"],
+    ["Meteo5cience (GADGET mix)",22,158,950141,1301,74,"RG"],
+    ["Point Break",23,101,971005,1183,0,"FG"],
+    ["Annihilator Method",24,110,958243,1493,0,"FG"],
+    ["Pneumonoultramicroscopicsilicovolcanoconiosis ft. Kagamine Len/GUMI",22,121,972450,1152,0,"RG"],
+    ["Can-can ~Orpheus in The Party Mix~ - SHORT CUT -",25,51,952491,793,0,"FG"],
+    ["MEGAHEARTZ",25,120,902836,1380,0,"RG"],
+    ["Boca",25,129,915890,1635,0,"RG"],
+    ["Odin",23,127,976240,1565,0,"TG"],
+    ["Underworld ft. Skizzo (PIU Edit.)",23,111,984346,1472,0,"MG"],
+    ["Underworld ft. Skizzo (PIU Edit.)",25,111,941971,1611,0,"RG"],
+    ["GLORIA",25,116,945885,1711,0,"RG"],
+    ["Kokugen Kairou Labyrinth",26,112,906317,1625,0,"RG"],
+    ["BRAIN POWER",24,112,943862,1376,56,"RG"],
+    ["Tomboy",22,120,962577,1081,0,"RG"],
+    ["Goodtek",24,126,928890,1393,0,"RG"],
+    ["Leather",26,178,888018,2327,0,"RG"],
+    ["Perpetual",24,109,945530,1293,0,"FG"],
+    ["Big Daddy",23,122,964066,1380,0,"MG"],
+    ["Pirate",21,130,987859,1164,0,"MG"],
+    ["Darkside of The Mind",25,120,941887,1741,0,"RG"],
+    ["Break Through Myself feat. Risa Yuzuki",25,126,919911,1643,0,"RG"],
+    ["Jupin - SHORT CUT -",23,48,982585,626,0,"TG"],
+    ["MURDOCH",24,101,938435,1246,82,"RG"],
+    ["Papasito (feat.  KuTiNA) - FULL SONG -",23,245,974365,2966,0,"FG"],
+    ["Gargoyle - FULL SONG -",25,378,844710,3207,0,"RG"],
+    ["Nade Nade",24,122,950843,1492,0,"FG"],
+    ["Kasou Shinja",24,119,969602,1722,0,"TG"],
+    ["New Rose",23,119,960378,1325,0,"FG"],
+    ["Festival of Death Moon",23,116,953445,1179,0,"RG"]
+  ];
+
+  // The whole Winter 2025 Doubles board. [name, total, charts, avgDifficulty, restSecs, avgScore]
+  var BOARD = [
+    ["김재현",59319,39,24.22,1324,951755],["yimmythe42",57325,36,23.96,1619,958673],
+    ["tieny",52979,31,24.18,2105,963510],["Redviper",47940,31,23.41,2235,972857],
+    ["Elixir",38788,36,22.76,2195,960122],["Litenang",37495,36,23.17,1577,928867],
+    ["uhtreyu",37035,30,23.78,2611,941368],["Selofeals",31399,27,22.86,2207,927988],
+    ["Badkitty",26954,35,21.02,1985,950397],["Tink",25191,35,19.89,1844,961890],
+    ["Cherry",12688,32,18.43,2130,904722]
+  ];
+  var ME = BOARD[0];
+
+  // Charts each opponent also played. [title, level, myScore, myPts, theirScore, theirPts]
+  var SHARED = {
+    "yimmythe42":[["Gargoyle - FULL SONG -",25,844710,3207,924890,5099],["8 6 - FULL SONG -",23,962566,2990,977661,3321],["Festival of Death Moon",23,953445,1179,974697,1408],["Slam",24,976489,1528,983047,1622],["Break Through Myself feat. Risa Yuzuki",25,919911,1643,922230,1669],["Underworld ft. Skizzo (PIU Edit.)",25,941971,1611,941589,1608],["FLVSH OUT",23,979784,1617,979213,1608],["GLORIA",25,945885,1711,943963,1697],["Pop Sequence",23,960218,1324,958573,1298],["Pneumonoultramicroscopicsilicovolcanoconiosis ft. Kagamine Len/GUMI",22,972450,1152,966636,1109],["Darkside of The Mind",25,941887,1741,924976,1619],["Big Daddy",23,964066,1380,946152,1161]],
+    "tieny":[["8 6 - FULL SONG -",23,962566,2990,981796,3449],["Perpetual",24,945530,1293,977318,1696],["Boca",25,915890,1635,951768,1986],["Nade Nade",24,950843,1492,970523,1778],["GLORIA",25,945885,1711,958126,1952],["Slam",24,976489,1528,982811,1619],["Telling Fortune Flower",23,979705,1438,981140,1456],["FLVSH OUT",23,979784,1617,975352,1552],["Adrenaline Blaster",23,976959,1653,964369,1509],["Gargoyle - FULL SONG -",25,844710,3207,786446,1377]],
+    "Redviper":[["Leather",26,888018,2327,904508,2547],["Perpetual",24,945530,1293,955330,1422],["Big Daddy",23,964066,1380,972913,1456],["Underworld ft. Skizzo (PIU Edit.)",23,984346,1472,985853,1491],["Can-can ~Orpheus in The Party Mix~ - SHORT CUT -",25,952491,793,952989,799],["Queencard",22,991718,1154,979251,1036]],
+    "Elixir":[["8 6 - FULL SONG -",23,962566,2990,955084,2767],["Telling Fortune Flower",23,979705,1438,958186,1226],["Nade Nade",24,950843,1492,903142,1133],["Point Break",23,971005,1183,934749,916],["Festival of Death Moon",23,953445,1179,945707,1102],["Tomboy",22,962577,1081,961037,1074],["Pneumonoultramicroscopicsilicovolcanoconiosis ft. Kagamine Len/GUMI",22,972450,1152,968865,1119],["Can-can ~Orpheus in The Party Mix~ - SHORT CUT -",25,952491,793,936789,724],["Queencard",22,991718,1154,948839,786],["Love is a Danger Zone pt. 2 - SHORT CUT -",23,973872,698,962494,651]],
+    "Litenang":[["8 6 - FULL SONG -",23,962566,2990,949840,2569],["Pirate",21,987859,1164,987493,1160],["Odin",23,976240,1565,937714,1167],["Meteo5cience (GADGET mix)",22,950141,1301,924080,1161],["Underworld ft. Skizzo (PIU Edit.)",23,984346,1472,941355,1035],["Slam",24,976489,1528,926907,1085],["Nade Nade",24,950843,1492,893786,1075],["Tomboy",22,962577,1081,954818,997],["Pneumonoultramicroscopicsilicovolcanoconiosis ft. Kagamine Len/GUMI",22,972450,1152,946785,925],["Queencard",22,991718,1154,953696,834],["Can-can ~Orpheus in The Party Mix~ - SHORT CUT -",25,952491,793,926186,692],["Jupin - SHORT CUT -",23,982585,626,938239,442]],
+    "uhtreyu":[["Slam",24,976489,1528,939288,1144],["Underworld ft. Skizzo (PIU Edit.)",23,984346,1472,956269,1173],["Nade Nade",24,950843,1492,900784,1112],["GLORIA",25,945885,1711,924061,1556],["Annihilator Method",24,958243,1493,942552,1289],["Point Break",23,971005,1183,946924,964],["Kokugen Kairou Labyrinth",26,906317,1625,897578,1530],["Tomboy",22,962577,1081,966397,1099],["Meteo5cience (GADGET mix)",22,950141,1301,949691,1297],["Pneumonoultramicroscopicsilicovolcanoconiosis ft. Kagamine Len/GUMI",22,972450,1152,964525,1099]],
+    "Selofeals":[["Papasito (feat.  KuTiNA) - FULL SONG -",23,974365,2966,809725,942],["FLVSH OUT",23,979784,1617,938572,1171],["Odin",23,976240,1565,936017,1159],["8 6 - FULL SONG -",23,962566,2990,953488,2705],["Pneumonoultramicroscopicsilicovolcanoconiosis ft. Kagamine Len/GUMI",22,972450,1152,951691,961],["Tomboy",22,962577,1081,967797,1105]],
+    "Badkitty":[["Pirate",21,987859,1164,944585,805],["Pneumonoultramicroscopicsilicovolcanoconiosis ft. Kagamine Len/GUMI",22,972450,1152,922459,829]],
+    "Tink":[],
+    "Cherry":[["8 6 - FULL SONG -",23,962566,2990,841115,1423]]
+  };
+
+  // His OTHER Doubles session — March of Murlocs 2, August 2024. Same mix, same chart type: the
+  // only lineage a season comparison may walk (D15).
+  var PRIOR = { name:"March of Murlocs 2", short:"MoM 2", when:"August 2024",
+                stats:[44139,32,24.63,2199,929644] };   // 24.63 balanced (24.13 by folder number)
+
+  // [title, nominal, seconds, score, pointsThen, levelInMoM2, levelInWinter2025]
+  var PRIOR_CHARTS = [
+    ["Chobit Flavor",24,113,938635,1290,24.5,24.513702204840666],
+    ["Pump me Amadeus",24,98,923654,1047,24.5,25.222064603513772],
+    ["Destr0yer",24,161,930409,1781,24.5,24.73058865912763],
+    ["Galaxy Collapse",24,124,909027,1128,24.5,25.5],
+    ["Imprinting",24,117,927040,1277,24.5,24.633222599285297],
+    ["Canon D - FULL SONG -",24,198,930880,2195,24.5,25.004943372690946],
+    ["Dignity",24,110,889258,851,24.5,25.5],
+    ["Allegro Con Fuoco - FULL SONG -",25,275,896718,2540,25.5,25.623592651907416],
+    ["BRAIN POWER",24,112,939830,1285,24.5,24.677471121464244],
+    ["MURDOCH",24,101,919830,1037,24.5,24.794983706029925],
+    ["Baroque Virus - FULL SONG -",23,318,979407,3861,23.5,23.5],
+    ["Love is a Danger Zone pt. 2",24,104,961337,1303,24.5,24.5],
+    ["R.I.P",24,127,927340,1388,24.5,24.5],
+    ["Uh-Heung",24,120,937515,1365,24.5,24.5],
+    ["Gun Rock",24,100,925521,1085,24.5,24.5],
+    ["Fire Noodle Challenge",25,150,875795,1254,25.5,25.5],
+    ["PRiMA MATERiA",24,127,936521,1439,24.5,24.5],
+    ["Horang Pungryuga",24,126,940987,1452,24.5,24.5],
+    ["Further",25,118,899473,1103,25.5,25.5],
+    ["Beethoven Virus",24,100,955432,1221,24.5,24.5],
+    ["MEGAHEARTZ",25,120,897306,1111,25.5,25.5],
+    ["Love is a Danger Zone pt. 2 - SHORT CUT -",23,58,976199,683,23.5,23.5],
+    ["Solfeggietto",25,105,897335,972,25.5,25.5],
+    ["Phalanx \"RS2018 edit\"",24,118,955034,1438,24.5,24.5],
+    ["Kasou Shinja",24,119,942707,1380,24.5,24.5],
+    ["The Quick Brown Fox Jumps Over The Lazy Dog",24,110,925720,1195,24.5,24.5],
+    ["Hercules",24,117,928554,1285,24.5,24.5],
+    ["ERRORCODE: 0",24,182,914721,1768,24.5,24.5],
+    ["Can-can ~Orpheus in The Party Mix~ - SHORT CUT -",25,51,938453,671,25.5,25.5],
+    ["Annihilator Method",24,110,940900,1267,24.5,24.5],
+    ["A Site De La Rue",24,99,943306,1151,24.5,24.5],
+    ["Vector",24,113,943765,1316,24.5,24.5]
+  ];
+
+  // The seven charts he played in BOTH seasons. [title, level, thenScore, thenPts, nowScore, nowPts]
+  var CROSS_SHARED = [
+    ["Kasou Shinja",24,942707,1380,969602,1722],
+    ["MURDOCH",24,919830,1037,938435,1246],
+    ["Annihilator Method",24,940900,1267,958243,1493],
+    ["Can-can ~Orpheus in The Party Mix~ - SHORT CUT -",25,938453,671,952491,793],
+    ["MEGAHEARTZ",25,897306,1111,902836,1380],
+    ["BRAIN POWER",24,939830,1285,943862,1376],
+    ["Love is a Danger Zone pt. 2 - SHORT CUT -",23,976199,683,973872,698]
+  ];
+
+  /* ---- the two seasons' frozen scoring configs, straight out of Tournament.Configuration ---- */
+  var CFG = {
+    mom2:   { LR:{20:650,21:760,22:930,23:1110,24:1300,25:1500,26:1710,27:1930},
+              G:{A:0.25,APlus:0.5,AA:0.75,AAPlus:1.0,AAA:1.1,AAAPlus:1.15,S:1.2,SPlus:1.26,SS:1.32,SSPlus:1.38,SSS:1.44,SSSPlus:1.5} },
+    w2025:  { LR:{20:650,21:760,22:930,23:1160,24:1450,25:1800,26:2210,27:2680},
+              G:{A:0,APlus:0.5,AA:0.75,AAPlus:0.9,AAA:1.0,AAAPlus:1.15,S:1.2,SPlus:1.26,SS:1.32,SSPlus:1.38,SSS:1.44,SSSPlus:1.5} }
+  };
+  // Phoenix 1 score→grade floors, from the ScoreRange attributes on PhoenixLetterGrade.
+  // NOT Phoenix 2's — P2 moved every floor below AAA.
+  var LADDER = [["F",0],["D",450000],["C",550000],["B",650000],["A",750000],["APlus",825000],
+                ["AA",900000],["AAPlus",925000],["AAA",950000],["AAAPlus",960000],["S",970000],
+                ["SPlus",975000],["SS",980000],["SSPlus",985000],["SSS",990000],["SSSPlus",995000]];
+  var LABEL = {APlus:"A+",AAPlus:"AA+",AAAPlus:"AAA+",SPlus:"S+",SSPlus:"SS+",SSSPlus:"SSS+"};
+  function gradeKey(score){
+    for (var i=LADDER.length-1;i>=0;i--) if (score>=LADDER[i][1]) return LADDER[i][0];
+    return "F";
+  }
+  function grade(score){ var k=gradeKey(score); return LABEL[k]||k; }
+  function gradeColor(g){
+    if (g[0]==="S") return "var(--rar-sapphire)";
+    if (g.indexOf("AAA")===0) return "var(--rar-gold)";
+    if (g.indexOf("AA")===0) return "var(--rar-silver)";
+    return "var(--rar-common)";
+  }
+  var PLATECOLOR = {RG:"var(--plate-copper)",FG:"var(--plate-copper)",TG:"var(--plate-silver)",
+                    MG:"var(--plate-silver)",EG:"var(--plate-gold)",UG:"var(--plate-ice)",PG:"var(--plate-ice)"};
+
+  // MoM runs a continuous grade scale, so a score between two rungs takes a modifier between
+  // the two rungs' — which is why a re-cut grade table moves every score, not just boundary ones.
+  function gradeModifier(cfg, score){
+    var k = gradeKey(score), i = 0;
+    for (var x=0;x<LADDER.length;x++) if (LADDER[x][0]===k) i=x;
+    var mod = cfg.G[k] !== undefined ? cfg.G[k] : 0;
+    if (i >= LADDER.length-1 || score >= 1000000) return mod;
+    var nextKey = LADDER[i+1][0], nextMod = cfg.G[nextKey] !== undefined ? cfg.G[nextKey] : mod;
+    return mod + (nextMod - mod) * (score - LADDER[i][1]) / (LADDER[i+1][1] - LADDER[i][1]);
+  }
+  // A snapshot of L+f (f in 0.5..1.5) interpolates between L and L+1, so L+0.5 pays exactly
+  // level L and L+1.5 pays the full next level (plan doc §4, §9.3).
+  function levelRating(cfg, nominal, eff){
+    var f = eff - nominal, a = cfg.LR[nominal], b = cfg.LR[nominal+1];
+    return a + (b - a) * (f - 0.5);
+  }
+  // points = level rating × song length against a 2-minute baseline × grade modifier.
+  // Verified against every stored row: Dignity 1300 × 110/120 × 0.71419 = 851, exactly as stored.
+  function pointsUnder(cfg, nominal, eff, secs, score){
+    return levelRating(cfg, nominal, eff) * (secs/120) * gradeModifier(cfg, score);
+  }
+
+  function mmss(sec){ var m=Math.floor(sec/60), s=Math.round(sec%60); return m+":"+(s<10?"0":"")+s; }
+  function n(v){ return v.toLocaleString("en-US"); }
+  function esc(s){ return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/"/g,"&quot;"); }
+  function ord(i){ return i + (["th","st","nd","rd"][(i%100-i%10!=10)*(i%10<4)*i%10] || "th"); }
+  function levelColor(l){
+    if (l<=21) return "var(--diff-easy)";
+    if (l<=22) return "var(--diff-medium)";
+    if (l<=24) return "var(--diff-hard)";
+    return "var(--diff-veryhard)";
+  }
+
+  var CHARTS = RAW.map(function(r,i){
+    return { ord:i+1, title:r[0], level:r[1], secs:r[2], score:r[3], pts:r[4], bonus:r[5],
+             plate:r[6], pps:r[4]/r[2] };
+  });
+  var seen={}; CHARTS.forEach(function(c){ if (seen[c.title]) c.repeat=true; seen[c.title]=1; });
+  var maxPps = Math.max.apply(null, CHARTS.map(function(c){return c.pps;}));
+
+  /* ================= where the points came from ================= */
+  function rankOf(vals, mine, lowerIsBetter){
+    return vals.slice().sort(function(a,b){ return lowerIsBetter?a-b:b-a; }).indexOf(mine)+1;
+  }
+  var LEVERS = [
+    { k:"Charts played", vals:BOARD.map(function(b){return b[2];}), mine:ME[2], fmt:n, better:"high" },
+    // Balanced difficulty, not the folder number: the season's frozen effective level is what
+    // actually priced each chart, so it is what the session was worth playing. It reads about half
+    // a level above the folder because a chart with no override sits at nominal + 0.5.
+    { k:"Avg difficulty", vals:BOARD.map(function(b){return b[3];}), mine:ME[3],
+      fmt:function(v){return v.toFixed(2);}, sub:function(){return "balanced for this season";},
+      better:"high" },
+    { k:"Avg grade", vals:BOARD.map(function(b){return b[5];}), mine:ME[5], fmt:grade,
+      sub:function(v){return n(Math.round(v))+" average score";}, better:"high" },
+    { k:"Downtime", vals:BOARD.map(function(b){return b[4];}), mine:ME[4], fmt:mmss, better:"low" }
+  ];
+  document.getElementById("levers").innerHTML = LEVERS.map(function(L){
+    var lo=Math.min.apply(null,L.vals), hi=Math.max.apply(null,L.vals);
+    var lowerBetter = L.better==="low", r = rankOf(L.vals,L.mine,lowerBetter);
+    var f = hi===lo?.5:(L.mine-lo)/(hi-lo);
+    var med = L.vals.slice().sort(function(a,b){return a-b;})[Math.floor(L.vals.length/2)];
+    var medF = hi===lo?.5:(med-lo)/(hi-lo);
+    var at = function(x){ return "calc(9px + (100% - 18px) * "+x.toFixed(4)+")"; };
+    var lead = r===1;
+    var verdict = lead ? (lowerBetter?"Least on this board":"Most on this board")
+                       : "<b>"+ord(r)+"</b> of "+L.vals.length+" on this board";
+    return '<div class="lever'+(lead?" lead":"")+'"><div class="k">'+L.k+'</div>'
+      + '<div class="v num">'+L.fmt(L.mine)+'</div>'
+      + (L.sub?'<div class="vsub">'+L.sub(L.mine)+'</div>':'')
+      + '<div class="rank">'+(lead?'<b>'+verdict+'</b>':verdict)+'</div>'
+      + '<div class="rail"><div class="track"><span class="med" style="left:'+at(medF)+'"></span>'
+      + '<span class="you" style="left:'+at(f)+'"></span></div>'
+      + '<div class="ends"><span>'+L.fmt(lo)+'</span><span>'+L.fmt(hi)+'</span></div></div></div>';
+  }).join("");
+
+  /* ================= compare ================= */
+  var sel = document.getElementById("cmpsel"), mode = "board";
+
+  function fillSelect(){
+    sel.innerHTML = "";
+    if (mode==="board"){
+      BOARD.slice(1).forEach(function(b,i){
+        var o=document.createElement("option");
+        o.value=i+1; o.textContent=ord(i+2)+" — "+b[0]+" ("+n(b[1])+")";
+        sel.appendChild(o);
+      });
+      sel.value="1";
+      document.getElementById("cmpscope").textContent = "Same board only — Singles and Doubles are never compared.";
+    } else {
+      var o=document.createElement("option");
+      o.value="prior"; o.textContent=PRIOR.name+" — "+PRIOR.when+" ("+n(PRIOR.stats[0])+")";
+      sel.appendChild(o);
+      document.getElementById("cmpscope").textContent = "Your Doubles sessions on Phoenix only — another chart type or mix is a different sport.";
+    }
+  }
+
+  function drawCompare(){
+    var them = mode==="board" ? BOARD[parseInt(sel.value,10)] : [PRIOR.short].concat(PRIOR.stats);
+    var cells = [
+      { k:"Charts played", a:ME[2], b:them[2], fmt:n, better:"high" },
+      { k:"Avg difficulty", a:ME[3], b:them[3], fmt:function(v){return v.toFixed(2);}, better:"high" },
+      { k:"Avg grade", a:ME[5], b:them[5], fmt:grade, better:"high", raw:true },
+      { k:"Downtime", a:ME[4], b:them[4], fmt:mmss, better:"low" }
+    ];
+    document.getElementById("cmpgrid").innerHTML = cells.map(function(c){
+      var diff=c.a-c.b, good = c.better==="low" ? diff<0 : diff>0;
+      var cls = diff===0?"flat":(good?"up":"down");
+      var shown = diff===0 ? "even"
+        : c.raw ? (diff>0?"+":"")+n(Math.round(diff))
+        : (diff>0?"+":"-")+c.fmt(Math.abs(diff)).replace("-","");
+      return '<div class="cmp-cell"><div class="k">'+c.k+'</div>'
+        + '<div class="cmp-row"><span class="who">김재현</span><span class="val num">'+c.fmt(c.a)+'</span>'
+        + '<span class="delta '+cls+'">'+shown+'</span></div>'
+        + '<div class="cmp-row"><span class="who">'+esc(them[0])+'</span>'
+        + '<span class="val num" style="color:var(--mix-muted)">'+c.fmt(c.b)+'</span></div></div>';
+    }).join("");
+
+    var dc=ME[2]-them[2], dd=ME[3]-them[3], dr=them[4]-ME[4], dg=ME[5]-them[5], parts=[];
+    if (dc!==0) parts.push("<b>"+Math.abs(dc)+" "+(dc>0?"more":"fewer")+" charts</b>");
+    if (Math.abs(dd)>=0.05) parts.push("<b>"+Math.abs(dd).toFixed(2)+" "+(dd>0?"harder":"easier")+"</b> on average");
+    if (Math.abs(dr)>=30) parts.push("<b>"+mmss(Math.abs(dr))+" "+(dr>0?"less":"more")+"</b> downtime");
+    if (Math.abs(dg)>=1000) parts.push("<b>"+n(Math.abs(Math.round(dg)))+" "+(dg>0?"higher":"lower")+"</b> average score");
+    var phrase = parts.length===0 ? "no meaningful difference"
+      : parts.length===1 ? parts[0]
+      : parts.slice(0,-1).join(", ")+" and "+parts[parts.length-1];
+    document.getElementById("cmpverdict").innerHTML = "Against "+esc(them[0])+", "+phrase
+      + " — worth <b>"+(ME[1]-them[1]>0?"+":"")+n(ME[1]-them[1])+" points</b>.";
+
+    document.getElementById("h2h").innerHTML = mode==="board"
+      ? h2hHtml(them[0], SHARED[them[0]]||[], them[0])
+      : h2hHtml(PRIOR.name, CROSS_SHARED.map(function(c){return [c[0],c[1],c[4],c[5],c[2],c[3]];}), PRIOR.short);
+    document.getElementById("rebase").innerHTML = mode==="season" ? ledgerHtml() : "";
+  }
+
+  // The charts both sessions contain. A total says who won; this says where.
+  function h2hHtml(whoLabel, rows, shortLabel){
+    if (!rows.length){
+      return '<div class="h2h"><h3>Charts you both played</h3>'
+        + '<p class="lede">Nothing in common — '+esc(whoLabel)+' picked an entirely different set.</p></div>';
+    }
+    var wins = rows.filter(function(r){ return r[2] > r[4]; }).length;
+    var sorted = rows.slice().sort(function(a,b){ return (b[5]-b[3]) - (a[5]-a[3]); });
+    var body = sorted.map(function(r){
+      var mine=r[2], theirs=r[4], myPts=r[3], theirPts=r[5];
+      var d = myPts-theirPts, iWin = mine>theirs;
+      return '<div class="h2hrow">'
+        + '<span class="bub" style="background:'+levelColor(r[1])+';width:30px;height:20px;font-size:12px">D'+r[1]+'</span>'
+        + '<span class="nm" title="'+esc(r[0])+'">'+esc(r[0])+'</span>'
+        + '<span class="sc"><span style="color:'+(iWin?"var(--rar-emerald)":"var(--mix-ink)")+'">'+n(mine)+'</span>'
+          + '<small>you · '+n(myPts)+' pts</small></span>'
+        + '<span class="sc"><span style="color:'+(!iWin?"var(--rar-emerald)":"var(--mix-muted)")+'">'+n(theirs)+'</span>'
+          + '<small>'+esc(shortLabel)+' · '+n(theirPts)+' pts</small></span>'
+        + '<span class="win '+(d>0?"up":d<0?"down":"flat")+'">'+(d>0?"+":"")+n(d)+'</span></div>';
+    }).join("");
+    // Rows lead with the charts that cost the most ground, so sorted[0] is the widest gap
+    // against you — not sorted[last], which is your best chart of the set.
+    var worst = sorted[0], swing = worst ? (worst[3]-worst[5]) : 0;
+    return '<div class="h2h"><h3>Charts you both played</h3>'
+      + '<p class="lede">'+rows.length+' in common, worst first. You scored higher on <b>'+wins+'</b> of them'
+      + (swing < 0 ? ', and <b>'+esc(worst[0])+'</b> alone cost you '+n(Math.abs(swing))+' points.' : '.')
+      + '</p>' + body + '</div>';
+  }
+
+  // A cross-season delta carries a confound a same-board delta does not: BOTH the chart balance
+  // and the scoring rules were re-frozen between the two seasons. Re-pricing the old session under
+  // the new season's config splits the difference into what changed underneath and what you did.
+  function ledgerHtml(){
+    var then=0, balanceOnly=0, rulesOnly=0, now=0, moved=[];
+    PRIOR_CHARTS.forEach(function(c){
+      var nom=c[1], secs=c[2], score=c[3], oldEff=c[5], newEff=c[6];
+      var a = pointsUnder(CFG.mom2,  nom, oldEff, secs, score);   // as it scored then
+      var b = pointsUnder(CFG.mom2,  nom, newEff, secs, score);   // new snapshot only
+      var d = pointsUnder(CFG.w2025, nom, oldEff, secs, score);   // new rules only
+      var e = pointsUnder(CFG.w2025, nom, newEff, secs, score);   // both
+      then+=a; balanceOnly+=b-a; rulesOnly+=d-a; now+=e;
+      if (Math.abs(newEff-oldEff) > 0.001) moved.push({title:c[0], from:oldEff, to:newEff, gain:b-a});
+    });
+    moved.sort(function(a,b){ return b.gain-a.gain; });
+    var rebased = PRIOR.stats[0] + (now - then);       // anchor on the stored total
+    var you = ME[1] - rebased;
+    var sg = function(v){ return (v>0?"+":"")+n(Math.round(v)); };
+    var cls = function(v){ return v>0?"up":v<0?"down":"flat"; };
+
+    return '<div class="ledger"><h3>What changed underneath you</h3>'
+      + '<p class="why">Every season freezes its own chart balance <em>and</em> its own scoring'
+      + ' tables at creation, so the same session is worth different totals in different seasons.'
+      + ' Re-pricing your ' + esc(PRIOR.name) + ' session — the same ' + PRIOR.stats[1] + ' charts,'
+      + ' the same scores — under Winter 2025 separates what moved underneath you from what you earned.</p>'
+      + '<div class="lrow"><span class="lbl">'+esc(PRIOR.name)
+        + '<small>'+PRIOR.when+', as it scored then</small></span>'
+        + '<span class="amt num">'+n(PRIOR.stats[0])+'</span><span class="chg"></span></div>'
+      + '<div class="lrow sub"><span class="lbl">Charts re-rated by the community</span>'
+        + '<span class="amt num"></span><span class="chg '+cls(balanceOnly)+'">'+sg(balanceOnly)+'</span></div>'
+      + '<div class="lrow sub"><span class="lbl">Scoring tables re-cut'
+        + '<small>the two multiply, so they come to more together than apart</small></span>'
+        + '<span class="amt num"></span><span class="chg '+cls(rulesOnly)+'">'+sg(rulesOnly)+'</span></div>'
+      + '<div class="lrow"><span class="lbl">The same session, scored as Winter 2025'
+        + '<small>'+moved.length+' of '+PRIOR.stats[1]+' charts re-rated; every level 23+ rating raised and the grade table tightened</small></span>'
+        + '<span class="amt num">'+n(Math.round(rebased))+'</span>'
+        + '<span class="chg '+cls(now-then)+'">'+sg(now-then)+' total</span></div>'
+      + '<div class="lrow total"><span class="lbl">Winter 2025<small>February 2025, this session</small></span>'
+        + '<span class="amt num">'+n(ME[1])+'</span>'
+        + '<span class="chg '+cls(you)+'">'+sg(you)+' you</span></div>'
+      + '<details class="disc"><summary>'+moved.length+' re-rated charts</summary>'
+      + moved.map(function(m){
+          return '<div class="rrow"><span>'+esc(m.title)+'</span>'
+            + '<span class="mv num">'+m.from.toFixed(2)+' → <b>'+m.to.toFixed(2)+'</b></span>'
+            + '<span class="gain '+cls(m.gain)+'">'+sg(m.gain)+'</span></div>';
+        }).join("")
+      + '</details>'
+      + '<details class="disc"><summary>what the scoring tables did</summary>'
+      + '<div class="rrow"><span>Level 23 rating</span><span class="mv num">1,110 → <b>1,160</b></span><span class="gain up">+4.5%</span></div>'
+      + '<div class="rrow"><span>Level 24 rating</span><span class="mv num">1,300 → <b>1,450</b></span><span class="gain up">+11.5%</span></div>'
+      + '<div class="rrow"><span>Level 25 rating</span><span class="mv num">1,500 → <b>1,800</b></span><span class="gain up">+20.0%</span></div>'
+      + '<div class="rrow"><span>Level 26 rating</span><span class="mv num">1,710 → <b>2,210</b></span><span class="gain up">+29.2%</span></div>'
+      + '<div class="rrow"><span>AAA multiplier</span><span class="mv num">1.10 → <b>1.00</b></span><span class="gain down">−9.1%</span></div>'
+      + '<div class="rrow"><span>AA+ multiplier</span><span class="mv num">1.00 → <b>0.90</b></span><span class="gain down">−10.0%</span></div>'
+      + '<div class="rrow"><span>A multiplier</span><span class="mv num">0.25 → <b>0.00</b></span><span class="gain down">zeroed</span></div>'
+      + '</details></div>';
+  }
+
+  Array.prototype.forEach.call(document.querySelectorAll('.cmp-head .segmented button'), function(btn){
+    btn.addEventListener("click", function(){
+      mode = btn.dataset.mode;
+      Array.prototype.forEach.call(document.querySelectorAll('.cmp-head .segmented button'), function(b){
+        b.setAttribute("aria-pressed", String(b===btn));
+      });
+      fillSelect(); drawCompare();
+    });
+  });
+  sel.addEventListener("change", drawCompare);
+  fillSelect(); drawCompare();
+
+  /* ================= the session ================= */
+  var SORTS = [
+    { key:"ord",  label:"Play order", note:"As played, first to last." },
+    { key:"pts",  label:"Points",     note:"Biggest single scores — the long songs win, which is not the same as being efficient." },
+    { key:"pps",  label:"Points per second", note:"Points banked per second of song. Short cuts top this list; Gargoyle sits near the bottom despite being the session's biggest score." },
+    { key:"level",label:"Difficulty",  note:"Hardest first." },
+    { key:"score",label:"Score",      note:"Cleanest play first." }
+  ];
+  var density = "Compact", sortKey = "ord";
+
+  function sorted(){
+    var l = CHARTS.slice();
+    if (sortKey==="pts")   l.sort(function(a,b){return b.pts-a.pts;});
+    if (sortKey==="pps")   l.sort(function(a,b){return b.pps-a.pps;});
+    if (sortKey==="level") l.sort(function(a,b){return b.level-a.level || b.pts-a.pts;});
+    if (sortKey==="score") l.sort(function(a,b){return b.score-a.score;});
+    return l;
+  }
+  function sortMeta(){ return SORTS.filter(function(s){return s.key===sortKey;})[0]; }
+
+  function gradeSpan(c, size){
+    var g = grade(c.score);
+    return '<span class="gradeicon" style="color:'+gradeColor(g)+';font-size:'+size+'px">'+g+'</span>';
+  }
+  function plateSpan(c){
+    return '<span class="plate" style="color:'+(PLATECOLOR[c.plate]||"var(--rar-common)")+'">'+c.plate+'</span>';
+  }
+
+  function renderComfortable(list){
+    return '<div class="cards">' + list.map(function(c){
+      return '<div class="ccard">'
+        + '<div class="ccard-jacket" role="button" tabindex="0" data-open="'+c.ord+'" aria-label="Open '+esc(c.title)+'">'
+          + '<span class="jacket">ART</span>'
+          + '<span class="bub" style="background:'+levelColor(c.level)+'">D'+c.level+'</span>'
+          + '<span class="ccard-ord num">'+c.ord+'</span>'
+          + '<button type="button" class="playbtn" data-play="'+c.ord+'" aria-label="Play video for '+esc(c.title)+'">'
+            + '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></button>'
+        + '</div>'
+        + '<div class="ccard-body">'
+          + '<div class="ccard-name" title="'+esc(c.title)+'">'+esc(c.title)+'</div>'
+          + '<div class="ccard-meta">'+gradeSpan(c,17)+plateSpan(c)
+            + '<span class="num" style="color:var(--mix-muted);font-size:12.5px">'+n(c.score)+'</span></div>'
+          + '<div class="ccard-meta"><span class="ccard-pts num">'+n(c.pts)+'</span>'
+            + '<span class="ccard-sub">pts · '+c.pps.toFixed(1)+' pps · '+mmss(c.secs)+'</span></div>'
+          + (c.bonus?'<div class="ccard-sub" style="color:var(--mix-accent)">+'+c.bonus+' chart bonus</div>':'')
+        + '</div></div>';
+    }).join("") + '</div>';
+  }
+
+  function renderCompact(list){
+    // One printed value per sticker, and the value is the MoM score — the points this chart
+    // put on the board, which is the currency the whole page is denominated in. The PIU score
+    // is not it: the grade in the other corner already says how cleanly it was played.
+    // When the list is ranked by something the sticker does not show, that value joins as a
+    // second line, so Compact never sorts by an invisible number.
+    var extra = { pps:function(c){return c.pps.toFixed(1)+" pps";},
+                  score:function(c){return n(c.score);} }[sortKey];
+    return '<div class="stickers">' + list.map(function(c){
+      return '<button type="button" class="sticker" data-open="'+c.ord+'" title="'+esc(c.title)
+          + ' · '+n(c.pts)+' pts · '+n(c.score)+' · '+c.pps.toFixed(1)+' pps">'
+        + '<span class="jacket">ART</span>'
+        + '<span class="bub" style="background:'+levelColor(c.level)+'">D'+c.level+'</span>'
+        + '<span class="corner-start">'+gradeSpan(c,12)+'</span>'
+        + '<span class="corner">'+n(c.pts)
+          + (extra?'<span class="corner-2">'+extra(c)+'</span>':'')+'</span>'
+        + '</button>';
+    }).join("") + '</div>';
+  }
+
+  function renderTable(list){
+    var cols = [["level","Chart"],["score","Score"],["pts","Points"],["pps","PPS"]];
+    var head = '<th><button type="button" data-sort="level">Chart</button></th>'
+      + '<th><button type="button" data-sort="score">Grade &amp; score</button></th>'
+      + '<th class="t-r"><button type="button" data-sort="pts">Points</button></th>'
+      + '<th class="t-r col-pps"><button type="button" data-sort="pps">PPS</button></th>'
+      + '<th class="t-r col-pps"><button type="button" data-sort="ord">Length</button></th>';
+    var body = list.map(function(c){
+      return '<tr data-open="'+c.ord+'" title="'+esc(c.title)+' · '+n(c.score)+'">'
+        + '<td><span class="t-ident"><span class="jacket">ART</span>'
+          + '<span class="bub" style="background:'+levelColor(c.level)+'">D'+c.level+'</span>'
+          + '<span class="t-name">'+esc(c.title)+(c.repeat?' <span style="color:var(--rar-sapphire);font-size:11px">2nd chart, same song</span>':'')+'</span></span></td>'
+        + '<td><span class="t-grade">'+gradeSpan(c,16)+plateSpan(c)
+          + '<span class="t-score num">'+n(c.score)+'</span></span></td>'
+        + '<td class="t-r num" style="font-family:var(--display);font-size:17px;font-weight:600">'+n(c.pts)
+          + (c.bonus?'<span style="color:var(--mix-accent);font-size:11px"> +'+c.bonus+'</span>':'')+'</td>'
+        + '<td class="t-r num col-pps">'+c.pps.toFixed(1)+'</td>'
+        + '<td class="t-r num col-pps" style="color:var(--mix-muted)">'+mmss(c.secs)+'</td></tr>';
+    }).join("");
+    return '<div class="tablewrap"><table class="run"><thead><tr>'+head+'</tr></thead><tbody>'+body+'</tbody></table></div>';
+  }
+
+  function drawRun(){
+    var list = sorted();
+    document.getElementById("run").innerHTML =
+      density==="Comfortable" ? renderComfortable(list)
+      : density==="Table" ? renderTable(list)
+      : renderCompact(list);
+    document.getElementById("runnote").textContent = sortMeta().note;
+    // Table sorts from its own headers, so the popover would be a second control for one job.
+    document.getElementById("sortwrap").style.display = density==="Table" ? "none" : "";
+    document.getElementById("sortcur").textContent = sortMeta().label.toLowerCase();
+    if (density==="Table"){
+      var th = document.querySelectorAll("table.run th");
+      Array.prototype.forEach.call(th, function(h){
+        var b = h.querySelector("button");
+        if (b && b.dataset.sort===sortKey) h.setAttribute("aria-sort","descending");
+        else h.removeAttribute("aria-sort");
+      });
+    }
+  }
+
+  document.getElementById("sortmenu").innerHTML = SORTS.map(function(s){
+    return '<button type="button" role="menuitem" data-sort="'+s.key+'">'
+      + '<span class="tick" data-tick="'+s.key+'"></span>'+s.label+'</button>';
+  }).join("");
+
+  function paintTicks(){
+    Array.prototype.forEach.call(document.querySelectorAll("[data-tick]"), function(t){
+      t.textContent = t.dataset.tick===sortKey ? "✓" : "";
+    });
+  }
+  paintTicks();
+
+  var sortbtn = document.getElementById("sortbtn"), sortmenu = document.getElementById("sortmenu");
+  function closeMenu(){ sortmenu.hidden = true; sortbtn.setAttribute("aria-expanded","false"); }
+  sortbtn.addEventListener("click", function(e){
+    e.stopPropagation();
+    sortmenu.hidden = !sortmenu.hidden;
+    sortbtn.setAttribute("aria-expanded", String(!sortmenu.hidden));
+  });
+  document.addEventListener("click", function(e){
+    if (!sortmenu.hidden && !sortmenu.contains(e.target)) closeMenu();
+  });
+  document.addEventListener("keydown", function(e){ if (e.key==="Escape") closeMenu(); });
+
+  // One delegated listener for every sort trigger — the popover's items and, in Table, the
+  // column headers. Re-rendering the session replaces those headers, so binding them directly
+  // would go stale on the first sort.
+  document.addEventListener("click", function(e){
+    var t = e.target.closest ? e.target.closest("[data-sort]") : null;
+    if (!t) return;
+    sortKey = t.dataset.sort; paintTicks(); closeMenu(); drawRun();
+  });
+
+  Array.prototype.forEach.call(document.querySelectorAll('.denbtns button'), function(btn){
+    btn.addEventListener("click", function(){
+      density = btn.dataset.den;
+      Array.prototype.forEach.call(document.querySelectorAll('.denbtns button'), function(b){
+        b.setAttribute("aria-pressed", String(b===btn));
+      });
+      drawRun();
+    });
+  });
+  drawRun();
+
+  /* ================= chart dialog ================= */
+  // The jacket and the play button open the SAME dialog; only the play button autoplays —
+  // the pattern ChartDetailsDialog already runs on (Pumbility.razor's AutoPlay binding).
+  var dlg = document.getElementById("dlg");
+  function openChart(ordinal, autoplay){
+    var c = CHARTS.filter(function(x){return x.ord===ordinal;})[0];
+    if (!c) return;
+    document.getElementById("dlghead").innerHTML =
+      '<span class="bub" style="background:'+levelColor(c.level)+'">D'+c.level+'</span>'
+      + '<span class="dlg-title" id="dlgtitle">'+esc(c.title)+'</span>';
+    document.getElementById("dlgbody").innerHTML =
+      '<div class="dlg-video">'+(autoplay
+        ? "▶ Chart video would autoplay here — the play button and the jacket open this same dialog, the button just starts it."
+        : "Chart video — press play. External embeds are blocked in this sandbox.")+'</div>'
+      + '<div class="dlg-stats">'
+      + '<div class="dlg-stat"><div class="k">Score</div><div class="v">'+n(c.score)+'</div></div>'
+      + '<div class="dlg-stat"><div class="k">Grade</div><div class="v" style="color:'+gradeColor(grade(c.score))+'">'+grade(c.score)+'</div></div>'
+      + '<div class="dlg-stat"><div class="k">Plate</div><div class="v" style="color:'+(PLATECOLOR[c.plate]||"")+'">'+c.plate+'</div></div>'
+      + '<div class="dlg-stat"><div class="k">Points</div><div class="v">'+n(c.pts)+'</div></div>'
+      + '<div class="dlg-stat"><div class="k">Per second</div><div class="v">'+c.pps.toFixed(1)+'</div></div>'
+      + '<div class="dlg-stat"><div class="k">Length</div><div class="v">'+mmss(c.secs)+'</div></div>'
+      + '</div>'
+      + (c.bonus?'<p style="margin:0;font-size:12.5px;color:var(--mix-accent)">+'+c.bonus+' chart bonus for playing level 22 or above.</p>':'')
+      + '<p style="margin:0;font-size:12.5px;color:var(--mix-muted)">Played '+ord(c.ord)+' of 39 in this session.</p>';
+    if (!dlg.open) dlg.showModal();
+  }
+  document.addEventListener("click", function(e){
+    var play = e.target.closest ? e.target.closest("[data-play]") : null;
+    if (play){ e.stopPropagation(); openChart(parseInt(play.dataset.play,10), true); return; }
+    var open = e.target.closest ? e.target.closest("[data-open]") : null;
+    if (open) openChart(parseInt(open.dataset.open,10), false);
+  });
+  document.addEventListener("keydown", function(e){
+    if (e.key!=="Enter" && e.key!==" ") return;
+    var open = e.target.closest ? e.target.closest("[data-open]") : null;
+    if (open && open.getAttribute("role")==="button"){ e.preventDefault(); openChart(parseInt(open.dataset.open,10), false); }
+  });
+  document.getElementById("dlgclose").addEventListener("click", function(){ dlg.close(); });
+
+  /* ================= pace ================= */
+  (function(){
+    var W=1000,H=220,PL=42,PR=12,PT=12,PB=26;
+    var restEach = ME[4]/(CHARTS.length-1), t=0, segs=[];
+    CHARTS.forEach(function(c,i){
+      segs.push({x0:t,x1:t+c.secs,y:c.pps,c:c});
+      t += c.secs + (i<CHARTS.length-1?restEach:0);
+    });
+    var total=t, maxY=Math.ceil(maxPps/5)*5;
+    var sx=function(v){return PL+v/total*(W-PL-PR);}, sy=function(v){return H-PB-v/maxY*(H-PT-PB);};
+    var avg = CHARTS.reduce(function(a,c){return a+c.pts;},0)/total;
+    var out="";
+    for (var g=0;g<=maxY;g+=5){
+      out += '<line x1="'+PL+'" y1="'+sy(g)+'" x2="'+(W-PR)+'" y2="'+sy(g)+'" stroke="rgba(233,239,247,.09)"/>'
+           + '<text x="'+(PL-7)+'" y="'+(sy(g)+4)+'" fill="#93A3B8" font-size="11" text-anchor="end">'+g+'</text>';
+    }
+    for (var m=0;m<=105;m+=15){
+      out += '<text x="'+sx(m*60)+'" y="'+(H-7)+'" fill="#93A3B8" font-size="11" text-anchor="middle">'+m+'m</text>';
+    }
+    out += '<line x1="'+PL+'" y1="'+sy(avg)+'" x2="'+(W-PR)+'" y2="'+sy(avg)+'" stroke="#FFD24A" stroke-width="1.5" stroke-dasharray="5 4" opacity=".85"/>';
+    segs.forEach(function(s){
+      var w=Math.max(sx(s.x1)-sx(s.x0),1.5);
+      out += '<rect x="'+sx(s.x0)+'" y="'+sy(s.y)+'" width="'+w+'" height="'+(sy(0)-sy(s.y))+'" fill="#3FA9F5" opacity=".22"/>'
+           + '<line x1="'+sx(s.x0)+'" y1="'+sy(s.y)+'" x2="'+sx(s.x1)+'" y2="'+sy(s.y)+'" stroke="#3FA9F5" stroke-width="2.5"><title>'
+           + esc(s.c.title)+' · D'+s.c.level+' · '+s.c.pps.toFixed(1)+' pps</title></line>';
+    });
+    out += '<text x="'+(W-PR)+'" y="'+(sy(avg)-6)+'" fill="#FFD24A" font-size="11" text-anchor="end">avg '+avg.toFixed(2)+' pps</text>';
+    document.getElementById("tl").innerHTML = out;
+  })();
+</script>

--- a/docs/design/march-of-murlocs-mocks/3-submit.html
+++ b/docs/design/march-of-murlocs-mocks/3-submit.html
@@ -1,0 +1,867 @@
+<title>MoM — Submit mock</title>
+<style>
+  :root {
+    --mix-bg:#070B15; --mix-surface:#161E2C; --mix-raised:#1E2A3D; --mix-nav:#0D1626;
+    --mix-primary:#3FA9F5; --mix-secondary:#FF6B35; --mix-accent:#FFD24A;
+    --mix-ink:#E9EFF7; --mix-muted:#93A3B8;
+    --chart-double:#38B6FF;
+    --rar-emerald:#3FD35A; --rar-gold:#FFD24A; --rar-silver:#CBD5E1; --rar-sapphire:#38B6FF; --rar-common:#8B98A9;
+    --diff-easy:#7CB342; --diff-medium:#FDD835; --diff-hard:#FB8C00; --diff-veryhard:#E53935;
+    --warn:#FFB020; --bad:#FF3B5C;
+    --line:rgba(233,239,247,.12); --line-strong:rgba(233,239,247,.22);
+    --display:"Barlow Condensed","Oswald","Roboto Condensed","Arial Narrow",system-ui,sans-serif;
+    --body:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"], :root[data-theme="dark"] { color-scheme: dark; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--mix-bg); color:var(--mix-ink); font-family:var(--body);
+         font-size:15px; line-height:1.5; -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:920px; margin:0 auto; padding:16px 16px 120px; }
+  .num { font-variant-numeric:tabular-nums; }
+  h1,h2,h3 { font-family:var(--display); font-weight:600; margin:0; text-wrap:balance; }
+
+  .mockbar { background:#12203a; border-bottom:1px solid var(--line); padding:9px 16px; font-size:12.5px;
+             color:var(--mix-muted); display:flex; flex-wrap:wrap; gap:6px 14px; align-items:center; }
+  .mockbar b { color:var(--mix-ink); font-weight:600; }
+  .note { border-left:2px solid var(--mix-accent); background:rgba(255,210,74,.06); padding:9px 13px;
+          margin:0; border-radius:0 5px 5px 0; font-size:13px; color:#E4D9BC; }
+  .note b { color:var(--mix-accent); font-weight:600; }
+
+  /* ---------- header ---------- */
+  .head { display:flex; align-items:center; gap:10px; flex-wrap:wrap; padding-bottom:11px;
+          border-bottom:1px solid var(--line); }
+  .crumb { color:var(--mix-muted); font-size:13px; text-decoration:none; }
+  .crumb:hover { color:var(--mix-primary); }
+  .typechip { display:inline-flex; align-items:center; gap:6px; font-family:var(--display); font-size:14px;
+              font-weight:600; letter-spacing:.06em; text-transform:uppercase; padding:3px 9px; border-radius:4px;
+              color:var(--chart-double); border:1px solid rgba(56,182,255,.45); background:rgba(56,182,255,.10); }
+  .draftpill { margin-left:auto; display:inline-flex; align-items:center; gap:7px; font-size:12px;
+               color:var(--mix-accent); border:1px solid rgba(255,210,74,.4); background:rgba(255,210,74,.09);
+               border-radius:20px; padding:3px 11px; }
+  .draftpill .dot { width:7px; height:7px; border-radius:50%; background:var(--mix-accent); }
+  .saved { font-size:12px; color:var(--mix-muted); }
+
+  .title { font-family:var(--display); font-size:32px; font-weight:700; line-height:1.05; margin:14px 0 2px; }
+  .lede { color:var(--mix-muted); font-size:13.5px; margin:0 0 16px; max-width:70ch; }
+
+  /* ---------- budget meter ---------- */
+  .budget { background:var(--mix-surface); border:1px solid var(--line); border-radius:8px; padding:14px 16px; }
+  .budget-top { display:flex; align-items:baseline; gap:12px; flex-wrap:wrap; }
+  .budget-used { font-family:var(--display); font-size:30px; font-weight:700; line-height:1; }
+  .budget-of { color:var(--mix-muted); font-size:13px; }
+  .budget-right { margin-left:auto; text-align:right; }
+  .budget-right .v { font-family:var(--display); font-size:22px; font-weight:600; line-height:1; }
+  .budget-right .k { font-size:10.5px; letter-spacing:.1em; text-transform:uppercase; color:var(--mix-muted); }
+  .meter { height:12px; border-radius:6px; background:var(--mix-raised); margin:11px 0 8px; overflow:hidden; display:flex; }
+  .meter i { display:block; height:100%; }
+  .meter .played { background:linear-gradient(90deg,#2C7FBF,var(--mix-primary)); }
+  .meter .pending { background:repeating-linear-gradient(90deg,rgba(63,169,245,.55) 0 5px,rgba(63,169,245,.2) 5px 10px); }
+  .budget-legend { font-size:12.5px; color:var(--mix-muted); }
+  .budget-legend b { color:var(--mix-ink); font-weight:600; }
+
+  /* ---------- entry row ---------- */
+  .entry { background:var(--mix-nav); border:1px solid var(--line-strong); border-radius:8px;
+           padding:12px 14px; margin-top:16px; }
+  .entry-grid { display:grid; grid-template-columns:1fr 130px auto auto; gap:10px; align-items:end; }
+  .field { position:relative; min-width:0; }
+  .field label { display:block; font-size:10.5px; letter-spacing:.1em; text-transform:uppercase;
+                 color:var(--mix-muted); margin-bottom:4px; }
+  .field input {
+    width:100%; background:var(--mix-raised); color:var(--mix-ink); border:1px solid var(--line-strong);
+    border-radius:6px; padding:9px 11px; font:inherit; font-size:14.5px; font-variant-numeric:tabular-nums;
+  }
+  .field input:focus { outline:2px solid var(--mix-primary); outline-offset:-1px; border-color:transparent; }
+  .field input::placeholder { color:#5E6E82; }
+  .sugg { position:absolute; z-index:50; top:100%; left:0; right:0; margin-top:4px; max-height:264px;
+          overflow-y:auto; background:var(--mix-raised); border:1px solid var(--line-strong);
+          border-radius:7px; box-shadow:0 12px 30px rgba(0,0,0,.55); padding:4px; }
+  .sugg[hidden] { display:none; }
+  .sugg button { display:flex; width:100%; align-items:center; gap:9px; background:transparent; border:0;
+                 color:var(--mix-ink); font:inherit; font-size:13.5px; text-align:left; padding:6px 8px;
+                 border-radius:5px; cursor:pointer; }
+  .sugg button:hover, .sugg button.on { background:rgba(63,169,245,.16); }
+  .sugg button[disabled] { opacity:.42; cursor:not-allowed; }
+  .sugg .why { margin-left:auto; font-size:11px; color:var(--mix-muted); white-space:nowrap; }
+  .sugg .why.block { color:var(--warn); }
+  .bub { border-radius:4px; display:grid; place-items:center; font-family:var(--display); font-weight:700;
+         color:#0B0F17; flex:none; }
+  .sugg .bub { width:34px; height:22px; font-size:12.5px; }
+  .sugg .len { font-size:11.5px; color:var(--mix-muted); font-variant-numeric:tabular-nums; }
+  /* The plate dropdown doubles as the result picker, exactly as RecordScoreForm does it:
+     a plate is a pass, "Broken" is the clean fail with no plate. Plates are worth 1.0 under
+     PUMBILITY+ so they change no Phoenix 1 score — they are captured because players want to
+     see them, and because Phoenix 2 prices them. */
+  .field select {
+    width:100%; background:var(--mix-raised); color:var(--mix-ink); border:1px solid var(--line-strong);
+    border-radius:6px; padding:9px 10px; font:inherit; font-size:14px;
+  }
+  .field select:focus { outline:2px solid var(--mix-primary); outline-offset:-1px; }
+  .btn { background:var(--mix-primary); color:#06101C; border:0; border-radius:6px; font:inherit;
+         font-size:13.5px; font-weight:600; padding:9px 16px; cursor:pointer; white-space:nowrap; }
+  .btn.ghost { background:transparent; color:var(--mix-ink); border:1px solid var(--line-strong); }
+  .btn.danger { background:transparent; color:var(--bad); border:1px solid rgba(255,59,92,.5); }
+  .btn:disabled { opacity:.45; cursor:not-allowed; }
+  .btn:focus-visible { outline:2px solid var(--mix-primary); outline-offset:2px; }
+  .entry-hint { font-size:12px; color:var(--mix-muted); margin-top:9px; }
+  .entry-hint kbd { background:var(--mix-raised); border:1px solid var(--line-strong); border-bottom-width:2px;
+                    border-radius:4px; padding:0 5px; font:inherit; font-size:11px; }
+
+  /* ---------- import ---------- */
+  .importrow { display:flex; align-items:center; gap:11px 14px; flex-wrap:wrap; margin-top:12px;
+               background:var(--mix-surface); border:1px solid var(--line); border-radius:8px; padding:11px 14px; }
+  .importrow .t { font-size:13.5px; }
+  .importrow .s { font-size:12px; color:var(--mix-muted); }
+  .importrow .s a { color:var(--mix-primary); }
+  .lockchip { display:inline-flex; align-items:center; gap:7px; font-size:12.5px; color:var(--rar-emerald);
+              border:1px solid rgba(63,211,90,.4); background:rgba(63,211,90,.09); border-radius:6px; padding:4px 10px; }
+  .lockchip svg { width:13px; height:13px; fill:currentColor; }
+  /* The credential fields are narrow on purpose: they are a fallback, not the page's subject. */
+  .credfields { display:flex; gap:9px; flex-wrap:wrap; align-items:flex-end; }
+  .credfields .field { width:190px; }
+  .credfields .field input { padding:7px 10px; font-size:13.5px; }
+
+  /* ---------- entered list ---------- */
+  .listhead { display:flex; align-items:baseline; gap:12px; flex-wrap:wrap; margin:24px 0 9px; }
+  .listhead h2 { font-size:13px; letter-spacing:.14em; text-transform:uppercase; color:var(--mix-muted);
+                 font-family:var(--body); font-weight:600; }
+  .runtotal { margin-left:auto; font-family:var(--display); font-size:26px; font-weight:700; }
+  .runtotal small { font-family:var(--body); font-size:11px; letter-spacing:.1em; text-transform:uppercase;
+                    color:var(--mix-muted); font-weight:400; margin-left:6px; }
+  .rows { display:flex; flex-direction:column; gap:3px; }
+  .erow { display:grid; grid-template-columns:26px 40px 1fr auto auto auto; gap:10px; align-items:center;
+          padding:5px 9px; border-radius:6px; background:var(--mix-surface); border:1px solid transparent;
+          font-variant-numeric:tabular-nums; }
+  .erow:hover { border-color:var(--line-strong); }
+  .erow.zero { background:rgba(255,176,32,.07); border-color:rgba(255,176,32,.3); }
+  .erow .ord { color:var(--mix-muted); font-size:11.5px; text-align:right; }
+  .erow .bub { width:40px; height:26px; font-size:15px; }
+  .ename { min-width:0; }
+  .ename .t { font-size:14px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .ename .s { font-size:11.5px; color:var(--mix-muted); }
+  .ename .s.warn { color:var(--warn); }
+  .egrade { font-family:var(--display); font-weight:700; font-size:16px; width:42px; text-align:right; }
+  .epts { font-family:var(--display); font-weight:600; font-size:19px; width:60px; text-align:right; }
+  .epts.zero { color:var(--warn); }
+  .eact { display:flex; gap:2px; }
+  .iconbtn { background:transparent; border:0; color:var(--mix-muted); cursor:pointer; border-radius:5px;
+             width:28px; height:28px; display:grid; place-items:center; }
+  .iconbtn:hover { color:var(--mix-ink); background:var(--mix-raised); }
+  .iconbtn:focus-visible { outline:2px solid var(--mix-primary); outline-offset:-2px; }
+  .iconbtn svg { width:15px; height:15px; fill:currentColor; }
+  .emptylist { border:1px dashed var(--line-strong); border-radius:8px; padding:26px 18px; text-align:center;
+               color:var(--mix-muted); font-size:13.5px; }
+
+  /* ---------- video + footer ---------- */
+  .videofield { margin-top:22px; max-width:520px; }
+  .footer {
+    position:sticky; bottom:0; margin-top:26px; background:linear-gradient(180deg,rgba(7,11,21,0),var(--mix-bg) 34%);
+    padding-top:18px;
+  }
+  .footer-inner { display:flex; align-items:center; gap:11px; flex-wrap:wrap;
+                  background:var(--mix-surface); border:1px solid var(--line-strong); border-radius:9px; padding:12px 15px; }
+  .footer-sum { font-size:13px; color:var(--mix-muted); }
+  .footer-sum b { color:var(--mix-ink); }
+  .footer-act { margin-left:auto; display:flex; gap:9px; flex-wrap:wrap; }
+
+  dialog { background:var(--mix-surface); color:var(--mix-ink); border:1px solid var(--line-strong);
+           border-radius:10px; padding:0; max-width:480px; width:calc(100% - 32px); }
+  dialog::backdrop { background:rgba(3,6,12,.72); }
+  .dlg-b { padding:17px 18px; }
+  .dlg-b h3 { font-size:21px; margin-bottom:7px; }
+  .dlg-b p { font-size:13.5px; color:var(--mix-muted); margin:0 0 10px; }
+  .dlg-b ul { margin:0; padding-left:18px; font-size:13.5px; color:var(--mix-muted); }
+  .dlg-b li { margin-bottom:4px; }
+  .dlg-a { display:flex; justify-content:flex-end; gap:9px; padding:0 18px 16px; }
+
+  /* ---------- import ---------- */
+  dialog.imp { max-width:640px; }
+  .imp-head { padding:15px 18px 12px; border-bottom:1px solid var(--line); }
+  .imp-head h3 { font-size:22px; }
+  .imp-head p { margin:4px 0 0; font-size:13px; color:var(--mix-muted); }
+  .imp-load { padding:34px 18px; text-align:center; color:var(--mix-muted); font-size:13.5px; }
+  .spin { width:26px; height:26px; margin:0 auto 11px; border-radius:50%;
+          border:2px solid var(--line-strong); border-top-color:var(--mix-primary); animation:sp .8s linear infinite; }
+  @keyframes sp { to { transform:rotate(360deg); } }
+  @media (prefers-reduced-motion:reduce) { .spin { animation:none; } }
+
+  .imp-found { padding:12px 18px; background:rgba(63,169,245,.07); border-bottom:1px solid var(--line);
+               display:flex; gap:14px; align-items:baseline; flex-wrap:wrap; }
+  .imp-found .n { font-family:var(--display); font-size:26px; font-weight:700; line-height:1; }
+  .imp-found .k { font-size:12.5px; color:var(--mix-muted); }
+  .imp-found .k b { color:var(--mix-ink); font-weight:600; }
+  .imp-list { max-height:330px; overflow-y:auto; padding:6px 8px; }
+  .imp-row { display:grid; grid-template-columns:62px 34px 1fr auto; gap:9px; align-items:center;
+             padding:4px 8px; border-radius:5px; cursor:pointer; font-variant-numeric:tabular-nums;
+             opacity:.4; border:1px solid transparent; }
+  .imp-row:hover { border-color:var(--line-strong); opacity:.75; }
+  .imp-row.in { opacity:1; background:rgba(63,169,245,.11); }
+  .imp-row.edge { box-shadow:inset 0 0 0 1px rgba(63,169,245,.5); }
+  .imp-row .tm { font-size:12px; color:var(--mix-muted); }
+  .imp-row.in .tm { color:var(--mix-ink); }
+  .imp-row .bub { width:34px; height:22px; font-size:12.5px; }
+  .imp-row .nm { font-size:13px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .imp-row .sc { font-size:12.5px; color:var(--mix-muted); }
+  .imp-gap { display:flex; align-items:center; gap:9px; padding:5px 8px; color:var(--mix-muted); font-size:11.5px; }
+  .imp-gap::before, .imp-gap::after { content:""; height:1px; background:var(--line); flex:1; }
+  .imp-note { padding:11px 18px; border-top:1px solid var(--line); font-size:12.5px; color:var(--mix-muted); }
+  .imp-warn { padding:10px 18px; border-top:1px solid var(--line); background:rgba(255,176,32,.08);
+              font-size:13px; color:#E8CF9E; }
+  .imp-warn b { color:var(--warn); }
+  .imp-bad { padding:10px 18px; border-top:1px solid var(--line); font-size:12.5px; color:var(--mix-muted); }
+  .imp-bad b { color:var(--mix-ink); }
+
+  @media (max-width:719.98px) {
+    .entry-grid { grid-template-columns:1fr 118px; }
+    .brk { grid-column:1; padding-bottom:0; }
+    .entry-grid .btn { grid-column:2; }
+    .erow { grid-template-columns:34px 1fr auto auto; gap:8px; }
+    .erow .ord { display:none; }
+    .egrade { display:none; }
+  }
+  @media (max-width:499.98px) {
+    .title { font-size:26px; }
+    .budget-used { font-size:24px; }
+    .runtotal { font-size:21px; }
+  }
+</style>
+
+<div class="mockbar">
+  <b>Slice 1 mock 3 of 6 — Submit</b>
+  <span>/MarchOfMurlocs/Session/{id}/Edit</span>
+  <span>Real charts, real Winter 2025 scoring config — points are computed, not typed</span>
+  <button type="button" id="credflip" style="background:var(--mix-raised);color:var(--mix-ink);border:1px solid var(--line-strong);border-radius:5px;font:inherit;font-size:12px;padding:4px 10px;cursor:pointer">Show: no saved password</button>
+</div>
+
+<div class="wrap">
+
+  <div class="head">
+    <a class="crumb" href="#">March of Murlocs</a>
+    <span style="color:var(--mix-muted)">/</span>
+    <a class="crumb" href="#">Winter 2025</a>
+    <span style="color:var(--mix-muted)">/</span>
+    <span class="typechip">D Doubles · Phoenix</span>
+    <span class="draftpill"><span class="dot"></span>Draft — only you can see this</span>
+  </div>
+
+  <h1 class="title">Record your session</h1>
+  <p class="lede">
+    Add every chart you played, in order. Nothing here reaches the board until you publish, and
+    you can leave and come back — this draft is saved as you go.
+  </p>
+
+  <div class="budget">
+    <div class="budget-top">
+      <span class="budget-used num" id="used">0:00</span>
+      <span class="budget-of">of 1:45:00 played</span>
+      <span class="budget-right"><span class="v num" id="left">1:45:00</span><span class="k">unclaimed</span></span>
+    </div>
+    <div class="meter"><i class="played" id="mplayed" style="width:0"></i><i class="pending" id="mpending" style="width:0"></i></div>
+    <div class="budget-legend" id="blegend"></div>
+  </div>
+
+  <div class="entry">
+    <div class="entry-grid">
+      <div class="field">
+        <label for="q">Chart</label>
+        <input id="q" type="text" autocomplete="off" placeholder="Type a song name — “gargo”, “under”, “8 6”" aria-expanded="false" aria-controls="sugg"/>
+        <div class="sugg" id="sugg" hidden role="listbox"></div>
+      </div>
+      <div class="field">
+        <label for="sc">Score</label>
+        <input id="sc" type="text" inputmode="numeric" placeholder="984346" aria-label="Score"/>
+      </div>
+      <div class="field">
+        <label for="res">Result</label>
+        <select id="res" aria-label="Plate, or broken">
+          <option value="">—</option>
+          <option value="BROKEN">Broken</option>
+          <option value="RG">RG · Rough Game</option>
+          <option value="FG">FG · Fair Game</option>
+          <option value="TG">TG · Talented Game</option>
+          <option value="MG">MG · Marvelous Game</option>
+          <option value="SG">SG · Superb Game</option>
+          <option value="EG">EG · Extreme Game</option>
+          <option value="UG">UG · Ultimate Game</option>
+          <option value="PG">PG · Perfect Game</option>
+        </select>
+      </div>
+      <button type="button" class="btn" id="add" disabled>Add</button>
+    </div>
+    <p class="entry-hint">
+      Pick a chart, type the score, press <kbd>Enter</kbd>. Focus goes straight back to the chart
+      box, so a whole session is search → score → Enter, over and over.
+      <kbd>Shift</kbd>+<kbd>Enter</kbd> files it as broken without reaching for the dropdown.
+    </p>
+  </div>
+
+  <div class="importrow" id="importrow"></div>
+
+  <div class="listhead">
+    <h2>Your session</h2>
+    <span class="runtotal num" id="total">0<small id="totalsub">points · 0 charts</small></span>
+  </div>
+  <div id="list"></div>
+
+  <div class="videofield field">
+    <label for="vid">Video link <span style="text-transform:none;letter-spacing:0">— optional, shown on the board</span></label>
+    <input id="vid" type="url" placeholder="https://youtube.com/..."/>
+  </div>
+
+  <div class="footer">
+    <div class="footer-inner">
+      <span class="footer-sum" id="fsum"></span>
+      <span class="footer-act">
+        <button type="button" class="btn danger" id="discard">Discard draft</button>
+        <button type="button" class="btn" id="publish">Publish to the board</button>
+      </span>
+    </div>
+  </div>
+
+  <p class="note" style="margin-top:24px">
+    <b>Three rules doing visible work here.</b> The chart list <b>hides what you have already
+    played</b> and <b>blocks what will not fit</b> in the remaining window — the same song at a
+    different level stays available, because that is a different chart. A play graded A or below
+    on Phoenix scores <b>zero and is not a chart</b>: it still eats your window and you may replay
+    it, which is why row 4 is called out in amber rather than hidden. And the <b>plate selector is
+    gone</b> — every plate is worth 1.0 under PUMBILITY+, so it was one decision per chart that
+    could not change anything. It comes back on Phoenix 2, where plates do score.
+  </p>
+</div>
+
+<dialog id="pubdlg" aria-labelledby="pubtitle">
+  <div class="dlg-b">
+    <h3 id="pubtitle">Publish this session?</h3>
+    <p>It goes on the Doubles board straight away, and it is recorded as played right now.</p>
+    <ul>
+      <li>A published session <b>cannot be edited</b>. If you get something wrong you delete it and record a new one.</li>
+      <li>Your score becomes public on the board even if your profile is private.</li>
+      <li>You can record another session this season whenever you like.</li>
+    </ul>
+  </div>
+  <div class="dlg-a">
+    <button type="button" class="btn ghost" id="pubcancel">Back to the draft</button>
+    <button type="button" class="btn" id="pubgo">Publish</button>
+  </div>
+</dialog>
+
+<dialog class="imp" id="impdlg" aria-labelledby="imptitle">
+  <div class="imp-head">
+    <h3 id="imptitle">Import from PIUGAME</h3>
+    <p id="impsub">Reading your recent scores…</p>
+  </div>
+  <div id="imploading" class="imp-load"><div class="spin"></div>Signing in as <b>DRMURLOC#7251</b> — no password needed, the site already has it.</div>
+  <div id="impbody" hidden>
+    <div class="imp-found">
+      <span><span class="n num" id="impn">0</span></span>
+      <span class="k" id="impk"></span>
+    </div>
+    <div class="imp-list" id="implist"></div>
+    <div class="imp-note">Click any play to move the nearest end of the selection.</div>
+    <div id="impwarn"></div>
+    <div class="imp-bad" id="impbad"></div>
+  </div>
+  <div class="dlg-a">
+    <button type="button" class="btn ghost" id="impcancel">Cancel</button>
+    <button type="button" class="btn" id="impgo" disabled>Add charts</button>
+  </div>
+</dialog>
+
+<dialog id="disdlg" aria-labelledby="distitle">
+  <div class="dlg-b">
+    <h3 id="distitle">Discard this draft?</h3>
+    <p id="distext"></p>
+  </div>
+  <div class="dlg-a">
+    <button type="button" class="btn ghost" id="discancel">Keep it</button>
+    <button type="button" class="btn danger" id="disgo">Discard</button>
+  </div>
+</dialog>
+
+<script>
+  /* ---- Winter 2025's frozen config, straight out of Tournament.Configuration ---- */
+  var LR = {20:650,21:760,22:930,23:1160,24:1450,25:1800,26:2210,27:2680};
+  var G  = {A:0,APlus:0.5,AA:0.75,AAPlus:0.9,AAA:1.0,AAAPlus:1.15,S:1.2,SPlus:1.26,SS:1.32,
+            SSPlus:1.38,SSS:1.44,SSSPlus:1.5};
+  // Phoenix 1 score→grade floors, from the ScoreRange attributes on PhoenixLetterGrade.
+  var LADDER = [["F",0],["D",450000],["C",550000],["B",650000],["A",750000],["APlus",825000],
+                ["AA",900000],["AAPlus",925000],["AAA",950000],["AAAPlus",960000],["S",970000],
+                ["SPlus",975000],["SS",980000],["SSPlus",985000],["SSS",990000],["SSSPlus",995000]];
+  var LABEL = {APlus:"A+",AAPlus:"AA+",AAAPlus:"AAA+",SPlus:"S+",SSPlus:"SS+",SSSPlus:"SSS+"};
+  var MAXTIME = 6300; // 1:45:00
+
+  function gradeKey(s){ for (var i=LADDER.length-1;i>=0;i--) if (s>=LADDER[i][1]) return LADDER[i][0]; return "F"; }
+  function grade(s){ var k=gradeKey(s); return LABEL[k]||k; }
+  function gradeColor(g){
+    if (g[0]==="S") return "var(--rar-sapphire)";
+    if (g.indexOf("AAA")===0) return "var(--rar-gold)";
+    if (g.indexOf("AA")===0) return "var(--rar-silver)";
+    return "var(--rar-common)";
+  }
+  function gradeMod(score){
+    var k=gradeKey(score), i=0;
+    for (var x=0;x<LADDER.length;x++) if (LADDER[x][0]===k) i=x;
+    var m = G[k]!==undefined ? G[k] : 0;
+    if (i>=LADDER.length-1 || score>=1000000) return m;
+    var nk=LADDER[i+1][0], nm = G[nk]!==undefined ? G[nk] : m;
+    return m + (nm-m)*(score-LADDER[i][1])/(LADDER[i+1][1]-LADDER[i][1]);
+  }
+  // No snapshot override in the mock's pool, so every chart sits at nominal+0.5 — which pays
+  // exactly its own level, the no-entry fallback (plan doc §9.3).
+  function points(level, secs, score){ return Math.round(LR[level]*(secs/120)*gradeMod(score)); }
+
+  function mmss(s){ var m=Math.floor(s/60), r=Math.round(s%60); return m+":"+(r<10?"0":"")+r; }
+  function hms(s){ var h=Math.floor(s/3600), m=Math.floor(s%3600/60), r=Math.round(s%60);
+                   return h+":"+(m<10?"0":"")+m+":"+(r<10?"0":"")+r; }
+  function n(v){ return v.toLocaleString("en-US"); }
+  function esc(s){ return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/"/g,"&quot;"); }
+  function levelColor(l){
+    if (l<=21) return "var(--diff-easy)";
+    if (l<=22) return "var(--diff-medium)";
+    if (l<=24) return "var(--diff-hard)";
+    return "var(--diff-veryhard)";
+  }
+  function bub(l){ return '<span class="bub" style="background:'+levelColor(l)+'">D'+l+'</span>'; }
+  // The Play Data plate metals: copper RG/FG, silver TG/MG, gold SG/EG, ice UG/PG.
+  var PLATECOLOR = {RG:"#B87333",FG:"#B87333",TG:"#CBD5E1",MG:"#CBD5E1",
+                    SG:"#FFD24A",EG:"#FFD24A",UG:"#9BE9FF",PG:"#9BE9FF"};
+  function plateColor(p){ return PLATECOLOR[p] || "var(--rar-common)"; }
+
+  /* ---- the searchable pool: real Phoenix Doubles charts, [title, level, seconds] ---- */
+  var POOL = [
+    ["Love is a Danger Zone pt. 2 - SHORT CUT -",23,58],["Slam",24,99],["DUEL",24,111],
+    ["Adrenaline Blaster",23,119],["Queencard",22,102],["Telling Fortune Flower",23,113],
+    ["8 6 - FULL SONG -",23,266],["FLVSH OUT",23,127],["Pop Sequence",23,119],
+    ["Final Audition Ep. 2-X",24,104],["Meteo5cience (GADGET mix)",22,158],["Point Break",23,101],
+    ["Annihilator Method",24,110],["Pneumonoultramicroscopicsilicovolcanoconiosis ft. Kagamine Len/GUMI",22,121],
+    ["Can-can ~Orpheus in The Party Mix~ - SHORT CUT -",25,51],["MEGAHEARTZ",25,120],["Boca",25,129],
+    ["Odin",23,127],["Underworld ft. Skizzo (PIU Edit.)",23,111],["Underworld ft. Skizzo (PIU Edit.)",25,111],
+    ["GLORIA",25,116],["Kokugen Kairou Labyrinth",26,112],["BRAIN POWER",24,112],["Tomboy",22,120],
+    ["Goodtek",24,126],["Leather",26,178],["Perpetual",24,109],["Big Daddy",23,122],["Pirate",21,130],
+    ["Darkside of The Mind",25,120],["Break Through Myself feat. Risa Yuzuki",25,126],["Jupin - SHORT CUT -",23,48],
+    ["MURDOCH",24,101],["Papasito (feat.  KuTiNA) - FULL SONG -",23,245],["Gargoyle - FULL SONG -",25,378],
+    ["Nade Nade",24,122],["Kasou Shinja",24,119],["New Rose",23,119],["Festival of Death Moon",23,116],
+    ["Chobit Flavor",24,113],["Pump me Amadeus",24,98],["Destr0yer",24,161],["Galaxy Collapse",24,124],
+    ["Imprinting",24,117],["Canon D - FULL SONG -",24,198],["Dignity",24,110],
+    ["Allegro Con Fuoco - FULL SONG -",25,275],["Baroque Virus - FULL SONG -",23,318],["R.I.P",24,127],
+    ["Uh-Heung",24,120],["Gun Rock",24,100],["Fire Noodle Challenge",25,150],["PRiMA MATERiA",24,127],
+    ["Horang Pungryuga",24,126],["Further",25,118],["Beethoven Virus",24,100],["Solfeggietto",25,105],
+    ["Phalanx \"RS2018 edit\"",24,118],["Hercules",24,117],["ERRORCODE: 0",24,182],["Vector",24,113],
+    ["A Site De La Rue",24,99],["The Quick Brown Fox Jumps Over The Lazy Dog",24,110]
+  ].map(function(c,i){ return {id:i, title:c[0], level:c[1], secs:c[2]}; });
+
+  function find(title, level){ return POOL.filter(function(c){ return c.title===title && c.level===level; })[0]; }
+
+  // A draft mid-entry. Real charts and real scores from 김재현's Winter 2025 session, plus one
+  // deliberately weak play so the zero-point rule is visible.
+  var entered = [
+    {c:find("Love is a Danger Zone pt. 2 - SHORT CUT -",23), score:973872, broke:false, plate:"FG"},
+    {c:find("Slam",24), score:976489, broke:false, plate:"FG"},
+    {c:find("DUEL",24), score:955044, broke:false, plate:"FG"},
+    {c:find("Dignity",24), score:742000, broke:true},
+    {c:find("Adrenaline Blaster",23), score:976959, broke:false, plate:"TG"},
+    {c:find("Queencard",22), score:991718, broke:false, plate:"MG"},
+    {c:find("Telling Fortune Flower",23), score:979705, broke:false, plate:"MG"},
+    {c:find("8 6 - FULL SONG -",23), score:962566, broke:false, plate:"RG"},
+    {c:find("FLVSH OUT",23), score:979784, broke:false, plate:"TG"},
+    {c:find("Pop Sequence",23), score:960218, broke:false, plate:"RG"},
+    {c:find("Meteo5cience (GADGET mix)",22), score:950141, broke:false, plate:"RG"},
+    {c:find("Point Break",23), score:971005, broke:false, plate:"FG"}
+  ];
+
+  function ptsOf(e){ return points(e.c.level, e.c.secs, e.score); }
+  // A zero-point play is a non-play: it does not count toward chart count and does not block
+  // replaying that chart. It still consumes the window (plan doc §1).
+  function isZero(e){ return ptsOf(e) === 0; }
+  function playedSecs(){ return entered.reduce(function(a,e){ return a+e.c.secs; }, 0); }
+  function scoringCount(){ return entered.filter(function(e){ return !isZero(e); }).length; }
+  function totalPts(){ return entered.reduce(function(a,e){ return a+ptsOf(e); }, 0); }
+  // The repeat ban keys on song + chart type + level, so the same song at another level is legal.
+  function used(c){ return entered.some(function(e){ return e.c.id===c.id && !isZero(e); }); }
+
+  // The window governs when a song may START, not when it must finish (owner, 2026-08-11) —
+  // closing a session on Gargoyle FULL SONG is the standard play. So the test is whether there is
+  // any window left at all, and the candidate's own length never enters into it. Every chart
+  // is provisionally the last one; adding another is what makes the previous one's full length
+  // binding, and that is the same check one chart later.
+  function fits(){ return playedSecs() < MAXTIME; }
+  // How far the final chart runs past the window, if it does.
+  function overhang(){ return Math.max(0, playedSecs() - MAXTIME); }
+
+  var ICON_DEL = '<svg viewBox="0 0 24 24"><path d="M6 19a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>';
+  var ICON_UP  = '<svg viewBox="0 0 24 24"><path d="M12 8l6 6H6z"/></svg>';
+  var ICON_DN  = '<svg viewBox="0 0 24 24"><path d="M12 16l-6-6h12z"/></svg>';
+
+  function renderBudget(){
+    var p = playedSecs(), over = overhang(), left = Math.max(0, MAXTIME - p);
+    document.getElementById("used").textContent = hms(Math.min(p, MAXTIME));
+    document.getElementById("left").textContent = over ? "—" : hms(left);
+    document.getElementById("mplayed").style.width = (Math.min(p,MAXTIME)/MAXTIME*100)+"%";
+    var q = current && current.secs && fits() ? Math.min(current.secs, left) : 0;
+    document.getElementById("mpending").style.width = (q/MAXTIME*100)+"%";
+
+    var msg;
+    if (over) {
+      msg = '<b>'+entered.length+'</b> charts entered. Your last chart ran <b>'+mmss(over)
+          + '</b> past the window, which is allowed — a song you started in time counts in full.';
+    } else if (!fits()) {
+      msg = '<b>'+entered.length+'</b> charts entered, and the window is exactly full. '
+          + 'Nothing more can be started.';
+    } else {
+      msg = '<b>'+entered.length+'</b> charts entered · <b>'+hms(left)+'</b> of the window unclaimed. '
+          + 'Whatever you do not fill with songs is recorded as rest.'
+          + (q ? ' <span style="color:var(--mix-primary)">Adding this chart uses '+mmss(q)+' of it.</span>' : '');
+    }
+    document.getElementById("blegend").innerHTML = msg;
+  }
+
+  function renderList(){
+    var el = document.getElementById("list");
+    if (!entered.length){
+      el.innerHTML = '<div class="emptylist">Nothing yet. Find your first chart above — or import the whole session from PIUGAME.</div>';
+    } else {
+      // Newest first: during entry you are checking what you just typed, not reading the arc.
+      // The ordinal keeps the real play order unambiguous.
+      var rows = entered.map(function(e,i){ return {e:e,i:i}; }).reverse();
+      el.innerHTML = '<div class="rows">' + rows.map(function(x){
+        var e=x.e, i=x.i, pts=ptsOf(e), z=pts===0, g=grade(e.score);
+        // The zero case says "scores zero" and stops; the row is already amber and its points
+        // already read 0. The reason why lives in the tooltip, not in the table.
+        var zTip = "A play graded A or below scores zero on Phoenix. It does not count toward your "
+                 + "chart count and you may play the chart again — but it still used your window.";
+        return '<div class="erow'+(z?" zero":"")+'"'+(z?' title="'+zTip+'"':'')+'>'
+          + '<span class="ord num">'+(i+1)+'</span>'
+          + bub(e.c.level)
+          + '<span class="ename"><span class="t" title="'+esc(e.c.title)+'">'+esc(e.c.title)+'</span>'
+            + '<span class="s'+(z?" warn":"")+'">'+n(e.score)+' · '+mmss(e.c.secs)
+            + (e.broke ? ' · <span style="color:var(--mix-secondary)">broken</span>'
+                       : e.plate ? ' · <span style="color:'+plateColor(e.plate)+'">'+e.plate+'</span>' : '')
+            + (z?' · scores zero':'')+'</span></span>'
+          + '<span class="egrade" style="color:'+gradeColor(g)+'">'+g+'</span>'
+          + '<span class="epts num'+(z?" zero":"")+'">'+n(pts)+'</span>'
+          + '<span class="eact">'
+            + '<button type="button" class="iconbtn" data-up="'+i+'" aria-label="Move earlier" '+(i===0?'disabled':'')+'>'+ICON_UP+'</button>'
+            + '<button type="button" class="iconbtn" data-dn="'+i+'" aria-label="Move later" '+(i===entered.length-1?'disabled':'')+'>'+ICON_DN+'</button>'
+            + '<button type="button" class="iconbtn" data-del="'+i+'" aria-label="Remove">'+ICON_DEL+'</button>'
+          + '</span></div>';
+      }).join("") + '</div>';
+    }
+    var t = totalPts(), c = scoringCount();
+    document.getElementById("total").innerHTML = n(t)+'<small>points · '+c+' chart'+(c===1?'':'s')+'</small>';
+    document.getElementById("totalsub");
+    document.getElementById("fsum").innerHTML =
+      '<b>'+n(t)+'</b> points across <b>'+c+'</b> charts · '+hms(playedSecs())+' played';
+    document.getElementById("publish").disabled = c < 1;
+  }
+
+  /* ---- the chart picker ---- */
+  var q = document.getElementById("q"), sc = document.getElementById("sc"),
+      sugg = document.getElementById("sugg"), addBtn = document.getElementById("add"),
+      res = document.getElementById("res");
+  var current = null, hi = -1, matches = [];
+
+  function search(term){
+    term = term.trim().toLowerCase();
+    if (!term) return [];
+    return POOL.filter(function(c){ return c.title.toLowerCase().indexOf(term) > -1; })
+      // Charts already banked drop out entirely — the repeat ban. Charts that cannot fit stay
+      // visible but disabled, because "why is this missing" is a worse question than "why is
+      // this greyed out", and the answer is printed beside it.
+      .filter(function(c){ return !used(c); })
+      .sort(function(a,b){ return a.title.localeCompare(b.title) || a.level-b.level; })
+      .slice(0, 40);
+  }
+  function renderSugg(){
+    // Emptied, not just hidden: a hidden listbox still holding its last options is markup a
+    // screen reader can reach and a test will happily read back as a live result.
+    if (!matches.length){ sugg.innerHTML = ""; sugg.hidden = true; q.setAttribute("aria-expanded","false"); return; }
+    // No per-row "will not fit": the window governs whether ANY chart may start, so it is one
+    // state for the whole picker rather than a property of the candidate. The banner says it.
+    var ok = fits();
+    sugg.innerHTML = matches.map(function(c,i){
+      return '<button type="button" role="option" data-pick="'+c.id+'" '+(ok?"":"disabled")+' class="'+(i===hi?"on":"")+'">'
+        + bub(c.level) + '<span style="min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'+esc(c.title)+'</span>'
+        + '<span class="len">'+mmss(c.secs)+'</span></button>';
+    }).join("");
+    sugg.hidden = false; q.setAttribute("aria-expanded","true");
+  }
+  function pick(id){
+    current = POOL.filter(function(c){ return c.id===id; })[0];
+    q.value = current.title + "  ·  D" + current.level;
+    sugg.hidden = true; hi = -1; matches = [];
+    renderBudget(); refreshAdd(); sc.focus();
+  }
+  function refreshAdd(){
+    var scoreOk = /^\d{1,7}$/.test(sc.value.replace(/,/g,"")) && +sc.value.replace(/,/g,"") <= 1000000;
+    addBtn.disabled = !(current && scoreOk && fits());
+  }
+  function commit(){
+    if (addBtn.disabled) return;
+    var r = res.value;
+    entered.push({ c:current, score:+sc.value.replace(/,/g,""),
+                   broke: r==="BROKEN", plate: (r && r!=="BROKEN") ? r : null });
+    current = null; q.value = ""; sc.value = ""; res.value = "";
+    matches = []; sugg.innerHTML = ""; sugg.hidden = true;
+    renderList(); renderBudget(); refreshAdd();
+    q.focus();  // straight back to the top of the loop
+  }
+
+  q.addEventListener("input", function(){ current = null; hi = -1; matches = search(q.value); renderSugg(); refreshAdd(); });
+  q.addEventListener("keydown", function(e){
+    if (sugg.hidden) return;
+    if (e.key==="ArrowDown"){ e.preventDefault(); hi = Math.min(hi+1, matches.length-1); renderSugg(); }
+    else if (e.key==="ArrowUp"){ e.preventDefault(); hi = Math.max(hi-1, 0); renderSugg(); }
+    else if (e.key==="Enter" && hi>=0 && fits()){ e.preventDefault(); pick(matches[hi].id); }
+    else if (e.key==="Escape"){ sugg.hidden = true; }
+  });
+  sc.addEventListener("input", refreshAdd);
+  sc.addEventListener("keydown", function(e){
+    // Shift+Enter files it as broken without reaching for the dropdown.
+    if (e.key!=="Enter") return;
+    e.preventDefault();
+    if (e.shiftKey) res.value = "BROKEN";
+    commit();
+  });
+  res.addEventListener("keydown", function(e){ if (e.key==="Enter"){ e.preventDefault(); commit(); } });
+  addBtn.addEventListener("click", commit);
+
+  document.addEventListener("click", function(e){
+    var p = e.target.closest ? e.target.closest("[data-pick]") : null;
+    if (p && !p.disabled){ pick(+p.dataset.pick); return; }
+    if (!sugg.hidden && !sugg.contains(e.target) && e.target!==q) sugg.hidden = true;
+
+    var del = e.target.closest ? e.target.closest("[data-del]") : null;
+    if (del){ entered.splice(+del.dataset.del,1); renderList(); renderBudget(); return; }
+    var up = e.target.closest ? e.target.closest("[data-up]") : null;
+    if (up){ var i=+up.dataset.up; entered.splice(i-1,0,entered.splice(i,1)[0]); renderList(); return; }
+    var dn = e.target.closest ? e.target.closest("[data-dn]") : null;
+    if (dn){ var j=+dn.dataset.dn; entered.splice(j+1,0,entered.splice(j,1)[0]); renderList(); }
+  });
+
+  /* ---- publish / discard ---- */
+  var pubdlg = document.getElementById("pubdlg"), disdlg = document.getElementById("disdlg");
+  document.getElementById("publish").addEventListener("click", function(){ pubdlg.showModal(); });
+  document.getElementById("pubcancel").addEventListener("click", function(){ pubdlg.close(); });
+  document.getElementById("pubgo").addEventListener("click", function(){ pubdlg.close(); });
+  document.getElementById("discard").addEventListener("click", function(){
+    document.getElementById("distext").textContent =
+      entered.length
+        ? "The "+entered.length+" charts you have entered go away and cannot be recovered. Nothing was ever on the board."
+        : "Nothing has been entered yet, so there is nothing to lose.";
+    disdlg.showModal();
+  });
+  document.getElementById("discancel").addEventListener("click", function(){ disdlg.close(); });
+  document.getElementById("disgo").addEventListener("click", function(){ disdlg.close(); });
+  /* ================= import =================
+     What PIUGAME hands back is an undifferentiated list of recent plays, so the work is
+     deciding which of them were the session. Timestamps make that answerable: a session is a
+     contiguous block, and the boundaries are the big gaps either side of it. Before Slice 5
+     lands there are no timestamps, and this degrades to picking the first and last play by
+     hand — which is what the page does today, and why it needs a range picker at all. */
+  var GAP_BREAK = 15*60;   // a gap longer than this is not a rest, it is a different visit
+
+  // A plausible day on the machine: a short warm-up, the session, and a few plays afterwards.
+  // The session's charts and scores are 김재현's real Winter 2025 session.
+  var RECENT = (function(){
+    var out = [], t = 0;
+    function push(title, level, score, rest){
+      var c = POOL.filter(function(x){ return x.title===title && x.level===level; })[0];
+      if (c) out.push({ c:c, score:score, at:t });
+      t += (c?c.secs:120) + rest;
+    }
+    push("Tomboy",22,948120,42); push("Pirate",21,961044,38); push("Queencard",22,955310,51);
+    t += 3*3600 + 41*60;                       // went away for most of the afternoon
+    var session = [["Love is a Danger Zone pt. 2 - SHORT CUT -",23,973872],["Slam",24,976489],
+      ["DUEL",24,955044],["Adrenaline Blaster",23,976959],["Queencard",22,991718],
+      ["Telling Fortune Flower",23,979705],["8 6 - FULL SONG -",23,962566],["FLVSH OUT",23,979784],
+      ["Pop Sequence",23,960218],["Final Audition Ep. 2-X",24,927315],["Meteo5cience (GADGET mix)",22,950141],
+      ["Point Break",23,971005],["Annihilator Method",24,958243],
+      ["Pneumonoultramicroscopicsilicovolcanoconiosis ft. Kagamine Len/GUMI",22,972450],
+      ["Can-can ~Orpheus in The Party Mix~ - SHORT CUT -",25,952491],["MEGAHEARTZ",25,902836],
+      ["Boca",25,915890],["Odin",23,976240],["Underworld ft. Skizzo (PIU Edit.)",23,984346],
+      ["Underworld ft. Skizzo (PIU Edit.)",25,941971],["GLORIA",25,945885],
+      ["Kokugen Kairou Labyrinth",26,906317],["BRAIN POWER",24,943862],["Tomboy",22,962577],
+      ["Goodtek",24,928890],["Leather",26,888018],["Perpetual",24,945530],["Big Daddy",23,964066],
+      ["Pirate",21,987859],["Darkside of The Mind",25,941887],
+      ["Break Through Myself feat. Risa Yuzuki",25,919911],["Jupin - SHORT CUT -",23,982585],
+      ["MURDOCH",24,938435],["Papasito (feat.  KuTiNA) - FULL SONG -",23,974365],
+      ["Gargoyle - FULL SONG -",25,844710],["Nade Nade",24,950843],["Kasou Shinja",24,969602],
+      ["New Rose",23,960378],["Festival of Death Moon",23,953445]];
+    var rests = [28,34,41,29,37,52,31,45];
+    session.forEach(function(r,i){
+      // one real breather in the middle, which is what pushes the wall-clock span over 1:45
+      push(r[0], r[1], r[2], i===19 ? 320 : rests[i % rests.length]);
+    });
+    t += 2*3600 + 8*60;                        // came back later that night
+    push("Vector",24,939200,44); push("Hercules",24,944870,0);
+    return out;
+  })();
+  // Two rows the matcher could not resolve — the real import returns these separately.
+  var UNMAPPED = ["Sarabande FULL SONG (D24?)", "Witch Doctor #1 - SHORT CUT - (D21?)"];
+
+  // Blocks are stretches of plays with no break longer than GAP_BREAK between them.
+  function blocks(){
+    var b = [[0]];
+    for (var i=1;i<RECENT.length;i++){
+      var prev = RECENT[i-1], gap = RECENT[i].at - (prev.at + prev.c.secs);
+      if (gap > GAP_BREAK) b.push([i]); else b[b.length-1].push(i);
+    }
+    return b;
+  }
+  function gapBefore(i){
+    if (i===0) return null;
+    var p = RECENT[i-1];
+    return RECENT[i].at - (p.at + p.c.secs);
+  }
+  function clock(sec){
+    var base = 16*3600 + 12*60;      // the first play of the day, 16:12
+    var s = base + sec, h = Math.floor(s/3600)%24, m = Math.floor(s%3600/60), r = Math.floor(s%60);
+    return (h<10?"0":"")+h+":"+(m<10?"0":"")+m+":"+(r<10?"0":"")+r;
+  }
+
+  var impStart = 0, impEnd = 0;
+
+  function impSelection(){
+    var sel = [];
+    for (var i=impStart;i<=impEnd;i++) sel.push(RECENT[i]);
+    return sel;
+  }
+  function impSongSecs(){ return impSelection().reduce(function(a,p){ return a+p.c.secs; }, 0); }
+  function impSpan(){
+    var a = RECENT[impStart], z = RECENT[impEnd];
+    return (z.at + z.c.secs) - a.at;
+  }
+
+  function renderImp(){
+    document.getElementById("implist").innerHTML = RECENT.map(function(p,i){
+      var g = gapBefore(i), sep = "";
+      if (g !== null && g > GAP_BREAK){
+        var hrs = Math.floor(g/3600), mins = Math.round(g%3600/60);
+        sep = '<div class="imp-gap">'+(hrs?hrs+"h ":"")+mins+"m gap</div>";
+      }
+      var inSel = i>=impStart && i<=impEnd, edge = i===impStart || i===impEnd;
+      return sep + '<div class="imp-row'+(inSel?" in":"")+(inSel&&edge?" edge":"")+'" data-imp="'+i+'" role="button" tabindex="0">'
+        + '<span class="tm">'+clock(p.at)+'</span>'
+        + bub(p.c.level)
+        + '<span class="nm" title="'+esc(p.c.title)+'">'+esc(p.c.title)+'</span>'
+        + '<span class="sc num">'+n(p.score)+'</span></div>';
+    }).join("");
+
+    var count = impEnd - impStart + 1, songs = impSongSecs(), span = impSpan();
+    document.getElementById("impn").textContent = count;
+    document.getElementById("impk").innerHTML =
+      'plays selected · <b>'+hms(songs)+'</b> of songs · <b>'+hms(span)+'</b> from first to last';
+
+    // Hard block: everything BEFORE the last play has to start inside the window, so it is the
+    // song time excluding the final chart that cannot exceed it — the last one may overhang.
+    // Soft warning: the wall-clock span may exceed it, and that is a judgement call (D10).
+    var last = RECENT[impEnd], songsBeforeLast = songs - last.c.secs;
+    var over = songsBeforeLast > MAXTIME, longSpan = span > MAXTIME;
+    var w = "";
+    if (over) w = '<div class="imp-warn"><b>Too long to import.</b> Everything before the last play '
+      + 'is already '+hms(songsBeforeLast)+' of songs, past the 1:45:00 window. Move an end in.</div>';
+    else if (longSpan) {
+      // Naming the biggest gap inside the selection beats telling someone to trim an end:
+      // the break that blew the window is usually in the middle, where no end reaches it.
+      var big = 0, bigAt = impStart;
+      for (var i=impStart+1;i<=impEnd;i++){ var g = gapBefore(i); if (g > big){ big = g; bigAt = i; } }
+      w = '<div class="imp-warn"><b>These plays span '+hms(span)+'</b>, and a session window is '
+        + '1:45:00. Your longest break inside it was <b>'+mmss(big)+'</b>, before '
+        + esc(RECENT[bigAt].c.title)+' at '+clock(RECENT[bigAt].at)+'. Import it anyway if that '
+        + 'was part of the session.</div>';
+    }
+    document.getElementById("impwarn").innerHTML = w;
+    document.getElementById("impbad").innerHTML = UNMAPPED.length
+      ? '<b>'+UNMAPPED.length+' plays could not be matched to a chart</b> and will not be imported: '
+        + UNMAPPED.map(esc).join(", ") + '. Add them by hand if they were part of the session.'
+      : "";
+    var go = document.getElementById("impgo");
+    go.disabled = over || count < 1;
+    go.textContent = "Add "+count+" chart"+(count===1?"":"s");
+  }
+
+  /* One click is only the STORED case. With nothing saved this is a username, a password and a
+     button — and nothing here offers to save them: remembering a credential is the Import Scores
+     page's job, and a second surface that stores passwords is a second surface to get wrong. */
+  var hasStored = true;
+  var LOCK = '<svg viewBox="0 0 24 24"><path d="M18 8h-1V6a5 5 0 0 0-10 0v2H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2zM9 6a3 3 0 0 1 6 0v2H9V6zm3 12a2 2 0 1 1 0-4 2 2 0 0 1 0 4z"/></svg>';
+
+  function renderImportRow(){
+    var el = document.getElementById("importrow");
+    if (hasStored){
+      el.innerHTML =
+        '<div><div class="t">Played on a machine linked to your PIUGAME account?</div>'
+        + '<div class="s">Import reads your recent scores and picks out the session.</div></div>'
+        + '<span class="lockchip">'+LOCK+'Saved on this device</span>'
+        + '<button type="button" class="btn ghost" style="margin-left:auto" id="importbtn">Import from PIUGAME</button>';
+    } else {
+      el.innerHTML =
+        '<div style="width:100%"><div class="t">Played on a machine linked to your PIUGAME account?</div>'
+        + '<div class="s">Sign in to PIUGAME and Import reads your recent scores and picks out the session. '
+        + 'Save it once on <a href="#">Import Scores</a> and this becomes one button.</div></div>'
+        + '<div class="credfields">'
+        + '<div class="field"><label for="piuu">PIUGAME.com username</label><input id="piuu" type="text" autocomplete="username"/></div>'
+        + '<div class="field"><label for="piup">PIUGAME.com password</label><input id="piup" type="password" autocomplete="current-password"/></div>'
+        + '<button type="button" class="btn ghost" id="importbtn" disabled>Import</button></div>';
+      var u = document.getElementById("piuu"), p = document.getElementById("piup");
+      var sync = function(){ document.getElementById("importbtn").disabled = !(u.value.trim() && p.value); };
+      u.addEventListener("input", sync); p.addEventListener("input", sync);
+    }
+  }
+
+  document.addEventListener("click", function(e){
+    if (!e.target.closest || !e.target.closest("#importbtn")) return;
+    startImport();
+  });
+
+  function startImport(){
+    document.getElementById("imploading").innerHTML = '<div class="spin"></div>'
+      + (hasStored
+          ? 'Signing in as <b>DRMURLOC#7251</b> — no password to type, this device already has it.'
+          : 'Signing in to PIUGAME…');
+    document.getElementById("imploading").hidden = false;
+    document.getElementById("impbody").hidden = true;
+    document.getElementById("impgo").disabled = true;
+    document.getElementById("impsub").textContent = "Reading your recent scores…";
+    document.getElementById("impdlg").showModal();
+    setTimeout(function(){
+      var bs = blocks();
+      // The session is the longest block that could plausibly be one — ties go to the most recent.
+      var best = bs[0];
+      bs.forEach(function(b){ if (b.length >= best.length) best = b; });
+      impStart = best[0]; impEnd = best[best.length-1];
+      document.getElementById("imploading").hidden = true;
+      document.getElementById("impbody").hidden = false;
+      document.getElementById("impsub").textContent =
+        "Read " + RECENT.length + " recent plays. The session below is the block between your two longest breaks.";
+      renderImp();
+    }, 900);
+  }
+
+  document.getElementById("implist").addEventListener("click", function(e){
+    var r = e.target.closest ? e.target.closest("[data-imp]") : null;
+    if (!r) return;
+    var i = +r.dataset.imp;
+    // Whichever end is nearer is the one that moves — one click, no handles to grab.
+    if (Math.abs(i-impStart) <= Math.abs(i-impEnd)) impStart = Math.min(i, impEnd);
+    else impEnd = Math.max(i, impStart);
+    renderImp();
+  });
+  document.getElementById("impcancel").addEventListener("click", function(){
+    document.getElementById("impdlg").close();
+  });
+  document.getElementById("impgo").addEventListener("click", function(){
+    impSelection().forEach(function(p){
+      if (!used(p.c) && fits()) entered.push({ c:p.c, score:p.score, broke:false, plate:null });
+    });
+    document.getElementById("impdlg").close();
+    renderList(); renderBudget();
+  });
+
+  document.getElementById("credflip").addEventListener("click", function(){
+    hasStored = !hasStored;
+    this.textContent = hasStored ? "Show: no saved password" : "Show: password saved";
+    renderImportRow();
+  });
+
+  renderImportRow(); renderList(); renderBudget();
+</script>

--- a/docs/design/march-of-murlocs-mocks/4-planner.html
+++ b/docs/design/march-of-murlocs-mocks/4-planner.html
@@ -1,0 +1,927 @@
+<title>MoM — Planner mock</title>
+<style>
+  :root {
+    --mix-bg:#070B15; --mix-surface:#161E2C; --mix-raised:#1E2A3D; --mix-nav:#0D1626;
+    --mix-primary:#3FA9F5; --mix-secondary:#FF6B35; --mix-accent:#FFD24A;
+    --mix-ink:#E9EFF7; --mix-muted:#93A3B8;
+    --chart-single:#FF6B35; --chart-double:#38B6FF;
+    --rar-emerald:#3FD35A; --rar-gold:#FFD24A; --rar-silver:#CBD5E1; --rar-sapphire:#38B6FF; --rar-common:#8B98A9;
+    --diff-easy:#7CB342; --diff-medium:#FDD835; --diff-hard:#FB8C00; --diff-veryhard:#E53935;
+    --warn:#FFB020; --bad:#FF3B5C;
+    --line:rgba(233,239,247,.12); --line-strong:rgba(233,239,247,.22);
+    --display:"Barlow Condensed","Oswald","Roboto Condensed","Arial Narrow",system-ui,sans-serif;
+    --body:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"], :root[data-theme="dark"] { color-scheme: dark; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--mix-bg); color:var(--mix-ink); font-family:var(--body);
+         font-size:15px; line-height:1.5; -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:1060px; margin:0 auto; padding:16px 16px 110px; }
+  .num { font-variant-numeric:tabular-nums; }
+  h1,h2,h3 { font-family:var(--display); font-weight:600; margin:0; text-wrap:balance; }
+
+  .mockbar { background:#12203a; border-bottom:1px solid var(--line); padding:9px 16px; font-size:12.5px;
+             color:var(--mix-muted); display:flex; flex-wrap:wrap; gap:6px 14px; align-items:center; }
+  .mockbar b { color:var(--mix-ink); font-weight:600; }
+  .note { border-left:2px solid var(--mix-accent); background:rgba(255,210,74,.06); padding:9px 13px;
+          margin:0; border-radius:0 5px 5px 0; font-size:13px; color:#E4D9BC; }
+  .note b { color:var(--mix-accent); font-weight:600; }
+
+  .frame-head { display:flex; align-items:flex-end; gap:14px; flex-wrap:wrap;
+                border-bottom:1px solid var(--line); padding-bottom:11px; }
+  .frame-title { font-family:var(--display); font-size:34px; font-weight:700; line-height:1; }
+  .frame-nav { display:flex; gap:4px; margin-left:auto; flex-wrap:wrap; }
+  .frame-nav a { color:var(--mix-muted); text-decoration:none; font-size:13px; padding:5px 10px; border-radius:5px; }
+  .frame-nav a:hover { color:var(--mix-ink); background:var(--mix-raised); }
+  .frame-nav a[aria-current] { color:var(--mix-ink); background:var(--mix-raised); }
+
+  h2.sec { font-size:13px; letter-spacing:.14em; text-transform:uppercase; color:var(--mix-muted);
+           font-family:var(--body); font-weight:600; margin:26px 0 11px;
+           display:flex; align-items:center; gap:10px; }
+  h2.sec::after { content:""; flex:1; height:1px; background:var(--line); }
+
+  /* ---------- controls ---------- */
+  .controls { display:flex; align-items:flex-end; gap:16px 22px; flex-wrap:wrap; margin-top:16px;
+              background:var(--mix-surface); border:1px solid var(--line); border-radius:8px; padding:14px 16px; }
+  .ctl label { display:block; font-size:10.5px; letter-spacing:.1em; text-transform:uppercase;
+               color:var(--mix-muted); margin-bottom:5px; }
+  .typegroup { display:inline-flex; }
+  .typegroup button { background:transparent; color:var(--mix-primary); border:1px solid var(--mix-primary);
+    font:inherit; font-size:13px; font-weight:600; padding:5px 15px; cursor:pointer; letter-spacing:.02em; }
+  .typegroup button:first-child { border-radius:5px 0 0 5px; }
+  .typegroup button:last-child { border-radius:0 5px 5px 0; margin-left:-1px; }
+  .typegroup button[aria-pressed="true"] { background:var(--mix-primary); color:#06101C; }
+  .typegroup button:focus-visible { outline:2px solid var(--mix-ink); outline-offset:-2px; z-index:1; }
+  .restwrap { display:flex; align-items:center; gap:11px; }
+  input[type=range] { width:200px; accent-color:var(--mix-primary); }
+  .restval { font-family:var(--display); font-size:24px; font-weight:700; min-width:52px; font-variant-numeric:tabular-nums; }
+  .btn { background:var(--mix-primary); color:#06101C; border:0; border-radius:6px; font:inherit;
+         font-size:13.5px; font-weight:600; padding:9px 16px; cursor:pointer; white-space:nowrap; }
+  .btn.ghost { background:transparent; color:var(--mix-ink); border:1px solid var(--line-strong); }
+  .btn:disabled { opacity:.45; cursor:not-allowed; }
+  .btn:focus-visible { outline:2px solid var(--mix-primary); outline-offset:2px; }
+
+  /* ---------- projection ---------- */
+  .proj { display:grid; grid-template-columns:auto 1fr; gap:18px 24px; align-items:center;
+          background:linear-gradient(180deg,rgba(63,169,245,.10),var(--mix-surface) 70%);
+          border:1px solid rgba(63,169,245,.34); border-radius:9px; padding:16px 18px; margin-top:14px; }
+  .proj-total { font-family:var(--display); line-height:1; }
+  .proj-total .n { font-size:50px; font-weight:700; color:var(--mix-accent); }
+  .proj-total .k { font-family:var(--body); font-size:11px; letter-spacing:.11em; text-transform:uppercase;
+                   color:var(--mix-muted); margin-top:5px; }
+  .proj-nums { display:grid; grid-template-columns:repeat(4,1fr); gap:12px; }
+  .pn .k { font-size:10.5px; letter-spacing:.1em; text-transform:uppercase; color:var(--mix-muted); }
+  .pn .v { font-family:var(--display); font-size:25px; font-weight:700; line-height:1.05; font-variant-numeric:tabular-nums; }
+  .pn .d { font-size:11.5px; font-variant-numeric:tabular-nums; }
+  .up { color:var(--rar-emerald); } .down { color:var(--mix-secondary); } .flat { color:var(--mix-muted); }
+  .overwarn { margin-top:11px; padding:9px 13px; border-radius:6px; font-size:13px;
+              background:rgba(255,176,32,.09); border:1px solid rgba(255,176,32,.35); color:#E8CF9E; }
+  .overwarn b { color:var(--warn); }
+
+  .versus { margin-top:12px; background:var(--mix-surface); border:1px solid var(--line);
+            border-radius:8px; padding:13px 16px; font-size:13.5px; color:#C6D3E2; }
+  .versus b { color:var(--mix-ink); }
+  .conv { display:flex; align-items:center; gap:12px; margin-top:9px; flex-wrap:wrap; }
+  .convbar { flex:1; min-width:170px; height:9px; border-radius:5px; background:var(--mix-raised); overflow:hidden; }
+  .convbar i { display:block; height:100%; background:linear-gradient(90deg,var(--mix-primary),var(--mix-accent)); }
+  .convpct { font-family:var(--display); font-size:22px; font-weight:700; font-variant-numeric:tabular-nums; }
+
+  /* ---------- list toolbar ---------- */
+  .listbar { display:flex; align-items:center; gap:10px; flex-wrap:wrap; margin-bottom:11px; }
+  .denbtns { display:inline-flex; gap:2px; }
+  .denbtns button { background:transparent; border:0; border-radius:5px; padding:5px; color:var(--mix-muted);
+                    cursor:pointer; display:grid; place-items:center; }
+  .denbtns button svg { width:19px; height:19px; fill:currentColor; }
+  .denbtns button:hover { color:var(--mix-ink); }
+  .denbtns button[aria-pressed="true"] { color:var(--mix-primary); }
+  .denbtns button:focus-visible { outline:2px solid var(--mix-primary); outline-offset:1px; }
+  .segmented { display:inline-flex; border:1px solid var(--line-strong); border-radius:6px; overflow:hidden; }
+  .segmented button { background:transparent; border:0; color:var(--mix-muted); font:inherit; font-size:12.5px;
+                      padding:6px 12px; cursor:pointer; }
+  .segmented button[aria-pressed="true"] { background:var(--mix-raised); color:var(--mix-ink); }
+  .segmented button:focus-visible { outline:2px solid var(--mix-primary); outline-offset:-2px; }
+  .sortwrap { position:relative; }
+  .sortbtn { display:inline-flex; align-items:center; gap:6px; background:transparent;
+             border:1px solid var(--line-strong); border-radius:6px; color:var(--mix-ink); font:inherit;
+             font-size:12.5px; padding:6px 11px; cursor:pointer; }
+  .sortbtn:hover { border-color:var(--mix-primary); }
+  .sortbtn svg { width:15px; height:15px; fill:currentColor; }
+  .sortbtn .cur { color:var(--mix-muted); }
+  .sortmenu { position:absolute; z-index:40; top:calc(100% + 5px); left:0; min-width:210px;
+              background:var(--mix-raised); border:1px solid var(--line-strong); border-radius:7px;
+              padding:5px; box-shadow:0 10px 26px rgba(0,0,0,.5); }
+  .sortmenu[hidden] { display:none; }
+  .sortmenu button { display:flex; width:100%; align-items:center; gap:8px; background:transparent; border:0;
+                     color:var(--mix-ink); font:inherit; font-size:13px; text-align:left; padding:7px 9px;
+                     border-radius:5px; cursor:pointer; }
+  .sortmenu button:hover { background:rgba(63,169,245,.14); }
+  .sortmenu button .tick { width:12px; color:var(--mix-primary); }
+  .listnote { font-size:12.5px; color:var(--mix-muted); flex:1 1 200px; }
+
+  /* ---------- shared chart bits ---------- */
+  .jacket { background:repeating-linear-gradient(135deg,#1B2637 0 6px,#16202F 6px 12px);
+            border:1px solid var(--line); display:grid; place-items:center; font-size:8px;
+            color:#4E6076; letter-spacing:.04em; border-radius:4px; flex:none; }
+  .bub { border-radius:4px; display:grid; place-items:center; font-family:var(--display); font-weight:700;
+         color:#0B0F17; flex:none; }
+  .gradeicon { font-family:var(--display); font-weight:700; line-height:1; }
+
+  /* ---------- comfortable ---------- */
+  .cards { display:grid; grid-template-columns:repeat(auto-fill,minmax(178px,1fr)); gap:12px; }
+  .ccard { background:var(--mix-surface); border:1px solid var(--line); border-radius:8px; overflow:hidden;
+           display:flex; flex-direction:column; }
+  .ccard.on { opacity:1; border-color:rgba(63,169,245,.5); }
+  .ccard-jacket { position:relative; aspect-ratio:1; width:100%; cursor:pointer; }
+  .ccard-jacket .jacket { width:100%; height:100%; border:0; border-radius:0; }
+  .ccard-jacket .bub { position:absolute; top:5px; left:5px; width:38px; height:25px; font-size:14px; }
+  /* Revealed on hover, always present for keyboard — the tier card's play treatment. */
+  .playbtn { position:absolute; inset:0; margin:auto; width:42px; height:42px; border-radius:50%;
+             background:rgba(0,0,0,.62); border:1px solid rgba(233,239,247,.5); color:var(--mix-ink);
+             display:grid; place-items:center; cursor:pointer; opacity:0; transition:opacity .12s; }
+  .ccard-jacket:hover .playbtn, .playbtn:focus-visible { opacity:1; }
+  .playbtn:focus-visible { outline:2px solid var(--mix-primary); outline-offset:2px; }
+  .playbtn svg { width:17px; height:17px; fill:currentColor; margin-left:2px; }
+  .ccard-pick { display:flex; align-items:center; gap:7px; margin-top:3px; padding-top:7px;
+                border-top:1px solid var(--line); font-size:12.5px; color:var(--mix-muted); cursor:pointer; }
+  .ccard.on .ccard-pick { color:var(--mix-primary); }
+  .ccard-body { padding:8px 10px 10px; display:flex; flex-direction:column; gap:4px; }
+  .ccard-name { font-size:13px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .ccard-meta { display:flex; align-items:center; gap:6px; font-variant-numeric:tabular-nums; font-size:12.5px; flex-wrap:wrap; }
+  .ccard-pts { font-family:var(--display); font-size:20px; font-weight:700; line-height:1; }
+  .ccard-sub { font-size:11.5px; color:var(--mix-muted); font-variant-numeric:tabular-nums; }
+
+  /* ---------- compact ---------- */
+  .stickers { display:grid; grid-template-columns:repeat(auto-fill,minmax(78px,1fr)); gap:7px; }
+  .sticker { position:relative; aspect-ratio:1; cursor:pointer; border:0; padding:0; background:none; }
+  .sticker:focus-visible { outline:2px solid var(--mix-primary); outline-offset:2px; }
+  .sticker .jacket { width:100%; height:100%; }
+  .sticker.on .jacket { border-color:var(--mix-primary); box-shadow:0 0 0 1px var(--mix-primary); }
+  .sticker .bub { position:absolute; top:3px; left:3px; width:30px; height:20px; font-size:12px; }
+  .corner { position:absolute; bottom:3px; right:3px; font-family:var(--display); font-weight:700;
+            font-size:12px; line-height:1.25; font-variant-numeric:tabular-nums;
+            background:rgba(0,0,0,.82); padding:1px 5px; border-radius:4px;
+            border:1px solid var(--mix-primary); color:var(--mix-primary); }
+  .corner-start { position:absolute; bottom:3px; left:3px; display:flex; align-items:center; gap:3px;
+                  background:rgba(0,0,0,.82); border:1px solid var(--mix-primary); border-radius:4px; padding:1px 3px; }
+  /* overflow:hidden because the checkmark's ADVANCE width runs wider than its ink, so a 19px
+     circle reports a 22px scroll width while looking perfectly centred. */
+  .sticker .tick { position:absolute; top:3px; right:3px; width:19px; height:19px; border-radius:50%;
+                   display:grid; place-items:center; overflow:hidden; line-height:1;
+                   background:rgba(0,0,0,.7); border:1px solid var(--line-strong);
+                   color:transparent; font-size:11px; font-weight:700; }
+  .sticker.on .tick { background:var(--mix-primary); border-color:var(--mix-primary); color:#06101C; }
+
+  /* ---------- table ---------- */
+  .tablewrap { overflow-x:auto; }
+  table.run { width:100%; border-collapse:collapse; font-variant-numeric:tabular-nums; }
+  table.run th { text-align:left; font-size:11px; letter-spacing:.1em; text-transform:uppercase;
+                 color:var(--mix-muted); font-weight:600; padding:6px 10px 6px 0;
+                 border-bottom:1px solid var(--line-strong); white-space:nowrap; }
+  table.run th button { background:none; border:0; color:inherit; font:inherit; letter-spacing:inherit;
+                        text-transform:inherit; cursor:pointer; padding:0; }
+  table.run th[aria-sort] button { color:var(--mix-ink); }
+  table.run td { padding:4px 10px 4px 0; border-bottom:1px solid var(--line); font-size:13.5px; }
+  table.run tbody tr { cursor:pointer; }
+  table.run tbody tr.on td { box-shadow:inset 2px 0 0 var(--mix-primary); }
+  table.run tbody tr:hover td { background:rgba(63,169,245,.07); }
+  .t-ident { display:flex; align-items:center; gap:8px; min-width:0; }
+  .t-ident .jacket { width:30px; height:30px; }
+  .t-ident .bub { width:34px; height:22px; font-size:12.5px; }
+  .t-name { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .t-r { text-align:right; }
+  .t-grade { display:flex; align-items:center; gap:5px; }
+  .t-score { color:var(--mix-muted); font-size:12.5px; }
+  .cb { width:16px; height:16px; accent-color:var(--mix-primary); }
+
+  /* ---------- action bar ---------- */
+  .actions { position:sticky; bottom:0; margin-top:24px;
+             background:linear-gradient(180deg,rgba(7,11,21,0),var(--mix-bg) 34%); padding-top:18px; }
+  .actions-inner { display:flex; align-items:center; gap:11px; flex-wrap:wrap; background:var(--mix-surface);
+                   border:1px solid var(--line-strong); border-radius:9px; padding:12px 15px; }
+  .actions-sum { font-size:13px; color:var(--mix-muted); }
+  .actions-sum b { color:var(--mix-ink); }
+  .actions-act { margin-left:auto; display:flex; gap:9px; flex-wrap:wrap; }
+  .savedchip { display:inline-flex; align-items:center; gap:6px; font-size:12.5px; color:var(--rar-emerald); }
+
+  /* ---------- dialogs ---------- */
+  dialog { background:var(--mix-surface); color:var(--mix-ink); border:1px solid var(--line-strong);
+           border-radius:10px; padding:0; max-width:520px; width:calc(100% - 32px); }
+  dialog::backdrop { background:rgba(3,6,12,.72); }
+  .dlg-head { display:flex; align-items:center; gap:10px; padding:13px 15px; border-bottom:1px solid var(--line); }
+  .dlg-head .bub { width:42px; height:27px; font-size:15px; }
+  .dlg-title { font-family:var(--display); font-size:21px; font-weight:600; line-height:1.15; min-width:0; }
+  .dlg-body { padding:14px 15px; display:flex; flex-direction:column; gap:12px; }
+  .dlg-video { aspect-ratio:16/9; border-radius:6px; display:grid; place-items:center; text-align:center;
+               background:repeating-linear-gradient(135deg,#101A28 0 8px,#0D1522 8px 16px);
+               border:1px solid var(--line); color:var(--mix-muted); font-size:12.5px; padding:12px; }
+  .dlg-stats { display:grid; grid-template-columns:repeat(auto-fit,minmax(94px,1fr)); gap:10px; }
+  .dlg-stat .k { font-size:10.5px; letter-spacing:.1em; text-transform:uppercase; color:var(--mix-muted); }
+  .dlg-stat .v { font-family:var(--display); font-size:20px; font-weight:600; font-variant-numeric:tabular-nums; }
+  .dlg-actions { display:flex; justify-content:flex-end; gap:9px; padding:0 15px 14px; }
+  .field label { display:block; font-size:10.5px; letter-spacing:.1em; text-transform:uppercase;
+                 color:var(--mix-muted); margin-bottom:4px; }
+  .field input[type=text] { width:100%; background:var(--mix-raised); color:var(--mix-ink);
+    border:1px solid var(--line-strong); border-radius:6px; padding:9px 11px; font:inherit; font-size:14.5px; }
+  .field input[type=text]:focus { outline:2px solid var(--mix-primary); outline-offset:-1px; }
+  .setrow { display:flex; align-items:center; gap:8px; padding:6px 8px; border-radius:5px; }
+  .setrow:hover { background:rgba(63,169,245,.12); }
+  .setrow .load { flex:1; min-width:0; background:none; border:0; color:var(--mix-ink); font:inherit;
+                  font-size:13px; text-align:left; cursor:pointer; padding:0; }
+  .setrow .load small { display:block; color:var(--mix-muted); font-size:11.5px; }
+  .setrow .kill { background:none; border:0; color:var(--mix-muted); cursor:pointer; font-size:15px;
+                  line-height:1; padding:2px 5px; border-radius:4px; }
+  .setrow .kill:hover { color:var(--bad); background:rgba(255,59,92,.12); }
+  .setsempty { padding:9px; font-size:12.5px; color:var(--mix-muted); }
+
+  @media (max-width:859.98px) { .proj { grid-template-columns:1fr; } .proj-nums { grid-template-columns:repeat(2,1fr); } }
+  @media (max-width:699.98px) { .t-name, .ccard-name { display:none; } .col-pps { display:none; } }
+  @media (max-width:499.98px) {
+    .frame-title { font-size:28px; }
+    .proj-total .n { font-size:38px; }
+    input[type=range] { width:140px; }
+    .t-score { display:none; }
+    .t-grade { flex-direction:column; align-items:flex-start; gap:2px; }
+    .stickers { grid-template-columns:repeat(auto-fill,minmax(70px,1fr)); }
+    .cards { grid-template-columns:repeat(auto-fill,minmax(140px,1fr)); }
+  }
+</style>
+
+<div class="mockbar">
+  <b>Slice 1 mock 4 of 6 — Planner</b>
+  <span>/MarchOfMurlocs/Planner</span>
+  <span>김재현's real Phoenix Doubles bests · 129 charts · Winter 2025 balance</span>
+</div>
+
+<div class="wrap">
+
+  <div class="frame-head">
+    <div>
+      <div class="frame-title">Planner</div>
+      <div style="font-size:13px;color:var(--mix-muted);margin-top:3px">
+        Build a set, tune it, and take it to the machine.
+      </div>
+    </div>
+    <nav class="frame-nav">
+      <a href="#">This season</a>
+      <a href="#" aria-current="page">Planner</a>
+      <a href="#">Past seasons</a>
+      <a href="#">Rules</a>
+    </nav>
+  </div>
+
+  <div class="controls">
+    <div class="ctl">
+      <label>Board</label>
+      <div class="typegroup" role="group" aria-label="Chart type">
+        <button type="button" data-type="D" aria-pressed="true">Doubles</button>
+        <button type="button" data-type="S" aria-pressed="false">Singles</button>
+      </div>
+    </div>
+    <div class="ctl">
+      <label for="rest">Rest you need between charts</label>
+      <div class="restwrap">
+        <input id="rest" type="range" min="10" max="120" step="5" value="35"/>
+        <span class="restval num" id="restval">35s</span>
+      </div>
+    </div>
+    <button type="button" class="btn ghost" id="rebuild">Suggest a set</button>
+  </div>
+
+  <div class="proj">
+    <div class="proj-total"><div class="n num" id="ptotal">0</div><div class="k">projected points</div></div>
+    <div class="proj-nums" id="pnums"></div>
+  </div>
+  <div id="overwarn"></div>
+
+  <div class="versus" id="versus"></div>
+
+  <h2 class="sec">Your set</h2>
+  <div class="listbar">
+    <div class="denbtns" role="group" aria-label="Density">
+      <button type="button" data-den="Comfortable" aria-pressed="false" title="Comfortable" aria-label="Comfortable">
+        <svg viewBox="0 0 24 24"><path d="M3 9h4V5H3v4zm0 5h4v-4H3v4zm5 0h4v-4H8v4zm5 0h4v-4h-4v4zM8 9h4V5H8v4zm5-4v4h4V5h-4zm5 9h3v-4h-3v4zm0-9v4h3V5h-3z"/></svg></button>
+      <button type="button" data-den="Compact" aria-pressed="true" title="Compact" aria-label="Compact">
+        <svg viewBox="0 0 24 24"><path d="M3 3h8v8H3zm10 0h8v8h-8zM3 13h8v8H3zm10 0h8v8h-8z"/></svg></button>
+      <button type="button" data-den="Table" aria-pressed="false" title="Table" aria-label="Table">
+        <svg viewBox="0 0 24 24"><path d="M21 8H3V4h18v4zm0 2H3v4h18v-4zm0 6H3v4h18v-4z"/></svg></button>
+    </div>
+    <!-- Everything leads and is the default: the page opens as your record book to browse, with
+       an empty set you fill by hand. Suggesting a set is an offer, not the starting position. -->
+    <div class="segmented" role="group" aria-label="Which charts">
+      <button type="button" data-scope="all" aria-pressed="true">Everything</button>
+      <button type="button" data-scope="set" aria-pressed="false">In your set</button>
+    </div>
+    <div class="sortwrap" id="sortwrap">
+      <button type="button" class="sortbtn" id="sortbtn" aria-haspopup="true" aria-expanded="false">
+        <svg viewBox="0 0 24 24"><path d="M3 6h12v2H3zm0 5h9v2H3zm0 5h6v2H3zm15-9v9.2l3-3 1.4 1.4-5.4 5.4-5.4-5.4L13 12.2l3 3V7z"/></svg>
+        Sort by <span class="cur" id="sortcur">set order</span>
+      </button>
+      <div class="sortmenu" id="sortmenu" hidden role="menu"></div>
+    </div>
+    <span class="listnote" id="listnote"></span>
+  </div>
+  <div id="list"></div>
+
+  <div class="actions">
+    <div class="actions-inner">
+      <span class="actions-sum" id="asum"></span>
+      <span class="actions-act">
+        <div class="sortwrap">
+          <button type="button" class="btn ghost" id="setsbtn" aria-haspopup="true" aria-expanded="false">Saved sets</button>
+          <div class="sortmenu" id="setsmenu" hidden role="menu" style="left:auto;right:0;bottom:calc(100% + 5px);top:auto;min-width:280px"></div>
+        </div>
+        <button type="button" class="btn ghost" id="csv">Download CSV</button>
+        <button type="button" class="btn" id="save">Save this set</button>
+      </span>
+    </div>
+  </div>
+
+  <dialog class="chart" id="dlg" aria-labelledby="dlgtitle">
+    <div class="dlg-head" id="dlghead"></div>
+    <div class="dlg-body" id="dlgbody"></div>
+    <div class="dlg-actions">
+      <button type="button" class="btn ghost" id="dlgpick"></button>
+      <button type="button" class="btn ghost" id="dlgclose">Close</button>
+    </div>
+  </dialog>
+
+  <dialog id="savedlg" aria-labelledby="savetitle">
+    <div class="dlg-body">
+      <h3 id="savetitle" style="font-family:var(--display);font-size:21px;margin-bottom:4px">Name this set</h3>
+      <p style="font-size:13px;color:var(--mix-muted);margin:0 0 11px">
+        Saved sets live with your account, so you can keep a few and pick one on the day.</p>
+      <div class="field"><label for="setname">Set name</label>
+        <input id="setname" type="text" maxlength="60" placeholder="Doubles — all out"/></div>
+    </div>
+    <div class="dlg-actions">
+      <button type="button" class="btn ghost" id="savecancel">Cancel</button>
+      <button type="button" class="btn" id="savego">Save</button>
+    </div>
+  </dialog>
+
+  <p class="note" style="margin-top:22px">
+    <b>This is a ceiling, not a prediction.</b> It prices every chart at your best score, and nobody
+    plays their best ninety minutes into a stamina session — which is what makes the gap worth
+    printing. Everything here is 김재현's real Phoenix Doubles record book under Winter 2025's frozen
+    balance, so the set and his actual session are directly comparable. Jacket art is external and the
+    sandbox blocks it, so each tile holds the real budget.
+  </p>
+</div>
+
+<script>
+  /* ---- Winter 2025's frozen config, straight out of Tournament.Configuration ---- */
+  var LR = {20:650,21:760,22:930,23:1160,24:1450,25:1800,26:2210,27:2680,28:3210,29:3800};
+  var G  = {A:0,APlus:0.5,AA:0.75,AAPlus:0.9,AAA:1.0,AAAPlus:1.15,S:1.2,SPlus:1.26,SS:1.32,
+            SSPlus:1.38,SSS:1.44,SSSPlus:1.5};
+  var LADDER = [["F",0],["D",450000],["C",550000],["B",650000],["A",750000],["APlus",825000],
+                ["AA",900000],["AAPlus",925000],["AAA",950000],["AAAPlus",960000],["S",970000],
+                ["SPlus",975000],["SS",980000],["SSPlus",985000],["SSS",990000],["SSSPlus",995000]];
+  var LABEL = {APlus:"A+",AAPlus:"AA+",AAAPlus:"AAA+",SPlus:"S+",SSPlus:"SS+",SSSPlus:"SSS+"};
+  var MAXTIME = 6300;
+  var STAGE_BREAK = 1.0;   // MoM keeps stage break out of the algorithm
+
+  function gradeKey(s){ for (var i=LADDER.length-1;i>=0;i--) if (s>=LADDER[i][1]) return LADDER[i][0]; return "F"; }
+  function grade(s){ var k=gradeKey(s); return LABEL[k]||k; }
+  function gradeColor(g){
+    if (g[0]==="S") return "var(--rar-sapphire)";
+    if (g.indexOf("AAA")===0) return "var(--rar-gold)";
+    if (g.indexOf("AA")===0) return "var(--rar-silver)";
+    return "var(--rar-common)";
+  }
+  function gradeMod(score){
+    var k=gradeKey(score), i=0;
+    for (var x=0;x<LADDER.length;x++) if (LADDER[x][0]===k) i=x;
+    var m = G[k]!==undefined ? G[k] : 0;
+    if (i>=LADDER.length-1 || score>=1000000) return m;
+    var nk=LADDER[i+1][0], nm = G[nk]!==undefined ? G[nk] : m;
+    return m + (nm-m)*(score-LADDER[i][1])/(LADDER[i+1][1]-LADDER[i][1]);
+  }
+  function levelRating(nominal, eff){ var f=eff-nominal, a=LR[nominal], b=LR[nominal+1]; return a+(b-a)*(f-0.5); }
+  function points(c){ return Math.round(levelRating(c.level,c.eff)*(c.secs/120)*gradeMod(c.score)*(c.brk?STAGE_BREAK:1)); }
+
+  function mmss(s){ var m=Math.floor(s/60), r=Math.round(s%60); return m+":"+(r<10?"0":"")+r; }
+  function hms(s){ var h=Math.floor(s/3600), m=Math.floor(s%3600/60), r=Math.round(s%60);
+                   return h+":"+(m<10?"0":"")+m+":"+(r<10?"0":"")+r; }
+  function n(v){ return v.toLocaleString("en-US"); }
+  function esc(s){ return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/"/g,"&quot;"); }
+  function levelColor(l){
+    if (l<=21) return "var(--diff-easy)";
+    if (l<=22) return "var(--diff-medium)";
+    if (l<=24) return "var(--diff-hard)";
+    return "var(--diff-veryhard)";
+  }
+  function bub(l,w,h,f){ return '<span class="bub" style="background:'+levelColor(l)
+    +(w?';width:'+w+'px;height:'+h+'px;font-size:'+f+'px':'')+'">D'+l+'</span>'; }
+
+  var POOL = [
+    ["Can-can ~Orpheus in The Party Mix~ - SHORT CUT -", 25, 51, 968935, "TG", 0, 25.5],
+    ["Paradoxx - SHORT CUT -", 26, 64, 915960, null, 1, 26.5],
+    ["Jupin - SHORT CUT -", 24, 48, 983108, "MG", 0, 24.5],
+    ["Neo Catharsis - SHORT CUT -", 25, 74, 934009, "RG", 0, 25.5],
+    ["Jupin - SHORT CUT -", 23, 48, 990296, "MG", 0, 23.5],
+    ["Murdoch vs Otada - SHORT CUT -", 24, 65, 942050, "FG", 0, 24.5],
+    ["Hymn of Golden Glory - SHORT CUT -", 24, 67, 984026, "MG", 0, 24.5],
+    ["Neo Catharsis", 27, 125, 823287, null, 1, 27.7264],
+    ["1948", 27, 125, 798181, null, 1, 27.5],
+    ["Repentance", 26, 105, 925031, "RG", 0, 26.5],
+    ["1949", 26, 106, 906924, "RG", 0, 26.5119],
+    ["Catastrophe", 26, 107, 917189, null, 1, 26.5],
+    ["Nyarlathotep - SHORT CUT -", 24, 72, 948296, "RG", 0, 25.3248],
+    ["Dignity", 26, 110, 8379, null, 1, 26.5773],
+    ["Dignity", 26, 110, 904251, null, 1, 26.5773],
+    ["Love is a Danger Zone pt. 2 - SHORT CUT -", 23, 58, 991240, "MG", 0, 23.5],
+    ["Shub Niggurath - SHORT CUT -", 23, 58, 951309, "FG", 0, 23.8091],
+    ["Chimera", 26, 112, 935477, "RG", 0, 26.5],
+    ["Kokugen Kairou Labyrinth", 26, 112, 938067, "FG", 0, 26.5],
+    ["Will-O-The-Wisp", 25, 92, 946306, "RG", 0, 25.5],
+    ["Telling Fortune Flower", 26, 113, 908814, "RG", 0, 26.5],
+    ["Shub Niggurath", 26, 113, 912455, null, 1, 26.5],
+    ["Cleaner", 26, 114, 923783, "RG", 0, 26.5],
+    ["Hercules", 26, 117, 901264, null, 1, 26.7275],
+    ["DUEL - SHORT CUT -", 23, 62, 987612, "MG", 0, 23.5],
+    ["Escape", 26, 119, 917751, "RG", 0, 26.5],
+    ["Conflict", 26, 120, 846029, null, 1, 26.5],
+    ["Doppelganger", 26, 120, 943793, "FG", 0, 26.5],
+    ["Dement ~After Legend~", 26, 121, 916114, null, 1, 26.5],
+    ["Aragami", 26, 121, 920563, null, 1, 26.6845],
+    ["Crimson Hood", 26, 122, 936208, "RG", 0, 26.5],
+    ["Achluoias", 26, 122, 920835, "FG", 0, 26.5],
+    ["* this game does not exist *", 26, 126, 866196, null, 1, 27.1809],
+    ["Super Akuma Emperor", 26, 127, 887295, null, 1, 26.5],
+    ["PRiMA MATERiA", 26, 127, 898160, null, 1, 27.0037],
+    ["Extreme Music School 2nd period feat. Nanahira", 26, 128, 832928, null, 1, 27.2006],
+    ["iRELLiA", 26, 128, 903605, null, 1, 26.5916],
+    ["Solfeggietto", 25, 105, 951612, "FG", 0, 25.5],
+    ["Moonlight - SHORT CUT -", 20, 38, 946969, "TG", 0, 20.8459],
+    ["Death Moon - SHORT CUT -", 23, 68, 969885, "TG", 0, 23.5],
+    ["CHAOS AGAIN", 26, 131, 913698, "RG", 0, 26.6542],
+    ["Human Extinction (PIU Edit.)", 25, 107, 904027, "RG", 0, 25.5],
+    ["Xeroize", 25, 107, 927476, "RG", 0, 25.96],
+    ["Murdoch vs Otada", 25, 108, 955407, "FG", 0, 25.5],
+    ["Cleaner - SHORT CUT -", 22, 56, 980925, "MG", 0, 22.5],
+    ["Indestructible", 25, 109, 952453, "FG", 0, 25.5],
+    ["F(R)IEND", 25, 109, 913808, "FG", 0, 26.0436],
+    ["Bee", 24, 88, 945720, "FG", 0, 25.5],
+    ["Skeptic", 25, 110, 952506, "FG", 0, 25.5],
+    ["Underworld ft. Skizzo (PIU Edit.)", 25, 111, 971254, "FG", 0, 25.5],
+    ["Heart Rabbit Coaster", 25, 111, 938475, "RG", 0, 25.5],
+    ["Mopemope", 25, 111, 889205, "RG", 0, 26.5],
+    ["PRiMA MATERiA - SHORT CUT -", 22, 58, 975203, "MG", 0, 22.5],
+    ["Papa Gonzales", 24, 91, 959582, "TG", 0, 25.0071],
+    ["Eternal Universe", 25, 113, 950267, "FG", 0, 25.5],
+    ["Cleaner", 25, 114, 929778, "RG", 0, 25.5],
+    ["Pumptris 8Bit ver. - SHORT CUT -", 22, 59, 972639, "FG", 0, 22.5],
+    ["Neo Catharsis - SHORT CUT -", 23, 74, 959158, "FG", 0, 23.5],
+    ["Vacuum", 25, 115, 934016, "FG", 0, 25.5446],
+    ["Beat of The War", 24, 93, 947315, "RG", 0, 24.5],
+    ["GLORIA", 25, 116, 941003, "RG", 0, 25.5],
+    ["Ghroth", 25, 116, 925563, "RG", 0, 25.5],
+    ["Spooky Macaron", 25, 116, 955037, "FG", 0, 25.5],
+    ["Jupin", 25, 117, 923229, "FG", 0, 25.8123],
+    ["Ultimatum", 25, 118, 934303, "RG", 0, 25.8939],
+    ["Further", 25, 118, 931181, "FG", 0, 25.5],
+    ["Etude OP 10-4", 25, 118, 918769, "RG", 0, 26.1077],
+    ["INVASION", 25, 118, 949819, "FG", 0, 25.5],
+    ["Poseidon - SHORT CUT -", 21, 50, 950349, "MG", 0, 21.5],
+    ["Nyarlathotep", 25, 119, 918506, "FG", 0, 25.5],
+    ["Ignis Fatuus(DM Ashura Mix)", 25, 119, 933179, "RG", 0, 25.5],
+    ["Brown Sky", 26, 147, 891326, null, 1, 26.5],
+    ["Darkside of The Mind", 25, 120, 963329, "FG", 0, 25.5],
+    ["Conflict", 25, 120, 954555, "FG", 0, 25.5],
+    ["MEGAHEARTZ", 25, 120, 962299, "TG", 0, 25.5],
+    ["1950", 25, 120, 911810, "RG", 0, 25.8053],
+    ["Can-can ~Orpheus in The Party Mix~ - SHORT CUT -", 21, 51, 982647, "MG", 0, 21.5],
+    ["Hymn of Golden Glory", 25, 121, 916805, "RG", 0, 25.6422],
+    ["Appassionata", 25, 121, 915297, "RG", 0, 26.0535],
+    ["†DOOF†SENC†", 25, 121, 940029, "FG", 0, 25.5],
+    ["Avalanche", 25, 121, 944369, "FG", 0, 25.5],
+    ["Pump me Amadeus", 24, 98, 961196, "TG", 0, 25.2221],
+    ["Yog-Sothoth", 25, 122, 928628, "RG", 0, 25.5721],
+    ["Slam", 24, 99, 991591, "MG", 0, 24.5],
+    ["A Site De La Rue", 24, 99, 974930, "TG", 0, 24.5],
+    ["Hyperion - SHORT CUT -", 21, 52, 983774, "MG", 0, 21.5],
+    ["Beethoven Virus", 24, 100, 972024, "TG", 0, 24.5],
+    ["Gun Rock", 24, 100, 956386, "FG", 0, 24.5],
+    ["SONIC BOOM", 25, 125, 948481, "FG", 0, 25.5],
+    ["Extreme Music School 1st period feat. Nanahira", 25, 125, 918010, "RG", 0, 25.9216],
+    ["Robot battle", 24, 101, 930565, "FG", 0, 24.9969],
+    ["MURDOCH", 24, 101, 967685, "TG", 0, 24.795],
+    ["Harmagedon", 24, 101, 948467, "FG", 0, 24.6741],
+    ["Break Through Myself feat. Risa Yuzuki", 25, 126, 937121, "RG", 0, 25.5],
+    ["Vacuum Cleaner", 26, 155, 908938, null, 1, 26.564],
+    ["Moonlight", 24, 102, 864821, null, 1, 25.5],
+    ["Odin", 25, 127, 912080, "RG", 0, 25.5],
+    ["TRICKL4SH 220", 25, 127, 949632, "FG", 0, 25.5032],
+    ["Kugutsu", 25, 127, 939537, "FG", 0, 25.6411],
+    ["Final Audition Ep. 2-2", 24, 103, 944347, "FG", 0, 25.3166],
+    ["That Kitty (PIU Edit.)", 24, 103, 962369, "TG", 0, 24.5],
+    ["Ignis Fatuus(DM Ashura Mix) - SHORT CUT -", 21, 54, 944676, "TG", 0, 21.5],
+    ["Destination - SHORT CUT -", 21, 54, 965467, "MG", 0, 21.5],
+    ["Viyella's Nightmare", 25, 128, 939513, "RG", 0, 25.5],
+    ["Boca", 25, 129, 950559, "FG", 0, 25.5],
+    ["Pupa", 25, 129, 949618, "RG", 0, 25.5872],
+    ["Final Audition Ep. 2-X", 24, 104, 964360, "TG", 0, 25.4216],
+    ["Love is a Danger Zone pt. 2", 24, 104, 984251, "MG", 0, 24.5],
+    ["Mental Rider", 24, 104, 954971, "FG", 0, 25.5],
+    ["Hymn of Golden Glory - SHORT CUT -", 22, 67, 981225, "FG", 0, 22.5],
+    ["Imperium", 25, 130, 898866, "RG", 0, 25.8523],
+    ["Just Hold On (To All Fighters)", 25, 130, 940351, "FG", 0, 25.5],
+    ["4NT", 24, 105, 972893, "FG", 0, 24.5],
+    ["ESP", 24, 105, 955776, "FG", 0, 24.5],
+    ["Ultimate Eyes", 24, 106, 959257, "FG", 0, 24.5],
+    ["Stardream -Eurobeat Remix- - SHORT CUT -", 22, 68, 991786, "MG", 0, 22.5],
+    ["BEMERA", 26, 163, 841104, null, 1, 26.7039],
+    ["Paved Garden", 24, 107, 966038, "TG", 0, 24.5],
+    ["Jupin - SHORT CUT -", 20, 48, 962031, "MG", 0, 21.5],
+    ["Murdoch vs Otada", 24, 108, 974023, "TG", 0, 24.5],
+    ["Kasou Shinja - SHORT CUT -", 21, 57, 996463, "SG", 0, 22.065],
+    ["Perpetual", 24, 109, 964526, "FG", 0, 24.5],
+    ["The Quick Brown Fox Jumps Over The Lazy Dog", 24, 110, 965382, "TG", 0, 24.5],
+    ["Dignity", 24, 110, 943451, "FG", 0, 25.5],
+    ["Bee", 23, 88, 969988, "TG", 0, 24.2046],
+    ["BEDLAM", 24, 110, 925652, "RG", 0, 25.5],
+    ["Yoropiku Pikuyoro !", 24, 110, 938269, "FG", 0, 24.5],
+    ["V3", 24, 110, 952987, "RG", 0, 24.7358],
+    ["Annihilator Method", 24, 110, 965564, "TG", 0, 24.5],
+    ["FFF - SHORT CUT -", 21, 58, 951216, "TG", 0, 21.5]
+  ];
+
+
+  var CHARTS = POOL.map(function(r,i){
+    var c = { id:i, title:r[0], level:r[1], secs:r[2], score:r[3], plate:r[4], brk:!!r[5], eff:r[6] };
+    c.pts = points(c); c.pps = c.pts / c.secs;
+    return c;
+  }).filter(function(c){ return c.pts > 0; });
+
+  var ACTUAL = { total:59319, charts:39, avgDiff:24.22, rest:1324, avgScore:951755 };
+
+  /* ---- the set is a SELECTION over the pool ----
+     Build solves one; everything after that is the player editing it, and every number on the
+     page recomputes from what is ticked. That is what makes the CSV worth downloading: it is
+     the set you decided on, not the set the greedy algorithm decided on. */
+  var chosen = {};        // id -> true
+  var order = [];         // set order, as built then edited
+
+  function build(minRest){
+    var ordered = CHARTS.slice().sort(function(a,b){ return b.pps - a.pps; });
+    var plan = [], play = 0;
+    ordered.forEach(function(c){
+      if (play >= MAXTIME) return;
+      var newPlay = play + c.secs, newCount = plan.length + 1;
+      if ((MAXTIME - newPlay) / newCount < minRest) return;
+      plan.push(c); play = newPlay;
+    });
+    // The window governs when a song may START, so once nothing else fits the rest budget you
+    // may still open one more — and the right one is the biggest you can still bank.
+    if (play < MAXTIME){
+      var taken = {}; plan.forEach(function(c){ taken[c.id]=1; });
+      var closer = CHARTS.filter(function(c){ return !taken[c.id]; })
+                         .sort(function(a,b){ return b.pts-a.pts; })[0];
+      if (closer) plan.push(closer);
+    }
+    chosen = {}; order = plan.map(function(c){ chosen[c.id]=true; return c.id; });
+    suggested = true;
+  }
+
+  function setCharts(){
+    var byId = {}; CHARTS.forEach(function(c){ byId[c.id]=c; });
+    return order.filter(function(id){ return chosen[id]; }).map(function(id){ return byId[id]; });
+  }
+  function avg(a,f){ return a.length ? a.reduce(function(x,y){ return x+f(y); },0)/a.length : 0; }
+
+  var density="Compact", scope="all", sortKey="order", minRest=35, suggested=false;
+  // Named, plural, and kept with the account — one example so the menu is not empty on arrival.
+  var savedSets = [{ name:"Doubles — all out", ids:null, when:"saved 6 Feb" }];
+  var SORTS=[{key:"order",label:"Set order",note:"As the set was solved — best value per second first, which is also a sensible play order while you are fresh."},
+             {key:"pps",label:"Points per second",note:"What each chart banks per second of song."},
+             {key:"pts",label:"Points",note:"Biggest single hauls. Long songs win here, which is not the same as being efficient."},
+             {key:"level",label:"Difficulty",note:"Hardest first, by balanced level."},
+             {key:"secs",label:"Length",note:"Shortest first."}];
+  function sortMeta(){ return SORTS.filter(function(s){return s.key===sortKey;})[0]; }
+
+  function visible(){
+    var list = scope==="set" ? setCharts() : CHARTS.slice();
+    if (sortKey==="pps") list.sort(function(a,b){ return b.pps-a.pps; });
+    else if (sortKey==="pts") list.sort(function(a,b){ return b.pts-a.pts; });
+    else if (sortKey==="level") list.sort(function(a,b){ return b.eff-a.eff || b.pts-a.pts; });
+    else if (sortKey==="secs") list.sort(function(a,b){ return a.secs-b.secs; });
+    else if (scope==="all") list.sort(function(a,b){
+      var ai=order.indexOf(a.id), bi=order.indexOf(b.id);
+      if (ai<0 && bi<0) return b.pps-a.pps;
+      if (ai<0) return 1; if (bi<0) return -1; return ai-bi;
+    });
+    return list;
+  }
+  function ordOf(c){ var i = order.indexOf(c.id); return chosen[c.id] && i>=0 ? setCharts().indexOf(c)+1 : null; }
+
+  function renderComfortable(list){
+    // The jacket is the video affordance, as /Pumbility renders it — jacket and play button both
+    // open the chart dialog, the button just autoplays. Picking lives in the body, so the two
+    // gestures never fight over the same pixels.
+    return '<div class="cards">' + list.map(function(c){
+      var on = !!chosen[c.id], g = grade(c.score);
+      return '<div class="ccard'+(on?" on":"")+'">'
+        + '<div class="ccard-jacket" role="button" tabindex="0" data-open="'+c.id+'" aria-label="Open '+esc(c.title)+'">'
+          + '<span class="jacket">ART</span>'+bub(c.level,38,25,14)
+          + '<button type="button" class="playbtn" data-play="'+c.id+'" aria-label="Play video for '+esc(c.title)+'">'
+            + '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></button>'
+        + '</div>'
+        + '<div class="ccard-body">'
+          + '<div class="ccard-name" title="'+esc(c.title)+'">'+esc(c.title)+'</div>'
+          + '<div class="ccard-meta"><span class="gradeicon" style="color:'+gradeColor(g)+';font-size:16px">'+g+'</span>'
+            + '<span class="num" style="color:var(--mix-muted);font-size:12px">'+n(c.score)+'</span></div>'
+          + '<div class="ccard-meta"><span class="ccard-pts num">'+n(c.pts)+'</span>'
+            + '<span class="ccard-sub">pts · '+c.pps.toFixed(1)+' pps · '+mmss(c.secs)+'</span></div>'
+          + '<label class="ccard-pick" data-pick="'+c.id+'">'
+            + '<input type="checkbox" class="cb" '+(on?"checked":"")+' tabindex="-1"/>'
+            + '<span>'+(on?"In your set":"Add to set")+'</span></label>'
+        + '</div></div>';
+    }).join("") + '</div>';
+  }
+
+  function renderCompact(list){
+    var extra = { pps:function(c){return c.pps.toFixed(1)+" pps";}, secs:function(c){return mmss(c.secs);} }[sortKey];
+    return '<div class="stickers">' + list.map(function(c){
+      var on = !!chosen[c.id], g = grade(c.score);
+      return '<button type="button" class="sticker'+(on?" on":"")+'" data-pick="'+c.id+'" aria-pressed="'+on+'"'
+        + ' title="'+esc(c.title)+' · '+n(c.pts)+' pts · '+n(c.score)+' · '+mmss(c.secs)+'">'
+        + '<span class="jacket">ART</span>'+bub(c.level,30,20,12)
+        + '<span class="tick">✓</span>'
+        + '<span class="corner-start"><span class="gradeicon" style="color:'+gradeColor(g)+';font-size:12px">'
+          + g+'</span></span>'
+        + '<span class="corner">'+(extra?extra(c):n(c.pts))+'</span>'
+        + '</button>';
+    }).join("") + '</div>';
+  }
+
+  function renderTable(list){
+    var head = '<th style="width:26px"></th>'
+      + '<th><button type="button" data-sort="level">Chart</button></th>'
+      + '<th><button type="button" data-sort="pts">Grade &amp; score</button></th>'
+      + '<th class="t-r"><button type="button" data-sort="pts">Points</button></th>'
+      + '<th class="t-r col-pps"><button type="button" data-sort="pps">PPS</button></th>'
+      + '<th class="t-r col-pps"><button type="button" data-sort="secs">Length</button></th>';
+    var body = list.map(function(c){
+      var on = !!chosen[c.id], g = grade(c.score), o = ordOf(c);
+      return '<tr class="'+(on?"on":"")+'" data-pick="'+c.id+'">'
+        + '<td><input type="checkbox" class="cb" '+(on?"checked":"")+' tabindex="-1" aria-label="'+esc(c.title)+'"/></td>'
+        + '<td><span class="t-ident">'+(o?'<span class="num" style="color:var(--mix-muted);font-size:11.5px;width:18px;text-align:right">'+o+'</span>':'<span style="width:18px"></span>')
+          + '<span class="jacket">ART</span>'+bub(c.level,34,22,12.5)
+          + '<span class="t-name">'+esc(c.title)+'</span></span></td>'
+        + '<td><span class="t-grade"><span class="gradeicon" style="color:'+gradeColor(g)+';font-size:15px">'+g+'</span>'
+          + '<span class="t-score num">'+n(c.score)+'</span></span></td>'
+        + '<td class="t-r num" style="font-family:var(--display);font-size:17px;font-weight:600">'+n(c.pts)+'</td>'
+        + '<td class="t-r num col-pps">'+c.pps.toFixed(1)+'</td>'
+        + '<td class="t-r num col-pps" style="color:var(--mix-muted)">'+mmss(c.secs)+'</td></tr>';
+    }).join("");
+    return '<div class="tablewrap"><table class="run"><thead><tr>'+head+'</tr></thead><tbody>'+body+'</tbody></table></div>';
+  }
+
+  function render(){
+    var set = setCharts();
+    var total = set.reduce(function(a,c){ return a+c.pts; }, 0);
+    var play = set.reduce(function(a,c){ return a+c.secs; }, 0);
+    var restLeft = Math.max(0, MAXTIME - play);
+    var perGap = set.length>1 ? restLeft/(set.length-1) : restLeft;
+    // Everything before the last chart has to start inside the window (§1).
+    var beforeLast = set.length ? play - set[set.length-1].secs : 0;
+    var over = beforeLast > MAXTIME;
+
+    document.getElementById("ptotal").textContent = n(total);
+    var nums = [
+      { k:"Charts", v:n(set.length), a:set.length, b:ACTUAL.charts, fmt:function(x){return n(x);} },
+      { k:"Avg difficulty", v:avg(set,function(c){return c.eff;}).toFixed(2),
+        a:avg(set,function(c){return c.eff;}), b:ACTUAL.avgDiff, fmt:function(x){return x.toFixed(2);} },
+      { k:"Avg grade", v:set.length?grade(Math.round(avg(set,function(c){return c.score;}))):"—",
+        a:avg(set,function(c){return c.score;}), b:ACTUAL.avgScore, fmt:function(x){return n(Math.round(x));} },
+      { k:"Downtime", v:hms(restLeft), a:restLeft, b:ACTUAL.rest, fmt:hms, lowerBetter:true }
+    ];
+    document.getElementById("pnums").innerHTML = nums.map(function(x){
+      var d = x.a-x.b, good = x.lowerBetter ? d<0 : d>0;
+      var cls = Math.abs(d)<0.005 ? "flat" : (good?"up":"down");
+      var shown = Math.abs(d)<0.005 ? "same as your session" : (d>0?"+":"−")+x.fmt(Math.abs(d))+" vs your session";
+      return '<div class="pn"><div class="k">'+x.k+'</div><div class="v">'+x.v+'</div>'
+        + '<div class="d '+cls+'">'+shown+'</div></div>';
+    }).join("");
+
+    document.getElementById("overwarn").innerHTML = over
+      ? '<div class="overwarn"><b>This set does not fit.</b> Everything before the last chart is '
+        + hms(beforeLast)+' of songs, past the 1:45:00 window. Take something out.</div>' : "";
+
+    var conv = total ? ACTUAL.total/total : 0;
+    document.getElementById("versus").innerHTML = set.length
+      ? 'Your best Winter 2025 session banked <b>'+n(ACTUAL.total)+'</b> across <b>'+ACTUAL.charts
+        + '</b> charts. This set is worth <b>'+n(total)+'</b> on paper, at <b>'+mmss(Math.round(perGap))
+        + '</b> of rest between charts.'
+        + '<div class="conv"><span>You converted</span><span class="convbar"><i style="width:'
+        + (Math.min(conv,1)*100).toFixed(1)+'%"></i></span><span class="convpct">'+(conv*100).toFixed(0)
+        + '%</span><span style="color:var(--mix-muted);font-size:12.5px">of your record book last time'
+        + ' — the rest is what stamina costs.</span></div>'
+      : 'Nothing selected. Rebuild the set, or tick charts from <b>Everything</b>.';
+
+    var list = visible();
+    document.getElementById("list").innerHTML =
+      density==="Comfortable" ? renderComfortable(list)
+      : density==="Table" ? renderTable(list) : renderCompact(list);
+    document.getElementById("listnote").textContent =
+      (scope==="set" ? set.length+" charts in your set. " : "All "+CHARTS.length+" charts you hold a scoring record on. ")
+      + sortMeta().note;
+    document.getElementById("sortcur").textContent = sortMeta().label.toLowerCase();
+
+    document.getElementById("asum").innerHTML = set.length
+      ? '<b>'+set.length+'</b> charts · <b>'+n(total)+'</b> points · '+hms(play)+' of songs'
+      : 'Nothing in your set yet — tick charts below, or press <b>Suggest a set</b>.';
+    document.getElementById("csv").disabled = !set.length;
+    document.getElementById("save").disabled = !set.length;
+    renderSets();
+  }
+
+  /* ---- CSV: the point of the whole page is walking to a machine with this ---- */
+  function csv(){
+    var rows = [["#","Song","Difficulty","Length","Your best","Grade","Projected points","Points per second"]];
+    setCharts().forEach(function(c,i){
+      rows.push([i+1, c.title, "D"+c.level, mmss(c.secs), c.score, grade(c.score), c.pts, c.pps.toFixed(1)]);
+    });
+    var body = rows.map(function(r){
+      return r.map(function(v){
+        v = String(v);
+        return /[",\n]/.test(v) ? '"'+v.replace(/"/g,'""')+'"' : v;
+      }).join(",");
+    }).join("\r\n");
+    // A BOM so Excel opens the Korean and Japanese song titles as UTF-8 instead of mojibake.
+    var blob = new Blob(["﻿"+body], {type:"text/csv;charset=utf-8"});
+    var a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "march-of-murlocs-winter-2025-doubles-set.csv";
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    setTimeout(function(){ URL.revokeObjectURL(a.href); }, 1000);
+  }
+
+  /* ---- wiring ---- */
+  document.getElementById("sortmenu").innerHTML = SORTS.map(function(s){
+    return '<button type="button" role="menuitem" data-sort="'+s.key+'"><span class="tick" data-tick="'+s.key+'"></span>'+s.label+'</button>';
+  }).join("");
+  function paintTicks(){
+    Array.prototype.forEach.call(document.querySelectorAll("[data-tick]"), function(t){
+      t.textContent = t.dataset.tick===sortKey ? "✓" : "";
+    });
+  }
+  var sortbtn=document.getElementById("sortbtn"), sortmenu=document.getElementById("sortmenu");
+  function closeMenu(){ sortmenu.hidden=true; sortbtn.setAttribute("aria-expanded","false"); }
+  sortbtn.addEventListener("click", function(e){
+    e.stopPropagation(); sortmenu.hidden=!sortmenu.hidden;
+    sortbtn.setAttribute("aria-expanded", String(!sortmenu.hidden));
+  });
+  document.addEventListener("keydown", function(e){ if (e.key==="Escape") closeMenu(); });
+
+  // One delegated listener: rows, stickers, cards and table headers all re-render on every
+  // change, so anything bound directly would go stale on the first click.
+  document.addEventListener("click", function(e){
+    var s = e.target.closest ? e.target.closest("[data-sort]") : null;
+    if (s){ sortKey=s.dataset.sort; paintTicks(); closeMenu(); render(); return; }
+    if (!sortmenu.hidden && !sortmenu.contains(e.target) && e.target!==sortbtn) closeMenu();
+
+    var p = e.target.closest ? e.target.closest("[data-pick]") : null;
+    if (p){
+      var id = +p.dataset.pick;
+      if (chosen[id]) delete chosen[id];
+      else { chosen[id] = true; if (order.indexOf(id) < 0) order.push(id); }
+      suggested = false; render();
+    }
+  });
+  document.addEventListener("keydown", function(e){
+    if (e.key!=="Enter" && e.key!==" ") return;
+    var p = e.target.closest ? e.target.closest("[data-pick]") : null;
+    if (p && p.getAttribute("role")==="button"){ e.preventDefault(); p.click(); }
+  });
+
+  // Dragging retunes a SUGGESTED set live, which is the good interaction — but it must never
+  // rewrite a set someone picked by hand, so a manual tick takes the set off autopilot.
+  document.getElementById("rest").addEventListener("input", function(){
+    minRest = +this.value;
+    document.getElementById("restval").textContent = minRest+"s";
+    if (suggested) build(minRest);
+    render();
+  });
+  document.getElementById("rebuild").addEventListener("click", function(){ build(minRest); render(); });
+  Array.prototype.forEach.call(document.querySelectorAll(".denbtns button"), function(b){
+    b.addEventListener("click", function(){
+      density=b.dataset.den;
+      Array.prototype.forEach.call(document.querySelectorAll(".denbtns button"), function(x){
+        x.setAttribute("aria-pressed", String(x===b)); });
+      render();
+    });
+  });
+  Array.prototype.forEach.call(document.querySelectorAll("[data-scope]"), function(b){
+    b.addEventListener("click", function(){
+      scope=b.dataset.scope;
+      Array.prototype.forEach.call(document.querySelectorAll("[data-scope]"), function(x){
+        x.setAttribute("aria-pressed", String(x===b)); });
+      render();
+    });
+  });
+  Array.prototype.forEach.call(document.querySelectorAll(".typegroup button"), function(b){
+    b.addEventListener("click", function(){
+      Array.prototype.forEach.call(document.querySelectorAll(".typegroup button"), function(x){
+        x.setAttribute("aria-pressed", String(x===b)); });
+    });
+  });
+  document.getElementById("csv").addEventListener("click", csv);
+
+  /* ---- named saved sets ---- */
+  function renderSets(){
+    document.getElementById("setsmenu").innerHTML = savedSets.length
+      ? savedSets.map(function(s,i){
+          var count = s.ids ? s.ids.length : 45;
+          return '<div class="setrow"><button type="button" class="load" data-load="'+i+'">'
+            + esc(s.name)+'<small>'+count+' charts · '+esc(s.when)+'</small></button>'
+            + '<button type="button" class="kill" data-kill="'+i+'" aria-label="Delete '+esc(s.name)+'">×</button></div>';
+        }).join("")
+      : '<div class="setsempty">No saved sets yet. Build one and press Save.</div>';
+  }
+  var setsbtn = document.getElementById("setsbtn"), setsmenu = document.getElementById("setsmenu");
+  setsbtn.addEventListener("click", function(e){
+    e.stopPropagation(); setsmenu.hidden = !setsmenu.hidden;
+    setsbtn.setAttribute("aria-expanded", String(!setsmenu.hidden));
+  });
+  document.addEventListener("click", function(e){
+    if (!setsmenu.hidden && !setsmenu.contains(e.target) && e.target!==setsbtn){
+      setsmenu.hidden = true; setsbtn.setAttribute("aria-expanded","false");
+    }
+    var l = e.target.closest ? e.target.closest("[data-load]") : null;
+    if (l){
+      var s = savedSets[+l.dataset.load];
+      if (s.ids){ chosen={}; order=s.ids.slice(); s.ids.forEach(function(id){ chosen[id]=true; }); }
+      else build(minRest);                       // the seeded example stands in for a solved set
+      setsmenu.hidden = true; scope="set";
+      Array.prototype.forEach.call(document.querySelectorAll("[data-scope]"), function(x){
+        x.setAttribute("aria-pressed", String(x.dataset.scope==="set")); });
+      render(); return;
+    }
+    var k = e.target.closest ? e.target.closest("[data-kill]") : null;
+    if (k){ savedSets.splice(+k.dataset.kill,1); renderSets(); }
+  });
+
+  var savedlg = document.getElementById("savedlg");
+  document.getElementById("save").addEventListener("click", function(){
+    var set = setCharts();
+    // A default worth keeping: the hardest thing in the set is what the set is about.
+    var top = set.slice().sort(function(a,b){ return b.eff-a.eff; })[0];
+    document.getElementById("setname").value =
+      "Doubles — " + set.length + " charts" + (top ? ", up to D"+top.level : "");
+    savedlg.showModal();
+    document.getElementById("setname").select();
+  });
+  document.getElementById("savecancel").addEventListener("click", function(){ savedlg.close(); });
+  document.getElementById("savego").addEventListener("click", function(){
+    var name = document.getElementById("setname").value.trim() || "Untitled set";
+    savedSets.unshift({ name:name, ids:setCharts().map(function(c){ return c.id; }), when:"saved just now" });
+    savedlg.close(); render();
+  });
+
+  /* ---- chart dialog: the jacket and the play button open the same thing ---- */
+  var dlg = document.getElementById("dlg"), dlgId = null;
+  function openChart(id, autoplay){
+    var c = CHARTS.filter(function(x){ return x.id===id; })[0];
+    if (!c) return;
+    dlgId = id;
+    var g = grade(c.score);
+    document.getElementById("dlghead").innerHTML = bub(c.level,42,27,15)
+      + '<span class="dlg-title" id="dlgtitle">'+esc(c.title)+'</span>';
+    document.getElementById("dlgbody").innerHTML =
+      '<div class="dlg-video">'+(autoplay
+        ? "▶ Chart video would autoplay here — the play button and the jacket open this same dialog, the button just starts it."
+        : "Chart video — press play. External embeds are blocked in this sandbox.")+'</div>'
+      + '<div class="dlg-stats">'
+      + '<div class="dlg-stat"><div class="k">Your best</div><div class="v">'+n(c.score)+'</div></div>'
+      + '<div class="dlg-stat"><div class="k">Grade</div><div class="v" style="color:'+gradeColor(g)+'">'+g+'</div></div>'
+      + '<div class="dlg-stat"><div class="k">Worth</div><div class="v">'+n(c.pts)+'</div></div>'
+      + '<div class="dlg-stat"><div class="k">Per second</div><div class="v">'+c.pps.toFixed(1)+'</div></div>'
+      + '<div class="dlg-stat"><div class="k">Length</div><div class="v">'+mmss(c.secs)+'</div></div>'
+      + '<div class="dlg-stat"><div class="k">Balanced</div><div class="v">'+c.eff.toFixed(2)+'</div></div>'
+      + '</div>';
+    document.getElementById("dlgpick").textContent = chosen[id] ? "Remove from set" : "Add to set";
+    if (!dlg.open) dlg.showModal();
+  }
+  document.addEventListener("click", function(e){
+    var p = e.target.closest ? e.target.closest("[data-play]") : null;
+    if (p){ e.stopPropagation(); openChart(+p.dataset.play, true); return; }
+    var o = e.target.closest ? e.target.closest("[data-open]") : null;
+    if (o) openChart(+o.dataset.open, false);
+  });
+  document.addEventListener("keydown", function(e){
+    if (e.key!=="Enter" && e.key!==" ") return;
+    var o = e.target.closest ? e.target.closest("[data-open]") : null;
+    if (o && o.getAttribute("role")==="button"){ e.preventDefault(); openChart(+o.dataset.open, false); }
+  });
+  document.getElementById("dlgclose").addEventListener("click", function(){ dlg.close(); });
+  document.getElementById("dlgpick").addEventListener("click", function(){
+    if (dlgId==null) return;
+    if (chosen[dlgId]) delete chosen[dlgId];
+    else { chosen[dlgId]=true; if (order.indexOf(dlgId)<0) order.push(dlgId); }
+    this.textContent = chosen[dlgId] ? "Remove from set" : "Add to set";
+    render();
+  });
+
+  paintTicks(); render();
+</script>

--- a/docs/design/march-of-murlocs-mocks/5-discord-card.html
+++ b/docs/design/march-of-murlocs-mocks/5-discord-card.html
@@ -1,0 +1,285 @@
+<title>MoM — Discord card mock</title>
+<style>
+  :root {
+    /* Discord's own dark surface, so the card can be judged where it will actually live. */
+    --dc-bg:#313338; --dc-raised:#2B2D31; --dc-input:#1E1F22; --dc-text:#DBDEE1;
+    --dc-muted:#949BA4; --dc-link:#00A8FC; --dc-btn:#4E5058; --dc-rule:#3F4147;
+    /* the site's Phoenix palette, for the page chrome around the mock */
+    --mix-bg:#070B15; --mix-surface:#161E2C; --mix-raised:#1E2A3D;
+    --mix-primary:#3FA9F5; --mix-accent:#FFD24A; --mix-ink:#E9EFF7; --mix-muted:#93A3B8;
+    --chart-double:#38B6FF;
+    --diff-easy:#7CB342; --diff-medium:#FDD835; --diff-hard:#FB8C00; --diff-veryhard:#E53935;
+    --rar-gold:#FFD24A; --rar-silver:#CBD5E1; --rar-sapphire:#38B6FF; --rar-common:#8B98A9;
+    --plate-copper:#B87333; --plate-silver:#CBD5E1;
+    --line:rgba(233,239,247,.12); --line-strong:rgba(233,239,247,.22);
+    --display:"Barlow Condensed","Oswald","Roboto Condensed","Arial Narrow",system-ui,sans-serif;
+    --body:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"], :root[data-theme="dark"] { color-scheme: dark; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--mix-bg); color:var(--mix-ink); font-family:var(--body);
+         font-size:15px; line-height:1.5; -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:900px; margin:0 auto; padding:16px 16px 70px; }
+  .num { font-variant-numeric:tabular-nums; }
+
+  .mockbar { background:#12203a; border-bottom:1px solid var(--line); padding:9px 16px; font-size:12.5px;
+             color:var(--mix-muted); display:flex; flex-wrap:wrap; gap:6px 14px; align-items:center; }
+  .mockbar b { color:var(--mix-ink); font-weight:600; }
+  .note { border-left:2px solid var(--mix-accent); background:rgba(255,210,74,.06); padding:9px 13px;
+          margin:0; border-radius:0 5px 5px 0; font-size:13px; color:#E4D9BC; }
+  .note b { color:var(--mix-accent); font-weight:600; }
+  h1 { font-family:var(--display); font-size:34px; font-weight:700; margin:0; line-height:1; }
+  h2.sec { font-size:13px; letter-spacing:.14em; text-transform:uppercase; color:var(--mix-muted);
+           font-weight:600; margin:30px 0 11px; display:flex; align-items:center; gap:10px; }
+  h2.sec::after { content:""; flex:1; height:1px; background:var(--line); }
+  .lede { color:var(--mix-muted); font-size:13.5px; margin:4px 0 0; max-width:72ch; }
+
+  /* ---------- discord surface ---------- */
+  .discord { background:var(--dc-bg); border-radius:9px; padding:16px 18px 18px; color:var(--dc-text);
+             font-size:15px; line-height:1.375; }
+  .msg { display:grid; grid-template-columns:40px 1fr; gap:14px; }
+  .botav { width:40px; height:40px; border-radius:50%; background:linear-gradient(140deg,#2C7FBF,#3FA9F5);
+           display:grid; place-items:center; font-size:19px; overflow:hidden; line-height:1; }
+  .msghead { display:flex; align-items:baseline; gap:8px; flex-wrap:wrap; margin-bottom:3px; }
+  .botname { font-weight:600; color:#fff; }
+  .bottag { background:#5865F2; color:#fff; font-size:10px; font-weight:600; border-radius:3px;
+            padding:1px 4px; text-transform:uppercase; letter-spacing:.02em; }
+  .stamp { color:var(--dc-muted); font-size:12px; }
+
+  /* Components V2 container: an accent bar down the left of a rounded panel. */
+  .cv2 { background:var(--dc-raised); border-radius:8px; border-left:4px solid var(--mix-primary);
+         padding:14px 16px; max-width:560px; }
+  .cv2-section { display:grid; grid-template-columns:1fr auto; gap:14px; align-items:start; }
+  .cv2-thumb { width:64px; height:64px; border-radius:8px; flex:none;
+               background:linear-gradient(140deg,#4B5566,#2A323F); display:grid; place-items:center;
+               font-size:9px; color:#8C97A6; letter-spacing:.04em; }
+  .h3 { font-size:20px; font-weight:700; color:#fff; line-height:1.25; }
+  .small { font-size:12.5px; color:var(--dc-muted); }
+  .divider { height:1px; background:var(--dc-rule); margin:12px 0; }
+  .row { display:flex; align-items:center; gap:6px; flex-wrap:wrap; margin:2px 0; }
+  .statline { display:flex; gap:6px 18px; flex-wrap:wrap; }
+  .statline b { color:#fff; }
+  .btnrow { display:flex; gap:8px; margin-top:12px; }
+  .dcbtn { background:var(--dc-btn); color:#fff; border:0; border-radius:4px; font:inherit; font-size:14px;
+           font-weight:500; padding:8px 16px; cursor:pointer; text-decoration:none; display:inline-block; }
+  .dcbtn:hover { filter:brightness(1.12); }
+
+  /* emoji stand-ins — the real card ships custom Discord emoji through the #TOKEN# vocabulary */
+  .em { display:inline-grid; place-items:center; border-radius:3px; font-family:var(--display);
+        font-weight:700; color:#0B0F17; height:19px; padding:0 5px; font-size:12.5px; vertical-align:-4px; }
+  .emg { display:inline-grid; place-items:center; height:19px; padding:0 4px; border-radius:3px;
+         font-family:var(--display); font-weight:700; font-size:12.5px; vertical-align:-4px;
+         border:1px solid currentColor; }
+  .emp { display:inline-grid; place-items:center; height:19px; padding:0 4px; border-radius:3px;
+         font-family:var(--display); font-weight:700; font-size:11.5px; vertical-align:-4px;
+         border:1px solid currentColor; }
+  .emmix { display:inline-grid; place-items:center; height:18px; padding:0 5px; border-radius:3px;
+           font-size:10.5px; font-weight:700; letter-spacing:.04em; vertical-align:-3px;
+           background:rgba(56,182,255,.18); color:#7FCBFF; }
+  .songname { color:#fff; }
+  .pts { font-weight:700; color:#fff; font-variant-numeric:tabular-nums; }
+
+  /* ---------- code / fallback panels ---------- */
+  pre { background:var(--mix-surface); border:1px solid var(--line); border-radius:8px; padding:13px 15px;
+        overflow-x:auto; font-size:12.5px; line-height:1.55; margin:0;
+        font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; color:#C9D6E4; }
+  pre .k { color:#7FCBFF; } pre .s { color:#C3E88D; } pre .c { color:#6E7F91; font-style:italic; }
+  .plain { background:var(--dc-bg); border-radius:8px; padding:14px 16px; color:var(--dc-text);
+           font-size:14.5px; line-height:1.45; }
+  .plain .small { display:block; }
+
+  /* ---------- slash command ---------- */
+  .cmd { background:var(--dc-bg); border-radius:9px; padding:14px 16px; }
+  .cmdline { display:flex; align-items:center; gap:8px; flex-wrap:wrap; color:var(--dc-muted); font-size:14px; }
+  .slash { background:rgba(88,101,242,.16); color:#A5B0FF; border-radius:4px; padding:1px 6px; font-weight:600; }
+  .cmdreply { margin-top:11px; padding-left:12px; border-left:2px solid var(--dc-rule); color:var(--dc-text); font-size:14.5px; }
+
+  @media (max-width:619.98px) {
+    h1 { font-size:27px; }
+    .msg { grid-template-columns:1fr; }
+    .botav { display:none; }
+    .cv2-section { grid-template-columns:1fr; }
+    .cv2-thumb { display:none; }
+  }
+</style>
+
+<div class="mockbar">
+  <b>Slice 1 mock 5 of 6 — Discord card</b>
+  <span>one card per published session</span>
+  <span>김재현's real Winter 2025 Doubles session</span>
+</div>
+
+<div class="wrap">
+
+  <h1>Discord card</h1>
+  <p class="lede">
+    What a channel sees when someone publishes a session. Composed as a <code>RichBotMessage</code> like
+    every other card on the site, so the Discord adapter owns the emoji swap and the Components V2
+    rendering — and gets the plain-text fallback for free.
+  </p>
+
+  <h2 class="sec">In the channel</h2>
+  <div class="discord">
+    <div class="msg">
+      <div class="botav">🐟</div>
+      <div>
+        <div class="msghead">
+          <span class="botname">PIU Scores</span>
+          <span class="bottag">App</span>
+          <span class="stamp">Today at 8:14 PM</span>
+        </div>
+
+        <div class="cv2">
+          <div class="cv2-section">
+            <div>
+              <div class="h3"><span class="emmix">PHX</span> 김재현 — 59,319 points</div>
+              <div class="small">March of Murlocs · Winter 2025 · Doubles · 1st of 11</div>
+            </div>
+            <div class="cv2-thumb">AVATAR</div>
+          </div>
+
+          <div class="divider"></div>
+
+          <div class="statline">
+            <span><b>39</b> charts</span>
+            <span><b>24.22</b> avg balanced level</span>
+            <span><span class="em" style="background:var(--diff-easy)">D21</span>
+                  → <span class="em" style="background:var(--diff-veryhard)">D26</span></span>
+          </div>
+          <div class="statline" style="margin-top:4px">
+            <span><b>22:04</b> downtime</span>
+            <span><span class="emg" style="color:var(--rar-gold)">AAA</span> average grade</span>
+          </div>
+
+          <div class="divider"></div>
+
+          <div class="small" style="margin-bottom:5px">Biggest five</div>
+          <div id="topfive"></div>
+
+          <div class="divider"></div>
+          <div class="small"><span class="emmix">PHX</span> Phoenix · PIU Scores</div>
+
+          <div class="btnrow"><a class="dcbtn" href="#">See the session</a></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <p class="note" style="margin-top:14px">
+    <b>Two judgement calls to check.</b> <b>“Top five”</b> is ranked by <b>points</b>, not raw score —
+    points are what the session is made of, and the score rides each row anyway. Ranked by score you would
+    get his five cleanest plays, which on this session are all 21s and 22s and say nothing about the session.
+    And <b>“1st of 11”</b> is an addition to your field list: a result card with no placement felt
+    odd, but it is one clause to cut.
+  </p>
+
+  <h2 class="sec">How it is composed</h2>
+  <pre id="compose"></pre>
+
+  <h2 class="sec">Plain-text fallback</h2>
+  <p class="lede" style="margin-bottom:11px">
+    What the adapter flattens to when a channel cannot take Components V2. The emoji tokens still
+    resolve; the container, thumbnail and button do not.
+  </p>
+  <div class="plain" id="plain"></div>
+
+  <h2 class="sec">Turning it on</h2>
+  <p class="lede" style="margin-bottom:11px">
+    A fourth <code>DiscordFeedKind</code> beside Weekly Charts, Daily Step and Official Leaderboards
+    — the same per-mix, community-independent subscription, so a channel opts in once and gets every
+    session on that mix. No community filtering: the event is not popular enough to need it.
+  </p>
+  <div class="cmd">
+    <div class="cmdline"><span class="slash">/piu feed</span> <b style="color:var(--dc-text)">mom</b>
+      <span>mix:</span> <b style="color:var(--dc-text)">Phoenix</b></div>
+    <div class="cmdreply">🐟 <b>March of Murlocs</b> results will post here for <b>Phoenix</b>.
+      One card each time somebody publishes a session.</div>
+  </div>
+
+  <p class="note" style="margin-top:24px">
+    <b>A published session only.</b> A draft never fires a card, and because a published session cannot be
+    edited there is never a second card correcting the first. Deleting a session leaves its card behind —
+    Discord messages cannot be unsent, and the link 404s, which you decided was fine for how rare
+    it is.
+  </p>
+</div>
+
+<script>
+  // 김재현's Winter 2025 Doubles session, top five by the points each chart banked.
+  // [title, level, score, points, grade, plate]
+  var TOP5 = [
+    ["Gargoyle - FULL SONG -",25,844710,3207,"A+","RG"],
+    ["8 6 - FULL SONG -",23,962566,2990,"AAA+","RG"],
+    ["Papasito (feat.  KuTiNA) - FULL SONG -",23,974365,2966,"S","FG"],
+    ["Leather",26,888018,2327,"A+","RG"],
+    ["Darkside of The Mind",25,941887,1741,"AA+","RG"]
+  ];
+  function esc(s){ return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/"/g,"&quot;"); }
+  function n(v){ return v.toLocaleString("en-US"); }
+  function levelColor(l){
+    if (l<=21) return "var(--diff-easy)";
+    if (l<=22) return "var(--diff-medium)";
+    if (l<=24) return "var(--diff-hard)";
+    return "var(--diff-veryhard)";
+  }
+  function gradeColor(g){
+    if (g[0]==="S") return "var(--rar-sapphire)";
+    if (g.indexOf("AAA")===0) return "var(--rar-gold)";
+    if (g.indexOf("AA")===0) return "var(--rar-silver)";
+    return "var(--rar-common)";
+  }
+  var PLATECOLOR = {RG:"var(--plate-copper)",FG:"var(--plate-copper)",TG:"var(--plate-silver)",
+                    MG:"var(--plate-silver)",SG:"var(--rar-gold)",EG:"var(--rar-gold)",
+                    UG:"#9BE9FF",PG:"#9BE9FF"};
+
+  document.getElementById("topfive").innerHTML = TOP5.map(function(t){
+    return '<div class="row">'
+      + '<span class="em" style="background:'+levelColor(t[1])+'">D'+t[1]+'</span>'
+      + '<span class="songname">'+esc(t[0])+'</span> — '
+      + '<span class="pts">'+n(t[3])+'</span>'
+      + '<span class="small num">'+n(t[2])+'</span>'
+      + '<span class="emg" style="color:'+gradeColor(t[4])+'">'+t[4]+'</span>'
+      + '<span class="emp" style="color:'+(PLATECOLOR[t[5]]||"var(--rar-common)")+'">'+t[5]+'</span>'
+      + '</div>';
+  }).join("");
+
+  // The composition, in the shape the sagas already use. Tokens stay untouched — the Discord
+  // adapter swaps #DIFFICULTY|…#, #LETTERGRADE|…#, #PLATE|…# and #MIX|…# for custom emoji.
+  var CODE =
+'<span class="c">// MoMPublishedSaga — one card per published session</span>\n' +
+'<span class="k">new</span> RichBotMessage(\n' +
+'  Header: <span class="k">new</span> RichBotSection(\n' +
+'    <span class="s">$"### #MIX|{mix}#**{user.Name}** — {total:N0} points\\n"</span> +\n' +
+'    <span class="s">$"-# March of Murlocs · {season.Name} · {board.ChartType} · {place.Ordinal()} of {board.Count}"</span>,\n' +
+'    user.ProfileImage),\n' +
+'  Blocks: [\n' +
+'    <span class="k">new</span> RichBotDivider(),\n' +
+'    <span class="k">new</span> RichBotText(\n' +
+'      <span class="s">$"**{charts:N0}** charts · **{avgBalanced:N2}** avg balanced level · "</span> +\n' +
+'      <span class="s">$"#DIFFICULTY|{lowest}# → #DIFFICULTY|{highest}#\\n"</span> +\n' +
+'      <span class="s">$"**{downtime:m\\\\:ss}** downtime · #LETTERGRADE|{avgGrade}|False# average grade"</span>),\n' +
+'    <span class="k">new</span> RichBotDivider(),\n' +
+'    <span class="k">new</span> RichBotText(\n' +
+'      <span class="s">"-# Biggest five\\n"</span> + <span class="k">string</span>.Join(<span class="s">"\\n"</span>, top5.Select(e =>\n' +
+'        <span class="s">$"#DIFFICULTY|{e.Chart.DifficultyString}# {e.Chart.Song.Name} — "</span> +\n' +
+'        <span class="s">$"**{e.SessionScore:N0}** -# {e.Score:N0} #- "</span> +\n' +
+'        <span class="s">$"#LETTERGRADE|{e.Grade}|{e.IsBroken}##PLATE|{e.Plate}#"</span>)))\n' +
+'  ],\n' +
+'  Footer: <span class="s">$"#MIX|{mix}# {mix.GetName()} · PIU Scores"</span>,\n' +
+'  AccentColor: <span class="c">/* the mix primary */</span> 0x3FA9F5,\n' +
+'  Links: [<span class="k">new</span> RichBotLink(<span class="s">"See the session"</span>,\n' +
+'    <span class="k">new</span> Uri(<span class="s">$"{SiteBase}/MarchOfMurlocs/Session/{session.Id}"</span>))])';
+  document.getElementById("compose").innerHTML = CODE;
+
+  document.getElementById("plain").innerHTML =
+      '<div style="font-weight:700;color:#fff;font-size:17px"><span class="emmix">PHX</span> 김재현 — 59,319 points</div>'
+    + '<span class="small">March of Murlocs · Winter 2025 · Doubles · 1st of 11</span>'
+    + '<div style="margin-top:7px"><b style="color:#fff">39</b> charts · <b style="color:#fff">24.22</b> avg balanced level · '
+    + '<span class="em" style="background:var(--diff-easy)">D21</span> → '
+    + '<span class="em" style="background:var(--diff-veryhard)">D26</span><br>'
+    + '<b style="color:#fff">22:04</b> downtime · <span class="emg" style="color:var(--rar-gold)">AAA</span> average grade</div>'
+    + '<div class="small" style="margin-top:7px">Biggest five</div>'
+    + document.getElementById("topfive").innerHTML
+    + '<div class="small" style="margin-top:7px"><span class="emmix">PHX</span> Phoenix · PIU Scores<br>'
+    + '<a href="#" style="color:var(--dc-link)">piuscores.arroweclip.se/MarchOfMurlocs/Session/8f3c…</a></div>';
+</script>

--- a/docs/design/march-of-murlocs-mocks/6-past-seasons.html
+++ b/docs/design/march-of-murlocs-mocks/6-past-seasons.html
@@ -1,0 +1,199 @@
+<title>MoM — Past seasons mock</title>
+<style>
+  :root {
+    --mix-bg:#070B15; --mix-surface:#161E2C; --mix-raised:#1E2A3D; --mix-nav:#0D1626;
+    --mix-primary:#3FA9F5; --mix-secondary:#FF6B35; --mix-accent:#FFD24A;
+    --mix-ink:#E9EFF7; --mix-muted:#93A3B8;
+    --chart-single:#FF6B35; --chart-double:#38B6FF;
+    --rar-gold:#FFD24A; --rar-silver:#CBD5E1; --daily-you:#4bb8ff;
+    --line:rgba(233,239,247,.12); --line-strong:rgba(233,239,247,.22);
+    --display:"Barlow Condensed","Oswald","Roboto Condensed","Arial Narrow",system-ui,sans-serif;
+    --body:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"], :root[data-theme="dark"] { color-scheme: dark; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--mix-bg); color:var(--mix-ink); font-family:var(--body);
+         font-size:15px; line-height:1.5; -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:1060px; margin:0 auto; padding:16px 16px 70px; }
+  .num { font-variant-numeric:tabular-nums; }
+  h1,h2,h3 { font-family:var(--display); font-weight:600; margin:0; text-wrap:balance; }
+
+  .mockbar { background:#12203a; border-bottom:1px solid var(--line); padding:9px 16px; font-size:12.5px;
+             color:var(--mix-muted); display:flex; flex-wrap:wrap; gap:6px 14px; align-items:center; }
+  .mockbar b { color:var(--mix-ink); font-weight:600; }
+  .mockbar button { background:var(--mix-raised); color:var(--mix-ink); border:1px solid var(--line-strong);
+                    border-radius:5px; font:inherit; font-size:12px; padding:4px 10px; cursor:pointer; }
+  .note { border-left:2px solid var(--mix-accent); background:rgba(255,210,74,.06); padding:9px 13px;
+          margin:0; border-radius:0 5px 5px 0; font-size:13px; color:#E4D9BC; }
+  .note b { color:var(--mix-accent); font-weight:600; }
+
+  /* the season page behind the dialog, so the trigger has context */
+  .frame-head { display:flex; align-items:flex-end; gap:14px; flex-wrap:wrap;
+                border-bottom:1px solid var(--line); padding-bottom:11px; }
+  .frame-title { font-family:var(--display); font-size:34px; font-weight:700; line-height:1; }
+  .frame-nav { display:flex; gap:4px; margin-left:auto; flex-wrap:wrap; }
+  .frame-nav a, .frame-nav button { color:var(--mix-muted); text-decoration:none; font-size:13px;
+    padding:5px 10px; border-radius:5px; background:none; border:0; font-family:inherit; cursor:pointer; }
+  .frame-nav a:hover, .frame-nav button:hover { color:var(--mix-ink); background:var(--mix-raised); }
+  .frame-nav a[aria-current] { color:var(--mix-ink); background:var(--mix-raised); }
+  .ghosted { opacity:.35; pointer-events:none; margin-top:18px; }
+  .gline { height:11px; border-radius:6px; background:var(--mix-surface); margin-bottom:9px; }
+
+  /* ---------- the dialog ---------- */
+  dialog { background:var(--mix-surface); color:var(--mix-ink); border:1px solid var(--line-strong);
+           border-radius:11px; padding:0; max-width:620px; width:calc(100% - 32px); }
+  dialog::backdrop { background:rgba(3,6,12,.74); }
+  .dlg-head { padding:15px 18px 12px; border-bottom:1px solid var(--line); }
+  .dlg-head h2 { font-size:24px; }
+  .dlg-head p { margin:3px 0 0; font-size:12.5px; color:var(--mix-muted); }
+  .dlg-body { max-height:min(62vh,520px); overflow-y:auto; padding:8px; }
+  .dlg-actions { display:flex; justify-content:flex-end; gap:9px; padding:11px 18px 14px;
+                 border-top:1px solid var(--line); }
+  .btn { background:var(--mix-primary); color:#06101C; border:0; border-radius:6px; font:inherit;
+         font-size:13.5px; font-weight:600; padding:8px 15px; cursor:pointer; }
+  .btn.ghost { background:transparent; color:var(--mix-ink); border:1px solid var(--line-strong); }
+  .btn:focus-visible { outline:2px solid var(--mix-primary); outline-offset:2px; }
+
+  .srow { display:block; width:100%; text-align:left; background:transparent; border:1px solid transparent;
+          border-radius:8px; padding:10px 12px; cursor:pointer; color:inherit; font:inherit; }
+  .srow:hover { background:var(--mix-raised); border-color:var(--line-strong); }
+  .srow:focus-visible { outline:2px solid var(--mix-primary); outline-offset:-2px; }
+  .srow.live { border-color:rgba(255,210,74,.45); background:rgba(255,210,74,.05); }
+  .srow-top { display:flex; align-items:baseline; gap:10px; flex-wrap:wrap; }
+  .sname { font-family:var(--display); font-size:21px; font-weight:600; line-height:1.1; }
+  .livechip { font-size:10.5px; letter-spacing:.08em; text-transform:uppercase; color:var(--mix-accent);
+              border:1px solid rgba(255,210,74,.5); border-radius:3px; padding:0 6px; }
+  .sdates { margin-left:auto; font-size:12.5px; color:var(--mix-muted); white-space:nowrap; }
+  .sboards { margin-top:7px; display:flex; flex-direction:column; gap:4px; }
+  .sboard { display:grid; grid-template-columns:26px 62px 1fr auto; gap:10px; align-items:baseline;
+            font-size:13px; font-variant-numeric:tabular-nums; }
+  .btype { font-family:var(--display); font-weight:700; font-size:13px; text-align:center;
+           border-radius:3px; padding:1px 0; }
+  .btype.d { color:var(--chart-double); border:1px solid rgba(56,182,255,.45); background:rgba(56,182,255,.10); }
+  .btype.s { color:var(--chart-single); border:1px solid rgba(255,107,53,.45); background:rgba(255,107,53,.10); }
+  .bruns { color:var(--mix-muted); }
+  .bwin { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .bwin b { color:var(--mix-ink); font-weight:600; }
+  .bwin .crown { color:var(--rar-gold); }
+  .byou { font-size:12px; color:var(--daily-you); white-space:nowrap; }
+  .byou.none { color:var(--mix-muted); }
+  .sempty { margin-top:7px; font-size:12.5px; color:var(--mix-muted); }
+
+  @media (max-width:519.98px) {
+    .sdates { margin-left:0; width:100%; }
+    .sboard { grid-template-columns:24px 1fr; row-gap:2px; }
+    .bruns { grid-column:2; }
+    .bwin, .byou { grid-column:2; }
+  }
+</style>
+
+<div class="mockbar">
+  <b>Slice 1 mock 6 of 6 — Past seasons</b>
+  <span>a dialog, not a page</span>
+  <span>every real MoM season, with DrMurloc's actual placements</span>
+  <button type="button" id="reopen">Reopen the dialog</button>
+</div>
+
+<div class="wrap">
+  <div class="frame-head">
+    <div>
+      <div class="frame-title">March of Murlocs</div>
+      <div style="font-size:13px;color:var(--mix-muted);margin-top:3px">
+        1 hour 45 minutes. Bank as many points as you can.
+      </div>
+    </div>
+    <nav class="frame-nav">
+      <a href="#" aria-current="page">This season</a>
+      <a href="#">Planner</a>
+      <button type="button" id="open">Past seasons</button>
+      <a href="#">Rules</a>
+    </nav>
+  </div>
+
+  <div class="ghosted" aria-hidden="true">
+    <div class="gline" style="width:38%;height:26px"></div>
+    <div class="gline" style="width:100%;height:64px"></div>
+    <div class="gline" style="width:100%"></div>
+    <div class="gline" style="width:96%"></div>
+    <div class="gline" style="width:99%"></div>
+    <div class="gline" style="width:92%"></div>
+    <div class="gline" style="width:97%"></div>
+  </div>
+
+  <p class="note" style="margin-top:26px">
+    <b>Why a dialog rather than a page.</b> There are <b>four</b> seasons with results in them, and
+    a quarterly cadence adds one a quarter — this is a picker, not a body of content, and a page
+    would be a route, an empty state and an SSR decision bought for a list of five rows. The
+    crawlable artifact is each <b>season's own page</b>, which the sitemap lists directly, so
+    nothing is hidden by keeping the index in a dialog. If it ever passes roughly twenty rows it
+    earns the page then.
+  </p>
+
+  <p class="note" style="margin-top:12px">
+    <b>One thing the dialog cannot do</b>, and it needs covering when this is built: it gives a
+    crawler no path between seasons. The season page should carry <b>previous / next season</b>
+    links of its own — cheap, and it is how the archive stays reachable without a route.
+  </p>
+</div>
+
+<dialog id="dlg" aria-labelledby="dtitle">
+  <div class="dlg-head">
+    <h2 id="dtitle">Seasons</h2>
+    <p>Every March of Murlocs so far. Pick one to see its boards.</p>
+  </div>
+  <div class="dlg-body" id="list"></div>
+  <div class="dlg-actions"><button type="button" class="btn ghost" id="close">Close</button></div>
+</dialog>
+
+<script>
+  // Every real MoM season, collapsed per §7: eight legacy tournament rows become five seasons.
+  // boards: [chartType, sessions, winner, topScore, yourPlace|null, yourScore|null]
+  var SEASONS = [
+    // The one invented season — there is no live MoM in the data to show this state with.
+    { name:"Winter 2026", dates:"1 Jan – 31 Mar 2026", live:true, boards:[
+        ["D", 3, "yimmythe42", 54118, 2, 51900],
+        ["S", 1, "GODDISH", 38402, null, null]] },
+    { name:"Winter 2025", dates:"2 Feb – 31 Mar 2025", boards:[
+        ["D", 11, "김재현", 59319, null, null],
+        ["S", 5, "ddrlevelasian", 54431, 2, 42596]] },
+    { name:"March of Murlocs 2", dates:"8 Jun – 8 Aug 2024", boards:[
+        ["D", 17, "FEFEMZ", 78691, 10, 35879],
+        ["S", 10, "Franco Cañoles", 65225, 2, 41782]] },
+    { name:"March of Murlocs", dates:"5 – 27 Nov 2023", boards:[
+        ["D", 17, "mattmiller", 49211, 15, 21121]] },
+    { name:"Practice", dates:"4 Oct – 2 Nov 2023", boards:[
+        ["D", 2, "DrMurloc", 27632, 1, 27632]] }
+  ];
+  var YOU = "DrMurloc";
+
+  function n(v){ return v.toLocaleString("en-US"); }
+  function esc(s){ return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/"/g,"&quot;"); }
+  function ord(i){ return i + (["th","st","nd","rd"][(i%100-i%10!=10)*(i%10<4)*i%10] || "th"); }
+
+  document.getElementById("list").innerHTML = SEASONS.map(function(s){
+    var boards = s.boards.map(function(b){
+      var type=b[0], sessions=b[1], winner=b[2], top=b[3], place=b[4], mine=b[5];
+      var youWon = winner === YOU;
+      return '<div class="sboard">'
+        + '<span class="btype '+type.toLowerCase()+'">'+type+'</span>'
+        + '<span class="bruns">'+sessions+(sessions===1?" session":" sessions")+'</span>'
+        + '<span class="bwin"><span class="crown">♛</span> <b>'+esc(winner)+'</b> '+n(top)+'</span>'
+        + (place
+            ? '<span class="byou">'+(youWon?"you won it":"you were "+ord(place)+" — "+n(mine))+'</span>'
+            : '<span class="byou none">you sat this one out</span>')
+        + '</div>';
+    }).join("");
+    return '<button type="button" class="srow'+(s.live?" live":"")+'">'
+      + '<span class="srow-top"><span class="sname">'+esc(s.name)+'</span>'
+      + (s.live?'<span class="livechip">running now</span>':'')
+      + '<span class="sdates">'+esc(s.dates)+'</span></span>'
+      + '<span class="sboards">'+boards+'</span>'
+      + '</button>';
+  }).join("");
+
+  var dlg = document.getElementById("dlg");
+  document.getElementById("open").addEventListener("click", function(){ dlg.showModal(); });
+  document.getElementById("reopen").addEventListener("click", function(){ if(!dlg.open) dlg.showModal(); });
+  document.getElementById("close").addEventListener("click", function(){ dlg.close(); });
+  dlg.showModal();
+</script>

--- a/docs/design/march-of-murlocs-mocks/README.md
+++ b/docs/design/march-of-murlocs-mocks/README.md
@@ -1,0 +1,50 @@
+# March of Murlocs — Slice 1 mocks
+
+Signed off 2026-08-11. These are the design artifacts behind
+[§11 of the plan](../march-of-murlocs.md#11-the-surfaces) — the doc is the specification and
+these are what it was agreed against. Open any file directly in a browser; they are standalone
+HTML with no build step, no network calls and no dependencies.
+
+| | Surface | Route |
+|---|---|---|
+| [1](1-season.html) | **Season** — the landing page | `/MarchOfMurlocs` |
+| [2](2-session-breakdown.html) | **Session Breakdown** | `/MarchOfMurlocs/Session/{id}` |
+| [3](3-submit.html) | **Submit** | `/MarchOfMurlocs/Session/{id}/Edit` |
+| [4](4-planner.html) | **Planner** | `/MarchOfMurlocs/Planner` |
+| [5](5-discord-card.html) | **Discord card** | — |
+| [6](6-past-seasons.html) | **Past seasons** — a dialog, no route | — |
+
+They are interactive, and the interactions are the point: flip densities, drag the Planner's rest
+slider, run the Submit page's import, switch the Season page between mid-season and opening week.
+Each carries a **mock bar** across the top naming itself and saying what its data is.
+
+## The data is real
+
+**Every figure came out of a production-synced database**, not from imagination — 김재현's Winter
+2025 Doubles session and his 129-chart Phoenix Doubles record book, the real Winter 2025 boards,
+DrMurloc's actual rivals and community memberships, and the two seasons' frozen scoring
+configurations. Everyone shown has a public profile, and MoM sessions are public on the board by
+rule regardless.
+
+That is why the mocks kept finding things. Two live defects (§2.8, §2.9) and one persistence
+trap (§9.5b) came out of drawing pages against real numbers; none of them would have surfaced
+against invented ones. **Do the same for the next slice's mocks.**
+
+Where something is *not* real it is called out in the page's own footnote. There are three, all
+because no real example exists yet: tieny's second Doubles session on the Season page (multiple
+sessions per season postdate all data, D16), the live Winter 2026 season in the Past seasons
+dialog, and the Submit page's draft.
+
+## What they cannot show
+
+- **Jacket and avatar art is external** and the Artifact sandbox blocks it, so those boxes are
+  placeholders at the real pixel budget. On the site the jacket is the identifier (UX rule 2).
+- **Discord custom emoji** are drawn as CSS chips. The real card ships `#DIFFICULTY|…#`,
+  `#LETTERGRADE|…#`, `#PLATE|…#` and `#MIX|…#` tokens and the adapter swaps them.
+- **MudBlazor** is not loaded. Controls are hand-built to match the components they stand in for —
+  the density buttons mirror `/Pumbility`'s `MudIconButton` group, the chart-type group mirrors the
+  tier lists' `MudButtonGroup`.
+
+Colours are the Phoenix palette lifted verbatim from `Services/Theming/MixThemes.cs`, and the row
+highlight set (`.is-me` / `.is-rival` / `.is-community` / `.is-both`) is copied from `site.css`
+rather than re-derived, so a MoM board wears the sitewide standard.

--- a/docs/design/march-of-murlocs.md
+++ b/docs/design/march-of-murlocs.md
@@ -1,6 +1,8 @@
 # March of Murlocs Overhaul
 
-Status: **Slice 0 landed; Slices 1–5 planned.** Exploration session 2026-08-09.
+Status: **Slice 0 landed. Slice 1 is complete — decisions settled and all six surfaces mocked
+(§11). The remaining slices were re-ordered afterwards (§8).** Explored 2026-08-09, workshopped
+and mocked 2026-08-10/11.
 
 March of Murlocs is the site's quarterly stamina ladder: 1 hour 45 minutes to bank as many
 points as you can, scored with PUMBILITY+. It has been running on autopilot since
@@ -18,7 +20,24 @@ Today's pages: [`MarchOfMurlocs.razor`](../../ScoreTracker/ScoreTracker/Pages/Co
 (the "Test Scores" planner). Logic lives in
 [`MarchOfMurlocsHandler.cs`](../../ScoreTracker/ScoreTracker.EventCompetition/Application/MarchOfMurlocsHandler.cs).
 
-Mock: **not yet built** — that is Slice 1, and it deliberately precedes the schema work.
+All four are **retired rather than ported** — see §11, which is what Slice 1 decided and what the
+mocks were built from. Slice 1 deliberately precedes the schema work so UI decisions can still move
+the tables, and it did: D16 alone deleted a uniqueness constraint from §6, D20 and D21 arrived from
+drawing the pages, and building them surfaced two live defects (§2.8, §2.9).
+
+**The six mocks are checked in** beside this doc at
+[`march-of-murlocs-mocks/`](march-of-murlocs-mocks/README.md) — standalone interactive HTML, no
+build step, every figure out of a production-synced database rather than imagined. Open them
+directly; the interactions are the point.
+
+| | Surface | Mock | Also live at |
+|---|---|---|---|
+| 1 | Season | [`1-season.html`](march-of-murlocs-mocks/1-season.html) | [artifact](https://claude.ai/code/artifact/1eee21b6-252c-46d0-bf82-78af5496f23f) |
+| 2 | Session Breakdown | [`2-session-breakdown.html`](march-of-murlocs-mocks/2-session-breakdown.html) | [artifact](https://claude.ai/code/artifact/55ff811f-b0c4-44d2-983c-91f20d425351) |
+| 3 | Submit | [`3-submit.html`](march-of-murlocs-mocks/3-submit.html) | [artifact](https://claude.ai/code/artifact/2bc91508-3bb6-4b1d-9f11-edcf083056b6) |
+| 4 | Planner | [`4-planner.html`](march-of-murlocs-mocks/4-planner.html) | [artifact](https://claude.ai/code/artifact/e62f1441-b673-4261-b96b-94b21319c8ca) |
+| 5 | Discord card | [`5-discord-card.html`](march-of-murlocs-mocks/5-discord-card.html) | [artifact](https://claude.ai/code/artifact/395daf21-13b8-4678-8183-557434bfd16a) |
+| 6 | Past seasons | [`6-past-seasons.html`](march-of-murlocs-mocks/6-past-seasons.html) | [artifact](https://claude.ai/code/artifact/f2f59b79-f76e-4d6d-a304-82a47568a6c6) |
 
 ---
 
@@ -31,14 +50,21 @@ deletion rather than a rule change (§3).
 
 - **Quarterly seasons.** Jan–Mar = *Winter*, Apr–Jun = *Spring*, Jul–Sep = *Summer*,
   Oct–Dec = *Fall*. A season ends at 23:59:59 on the last day of its final month, UTC−5.
-- **1 hour 45 minutes** of play per session.
-- **Singles and Doubles are separate boards.** As of this pass, so are Phoenix and Phoenix 2.
+- **1 hour 45 minutes** of play per session. **The window governs when a song may *start*, not
+  when it must finish** — a chart you started before the buzzer counts in full, and closing a session
+  on Gargoyle FULL SONG is the standard play (owner, 2026-08-11). `CanAdd` implements the stricter
+  rule today; see §2.9.
+- **Singles and Doubles are separate boards, and nothing in MoM ever compares them** (D15).
+  As of this pass, Phoenix and Phoenix 2 are separate too.
+- **A player may run a season as many times as they like** (D16). Each is its own session
+  and boards rank sessions, not players — three good sessions may hold the top three places.
+  In practice almost nobody runs twice; the session is brutal.
 - **Repeats are banned** — but the identity is song + chart type + *level*. The same song at a
   different difficulty is a different chart and is legal.
 - **Ties never happen in practice**; when they do, **earliest submission wins**.
-- **Phoenix 1: A and below are worth zero, and a zero-point play is a non-play** — it does not
-  count toward chart count and does not block replaying that chart. It still consumes session
-  time.
+- **Phoenix 1: A and below are *meant* to be worth zero, and a zero-point play is a non-play** —
+  it does not count toward chart count and does not block replaying that chart. It still consumes
+  session time. **The rule does not currently hold: see §2.8.**
 - **Phoenix 2: the "A or below" rule is unsettled** and will be decided after the scoring
   experiment (§10). P2 ships on stock P2 pumbility, where the worst grade still pays 0.90.
 - Song length scales value, with a 2-minute baseline.
@@ -50,7 +76,7 @@ deletion rather than a rule change (§3).
 
 ---
 
-## 2. Why now — six defects, all confirmed against production-synced data
+## 2. Why now — eight defects, all confirmed against production-synced data
 
 ### 2.1 The runaway — **fixed in Slice 0**; the junk rows are still owner-run cleanup
 
@@ -143,6 +169,66 @@ be accepted. 2.5 is what makes this checkable for the first time.
 - `RecordTournamentSession.DifficultyBubblePath` is dead — the `DifficultyBubble` component
   replaced it.
 
+### 2.8 The anti-mash zero does not actually zero anything — found 2026-08-10
+
+**The continuous grade scale interpolates straight through the zeroed rungs, so "A and below is
+worth zero" is only true at or below 750,000.**
+
+`ContinuousLetterGradeScale = true` means a score between two rungs takes a modifier between the
+two rungs' values. PUMBILITY+ sets A to `0` and A+ to `0.50`, and the A band runs 750,000–824,999
+— so the interpolation ramps a *zeroed* grade from 0 up to very nearly 0.5 across that band:
+
+| Score | Grade | Modifier |
+|---|---|---|
+| 750,000 | A | 0.000 |
+| 780,000 | A | 0.200 |
+| 812,400 | A | 0.416 |
+| 824,999 | A | **0.500** |
+
+The consequence is exactly the mash the grade rewrite exists to prevent. Priced under Winter
+2025's own frozen config:
+
+- a level 26 mashed to **824,999** over 112 seconds pays **1,031**
+- a level 22 played cleanly to a **AAA** over 120 seconds pays **930**
+
+So barely scraping an A on a 26 beats a clean AAA on a 22 — and §5's whole argument for the
+Phoenix 1 kicker assumes the opposite. §5's table saying the Phoenix 1 zero cliff is "< 825,000"
+is wrong for the same reason; the real cliff is < 750,000.
+
+Two candidate fixes, both one value. `MinimumScore = 825000` on the Phoenix 1 MoM config makes the
+cliff real (`if (score < MinimumScore) return 0`) — it is the same knob §10 already earmarks for
+the Phoenix 2 question. Or the grade table sets A to a small negative so the interpolation crosses
+zero at the intended place, which is clever and unreadable and should not be chosen.
+
+**This is a rules question, not just a bug**: the owner may decide a partial credit for a scraped
+A is fine. But it is not what §1 says, and it has been live since the grade rewrite landed.
+
+### 2.9 The window check refuses a legal closing song — found 2026-08-11
+
+`TournamentSession.CanAdd` tests `TotalPlayTime + duration > MaxTime`, which requires the final
+chart to *finish* inside the window. The rule is that it only has to **start** inside it (§1), so
+the check is too strict by up to the length of one song — and it bites exactly the play people
+actually make, closing on a six-minute full song.
+
+The correct test is simpler than the current one, and the candidate's own length does not enter
+into it:
+
+```
+may add  ⟺  sum of every duration already entered  <  MaxTime
+```
+
+Every chart is provisionally the last, so this is the only condition at entry time; adding another
+after it is what makes the previous one's full length binding, and that is the same check one
+chart later. Consequences worth writing down:
+
+- **`TotalPlayTime` can now exceed `MaxTime`**, so derived rest must floor at zero rather than go
+  negative. A session that overhangs has *no* rest by construction — it filled the window.
+- **The import's hard block moves too**: it is the song time *excluding the final play* that
+  cannot exceed the window.
+- **Nothing in the existing data changes.** The tightest real session is esi's 42-chart session with
+  13:43 of rest, so no stored row is anywhere near the cap and no historical total re-scores.
+  This has never bound — it would have bitten the first person to try the Gargoyle close.
+
 ---
 
 ## 3. Locked decisions
@@ -158,11 +244,19 @@ be accepted. 2.5 is what makes this checkable for the first time.
 | D7 | **Migrate all legacy seasons.** Copy, never move. | 62 sessions of history. Copying keeps a botched migration recoverable and leaves `PhotoVerification` without orphans. |
 | D8 | **Delta-only chart-level snapshots.** | Measured −60%. The equivalence is exact, not approximate (§9.3). |
 | D9 | **`MoM*` naming**, not a generic "stamina ladder". | MoM is always going to be the only one. |
-| D10 | **Hard block** on duration overflow; **soft warning** on timestamp span. | A session that *cannot* fit is invalid; a session that *looks* stitched together is a judgement call. |
+| D10 | **Hard block** on duration overflow; **soft warning** on timestamp span. Duration overflow means *everything before the last chart* exceeds the window — the last one may overhang (§1, §2.9). | A session that *cannot* fit is invalid; a session that *looks* stitched together is a judgement call. |
 | D11 | **PUMBILITY+ tracks the mix's own rating system.** | See §5. P1 needed heavy correction; P2 does not. |
 | D12 | **Phoenix 2 ships admin-gated.** | Scoring gets min/maxed in a dedicated session before players see it. |
 | D13 | **Empty ended seasons are pruned** when the next season is created. | Owner call. Keeps the table honest without a cron. |
-| D14 | **The targets screen lives inside MoM.** | Self-encapsulated; it is a MoM page, not a pumbility page. |
+| D14 | **The targets screen is two tenses of one breakdown** — a Planner before you play and a Session Breakdown after — both inside MoM. | Self-encapsulated; it is a MoM page, not a pumbility page. Owner 2026-08-10: people enter once a season and the event is a competition against yourself, so *understanding your own session* beats ranking against strangers. |
+| D15 | **Nothing in MoM ever compares Singles to Doubles.** | Owner 2026-08-10. Fundamentally different approaches and scoring results. Rules out combined totals, cross-type averages, and any breakdown axis spanning both — an "average difficulty 24.1" means nothing unless you know the type. §11.6. |
+| D16 | **A player may run a season many times; boards rank sessions, not players.** | Owner 2026-08-10. Three good sessions may hold the top three places — "if someone does 3 of these in 3 months, they deserve being top 3". Kills `UNIQUE (BoardId, UserId)` and makes recorded date a load-bearing board column. |
+| D17 | **Draft → published → frozen.** A draft is visible only to its owner and never reaches a board; publishing freezes the session; a correction is delete-and-resubmit. | Owner 2026-08-10. Thirty hand-typed charts must survive a stray navigation, and a published session is a record of a thing that happened. Delete must therefore exist, or a typo is permanent. |
+| D18 | **Recorded date is the moment of publication, and is not editable.** | Owner 2026-08-10. Manual entry has nothing to derive a play time from until timestamps land (Slice 3), and a player-supplied date is a field to get wrong. Resubmitting after a delete moves the date — which only affects tie-breaks, which never happen. |
+| D19 | **MoM declares its mixes in `MixCapabilities`**, like every other section — Phoenix 1 and 2, never a legacy mix. | Landed on main 2026-08-10: the desktop menu and the phone More sheet are two renderings of one rule set, and two copies of a rule is how the recording form lost its legacy branch. |
+| D20 | **A cross-season comparison re-prices the old session under the new season's whole frozen config** — snapshot *and* scoring tables — and reports what moved underneath separately from what the player earned. | Owner 2026-08-10. A raw season-over-season delta silently mixes "I got better" with "the game changed". Measured between MoM 2 and Winter 2025, both moved: 10 charts re-rated **and** every level-23+ rating raised while the grade table was cut. §11.3. |
+| D21 | **The session list carries all three sanctioned densities**, with sort behind a **Sort by** popover in Comfortable and Compact, and on the column headers in Table. | Owner 2026-08-10. UX rule 5's three modes, no fourth. A visible button group spent toolbar width on a control that is used once; Table already sorts from its headers, so a popover there would be a second control for one job. §11.3. |
+| D22 | **The word is "session", everywhere.** Not run, not attempt, not entry. | Owner, 2026-08-10 and enforced again 2026-08-11 after "run" crept back into every mock. One ubiquitous term for the thing a player records, publishes, breaks down and plans — page copy, headings, Discord cards, localization keys and the `MoMSession` table alike. "Run" reads fine in isolation, which is exactly why it keeps returning. |
 
 ### Explicitly rejected
 
@@ -274,7 +368,7 @@ below 950,000, which bounds the behavioural change precisely:
 
 | | Phoenix 1 | Phoenix 2 |
 |---|---|---|
-| Zero cliff | < 825,000 | *none in this pass* |
+| Zero cliff | < 750,000 *(intended < 825,000 — see §2.8)* | *none in this pass* |
 | 0.50 → 1.00 ramp | 825k → 950k | *n/a — P2 uses its own 0.90 → 1.50* |
 
 Implementation: keep the parameterless `ScoringConfiguration.PumbilityPlus` **exactly as it is**
@@ -315,21 +409,29 @@ scores.MoMChartLevel                      -- balance snapshot, DELTA ROWS ONLY
   SeasonId, MixId, ChartId  PK
   Level       float
 
-scores.MoMEntry
+scores.MoMSession
   Id                uniqueidentifier PK
   BoardId           FK -> MoMBoard
   UserId            uniqueidentifier      -- purge key (§9.7)
+  PublishedAt       datetimeoffset NULL   -- NULL = draft (D17); once set it is the
+                                          --   recorded date (D18) and the tie-break clock
   TotalScore        int
   ChartsPlayed      int                   -- excludes zero-point plays on P1 (§1)
   RestTime          bigint
-  AverageDifficulty float
+  AverageDifficulty float                 -- BALANCED level, not the folder number (§11.6)
+  AverageGrade      float
+  LowestLevel       tinyint
+  HighestLevel      tinyint
   VideoUrl          nvarchar(500) NULL    -- D6: showcase, not validation
-  SubmittedAt       datetimeoffset        -- tie-break: earliest wins
+  CreatedAt         datetimeoffset
   UpdatedAt         datetimeoffset
-  UNIQUE (BoardId, UserId)
 
-scores.MoMEntryChart                      -- normalized; replaces the JSON blob
-  EntryId, Ordinal  PK
+  CREATE INDEX IX_MoMSession_Board ON scores.MoMSession (BoardId, TotalScore DESC)
+      WHERE PublishedAt IS NOT NULL;      -- the board read; drafts are never on it
+  -- Deliberately NO unique on (BoardId, UserId): a player may run a season many times (D16).
+
+scores.MoMSessionChart                    -- normalized; replaces the JSON blob
+  SessionId, Ordinal  PK
   ChartId     uniqueidentifier
   Score       int
   Plate       nvarchar(20)
@@ -339,12 +441,16 @@ scores.MoMEntryChart                      -- normalized; replaces the JSON blob
   PlayedAt    datetimeoffset NULL         -- §2.5
 ```
 
+**Everything on `MoMSession` below `PublishedAt` is a derived cache** of its `MoMSessionChart`
+rows — recomputed on every save, never edited independently. They exist so a board render and a
+Discord card do not have to open thirty chart rows per session; they are not a second truth.
+
 **Why the scoring config is stored, not derived.** MoM's config is fully determined by
 (mix, chart type) today, so rebuilding it on read is tempting — but then any tweak to the 22+
 table retroactively rescores 2024. Four serialized rows per season is cheap insurance for a
 competitive ladder.
 
-**Why `MoMEntryChart` is normalized.** `GetLeaderboardRecords` currently calls `GetSession` per
+**Why `MoMSessionChart` is normalized.** `GetLeaderboardRecords` currently calls `GetSession` per
 player, each deserializing JSON and re-fetching charts — a live N+1 on every board render.
 Normalized rows also give `PlayedAt` a home.
 
@@ -387,19 +493,40 @@ Notes for whoever writes it:
 
 ## 8. Slices
 
-Ordered so that UI decisions can still move the schema.
+Ordered so that UI decisions can still move the schema — which they did, so **the back half was
+re-ordered after Slice 1** (2026-08-11). What changed and why is under the table.
 
 | Slice | Contents | Depends on |
 |---|---|---|
-| **0 — Stop the bleeding** ✅ *code landed* | Quarter map replaced with arithmetic; season year derived from the previous season with catch-up to the current quarter; seasons created highlighted. `MarchOfMurlocsHandler` only — no schema change. **Still owner-run: `mom-cleanup.sql`, including the empty-season prune.** | — |
-| **1 — Settle on mocks** | UX/UI pass: season page, board page, record flow, targets screen. Design only, no code. | 0 |
-| **2 — Own the data** | Five tables, model contribution, purge manifest, repository, migrate five seasons, cycle rewritten onto `MoMSeason`. Pages repointed, visually unchanged. | 1 |
-| **3 — Per-mix boards** | Four boards, mix-correct grading and snapshots, PUMBILITY2+, Phoenix 2 admin-gated. | 2 |
-| **4 — UX build** | Build Slice 1's mocks. Verification removal, rapid entry, paste box, CSV. | 3 |
-| **5 — Timestamps** | Plumb `RecordedAt`, auto-select the contiguous run, soft span warning. | 4 |
-| **separate session** | Phoenix 2 scoring min/max (≈6 rounds, owner estimate). | 3 |
+| **0 — Stop the bleeding** ✅ *shipped* | Quarter map replaced with arithmetic; season year derived from the previous season with catch-up to the current quarter; seasons created highlighted. `MarchOfMurlocsHandler` only — no schema change. **Still owner-run: `mom-cleanup.sql`, including the empty-season prune.** | — |
+| **1 — Settle on mocks** ✅ *done* | UX/UI pass across the six surfaces. Design only, no code. D14–D22 and §11; the six mocks are checked in beside this doc. | 0 |
+| **R — The two rule fixes** *out of band, ship any time* | §2.9's window predicate, and §2.8's `MinimumScore` if the owner wants it now rather than with the P2 scoring session. One value and one condition, plus regression tests. No schema, no UI, no dependency on anything below. | — |
+| **2 — Own the data** | Five tables, model contribution, purge manifest, repository, migrate five seasons, cycle rewritten onto `MoMSeason`. **"Repointed" means the repository is swapped behind the old pages, not that they are rebuilt** — they are deleted in Slice 4 either way, and the point of the swap is to run the new tables under real traffic before the UI depends on them. | 1 |
+| **3 — Timestamps** *was Slice 5* | Plumb `RecordedAt` through `OfficialRecordedScore` (§2.5). An OfficialMirror change; touches none of MoM's tables. | — |
+| **4a — Read surfaces** | Season, Session Breakdown, Past seasons dialog. The Stamina→MoM rename, verification removal (D5), the old pages deleted. | 2 |
+| **4b — Write surfaces** | Submit — draft/publish lifecycle, minimal-click entry, the import with gap detection — and the Planner with named saved sets and CSV. | 2, 3 |
+| **4c — Discord card** | The fourth `DiscordFeedKind`, the card, `/piu feed mom`. | 2 |
+| **5 — Per-mix boards** *was Slice 3* | Four boards live, mix-correct grading and snapshots, PUMBILITY2+, `MixCapabilities` entry (D19), Phoenix 2 ungated. | 2, and the scoring session |
+| **separate session** | Phoenix 2 scoring min/max (≈6 rounds, owner estimate). | — |
 
-**Slice 0 is urgent.** The job fires daily at 11:00 UTC and each run adds roughly 3,700 rows.
+**Why the back half moved.**
+
+- **Per-mix boards went last because nothing they fix is live.** All 62 MoM sessions ever recorded
+  are Phoenix; **zero Phoenix 2 sessions exist**. So §2.3 and §2.4 have never mis-scored anything —
+  they are latent, not active. And since D12 ships Phoenix 2 admin-gated until the scoring session,
+  building it earlier is speculative work nobody can see or validate.
+- **Timestamps moved ahead of the UX build** so the import is built once. The Submit mock is drawn
+  against gap detection (§11.4); with timestamps still last, Slice 4 would build the manual
+  first/last range picker and then replace it.
+- **The UX build split three ways** because it had grown to six surfaces plus a rename plus a
+  lifecycle plus a feed. Read, write and Discord are independently shippable against the same
+  tables, and 4a is what finally deletes the old pages.
+- **The two rule fixes came out of band** because they belong to no slice: they are live defects
+  found while drawing the mocks, each about one line, and they depend on nothing. §2.9 is a plain
+  bug. §2.8 is a rules call the owner may want to take alongside the Phoenix 2 "A or below"
+  question (§10.1) — it is the same `MinimumScore` knob and the same shape of decision.
+  **Neither re-scores a stored session**: each season freezes its config at creation, so a change
+  to `CreateScoring()` reaches only seasons made after it.
 
 `mom-cleanup.sql` is dry-run by default, has been tested end to end, and refuses to delete any
 season carrying player data.
@@ -466,6 +593,25 @@ Hoisting it into the factory would silently re-value every stored stat and chang
 partner tools consume. The contract test pins the wire *shape*, not the values, so nothing would
 catch it.
 
+### 9.5b A frozen board config drops Phoenix 2's Singles pricing
+
+**Resolve the config for the board's chart type *before* freezing it.**
+
+`ScoringConfiguration` gained `SinglesLetterGradeModifiers` / `SinglesPlateModifiers` on
+2026-08-10, because Phoenix 2 prices some grades and plates differently on Singles than on
+Doubles. Every read inside the formula goes through `LetterGradeModifierFor` / `PlateModifierFor`,
+so the split is honoured everywhere in memory.
+
+It is *not* honoured through persistence. `TournamentConfigurationJsonEntity` maps only the shared
+tables, by design — it is what lets a configuration written before the split still deserialize and
+score identically. But §6 stores a **frozen serialized config per board**, so a Phoenix 2 · Singles
+board would freeze a config with its Singles pricing stripped and quietly score as a Double.
+
+The fix is better than widening the DTO: **every MoM board is exactly one chart type** (D3), so at
+freeze time flatten that type's overrides into the shared tables — Singles values on a Singles
+board, shared values on a Doubles board. The stored config comes out type-free by construction and
+the persistence gap cannot bite. A board carrying a two-type table would be meaningless anyway.
+
 ### 9.6 Never cross-wire the official mirror with the tournament formula
 
 `Phoenix2PumbilityScoring` mirrors piugame's own number and must stay discrete-grade /
@@ -474,7 +620,7 @@ PUMBILITY2+ is a tournament formula. Two configs, never merged. Comment both.
 
 ### 9.7 Ratchets that will go red if missed
 
-- `MoMEntry` must join the vertical's `UserOwned` purge manifest with `UserId` as the purge key,
+- `MoMSession` must join the vertical's `UserOwned` purge manifest with `UserId` as the purge key,
   or `AccountPurgeCoverageTests` fails.
 - The `IDbModelContribution` must be listed in `VerticalModelContributions.All()`, or scaffolded
   migrations silently drop every MoM table.
@@ -502,6 +648,355 @@ change.
    `PgLetterGradeModifier` equal to SSS+'s 1.50, continuous interpolation from 995,000 to
    1,000,000 is **flat**, so the top 5,000 points of score are worth nothing. One value to change
    once the targets screen shows how it plays.
-3. **Targets screen shape** — locked to living inside MoM (D14); the page itself is Slice 1.
-   Starting point is `AutoBuildSessionHandler` with a per-chart contribution breakdown, pointed
-   at a chosen mix's scores.
+*(Resolved 2026-08-10: the targets-screen shape — it is the Planner and the Session Breakdown,
+two tenses of the four-lever model, D14 and §11. **One draft at a time**, whose only two exits are
+Discard and Publish, so a draft is never a workspace. And a **deleted session's Discord card is
+left to 404** — the card cannot be unsent, but the case is rare enough not to buy a tombstone
+page for.)*
+
+---
+
+## 11. The surfaces
+
+Settled with the owner over three workshop rounds, 2026-08-09/10. Mocks build from this section.
+
+### 11.1 The six surfaces
+
+| Surface | Route | Leads with |
+|---|---|---|
+| **Season** | `/MarchOfMurlocs` | your best session and how many you have played, then the Doubles board, then Singles |
+| **Past Seasons** | *a dialog, no route* | a season picker over whatever page you are on (§11.8) |
+| **Session Breakdown** | `/MarchOfMurlocs/Session/{id}` | one session's four numbers, its charts, its timeline |
+| **Submit** | `/MarchOfMurlocs/Session/{id}/Edit` | draft editing; publishing freezes the session |
+| **Planner** | `/MarchOfMurlocs/Planner` | a projected session in the same four numbers |
+
+The old pages are **retired, not ported** — `MarchOfMurlocs.razor` (a directory of eight
+tournaments with the live one buried among them), `StaminaTournament.razor`,
+`RecordTournamentSession.razor` and `SessionBuilder.razor` all go. The directory shape is what let
+Spring 2026 run a full quarter to zero submissions alongside 39 days of garbage.
+
+### 11.2 The Season page
+
+The live season *is* the landing page; there is no tournament directory. Order is: your standing,
+then Doubles, then Singles — Doubles first because that is where the event's history lives.
+
+**Which boards you see follows the mix you are on**, exactly as weekly boards now do: a Phoenix 1
+player sees Phoenix 1's two boards and never learns Phoenix 2's exist. That plus D19 is the whole
+of the four-board question — four boards exist, two are ever on screen, and D15 forbids comparing
+even those two.
+
+**Your standing** is your best session and a count — *"3rd — 47,300 · you have played this season 3
+times"* — with each session reachable. If you have not, this is the Submit call to action instead.
+
+**Phoenix 2 before the scoring session** (D12) shows the board explaining itself rather than
+hiding: *"Phoenix 2 scoring is still being tuned."* That is the current nav philosophy — a link is
+hidden only when the thing it points at does not exist for that mix, and everything else shows up
+and explains itself on arrival.
+
+**One board at a time, with a Doubles / Singles button group** in the tier lists' own idiom —
+joined buttons, active filled, inactive outlined (owner, 2026-08-10). Doubles is the default.
+Stacking both boards made the page a scroll; a group makes the pair legible without ever putting
+their numbers side by side, which D15 forbids anyway. The two standing cards double as the
+switcher, so the card that says you have not played Singles is also how you get to that board.
+
+**Boards rank sessions** (D16), pure score order, so one player may hold several places. Recorded
+date is what tells two of their sessions apart, which is why D18 pins it. Rows wear the standard
+board skin — `.olb-rank-card`, no card wrapper, no density toggle. The Official Leaderboards
+rankings board is the named golden standard for every board on the site; MoM is not an exception.
+
+**A row carries the player, not just a name**: avatar, country flag and name, the `UserLabel`
+anatomy with an avatar in front of it (`CommunityLeaderboard` is the precedent, at 26–30px).
+
+**Relationship highlighting is the sitewide utility set, not a MoM invention** — `.is-me`,
+`.is-rival`, `.is-community`, `.is-both` from `site.css`: one geometry (a tint plus a bar down
+each edge), colour the only variable, precedence **you → both → rival → community**. A legend sits
+above the board and every row repeats the relationship in its `title` and `aria-label`, because
+the fill is otherwise colour alone.
+
+**Static SSR.** The boards are real crawlable HTML with no circuit — a MoM season board is exactly
+the content the SSR migration exists for, and a past season never changes, so it caches perfectly.
+The submit affordance is a link, not an island.
+
+### 11.3 Session Breakdown
+
+Its own page, reachable from any board row. Keeps what the old expandable row did well — the chart
+cards and the points-per-second timeline — at a much higher visual standard, and adds the four
+levers (§11.6) as the thing you actually read first.
+
+Carries **compare**, in two modes. Against another session on **this board** — same board by
+construction, so it cannot violate D15, and the most motivating version of the model: *four more
+charts, six fewer minutes of downtime, average grade held.* And against **your own past seasons**,
+walking the board lineage — same mix, same chart type, back through time. A different chart type
+or a different mix is a different sport and is never offered.
+
+Both modes also list **the charts the two sessions have in common**, worst gap first. A total says who
+won; this says where. Against yimmythe42, 12 of 김재현's charts overlap and Gargoyle alone cost him
+1,892 points — on a board he won by 1,994.
+
+#### The re-rating split (D20)
+
+A season comparison has a confound a same-board comparison does not: **each season freezes its own
+chart balance *and* its own scoring tables** at creation, so the same session is worth different totals
+in different seasons. A raw delta silently mixes "I got better" with "the game changed."
+
+The fix is a counterfactual. Re-price the old session — *the same charts, the same scores* — under the
+new season's whole frozen config, and split what moved:
+
+```
+March of Murlocs 2 · Aug 2024                          44,139
+    charts re-rated by the community                              +810
+    scoring tables re-cut                                       +2,449
+  the same session, scored as Winter 2025                  47,923   +3,784  total
+Winter 2025 · Feb 2025                                 59,319  +11,396  you
+```
+
+Those are 김재현's real numbers, computed from both stored configs. **Two different things moved,
+and only one of them is what anyone would have guessed:**
+
+- **10 of his 32 charts were re-rated**, all upward — Galaxy Collapse and Dignity each a full level.
+- **The scoring tables were re-cut too.** Every level-23-and-up rating rose (L23 1,110 → 1,160;
+  L26 1,710 → 2,210) while the grade table tightened (AAA 1.10 → 1.00, AA+ 1.00 → 0.90, A 0.25 → 0).
+  That is the Phoenix-1 anti-mash rewrite of §4 landing *between* the two seasons — and it is worth
+  three times the chart re-ratings.
+
+Without the split he reads a +15,180 improvement, and 3,784 of it was the game moving under him.
+
+Two implementation notes. The parts **multiply**, so they sum to less than the total — say so
+rather than printing three numbers that appear not to add up. And label the middle line as a
+re-pricing, never as a score he achieved: he might not have picked those charts under the new
+balance.
+
+This needs no new data — both configs and both snapshots are already stored per season. It is the
+§4 arithmetic run four times per chart (old/new snapshot × old/new tables).
+
+#### Densities (D21)
+
+The density control is **three bare icon buttons**, exactly as `/Pumbility` renders it — no
+segmented chrome, the active one carrying the mix primary, the name in the tooltip and the
+aria-label (`ViewComfy`, `GridView`, `TableRows`).
+
+Comfortable is a card per chart — jacket, grade, plate, score, points, per-second rate — with the
+**play affordance on the jacket**. Compact is the tier list's sticker sheet: jacket, difficulty
+bubble, the grade in one bottom corner and **one printed value in the other**, styled as
+`.tier-chart-card-corner` + `.pmb-corner-gain` — opaque black backdrop, outlined in the mix
+primary. **That value is the MoM score, not the PIU score** (owner, 2026-08-10): points are the
+currency the page is denominated in, and the grade in the other corner already says how cleanly
+the chart was played. When the list is ranked by something the sticker does not print, that value
+joins as a second line, so Compact never sorts by a number the reader cannot see. Table wears the pumbility
+table's width ladder: points-per-second and length go at 900, the song name at 700 (jacket and
+bubble already say which chart it is), and at 500 the numeric score drops so grade art and plate
+**stack** rather than shrink.
+
+**The jacket and the play button open the same dialog**; only the play button autoplays the chart
+video. That is `ChartDetailsDialog`'s existing contract (`AutoPlay`, as `Pumbility.razor` binds
+it), and every density opens it — a sticker tap and a table row click land in the same place.
+
+### 11.4 Submit
+
+Its own page and not a panel on the Season page, for three reasons that agree: thirty charts
+entered over several minutes should not live under a board you might scroll away from; the Season
+page is static SSR and a form would drag the whole page into a circuit; and a half-entered session
+should survive a closed tab. A draft *is* a session (D17), so Submit is the same route family as
+the Breakdown and "New session" simply creates a draft.
+
+**Minimising clicks matters more than it looks** — Phoenix 1 goes manual-only in a month, and
+manual entry carried the first three seasons before the import route existed. Two things pay for
+themselves:
+
+- **The plate selector replaces the Broke checkbox**, in `RecordScoreForm`'s own idiom: one
+  dropdown carrying *Broken* and the eight plates, where a plate is a pass and Broken is the
+  clean fail with no plate. Plates are worth 1.0 under PUMBILITY+ so they change no Phoenix 1
+  score — they are captured because players want to see them, and because Phoenix 2 prices them
+  (owner, 2026-08-11, reversing the earlier "hide it on Phoenix 1"). It stays optional, so the
+  three-key loop is unaffected, and **Shift+Enter files a run as broken** without reaching for it.
+- The picker stays open with focus returned to the chart field, so entry is
+  *chart → score → Enter*.
+
+**The 1h45 budget is visible** — a bar filled by song duration with the rest-time remainder
+called out. There is no meter today at all; `CanAdd` simply refuses and says nothing.
+
+**The import path stays** (D4 is a month away, not today) and it **reuses a stored piugame
+credential** the way `/UploadPhoenixScores` does — a lock chip reading *Saved on this device* and
+a single Import button, rather than prompting for a password this device already holds.
+
+**One click is the stored case only.** With nothing saved it is a username, a password and an
+Import button, exactly as the upload page renders it. **This page never offers to save them**
+(owner, 2026-08-10): remembering a credential is Import Scores' job, and a second surface that
+stores passwords is a second surface to get wrong. It points at that page instead, so the fallback
+is a fallback rather than a dead end.
+
+#### The import flow
+
+What PIUGAME returns is an undifferentiated list of recent plays, so the whole problem is deciding
+which of them were the session. **Timestamps answer it**: a run is a contiguous block, and its
+boundaries are the long gaps either side. The dialog reads the recent plays, splits them wherever
+a gap exceeds fifteen minutes, and pre-selects the longest block — everything outside it dims but
+stays on screen, with the gap printed between blocks ("3h 42m gap"), so the choice is legible
+rather than magic. **Clicking any play moves whichever end is nearer**, which needs no drag
+handles and works the same on a phone.
+
+Three checks ride along, and D10 splits them exactly:
+
+- **Song time over 1:45:00 is a hard block** — the Add button disables and says so.
+- **Wall-clock span over 1:45:00 is a soft warning**, because it is a judgement call. It names the
+  culprit rather than gesturing at it: *"your longest break inside it was 5:20, before GLORIA at
+  20:57:17."* Telling someone to trim an end is useless when the break is in the middle, where no
+  end reaches it.
+- **Unmatched plays are listed by name**, since they have to be added by hand.
+
+Charts already in the draft are skipped on import rather than doubling up — the repeat ban (§1)
+applies to the import path as much as the picker.
+
+**Without timestamps there is nothing to detect a gap with**, and this degrades to picking the first and last play
+by hand. That is what the page does today, and the reason it needs a range picker at all.
+
+### 11.5 Planner
+
+The Planner is the Season's *future* tense: pick a chart type — D15 means it cannot plan across
+both — and it solves a run from your record book, reported in the same four numbers, so what you
+are chasing and what you posted are described identically. `AutoBuildSessionHandler` is the engine
+and already exists: charts in descending points-per-second, taken while the average rest holds up.
+
+**Rest per chart is the only control, and it is the whole feature.** It is what actually decides
+how long a run can be, and the plan re-solves as it moves. On 김재현's real Doubles record book:
+
+| Rest per chart | Charts | Projected |
+|---|---|---|
+| 10s | 54 | 93,077 |
+| 35s | 45 | 78,448 |
+| 60s | 39 | 67,697 |
+| 120s | 29 | 51,161 |
+
+**The plan ends on a closing move**, flagged in the list: once nothing more fits the rest budget
+you may still *start* one more (§1), so the run closes on the biggest single chart left. That is
+the rule turned into a suggestion.
+
+**Say plainly that it is a ceiling.** It assumes every chart played to your best, which nobody
+manages ninety minutes into a stamina session — and the gap is the interesting part, so the page
+prints it as a **conversion rate**: 김재현 banked 59,319 against a 78,448 record book, or **76%**.
+At 60s rest the plan lands on exactly his 39 charts and projects 67,697, an 88% conversion at
+matched volume. Nothing else on the site can tell a player what stamina costs them.
+
+#### The set is a selection, and it leaves with you
+
+**The page opens on Everything with an empty set** (owner, 2026-08-11) — your record book to
+browse, filled by hand. Suggesting a set is an offer, not the starting position, and every number
+recomputes from what is ticked. One list in the three sanctioned densities — the Session
+Breakdown's, verbatim, jackets and all — with a scope toggle leading on **Everything**, so the pool
+is the same list rather than a second one.
+
+Ticking in Compact is the sticker itself and in Table a checkbox column. **In Comfortable the
+jacket is the video affordance, not the tick** — jacket and play button open the chart dialog, the
+button autoplaying, exactly as `/Pumbility` binds `AutoPlay` — so picking lives in the card body
+instead, where the two gestures cannot fight over the same pixels.
+
+**Selection reads as an outline, never as dimming** (owner, 2026-08-11): an unpicked chart is not
+lesser information, and fading four-fifths of a browsing surface to mark the fifth is the wrong
+way round. A picked card takes the mix primary on its border, a picked sticker a ring, a picked
+row an inset accent. **Set position is not printed on a tile** either — Compact's second corner
+stays the projected grade whether or not the chart is picked, because the grade is what the tile
+is telling you and the ordinal is only the CSV's business.
+
+**The rest slider retunes a suggested set live, and never a hand-built one.** A manual tick takes
+the set off autopilot; otherwise dragging would silently discard the set someone just chose.
+
+A hand-edited set can stop fitting, so the window check runs on it live and says so — the same
+all-but-the-last rule as §2.9.
+
+**Download CSV is the point of the page**: the set walks to a machine as a numbered list of song,
+difficulty, length, your best, grade, projected points and rate. It needs **no backend at all** —
+a client-side blob, with a BOM so Excel opens Korean and Japanese titles as UTF-8 rather than
+mojibake.
+
+**Saved sets are plural and named** (owner, 2026-08-11), so Save asks for a name — prefilled with
+something worth keeping (*"Doubles — 33 charts, up to D26"*) — and a Saved sets menu loads or
+deletes them.
+
+That still does not need a table. **A JSON list in UiSettings**, keyed per board like the density
+preferences, holds `{name, orderedChartIds}` for a handful of sets: no migration, no repository,
+and — the deciding argument — **no purge-manifest entry**, because a user's settings are already
+deleted with the user. A new `MoMPlan` table would need one (§9.7), and would earn its keep only
+if plans ever had to be shared or queried across accounts.
+
+### 11.6 The four numbers
+
+**"The four levers" is the internal name and must never reach the screen** (owner, 2026-08-10 —
+it means nothing to a player). The section is headed *"Where the points came from"*, which is the
+question it answers and close to how the owner described it unprompted.
+
+Total score is *how many charts × how hard × how well*, capped by time. So a run — planned or
+played — is described by four numbers, and a comparison is those four side by side:
+
+| Lever | What it answers |
+|---|---|
+| **Charts played** | how many you got through |
+| **Average difficulty** | what the base rating paid — **balanced, not the folder number** |
+| **Average grade** | the multiplier you earned |
+| **Downtime** | what capped the count |
+
+**Average difficulty is the season's frozen balanced level** (§4 layer 4), not the chart's folder
+number (owner, 2026-08-11). The balanced level is what actually priced the chart, so it is what
+the run was worth playing; the folder number is a label. `UserTournamentSession.AverageDifficulty`
+stores the nominal average today and has to change with the rest of §6.
+
+It reads roughly half a level above the folder average, because a chart with no override sits at
+`nominal + 0.5` — 김재현's Winter 2025 run is **24.22 balanced against 23.67 by folder**. Label it
+so that gap does not read as a bug. It also moves the gaps between players: he and tieny are 0.15
+apart by folder and **0.04** apart balanced, and his own two seasons flip from *0.09 harder* to
+**0.41 easier**, which is the opposite conclusion.
+
+Downtime is the one players talk about most, and it is the only lever that is purely logistical
+rather than physical — which is exactly why it is worth showing.
+
+**Plates are a fifth bar on Phoenix 2 only.** They are 1.0 across the board on Phoenix 1, so a
+plate axis there would render four bars of nothing.
+
+**D15 binds this section hardest.** Every one of these numbers is meaningless across chart types,
+so a comparison is always within one board: your session against your other session, or against
+another player on the same board. Never a season total, never a cross-type average.
+
+### 11.7 Discord
+
+**A fourth `DiscordFeedKind`**, beside WeeklyCharts, DailyStep and OfficialLeaderboards — the same
+per-mix, community-independent subscription, reached the same way: `/piu feed mom mix:Phoenix`.
+A channel opts in once and gets every run on that mix. No per-community filtering; the event is not
+popular enough to need it.
+
+**One card per published session** (D17 — a draft never fires one). Because a published run cannot
+be edited, no second card ever corrects a first.
+
+Composed as a **`RichBotMessage`** like every other card, so the Discord adapter owns the emoji swap
+(`#MIX|…#`, `#DIFFICULTY|…#`, `#LETTERGRADE|…|…#`, `#PLATE|…#`), the Components V2 rendering and the
+plain-text fallback:
+
+- **Header** — `### #MIX|…#**{name}** — {total} points`, with `-# March of Murlocs · {season} ·
+  {chart type} · {place}`, the player's avatar as the section thumbnail. The board is named because
+  a number without a chart type says nothing (D15).
+- **Stats** — chart count, average balanced level, lowest → highest difficulty, downtime, average
+  grade.
+- **Biggest five** — ranked by **points, not raw score**. Points are what the run is made of, and
+  the score rides each row anyway; ranked by score this run returns five 21s and 22s, which says
+  nothing about it.
+- **Footer + link** — the mix line, and *See the run* to the Session Breakdown.
+
+Two things to settle when it is built: **placement (“1st of 11”) is an addition to the owner's
+field list** — a result card with no placement reads oddly, but it is one clause to cut. And a
+**deleted run leaves its card behind** with a link that 404s (§10), which is accepted.
+
+MoM has never had any Discord presence, which is part of why §2.2 went unnoticed for 39 days.
+
+### 11.8 Past seasons is a dialog, not a page
+
+**There is no `/Seasons` route** (owner, 2026-08-11). Four seasons hold results and the quarterly
+cadence adds one a quarter, so this is a picker rather than a body of content — and a page would
+buy a route, an empty state and an SSR decision for a list of five rows.
+
+The dialog lists every season newest first: name, dates, and a line per board carrying the run
+count, the winner and **how you did on it** — *you won it* / *you were 10th — 35,879* / *you sat
+this one out*. The live season sits at the top with a **running now** chip. Picking one opens that
+season's page.
+
+Nothing is hidden by this. **The crawlable artifact is each season's own page**, which the sitemap
+lists directly. But the dialog gives a crawler no path *between* seasons, so the season page has to
+carry **previous / next season** links of its own — cheap, and it is what keeps the archive
+reachable without a route. If the list ever passes roughly twenty rows it earns the page then.


### PR DESCRIPTION
Slice 1 of the [March of Murlocs overhaul](docs/design/march-of-murlocs.md). **Design only — no
code changes.** Two commits: the mocks, and the plan they settled.

## The mocks

Six standalone interactive pages checked in at
[`docs/design/march-of-murlocs-mocks/`](docs/design/march-of-murlocs-mocks/README.md), numbered in
journey order. No build step, no network calls — open the file. They are also published as
Artifacts, linked from the plan's header.

| | Surface | |
|---|---|---|
| 1 | Season | your standing, then one board with a Doubles/Singles group |
| 2 | Session Breakdown | where the points came from, in three densities |
| 3 | Submit | draft lifecycle, three-key entry, the window meter, PIUGAME import |
| 4 | Planner | an editable set solved from your record book, CSV out |
| 5 | Discord card | Components V2, its composition, the fallback, the feed command |
| 6 | Past seasons | a dialog, not a page |

**Every figure came out of a production-synced database rather than imagination** — a real Winter
2025 Doubles session, a real 129-chart record book, the real boards, the owner's actual rivals and
communities, both seasons' frozen scoring configurations. Everyone shown has a public profile, and
MoM sessions are public on the board by rule regardless.

That choice is why the mocks kept finding things. **None of the three findings below would have
surfaced against invented numbers.**

## What drawing the pages found

**§2.8 — the anti-mash zero does not zero anything.** `ContinuousLetterGradeScale` interpolates
straight through the zeroed A rung, so "A and below is worth zero" only holds at or below 750,000,
not 825,000. Priced under Winter 2025's own config: a level 26 mashed to **824,999 pays 1,031**,
while a level 22 played cleanly to **AAA pays 930**. Scraping an A on a 26 beats a clean AAA on a
22 — precisely the mash the grade rewrite exists to prevent.

**§2.9 — the window check refuses a legal closing song.** The window governs when a song may
*start*, so the duration test is too strict by up to one song and blocks the standard play of
closing on Gargoyle FULL SONG. The correct test is simpler: *total duration already entered <
MaxTime*, with the candidate's own length not entering into it.

**§9.5b — a frozen board config would strip Phoenix 2's Singles pricing.** Per-chart-type scoring
tables landed on main while this was being drawn, but the persistence DTO maps only the shared
tables. Since every MoM board is exactly one chart type, resolving the config for that type at
freeze time closes the gap without widening the DTO.

Neither §2.8 nor §2.9 re-scores a stored session: each season freezes its config at creation, so a
change reaches only seasons made after it. Both are rules questions as much as bugs, and §2.8 may
want deciding alongside the Phoenix 2 "A or below" question — same knob, same shape.

## Decisions

D14–D22, the load-bearing ones being: a player may run a season many times and **boards rank
sessions, not players** (which deleted `UNIQUE (BoardId, UserId)` from the schema before the table
existed); **nothing in MoM ever compares Singles to Doubles**; a session goes **draft → published →
frozen**; average difficulty is the **balanced** level, not the folder number; and **the word is
"session" everywhere**, written down because "run" crept back into all six mocks and reads fine in
isolation.

## Re-ordered plan

Per-mix boards move to last — **all 62 MoM sessions ever recorded are Phoenix and no Phoenix 2
session exists**, so they fix nothing live and ship gated behind the scoring session anyway.
Timestamps move ahead of the UX build so the import is built once. The UX build splits into read,
write and Discord. The two rule fixes come out of band, depending on nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
