### PR TITLE
fix(pumbility): Your charts average is the mean of the charts you hold

### DIFF
--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityPageSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PumbilityPageSaga.cs
@@ -134,8 +134,8 @@ namespace ScoreTracker.PlayerProgress.Application
             }
 
             var total = pool.Sum(p => p.Value);
-            var totals = await PoolTotalsFor(request.UserId, mix, request.Pool, total, bar, charts, scoring,
-                reachable, cancellationToken);
+            var totals = await PoolTotalsFor(request.UserId, mix, request.Pool, total, bar, pool.Length,
+                charts, scoring, reachable, cancellationToken);
 
             return new PumbilityPageRecord(mix, request.Pool, total, bar, barChart,
                 pool, waiting, top, Breakdown(pool, charts, scoring), totals?.Totals,
@@ -198,7 +198,7 @@ namespace ScoreTracker.PlayerProgress.Application
         ///     this whole handler.
         /// </summary>
         private async Task<(PoolTotals Totals, IReadOnlyList<TitleRail> Rails)?> PoolTotalsFor(Guid userId,
-            MixEnum mix, ChartType? scope, double scopeTotal, double? scopeBar,
+            MixEnum mix, ChartType? scope, double scopeTotal, double? scopeBar, int scopeCount,
             IReadOnlyDictionary<Guid, Chart> charts, ScoringConfiguration scoring,
             IReadOnlyDictionary<Guid, double> reachable, CancellationToken cancellationToken)
         {
@@ -206,9 +206,9 @@ namespace ScoreTracker.PlayerProgress.Application
             // split to show nor a ladder to show it against.
             if (mix != MixEnum.Phoenix2) return null;
 
-            async Task<(double Total, double? Bar)> PoolFor(ChartType? type)
+            async Task<(double Total, double? Bar, int Count)> PoolFor(ChartType? type)
             {
-                if (type == scope) return (scopeTotal, scopeBar);
+                if (type == scope) return (scopeTotal, scopeBar, scopeCount);
 
                 var values = (await _mediator.Send(new GetTop50ForPlayerQuery(userId, type, PoolSize, mix),
                         cancellationToken))
@@ -218,7 +218,7 @@ namespace ScoreTracker.PlayerProgress.Application
                     .OrderByDescending(v => v)
                     .ToArray();
 
-                return (values.Sum(), values.Length >= PoolSize ? values[^1] : null);
+                return (values.Sum(), values.Length >= PoolSize ? values[^1] : null, values.Length);
             }
 
             var all = await PoolFor(null);
@@ -245,8 +245,8 @@ namespace ScoreTracker.PlayerProgress.Application
             return (new PoolTotals(all.Total, singles.Total, doubles.Total),
                 rail == null ? Array.Empty<TitleRail>() : new[] { rail });
 
-            TitleRail? Rail(PumbilityPool pool, (double Total, double? Bar) figures, ChartType exampleType,
-                ChartType? exampleScope)
+            TitleRail? Rail(PumbilityPool pool, (double Total, double? Bar, int Count) figures,
+                ChartType exampleType, ChartType? exampleScope)
             {
                 if (!ladders.TryGetValue(pool, out var ladder) || ladder.Length == 0) return null;
 
@@ -262,8 +262,7 @@ namespace ScoreTracker.PlayerProgress.Application
                     : AskExamples(scoring, exampleType, ask);
 
                 // What the fifty would average if every suggestion landed. Over PoolSize rather
-                // than over however many charts exist, so it is comparable to the ask and to the
-                // average beside it.
+                // than over however many charts exist, so it is comparable to the ask.
                 var projectable = reachable
                     .Where(kv => exampleScope == null || charts[kv.Key].Type == exampleScope)
                     .Select(kv => kv.Value)
@@ -272,9 +271,12 @@ namespace ScoreTracker.PlayerProgress.Application
                     .Take(PoolSize)
                     .ToArray();
 
+                // The average is over the charts actually held: a ten-chart pool averaging 400
+                // reads 400, not 80. It moves as the pool fills, and lands on the ask's
+                // fifty-denominator once the pool is full.
                 return new TitleRail(pool, figures.Total, held?.Name.ToString(),
                     held?.CompletionRequired ?? 0, next?.Name.ToString(), next?.CompletionRequired,
-                    ask, figures.Total / (double)PoolSize, figures.Bar, examples,
+                    ask, figures.Count == 0 ? 0 : figures.Total / figures.Count, figures.Bar, examples,
                     projectable.Length == 0 ? null : projectable.Sum() / (double)PoolSize);
             }
         }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/PumbilityPageRecord.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/PumbilityPageRecord.cs
@@ -128,7 +128,11 @@ public sealed record PoolTotals(double All, double Singles, double Doubles);
 /// <param name="Held">The highest rung the pool clears, or null below the first one.</param>
 /// <param name="Next">The rung above it, or null at the top of the ladder.</param>
 /// <param name="Ask">What <see cref="Next" /> asks of every chart in a full pool.</param>
-/// <param name="Average">What the pool's charts are worth each today, over a full fifty.</param>
+/// <param name="Average">
+///     What the charts in the pool are worth each today — the mean over the charts actually
+///     held, so below a full fifty it moves as the pool fills. The ask beside it keeps the
+///     fifty-denominator, because a threshold is a demand on a full pool.
+/// </param>
 /// <param name="Bar">This pool's fiftieth chart, or null before it holds fifty.</param>
 /// <param name="Examples">
 ///     What chart meets the ask, at each of three reference grades — the actionable half, since a
@@ -158,9 +162,6 @@ public sealed record TitleRail(
     public double Progress => NextThreshold == null || NextThreshold.Value <= HeldThreshold
         ? 1
         : Math.Clamp((Value - HeldThreshold) / (double)(NextThreshold.Value - HeldThreshold), 0, 1);
-
-    /// <summary>What every chart still has to find. Zero at the top of the ladder.</summary>
-    public double PerChartGap => Math.Max(0, Ask - Average);
 
     /// <summary>What the pool as a whole still has to find.</summary>
     public double Gap => NextThreshold == null ? 0 : Math.Max(0, NextThreshold.Value - Value);

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityPageSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PumbilityPageSagaTests.cs
@@ -354,8 +354,22 @@ public sealed class PumbilityPageSagaTests
         Assert.NotNull(rail.NextThreshold);
         Assert.Equal(rail.NextThreshold!.Value / 50.0, rail.Ask, 6);
         Assert.Equal(rail.Value / 50.0, rail.Average, 6);
-        Assert.Equal(Math.Max(0, rail.Ask - rail.Average), rail.PerChartGap, 6);
         Assert.InRange(rail.Progress, 0, 1);
+    }
+
+    [Fact]
+    public async Task TheAverageIsOverTheChartsYouHoldNotAFullFifty()
+    {
+        // A ten-chart pool averaging ~400 must read ~400. Spread over fifty it read ~80 — a
+        // number lower than every chart on the board it sits above. The ask keeps the
+        // fifty-denominator; the average does not.
+        var ctx = new PageContext().WithPool(10, ChartType.Single, 21);
+
+        var page = await ctx.Saga.Handle(new GetPumbilityPageQuery(ctx.UserId, MixEnum.Phoenix2, ChartType.Single),
+            CancellationToken.None);
+
+        var rail = Assert.Single(page.Rails!);
+        Assert.Equal(rail.Value / 10.0, rail.Average, 6);
     }
 
     [Theory]
@@ -388,6 +402,8 @@ public sealed class PumbilityPageSagaTests
 
         var rail = Assert.Single(page.Rails!);
         Assert.Equal(0, rail.Value);
+        // Zero charts average zero — never a divide-by-nothing NaN.
+        Assert.Equal(0, rail.Average);
         Assert.Null(rail.Held);
         Assert.NotNull(rail.Next);
     }

--- a/docs/design/pumbility-overhaul.md
+++ b/docs/design/pumbility-overhaul.md
@@ -304,9 +304,13 @@ are exact against the formula.
 
 **Edge states, both drawn:**
 
-- **A thin pool.** *"Your pool holds 7 of 50. BRONZE asks 200.00 a chart across fifty."* Under what
-  any level-10 chart pays at AA, so until the pool is full the ask is the pool itself. This is the
-  common case for months after a mix launch, not an afterthought.
+- **A thin pool.** The ask keeps its fifty-denominator — a threshold is a demand on a full pool
+  however much of one exists — but **your charts average divides by the charts actually held**
+  (owner, 2026-08-13): a ten-chart pool averaging 400 reads 400, not 80. The number moves as the
+  pool fills, which is accepted. (An earlier draft of this state reworded the whole cell row —
+  *"Your pool holds 7 of 50. BRONZE asks 200.00 a chart across fifty."* — and was never built;
+  dividing the average by fifty in the meantime is what a player reported as a wrong number.)
+  This is the common case for months after a mix launch, not an afterthought.
 - **The top of a ladder.** The rail states that nothing sits above ABYSS ABSOLUTE rather than
   vanishing, so the section never disappears on the one player it should be congratulating.
 
@@ -750,7 +754,7 @@ that harness yet. The mix-dependent half is covered one layer down — the saga 
 | R8 | Docs | This section, `ARCHITECTURE.md`'s Progress row |
 
 R1 is deliberately first and deliberately alone: it is a live bug, it needs no UI, and every figure
-in R5 divides by fifty — an average over a pool holding a passed S9 is wrong by construction.
+in R5 is computed off the pool — an average over a pool holding a passed S9 is wrong by construction.
 
 ### 6.5 How a projection is held
 


### PR DESCRIPTION
## What

Discord report: on **Your Pool**, the "Your charts average" cell in the Your PUMBILITY titles rail always divided the pool total by 50, even below a full pool - a ten-chart pool averaging ~400 printed **80.00**, a number lower than every chart on the board beneath it.

`TitleRail.Average` is now the mean over the charts actually held, so it moves as the pool fills (owner-accepted). Zero charts read 0 rather than NaN.

## What deliberately did NOT change

- **The ask keeps its fifty-denominator.** A title threshold is a demand on a full pool however much of one exists; that is the whole per-chart-ask device.
- **"Your projected top 50" keeps `/50`** - its label and its realism check against the ask are both full-pool semantics.
- Consequence: below fifty, Ask − Average no longer scales to the total remaining gap. `PerChartGap` (that exact cross-denominator subtraction, rendered nowhere in any UI) is removed from the contract rather than left computing a now-meaningless number.

## Docs

`docs/design/pumbility-overhaul.md` §3.7's thin-pool edge state - drawn as a rewording ("... asks 200.00 a chart *across fifty*") and never built - now records this shipped resolution instead.

## Tests

- New: `TheAverageIsOverTheChartsYouHoldNotAFullFifty` (10-chart pool → `Total/10`).
- `AnEmptyPoolStillGetsItsRailRatherThanNone` now also pins `Average == 0` (divide-by-zero guard).
- Full fast suite: **3489 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
