### PR TITLE
The reconnect overlay stops taking the page hostage

### DIFF
--- a/ScoreTracker/ScoreTracker/App.razor
+++ b/ScoreTracker/ScoreTracker/App.razor
@@ -154,12 +154,31 @@
                 <p class="reconnect-sub">@L["Scrolling and links still work. Buttons don't."]</p>
             </div>
         </div>
-        @* Reconnect ran out of attempts — the server may still be there, so offer another go. *@
+        @* The server parked the circuit rather than losing it (.NET 10 pause/resume). Reconnecting
+           does not recover one of these — resuming does, so this state carries its own verb. *@
+        <div class="reconnect-state reconnect-on-paused">
+            <div class="reconnect-body">
+                <p class="reconnect-title">@L["Session paused."]</p>
+                <p class="reconnect-sub">@L["Scrolling and links still work. Resume to use buttons."]</p>
+                <button type="button" class="reconnect-btn" onclick="Blazor.resumeCircuit()">@L["Resume"]</button>
+            </div>
+        </div>
+        @* Reconnect ran out of attempts — the server may still be there, so offer another go.
+           Falling through to resumeCircuit mirrors what the framework's own dialog does: a
+           reconnect returns false rather than throwing when the circuit was parked, not dropped. *@
         <div class="reconnect-state reconnect-on-failed">
             <div class="reconnect-body">
                 <p class="reconnect-title">@L["Couldn't reconnect."]</p>
                 <p class="reconnect-sub">@L["Scrolling and links still work. Buttons need a reconnect."]</p>
-                <button type="button" class="reconnect-btn" onclick="Blazor.reconnect()">@L["Try again"]</button>
+                <button type="button" class="reconnect-btn" onclick="Blazor.reconnect().then(ok => ok || Blazor.resumeCircuit())">@L["Try again"]</button>
+            </div>
+        </div>
+        @* Resume was offered and refused: the stored state is gone, and only a fresh load rebuilds. *@
+        <div class="reconnect-state reconnect-on-resume-failed">
+            <div class="reconnect-body">
+                <p class="reconnect-title">@L["Couldn't resume the session."]</p>
+                <p class="reconnect-sub">@L["Scrolling and links still work. Buttons need a reload."]</p>
+                <button type="button" class="reconnect-btn" onclick="location.reload()">@L["Reload the page"]</button>
             </div>
         </div>
         @* The server answered and refused: that circuit is gone, and only a fresh load builds one. *@

--- a/ScoreTracker/ScoreTracker/App.razor
+++ b/ScoreTracker/ScoreTracker/App.razor
@@ -141,23 +141,34 @@
 @* Blazor builds its own reconnect overlay — framework markup, framework light styling — but
    only when the document has none of its own. Supplying the element switches it to toggling
    state classes on ours instead (components-reconnect-show / -hide / -failed / -rejected), so
-   the overlay is site chrome. Reads --mix-* only: every --mud-* var is emitted by
-   MudThemeProvider inside the circuit, which is the thing this overlay exists to report on. *@
+   the overlay is site chrome. It docks in a corner rather than covering the page (site.css),
+   which is why every state carries a second line: undimmed, the card is the only thing saying
+   the controls are dead. Reads --mix-* only: every --mud-* var is emitted by MudThemeProvider
+   inside the circuit, which is the thing this overlay exists to report on. *@
 <div id="components-reconnect-modal" data-nosnippet aria-live="assertive">
     <div class="reconnect-card">
         <div class="reconnect-state reconnect-on-show">
             <span class="reconnect-spinner" aria-hidden="true"></span>
-            <p class="reconnect-title">@L["Reconnecting…"]</p>
+            <div class="reconnect-body">
+                <p class="reconnect-title">@L["Reconnecting…"]</p>
+                <p class="reconnect-sub">@L["Scrolling and links still work. Buttons don't."]</p>
+            </div>
         </div>
         @* Reconnect ran out of attempts — the server may still be there, so offer another go. *@
         <div class="reconnect-state reconnect-on-failed">
-            <p class="reconnect-title">@L["Couldn't reconnect."]</p>
-            <button type="button" class="reconnect-btn" onclick="Blazor.reconnect()">@L["Try again"]</button>
+            <div class="reconnect-body">
+                <p class="reconnect-title">@L["Couldn't reconnect."]</p>
+                <p class="reconnect-sub">@L["Scrolling and links still work. Buttons need a reconnect."]</p>
+                <button type="button" class="reconnect-btn" onclick="Blazor.reconnect()">@L["Try again"]</button>
+            </div>
         </div>
         @* The server answered and refused: that circuit is gone, and only a fresh load builds one. *@
         <div class="reconnect-state reconnect-on-rejected">
-            <p class="reconnect-title">@L["Your session ended."]</p>
-            <button type="button" class="reconnect-btn" onclick="location.reload()">@L["Reload the page"]</button>
+            <div class="reconnect-body">
+                <p class="reconnect-title">@L["Your session ended."]</p>
+                <p class="reconnect-sub">@L["Scrolling and links still work. Buttons need a reload."]</p>
+                <button type="button" class="reconnect-btn" onclick="location.reload()">@L["Reload the page"]</button>
+            </div>
         </div>
     </div>
 </div>

--- a/ScoreTracker/ScoreTracker/App.razor
+++ b/ScoreTracker/ScoreTracker/App.razor
@@ -152,6 +152,16 @@
             <div class="reconnect-body">
                 <p class="reconnect-title">@L["Reconnecting…"]</p>
                 <p class="reconnect-sub">@L["Scrolling and links still work. Buttons don't."]</p>
+                @* Blazor fills both spans by id and adds -retrying once the ladder starts backing
+                   off, so the count is framework state, not ours to track. The spans go in through
+                   MarkupString because the two numbers have to move with the sentence: word order
+                   around them is the translator's call, not the English's. *@
+                <p class="reconnect-sub reconnect-retry-line">
+                    @((MarkupString)string.Format(
+                        L["Attempt {0} of {1}"].Value,
+                        "<span id=\"components-reconnect-current-attempt\"></span>",
+                        "<span id=\"components-reconnect-max-retries\"></span>"))
+                </p>
             </div>
         </div>
         @* The server parked the circuit rather than losing it (.NET 10 pause/resume). Reconnecting
@@ -206,8 +216,11 @@
 </div>
 
 @* blazor.web.js stays on its plain name: the framework versions and caches its own boot script,
-   and the manifest entry for it is not ours to redirect. *@
-<script src="_framework/blazor.web.js"></script>
+   and the manifest entry for it is not ours to redirect. autostart is off so reconnect.js can
+   pass reconnection options to start() — it must stay the very next script, since nothing on
+   the page is interactive until it runs. *@
+<script src="_framework/blazor.web.js" autostart="false"></script>
+<script src="@Assets["js/reconnect.js"]"></script>
 <script src="@Assets["_content/MudBlazor/MudBlazor.min.js"]"></script>
 <script src="@Assets["js/page-dock.js"]"></script>
 <script src="@Assets["js/nav.js"]"></script>

--- a/ScoreTracker/ScoreTracker/App.razor
+++ b/ScoreTracker/ScoreTracker/App.razor
@@ -227,6 +227,9 @@
 <script src="@Assets["js/dashboard-grid.js"]"></script>
 <script src="@Assets["js/credential-storage.js"]"></script>
 <script src="@Assets["js/challenge-board.js"]"></script>
+@* Ctrl+Alt+R cycles the reconnect overlay through its states; Ctrl+Alt+X clears it. The
+   paused/resume-failed states can't be provoked on demand, so this is how they get seen. *@
+<script src="@Assets["js/reconnect-preview.js"]"></script>
 </body>
 </html>
 

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -5799,6 +5799,15 @@
   <data name="Scroll right" xml:space="preserve">
     <value>Scroll right</value>
   </data>
+  <data name="Scrolling and links still work. Buttons don't." xml:space="preserve">
+    <value>Scrolling and links still work. Buttons don't.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reconnect." xml:space="preserve">
+    <value>Scrolling and links still work. Buttons need a reconnect.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
+    <value>Scrolling and links still work. Buttons need a reload.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Search</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -1657,6 +1657,9 @@
   <data name="Couldn't reconnect." xml:space="preserve">
     <value>Couldn't reconnect.</value>
   </data>
+  <data name="Couldn't resume the session." xml:space="preserve">
+    <value>Couldn't resume the session.</value>
+  </data>
   <data name="Couldn't unlock your saved password. Enter it to import." xml:space="preserve">
     <value>Couldn't unlock your saved password. Enter it to import.</value>
   </data>
@@ -5551,6 +5554,9 @@
   <data name="Results and the new lineup post when the board rotates each Monday." xml:space="preserve">
     <value>Results and the new lineup post when the board rotates each Monday.</value>
   </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Resume</value>
+  </data>
   <data name="Review access" xml:space="preserve">
     <value>Review access</value>
   </data>
@@ -5808,6 +5814,9 @@
   <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
     <value>Scrolling and links still work. Buttons need a reload.</value>
   </data>
+  <data name="Scrolling and links still work. Resume to use buttons." xml:space="preserve">
+    <value>Scrolling and links still work. Resume to use buttons.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Search</value>
   </data>
@@ -5924,6 +5933,9 @@
   </data>
   <data name="Session mode hands your server a live piugame.com key, so every player agrees to it individually — nobody arrives through &quot;share with all tools&quot;. It can only be switched on while no player is connected, and a header is required." xml:space="preserve">
     <value>Session mode hands your server a live piugame.com key, so every player agrees to it individually — nobody arrives through "share with all tools". It can only be switched on while no player is connected, and a header is required.</value>
+  </data>
+  <data name="Session paused." xml:space="preserve">
+    <value>Session paused.</value>
   </data>
   <data name="Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp." xml:space="preserve">
     <value>Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -754,6 +754,9 @@
   <data name="at {0} or better" xml:space="preserve">
     <value>at {0} or better</value>
   </data>
+  <data name="Attempt {0} of {1}" xml:space="preserve">
+    <value>Attempt {0} of {1}</value>
+  </data>
   <data name="Attempts before this clear" xml:space="preserve">
     <value>Attempts before this clear</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -1657,6 +1657,9 @@
   <data name="Couldn't reconnect." xml:space="preserve">
     <value>Glorgmrgrorp lurgmrpblarg.</value>
   </data>
+  <data name="Couldn't resume the session." xml:space="preserve">
+    <value>Glorgmrgrorp gurglurg mrp grrglgrrglgl.</value>
+  </data>
   <data name="Couldn't unlock your saved password. Enter it to import." xml:space="preserve">
     <value>Glorgmrgrorp blargglorg gromurp murpmurm glorgmrpmurm. Morgmurp gl grgl glorggl.</value>
   </data>
@@ -5551,6 +5554,9 @@
   <data name="Results and the new lineup post when the board rotates each Monday." xml:space="preserve">
     <value>Murglurgmorg ro mrp grgl mrglglorg grogrgl mrpgrrgl mrp mrglblarg morggrrglglorg blubmurp Lurggrrgl.</value>
   </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Gurglurg</value>
+  </data>
   <data name="Review access" xml:space="preserve">
     <value>Murgl golba</value>
   </data>
@@ -5808,6 +5814,9 @@
   <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
     <value>Glrmurgro arg plglrgl larg murmgl. Prglglubarg gurgmarg a mrglmurg.</value>
   </data>
+  <data name="Scrolling and links still work. Resume to use buttons." xml:space="preserve">
+    <value>Glrmurgro arg plglrgl larg murmgl. Gurglurg ro gro prglglubarg.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Grrglgro</value>
   </data>
@@ -5924,6 +5933,9 @@
   </data>
   <data name="Session mode hands your server a live piugame.com key, so every player agrees to it individually — nobody arrives through &quot;share with all tools&quot;. It can only be switched on while no player is connected, and a header is required." xml:space="preserve">
     <value>Grumba marogl blorp am olo PIUGAME grumb — opa pragl bloop golba am olo. Marogl bo blurgl la bloop, opa grumb alla.</value>
+  </data>
+  <data name="Session paused." xml:space="preserve">
+    <value>Grrglgrrglgl brglblub.</value>
   </data>
   <data name="Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp." xml:space="preserve">
     <value>Grrglgrrglgl morgmurpmrp grrglgrglmarg lurg mrp urg mrp — gro grgl UG murp, 2 Lurg, argl grrgllurg maglmrgl.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -754,6 +754,9 @@
   <data name="at {0} or better" xml:space="preserve">
     <value>og {0} ol mrrgl</value>
   </data>
+  <data name="Attempt {0} of {1}" xml:space="preserve">
+    <value>Murgrglarg {0} gl {1}</value>
+  </data>
   <data name="Attempts before this clear" xml:space="preserve">
     <value>Blub arg palo</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -5799,6 +5799,15 @@
   <data name="Scroll right" xml:space="preserve">
     <value>Rglmurg rogro</value>
   </data>
+  <data name="Scrolling and links still work. Buttons don't." xml:space="preserve">
+    <value>Glrmurgro arg plglrgl larg murmgl. Prglglubarg bo.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reconnect." xml:space="preserve">
+    <value>Glrmurgro arg plglrgl larg murmgl. Prglglubarg gurgmarg a lurgmrpblarg.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
+    <value>Glrmurgro arg plglrgl larg murmgl. Prglglubarg gurgmarg a mrglmurg.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Grrglgro</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -748,6 +748,9 @@
   <data name="at {0} or better" xml:space="preserve">
     <value>con {0} o mejor</value>
   </data>
+  <data name="Attempt {0} of {1}" xml:space="preserve">
+    <value>Intento {0} de {1}</value>
+  </data>
   <data name="Attempts before this clear" xml:space="preserve">
     <value>Intentos antes de superarlo</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -5749,6 +5749,15 @@
   <data name="Scroll right" xml:space="preserve">
     <value>Desplazar a la derecha</value>
   </data>
+  <data name="Scrolling and links still work. Buttons don't." xml:space="preserve">
+    <value>El desplazamiento y los enlaces siguen funcionando. Los botones no.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reconnect." xml:space="preserve">
+    <value>El desplazamiento y los enlaces siguen funcionando. Los botones necesitan reconectar.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
+    <value>El desplazamiento y los enlaces siguen funcionando. Los botones necesitan recargar la página.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Buscar</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -1645,6 +1645,9 @@
   <data name="Couldn't reconnect." xml:space="preserve">
     <value>No se pudo reconectar.</value>
   </data>
+  <data name="Couldn't resume the session." xml:space="preserve">
+    <value>No se pudo reanudar la sesión.</value>
+  </data>
   <data name="Couldn't unlock your saved password. Enter it to import." xml:space="preserve">
     <value>No se pudo desbloquear tu contraseña guardada. Introdúcela para importar.</value>
   </data>
@@ -5506,6 +5509,9 @@
   <data name="Results and the new lineup post when the board rotates each Monday." xml:space="preserve">
     <value>Los resultados y los nuevos charts se publican cuando el leaderboard rota cada lunes.</value>
   </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Reanudar</value>
+  </data>
   <data name="Review access" xml:space="preserve">
     <value>Revisar el acceso</value>
   </data>
@@ -5758,6 +5764,9 @@
   <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
     <value>El desplazamiento y los enlaces siguen funcionando. Los botones necesitan recargar la página.</value>
   </data>
+  <data name="Scrolling and links still work. Resume to use buttons." xml:space="preserve">
+    <value>El desplazamiento y los enlaces siguen funcionando. Reanuda para usar los botones.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Buscar</value>
   </data>
@@ -5874,6 +5883,9 @@
   </data>
   <data name="Session mode hands your server a live piugame.com key, so every player agrees to it individually — nobody arrives through &quot;share with all tools&quot;. It can only be switched on while no player is connected, and a header is required." xml:space="preserve">
     <value>El modo sesión entrega a tu servidor una clave activa de piugame.com, así que cada jugador lo acepta individualmente: nadie llega por "compartir con todas las herramientas". Solo se puede activar mientras no haya ningún jugador conectado, y hace falta una cabecera.</value>
+  </data>
+  <data name="Session paused." xml:space="preserve">
+    <value>Sesión en pausa.</value>
   </data>
   <data name="Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp." xml:space="preserve">
     <value>Resumen de sesión capturado al importar: una placa UG nueva, 2 récords personales, una lámpara de carpeta.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -748,6 +748,9 @@
   <data name="at {0} or better" xml:space="preserve">
     <value>con {0} o mejor</value>
   </data>
+  <data name="Attempt {0} of {1}" xml:space="preserve">
+    <value>Intento {0} de {1}</value>
+  </data>
   <data name="Attempts before this clear" xml:space="preserve">
     <value>Intentos antes de superarlo</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -5751,6 +5751,15 @@
   <data name="Scroll right" xml:space="preserve">
     <value>Desplazar a la derecha</value>
   </data>
+  <data name="Scrolling and links still work. Buttons don't." xml:space="preserve">
+    <value>El desplazamiento y los enlaces siguen funcionando. Los botones no.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reconnect." xml:space="preserve">
+    <value>El desplazamiento y los enlaces siguen funcionando. Los botones necesitan reconectar.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
+    <value>El desplazamiento y los enlaces siguen funcionando. Los botones necesitan recargar la página.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Buscar</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -1645,6 +1645,9 @@
   <data name="Couldn't reconnect." xml:space="preserve">
     <value>No se pudo reconectar.</value>
   </data>
+  <data name="Couldn't resume the session." xml:space="preserve">
+    <value>No se pudo reanudar la sesión.</value>
+  </data>
   <data name="Couldn't unlock your saved password. Enter it to import." xml:space="preserve">
     <value>No se pudo desbloquear tu contraseña guardada. Introdúcela para importar.</value>
   </data>
@@ -5508,6 +5511,9 @@
   <data name="Results and the new lineup post when the board rotates each Monday." xml:space="preserve">
     <value>Los resultados y los nuevos charts se publican cuando la clasificación rota cada lunes.</value>
   </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Reanudar</value>
+  </data>
   <data name="Review access" xml:space="preserve">
     <value>Revisar el acceso</value>
   </data>
@@ -5760,6 +5766,9 @@
   <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
     <value>El desplazamiento y los enlaces siguen funcionando. Los botones necesitan recargar la página.</value>
   </data>
+  <data name="Scrolling and links still work. Resume to use buttons." xml:space="preserve">
+    <value>El desplazamiento y los enlaces siguen funcionando. Reanuda para usar los botones.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Buscar</value>
   </data>
@@ -5876,6 +5885,9 @@
   </data>
   <data name="Session mode hands your server a live piugame.com key, so every player agrees to it individually — nobody arrives through &quot;share with all tools&quot;. It can only be switched on while no player is connected, and a header is required." xml:space="preserve">
     <value>El modo sesión entrega a tu servidor una llave activa de piugame.com, así que cada jugador lo acepta individualmente: nadie llega por "compartir con todas las herramientas". Solo se puede activar mientras no haya ningún jugador conectado, y hace falta un encabezado.</value>
+  </data>
+  <data name="Session paused." xml:space="preserve">
+    <value>Sesión en pausa.</value>
   </data>
   <data name="Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp." xml:space="preserve">
     <value>Resumen de sesión capturado al importar: una placa UG nueva, 2 récords personales, una lámpara de carpeta.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -5798,6 +5798,15 @@
   <data name="Scroll right" xml:space="preserve">
     <value>Défiler vers la droite</value>
   </data>
+  <data name="Scrolling and links still work. Buttons don't." xml:space="preserve">
+    <value>Le défilement et les liens fonctionnent toujours. Pas les boutons.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reconnect." xml:space="preserve">
+    <value>Le défilement et les liens fonctionnent toujours. Les boutons attendent la reconnexion.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
+    <value>Le défilement et les liens fonctionnent toujours. Les boutons exigent un rechargement.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Chercher</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -1656,6 +1656,9 @@
   <data name="Couldn't reconnect." xml:space="preserve">
     <value>Échec de la reconnexion.</value>
   </data>
+  <data name="Couldn't resume the session." xml:space="preserve">
+    <value>Échec de la reprise de la session.</value>
+  </data>
   <data name="Couldn't unlock your saved password. Enter it to import." xml:space="preserve">
     <value>Impossible de déverrouiller votre mot de passe enregistré. Saisissez-le pour importer.</value>
   </data>
@@ -5550,6 +5553,9 @@
   <data name="Results and the new lineup post when the board rotates each Monday." xml:space="preserve">
     <value>Les résultats et les nouveaux charts sont publiés à la rotation du leaderboard chaque lundi.</value>
   </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Reprendre</value>
+  </data>
   <data name="Review access" xml:space="preserve">
     <value>Vérifier les accès</value>
   </data>
@@ -5807,6 +5813,9 @@
   <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
     <value>Le défilement et les liens fonctionnent toujours. Les boutons exigent un rechargement.</value>
   </data>
+  <data name="Scrolling and links still work. Resume to use buttons." xml:space="preserve">
+    <value>Le défilement et les liens fonctionnent toujours. Reprenez pour utiliser les boutons.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Chercher</value>
   </data>
@@ -5923,6 +5932,9 @@
   </data>
   <data name="Session mode hands your server a live piugame.com key, so every player agrees to it individually — nobody arrives through &quot;share with all tools&quot;. It can only be switched on while no player is connected, and a header is required." xml:space="preserve">
     <value>Le mode session confie à votre serveur une clé piugame.com active, donc chaque joueur l'accepte individuellement — personne n'arrive par « partager avec tous les outils ». Il ne peut être activé que tant qu'aucun joueur n'est connecté, et un en-tête est obligatoire.</value>
+  </data>
+  <data name="Session paused." xml:space="preserve">
+    <value>Session en pause.</value>
   </data>
   <data name="Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp." xml:space="preserve">
     <value>Résumé de session capturé à l'import — une nouvelle plaque UG, 2 records personnels, une lampe de dossier.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -754,6 +754,9 @@
   <data name="at {0} or better" xml:space="preserve">
     <value>avec {0} ou mieux</value>
   </data>
+  <data name="Attempt {0} of {1}" xml:space="preserve">
+    <value>Tentative {0} sur {1}</value>
+  </data>
   <data name="Attempts before this clear" xml:space="preserve">
     <value>Essais avant cette réussite</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -5799,6 +5799,15 @@
   <data name="Scroll right" xml:space="preserve">
     <value>Scorri a destra</value>
   </data>
+  <data name="Scrolling and links still work. Buttons don't." xml:space="preserve">
+    <value>Scorrimento e link funzionano ancora. I pulsanti no.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reconnect." xml:space="preserve">
+    <value>Scorrimento e link funzionano ancora. I pulsanti richiedono la riconnessione.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
+    <value>Scorrimento e link funzionano ancora. I pulsanti richiedono un ricaricamento.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Cerca</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -754,6 +754,9 @@
   <data name="at {0} or better" xml:space="preserve">
     <value>con {0} o meglio</value>
   </data>
+  <data name="Attempt {0} of {1}" xml:space="preserve">
+    <value>Tentativo {0} di {1}</value>
+  </data>
   <data name="Attempts before this clear" xml:space="preserve">
     <value>Tentativi prima di superarlo</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -1657,6 +1657,9 @@
   <data name="Couldn't reconnect." xml:space="preserve">
     <value>Riconnessione non riuscita.</value>
   </data>
+  <data name="Couldn't resume the session." xml:space="preserve">
+    <value>Ripresa della sessione non riuscita.</value>
+  </data>
   <data name="Couldn't unlock your saved password. Enter it to import." xml:space="preserve">
     <value>Impossibile sbloccare la password salvata. Inseriscila per importare.</value>
   </data>
@@ -5551,6 +5554,9 @@
   <data name="Results and the new lineup post when the board rotates each Monday." xml:space="preserve">
     <value>I risultati e i nuovi chart vengono pubblicati quando la classifica ruota ogni lunedì.</value>
   </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Riprendi</value>
+  </data>
   <data name="Review access" xml:space="preserve">
     <value>Controlla gli accessi</value>
   </data>
@@ -5808,6 +5814,9 @@
   <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
     <value>Scorrimento e link funzionano ancora. I pulsanti richiedono un ricaricamento.</value>
   </data>
+  <data name="Scrolling and links still work. Resume to use buttons." xml:space="preserve">
+    <value>Scorrimento e link funzionano ancora. Riprendi per usare i pulsanti.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Cerca</value>
   </data>
@@ -5924,6 +5933,9 @@
   </data>
   <data name="Session mode hands your server a live piugame.com key, so every player agrees to it individually — nobody arrives through &quot;share with all tools&quot;. It can only be switched on while no player is connected, and a header is required." xml:space="preserve">
     <value>La modalità sessione consegna al tuo server una chiave piugame.com attiva, quindi ogni giocatore acconsente singolarmente: nessuno arriva da "condividi con tutti gli strumenti". Si può attivare solo mentre nessun giocatore è connesso, e serve un'intestazione.</value>
+  </data>
+  <data name="Session paused." xml:space="preserve">
+    <value>Sessione in pausa.</value>
   </data>
   <data name="Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp." xml:space="preserve">
     <value>Riepilogo di sessione catturato all'importazione — una nuova targa UG, 2 record personali, una lampada di cartella.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -1657,6 +1657,9 @@
   <data name="Couldn't reconnect." xml:space="preserve">
     <value>再接続できませんでした。</value>
   </data>
+  <data name="Couldn't resume the session." xml:space="preserve">
+    <value>セッションを再開できませんでした。</value>
+  </data>
   <data name="Couldn't unlock your saved password. Enter it to import." xml:space="preserve">
     <value>保存済みのパスワードを解除できませんでした。インポートするには入力してください。</value>
   </data>
@@ -5551,6 +5554,9 @@
   <data name="Results and the new lineup post when the board rotates each Monday." xml:space="preserve">
     <value>毎週月曜のボード更新時に、結果と新しいラインナップが投稿されます。</value>
   </data>
+  <data name="Resume" xml:space="preserve">
+    <value>再開</value>
+  </data>
   <data name="Review access" xml:space="preserve">
     <value>アクセスを確認</value>
   </data>
@@ -5808,6 +5814,9 @@
   <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
     <value>スクロールとリンクは使えます。ボタンにはページの再読み込みが必要です。</value>
   </data>
+  <data name="Scrolling and links still work. Resume to use buttons." xml:space="preserve">
+    <value>スクロールとリンクは使えます。ボタンを使うには再開してください。</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>検索</value>
   </data>
@@ -5924,6 +5933,9 @@
   </data>
   <data name="Session mode hands your server a live piugame.com key, so every player agrees to it individually — nobody arrives through &quot;share with all tools&quot;. It can only be switched on while no player is connected, and a header is required." xml:space="preserve">
     <value>セッションモードは有効な piugame.com のキーをサーバーに渡すため、プレイヤーごとの同意が必要です — 「すべてのツールと共有」からは入ってきません。接続中のプレイヤーがいないときだけ有効にでき、ヘッダーが必須です。</value>
+  </data>
+  <data name="Session paused." xml:space="preserve">
+    <value>セッションを一時停止しました。</value>
   </data>
   <data name="Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp." xml:space="preserve">
     <value>インポート時にセッションのまとめを記録 — 新しい UG プレート、自己ベスト2件、フォルダーランプ1件。</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -5799,6 +5799,15 @@
   <data name="Scroll right" xml:space="preserve">
     <value>右へスクロール</value>
   </data>
+  <data name="Scrolling and links still work. Buttons don't." xml:space="preserve">
+    <value>スクロールとリンクは使えます。ボタンは使えません。</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reconnect." xml:space="preserve">
+    <value>スクロールとリンクは使えます。ボタンには再接続が必要です。</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
+    <value>スクロールとリンクは使えます。ボタンにはページの再読み込みが必要です。</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>検索</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -754,6 +754,9 @@
   <data name="at {0} or better" xml:space="preserve">
     <value>{0}以上で</value>
   </data>
+  <data name="Attempt {0} of {1}" xml:space="preserve">
+    <value>{1} 回中 {0} 回目</value>
+  </data>
   <data name="Attempts before this clear" xml:space="preserve">
     <value>クリアまでの試行回数</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -1645,6 +1645,9 @@
   <data name="Couldn't reconnect." xml:space="preserve">
     <value>다시 연결하지 못했습니다.</value>
   </data>
+  <data name="Couldn't resume the session." xml:space="preserve">
+    <value>세션을 다시 시작하지 못했습니다.</value>
+  </data>
   <data name="Couldn't unlock your saved password. Enter it to import." xml:space="preserve">
     <value>저장된 비밀번호를 열 수 없습니다. 가져오려면 입력하세요.</value>
   </data>
@@ -5508,6 +5511,9 @@
   <data name="Results and the new lineup post when the board rotates each Monday." xml:space="preserve">
     <value>매주 월요일 보드가 갱신되면 결과와 새로운 라인업이 게시됩니다.</value>
   </data>
+  <data name="Resume" xml:space="preserve">
+    <value>다시 시작</value>
+  </data>
   <data name="Review access" xml:space="preserve">
     <value>접근 권한 검토</value>
   </data>
@@ -5760,6 +5766,9 @@
   <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
     <value>스크롤과 링크는 그대로 작동합니다. 버튼은 페이지를 새로 고쳐야 합니다.</value>
   </data>
+  <data name="Scrolling and links still work. Resume to use buttons." xml:space="preserve">
+    <value>스크롤과 링크는 그대로 작동합니다. 버튼을 쓰려면 다시 시작하세요.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>검색</value>
   </data>
@@ -5876,6 +5885,9 @@
   </data>
   <data name="Session mode hands your server a live piugame.com key, so every player agrees to it individually — nobody arrives through &quot;share with all tools&quot;. It can only be switched on while no player is connected, and a header is required." xml:space="preserve">
     <value>세션 모드는 살아 있는 piugame.com 키를 서버에 전달하므로 플레이어마다 개별 동의가 필요합니다 — '모든 도구와 공유'로는 들어오지 않습니다. 연결된 플레이어가 없을 때만 켤 수 있고 헤더가 필요합니다.</value>
+  </data>
+  <data name="Session paused." xml:space="preserve">
+    <value>세션이 일시 중지되었습니다.</value>
   </data>
   <data name="Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp." xml:space="preserve">
     <value>임포트하는 동안 세션 요약이 기록됩니다 — 새 UG 플레이트, 개인 기록 2개, 폴더 램프 1개.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -5751,6 +5751,15 @@
   <data name="Scroll right" xml:space="preserve">
     <value>오른쪽으로 스크롤</value>
   </data>
+  <data name="Scrolling and links still work. Buttons don't." xml:space="preserve">
+    <value>스크롤과 링크는 그대로 작동합니다. 버튼은 안 됩니다.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reconnect." xml:space="preserve">
+    <value>스크롤과 링크는 그대로 작동합니다. 버튼은 다시 연결해야 합니다.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
+    <value>스크롤과 링크는 그대로 작동합니다. 버튼은 페이지를 새로 고쳐야 합니다.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>검색</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -748,6 +748,9 @@
   <data name="at {0} or better" xml:space="preserve">
     <value>{0} 이상 기준</value>
   </data>
+  <data name="Attempt {0} of {1}" xml:space="preserve">
+    <value>{1}회 중 {0}회</value>
+  </data>
   <data name="Attempts before this clear" xml:space="preserve">
     <value>클리어까지의 시도 횟수</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -5751,6 +5751,15 @@
   <data name="Scroll right" xml:space="preserve">
     <value>Rolar para a direita</value>
   </data>
+  <data name="Scrolling and links still work. Buttons don't." xml:space="preserve">
+    <value>A rolagem e os links continuam funcionando. Os botões não.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reconnect." xml:space="preserve">
+    <value>A rolagem e os links continuam funcionando. Os botões precisam reconectar.</value>
+  </data>
+  <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
+    <value>A rolagem e os links continuam funcionando. Os botões precisam de um recarregamento.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Buscar</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1645,6 +1645,9 @@
   <data name="Couldn't reconnect." xml:space="preserve">
     <value>Não foi possível reconectar.</value>
   </data>
+  <data name="Couldn't resume the session." xml:space="preserve">
+    <value>Não foi possível retomar a sessão.</value>
+  </data>
   <data name="Couldn't unlock your saved password. Enter it to import." xml:space="preserve">
     <value>Não foi possível desbloquear sua senha salva. Digite-a para importar.</value>
   </data>
@@ -5508,6 +5511,9 @@
   <data name="Results and the new lineup post when the board rotates each Monday." xml:space="preserve">
     <value>Os resultados e os novos charts são publicados quando a classificação é renovada toda segunda-feira.</value>
   </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Retomar</value>
+  </data>
   <data name="Review access" xml:space="preserve">
     <value>Revisar o acesso</value>
   </data>
@@ -5760,6 +5766,9 @@
   <data name="Scrolling and links still work. Buttons need a reload." xml:space="preserve">
     <value>A rolagem e os links continuam funcionando. Os botões precisam de um recarregamento.</value>
   </data>
+  <data name="Scrolling and links still work. Resume to use buttons." xml:space="preserve">
+    <value>A rolagem e os links continuam funcionando. Retome para usar os botões.</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Buscar</value>
   </data>
@@ -5876,6 +5885,9 @@
   </data>
   <data name="Session mode hands your server a live piugame.com key, so every player agrees to it individually — nobody arrives through &quot;share with all tools&quot;. It can only be switched on while no player is connected, and a header is required." xml:space="preserve">
     <value>O modo sessão entrega ao seu servidor uma chave ativa do piugame.com, então cada jogador concorda individualmente — ninguém chega por "compartilhar com todas as ferramentas". Só dá para ligar enquanto nenhum jogador está conectado, e um cabeçalho é obrigatório.</value>
+  </data>
+  <data name="Session paused." xml:space="preserve">
+    <value>Sessão pausada.</value>
   </data>
   <data name="Session roundup captured on the way in — a new UG plate, 2 PBs, one folder lamp." xml:space="preserve">
     <value>Resumo da sessão capturado na importação — uma placa UG nova, 2 recordes pessoais, uma lâmpada de pasta.</value>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -748,6 +748,9 @@
   <data name="at {0} or better" xml:space="preserve">
     <value>com {0} ou melhor</value>
   </data>
+  <data name="Attempt {0} of {1}" xml:space="preserve">
+    <value>Tentativa {0} de {1}</value>
+  </data>
   <data name="Attempts before this clear" xml:space="preserve">
     <value>Tentativas antes de passar</value>
   </data>

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -198,12 +198,13 @@ body {
     margin-top: 8px;
     align-self: flex-start;
     padding: 6px 14px;
-    font-size: .82rem;
     border-radius: 6px;
     border: 1px solid var(--mix-primary);
     background: var(--mix-primary);
     color: var(--mix-primary-contrast);
+    /* The shorthand resets every font-* longhand, so the size must come after it. */
     font: inherit;
+    font-size: .82rem;
     font-weight: 600;
     cursor: pointer;
 }

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -63,21 +63,30 @@ body {
 
 /* ===== The circuit-drop overlay =====
    App.razor supplies #components-reconnect-modal, so Blazor stops building its own and just
-   toggles state classes on ours. Everything here is --mix-*: a dropped circuit is exactly the
-   moment MudThemeProvider's --mud-* vars can't be relied on. Every rule is id-scoped because
-   MudBlazor ships its own #components-reconnect-modal rules (background, z-index, and a
+   toggles state classes on ours. The framework's user-supplied-dialog path sets classes and
+   nothing else — no inert, no scroll lock — so how much of the page an outage covers is
+   decided entirely here, and it covers a corner. A dropped circuit leaves the rendered page
+   readable: scrolling works, the static shell's nav works, and every navigation is a full
+   document load, so a link the reader can still see and click is the fastest repair available
+   to them. Dimming the page hid that and left them watching a spinner instead.
+   Everything here is --mix-*: a dropped circuit is exactly the moment MudThemeProvider's
+   --mud-* vars can't be relied on. Every rule is id-scoped because MudBlazor ships its own
+   #components-reconnect-modal rules (background, z-index, and a
    `#components-reconnect-modal button` that outranks a bare class). */
 
 #components-reconnect-modal {
     display: none;
     position: fixed;
-    inset: 0;
-    align-items: center;
-    justify-content: center;
-    padding: 16px;
+    /* Docked, not draped: under the app bar, clear of the mobile bottom nav. */
+    inset: auto;
+    top: calc(var(--shell-appbar-h) + 8px);
+    right: 8px;
+    max-width: min(340px, calc(100vw - 16px));
     /* !important answers MudBlazor's own !important background; site.css loads after theirs. */
-    background: color-mix(in srgb, var(--mix-bg) 82%, transparent) !important;
-    backdrop-filter: blur(2px);
+    background: none !important;
+    /* The box shrink-wraps its card today, so this changes nothing today. It is what keeps a
+       later padding or max-width edit from quietly parking a dead click zone over the page. */
+    pointer-events: none;
 }
 
 /* No state class means no circuit trouble; -hide is the reconnected case. Both stay down. */
@@ -88,15 +97,25 @@ body {
 }
 
 #components-reconnect-modal .reconnect-card {
-    min-width: 240px;
-    padding: 22px 28px;
+    display: flex;
+    gap: 12px;
+    padding: 12px 15px;
     border-radius: 10px;
     border: 1px solid color-mix(in srgb, var(--mix-ink) 14%, transparent);
     background: var(--mix-surface);
     color: var(--mix-ink);
     box-shadow: 0 14px 44px -16px color-mix(in srgb, var(--mix-bg) 90%, transparent);
     font-family: var(--font-body);
-    text-align: center;
+    text-align: left;
+    /* The dock above is inert so the page keeps its clicks; the card takes its own back,
+       because two of the three states carry a button that has to be reachable. */
+    pointer-events: auto;
+}
+
+/* A dead session reads differently from a retry in progress: same box, louder edge. */
+#components-reconnect-modal.components-reconnect-failed .reconnect-card,
+#components-reconnect-modal.components-reconnect-rejected .reconnect-card {
+    border-left: 3px solid var(--mix-secondary);
 }
 
 /* All three states ship; the class Blazor set decides which one has a box. */
@@ -105,7 +124,16 @@ body {
 #components-reconnect-modal.components-reconnect-show .reconnect-on-show,
 #components-reconnect-modal.components-reconnect-failed .reconnect-on-failed,
 #components-reconnect-modal.components-reconnect-rejected .reconnect-on-rejected {
-    display: block;
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+#components-reconnect-modal .reconnect-body {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
 }
 
 #components-reconnect-modal .reconnect-title {
@@ -114,13 +142,22 @@ body {
     font-size: 1.15rem;
     font-weight: 600;
     letter-spacing: .01em;
+    line-height: 1.15;
+}
+
+/* Says which controls are dead. Undimmed, nothing else on screen says it. */
+#components-reconnect-modal .reconnect-sub {
+    margin: 0;
+    font-size: .78rem;
+    color: var(--mix-ink-muted);
 }
 
 #components-reconnect-modal .reconnect-spinner {
     display: block;
-    width: 28px;
-    height: 28px;
-    margin: 0 auto 12px;
+    width: 20px;
+    height: 20px;
+    flex: none;
+    margin-top: 3px;
     border-radius: 50%;
     border: 3px solid color-mix(in srgb, var(--mix-ink) 18%, transparent);
     border-top-color: var(--mix-primary);
@@ -136,8 +173,10 @@ body {
 }
 
 #components-reconnect-modal .reconnect-btn {
-    margin-top: 16px;
-    padding: 8px 18px;
+    margin-top: 8px;
+    align-self: flex-start;
+    padding: 6px 14px;
+    font-size: .82rem;
     border-radius: 6px;
     border: 1px solid var(--mix-primary);
     background: var(--mix-primary);

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -164,6 +164,16 @@ body {
     color: var(--mix-ink-muted);
 }
 
+/* -retrying rides on top of -show once the ladder starts backing off. Before that the
+   attempts are instant, so there is no wait worth counting and the line stays down. */
+#components-reconnect-modal .reconnect-retry-line {
+    font-variant-numeric: tabular-nums;
+}
+
+#components-reconnect-modal:not(.components-reconnect-retrying) .reconnect-retry-line {
+    display: none;
+}
+
 #components-reconnect-modal .reconnect-spinner {
     display: block;
     width: 20px;

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -89,9 +89,13 @@ body {
     pointer-events: none;
 }
 
-/* No state class means no circuit trouble; -hide is the reconnected case. Both stay down. */
+/* No state class means no circuit trouble; -hide is the reconnected case. Both stay down.
+   Every other class the framework can set has to be listed: an unlisted one leaves the box
+   hidden, which is a frozen page with nothing on screen accounting for it. */
 #components-reconnect-modal.components-reconnect-show,
+#components-reconnect-modal.components-reconnect-paused,
 #components-reconnect-modal.components-reconnect-failed,
+#components-reconnect-modal.components-reconnect-resume-failed,
 #components-reconnect-modal.components-reconnect-rejected {
     display: flex;
 }
@@ -114,15 +118,23 @@ body {
 
 /* A dead session reads differently from a retry in progress: same box, louder edge. */
 #components-reconnect-modal.components-reconnect-failed .reconnect-card,
+#components-reconnect-modal.components-reconnect-resume-failed .reconnect-card,
 #components-reconnect-modal.components-reconnect-rejected .reconnect-card {
     border-left: 3px solid var(--mix-secondary);
 }
 
-/* All three states ship; the class Blazor set decides which one has a box. */
+/* Paused is neither: the circuit is waiting to be picked up, not gone. */
+#components-reconnect-modal.components-reconnect-paused .reconnect-card {
+    border-left: 3px solid var(--mix-accent);
+}
+
+/* Every state ships; the class Blazor set decides which one has a box. */
 #components-reconnect-modal .reconnect-state { display: none; }
 
 #components-reconnect-modal.components-reconnect-show .reconnect-on-show,
+#components-reconnect-modal.components-reconnect-paused .reconnect-on-paused,
 #components-reconnect-modal.components-reconnect-failed .reconnect-on-failed,
+#components-reconnect-modal.components-reconnect-resume-failed .reconnect-on-resume-failed,
 #components-reconnect-modal.components-reconnect-rejected .reconnect-on-rejected {
     display: flex;
     gap: 12px;

--- a/ScoreTracker/ScoreTracker/wwwroot/js/reconnect-preview.js
+++ b/ScoreTracker/ScoreTracker/wwwroot/js/reconnect-preview.js
@@ -1,0 +1,53 @@
+// Debug harness for the reconnect overlay (#components-reconnect-modal in App.razor).
+//
+// Ctrl+Alt+R  cycles the overlay through every state class Blazor can set.
+// Ctrl+Alt+X  clears it.
+//
+// The paused and resume-failed states only occur when the server parks a circuit, which
+// cannot be provoked on demand — this is the one way to see every state on a real page.
+// It forces the classes by hand, so it shows what each state looks like; it does not prove
+// the wiring. A real state change from Blazor overwrites whatever this set, and the classes
+// are plain CSS togglable from any devtools console, so shipping the shortcut exposes
+// nothing a visitor could not already do.
+(function () {
+    var STATES = [
+        ['components-reconnect-show'],
+        ['components-reconnect-show', 'components-reconnect-retrying'],
+        ['components-reconnect-paused'],
+        ['components-reconnect-failed'],
+        ['components-reconnect-resume-failed'],
+        ['components-reconnect-rejected']
+    ];
+    var i = -1;
+
+    function modal() { return document.getElementById('components-reconnect-modal'); }
+
+    function clear() {
+        var m = modal();
+        if (!m) return;
+        m.className = '';
+        i = -1;
+    }
+
+    function next() {
+        var m = modal();
+        if (!m) { console.warn('[reconnect-preview] no #components-reconnect-modal on this page'); return; }
+        i = (i + 1) % STATES.length;
+        m.className = STATES[i].join(' ');
+
+        // Blazor fills these on a real outage; nothing fills them when the classes are forced.
+        var attempt = document.getElementById('components-reconnect-current-attempt');
+        var max = document.getElementById('components-reconnect-max-retries');
+        if (attempt) attempt.innerText = '5';
+        if (max) max.innerText = '12';
+
+        console.log('[reconnect-preview] ' + (i + 1) + '/' + STATES.length + ' — ' + STATES[i].join(' '));
+    }
+
+    document.addEventListener('keydown', function (e) {
+        if (!e.ctrlKey || !e.altKey) return;
+        var k = (e.key || '').toLowerCase();
+        if (k === 'r') { e.preventDefault(); next(); }
+        else if (k === 'x') { e.preventDefault(); clear(); }
+    });
+})();

--- a/ScoreTracker/ScoreTracker/wwwroot/js/reconnect.js
+++ b/ScoreTracker/ScoreTracker/wwwroot/js/reconnect.js
@@ -1,0 +1,28 @@
+// Boots Blazor by hand so the reconnect ladder can be shortened. blazor.web.js is loaded
+// with autostart="false" directly above this file; nothing else may sit between them,
+// because until start() runs the page has no circuit at all.
+//
+// The framework's default ladder is 30 attempts spaced 0ms (1-9), 5s (10-19) and 30s
+// (20-29): six minutes of spinner before the reader is offered a button to press. A circuit
+// is either back within a few seconds or it needs a person, and the six minutes bought
+// nothing but a stuck-looking page.
+//
+// Twelve attempts: four immediate, for a websocket dropped by a sleeping laptop or a wifi
+// handover, then eight at three seconds, which covers roughly the window an app restart
+// needs. That reaches "Couldn't reconnect." in about 25 seconds. Both numbers are judgment,
+// not measurement — the ladder cannot be tuned without knowing why circuits drop here, and
+// a wrong-but-bounded guess beats an unbounded default.
+//
+// maxRetries also reaches the overlay: Blazor writes it into
+// #components-reconnect-max-retries, which is where the card's "Attempt 5 of 12" gets its
+// second number.
+Blazor.start({
+    circuit: {
+        reconnectionOptions: {
+            maxRetries: 12,
+            retryIntervalMilliseconds: function (attempt) {
+                return attempt < 4 ? 0 : 3000;
+            }
+        }
+    }
+});

--- a/docs/TECHNOLOGIES.md
+++ b/docs/TECHNOLOGIES.md
@@ -28,6 +28,8 @@ The framework's build-time asset pipeline, in place of `UseStaticFiles`. Every f
 
 The three ES modules the circuit imports at runtime (`./js/helpers.js`, `./js/life-calculator.js`, `./js/phoenix-recap.js`) have no tag to carry a hashed name, so `<ImportMap />` in `App.razor` rewrites those specifiers in the browser — the C# call sites keep asking for the plain path. `_framework/blazor.web.js` stays on its plain name; the framework versions its own boot script.
 
+⚠ **`blazor.web.js` carries `autostart="false"`, and `js/reconnect.js` is what starts it.** It passes reconnection options (a twelve-rung retry ladder instead of the framework's thirty) that `Blazor.start()` only accepts at boot. The consequence is that the two tags are ordered, not merely adjacent: until `reconnect.js` runs there is no circuit, so nothing may be inserted between them and `reconnect.js` must never grow a reason to fail. Everything else in that block is order-independent.
+
 DartSassBuilder runs **before** the manifest is fingerprinted (verified: editing `charts.scss` moves the hash on `charts.<hash>.css`), so a Sass-only change busts the cache like any other. Ratcheted by `StaticAssetVersioningTests`.
 
 ### Localization (resx)


### PR DESCRIPTION
A dropped circuit dimmed and blurred the whole viewport behind a centred card, so a reader who only wanted to finish looking at a chart got a spinner over it — for up to six minutes, as it turns out.

Nothing in the framework required any of that. Blazor's user-supplied-dialog path sets state classes on our element and does nothing else — no `inert`, no scroll lock — so the blocking was entirely `site.css`'s, and the six minutes were the untouched default reconnection ladder.

**[Mock of every state, before and after.](https://claude.ai/code/artifact/071a2bc6-e31b-4942-9667-5a07d7cb3a49)**

## The commits, in order

**1 · The overlay docks in a corner.** Top-right, under the app bar, clear of the mobile bottom nav. The page below stays readable and scrollable, the static shell's nav still works, and because every navigation is a full document load, *a link the reader can still see and click is the fastest repair available to them* — which the dim was hiding.

Undimmed, the card is the only thing on screen saying the controls are dead, so each state gained a line naming which ones and what fixes them. Failed and ended also take a `--mix-secondary` left edge; a corner toast that has given up should not read the same as one still trying.

**2 · The two states that rendered nothing.** .NET 10 can park a circuit instead of losing it, setting `components-reconnect-paused` or `-resume-failed`. The CSS listed show/failed/rejected only, so either class landed on an element with no matching rule: a frozen page with nothing on screen accounting for it, and the one control that could recover it never drawn. Both now ship, and Try again falls through to `resumeCircuit` the way the framework's own dialog does — `reconnect()` returns false rather than throwing when the circuit was parked, so a bare `reconnect()` left the reader pressing a button that could not work.

**3 · The ladder goes from ~6 minutes to ~25 seconds.** The default is 30 attempts spaced 0ms (1–9), 5s (10–19) and 30s (20–29). Now twelve — four immediate, eight at three seconds. The cap makes a count worth showing, so the card carries one; Blazor fills both spans by id and adds `-retrying` once the ladder backs off, so the line reports framework state rather than tracking its own.

**4 · Docs.** `autostart="false"` makes `js/reconnect.js` load-bearing — until it runs there is no circuit — so `TECHNOLOGIES.md` says the two script tags are ordered, not merely adjacent.

**5 · Sonar's one finding, fixed.** `font-size` sat before `font: inherit` in the button, and the shorthand resets every longhand it doesn't name — the size never applied.

**6 · The state harness ships.** Ctrl+Alt+R cycles the overlay through every state, Ctrl+Alt+X clears it. Kept deliberately: `paused`/`resume-failed` only occur when the server parks a circuit, which can't be provoked on demand, so a shipped shortcut is the only way to lay eyes on them — including in production, where they'll actually fire. It forces classes by hand (proves looks, not wiring), a real Blazor state change overwrites it, and the classes are plain CSS anyone could toggle from devtools, so it exposes nothing.

## Scope

All presentation. `ScoreTracker.Web` only: `site.css`, `App.razor`, new `wwwroot/js/reconnect.js` + `reconnect-preview.js`, eight new keys across all nine locales, one doc paragraph. No Domain, Application, Data, vertical, port, handler, entity, or migration.

## What I'd flag

- **The retry numbers are a bounded guess, not a measurement**, and the file says so. They cannot be tuned without knowing why circuits actually drop here. A wrong-but-bounded ladder still beats an unbounded default.
- **The real trade in un-dimming**: the page underneath looks alive but anything through the circuit is dead. Someone can poke a `/Charts` filter three times before reading the toast. The subtitle copy is the mitigation; if it does not land in the field, the fallback is a louder card, not the dim.
- **`autostart="false"` is the only load-bearing bit here.** A broken `reconnect.js` means Blazor never boots. Commit 3 is the one to revert alone if anything smells; commits 1 and 2 touch nothing that can fail closed.
- **Not done, deliberately**: the framework's default dialog re-tries on `visibilitychange`; the user-supplied path does not, so a phone returning from background shows "Couldn't reconnect." and needs a tap. Worth its own change, and it wants a field test rather than a rider on this one.
- `UiColorTokenTests` scans `Pages`/`Components`/`Shared` only, so `App.razor` at the Web root is outside it. Nothing here adds a literal, but the build would not have caught one.

## Testing

Web + Tests build clean; the 76 architecture ratchets pass, including the localization set (alphabetical insertion, nine-locale parity, case collisions, the Murloc alphabet), `StylesheetStructureTests` and `StaticAssetVersioningTests`. No suite asserts this overlay today — bUnit cannot meaningfully render `App.razor`'s static portion — so the states themselves want a field pass: **Ctrl+Alt+R on any page** cycles all six looks. The wiring itself is provable by stopping the AppHost with a page open and watching the real ladder run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
