### PR TITLE
PUMBILITY level markers: big enough to read

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/PumbilityLevelMarkersTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/PumbilityLevelMarkersTests.cs
@@ -94,26 +94,38 @@ public sealed class PumbilityLevelMarkersTests : ComponentTestBase
     }
 
     [Fact]
-    public void TheTickFragmentRendersPositionsCurrentAndHoverNames()
+    public void TheTickFragmentFramesTheBarWithLabelledMarkers()
     {
         var cut = RenderComponent<PumbilityLevelTicks>(p => p
-            .Add(x => x.Floor, 17_000).Add(x => x.Ceiling, 18_000).Add(x => x.Pool, 17_602.69));
+            .Add(x => x.Floor, 17_000).Add(x => x.Ceiling, 18_000).Add(x => x.Pool, 17_602.69)
+            .AddChildContent("<div class='probe-bar'></div>"));
+
+        // The bar renders unchanged inside the frame; the labelled ticks ride the overlay.
+        Assert.Single(cut.FindAll(".pmb-lvl-frame .probe-bar"));
 
         var ticks = cut.FindAll(".pmb-lvl-tick");
         Assert.Equal(4, ticks.Count);
         Assert.Equal(new[] { "left:20%", "left:40%", "left:60%", "left:80%" },
             ticks.Select(t => t.GetAttribute("style")));
+        // Every marker says its level out loud — the visible label was the owner's whole ask.
+        Assert.Equal(new[] { "LV.2", "LV.3", "LV.4", "LV.5" },
+            ticks.Select(t => t.QuerySelector("b")!.TextContent));
         Assert.Contains("cur", Assert.Single(ticks, t => t.GetAttribute("title") == "DIAMOND LV.4 · 17,600")
             .GetAttribute("class"));
     }
 
     [Fact]
-    public void TheTickFragmentRendersNothingForABareSpan()
+    public void ABareSpanRendersItsBarWithNoFrameAtAll()
     {
+        // BRONZE's first rung holds no levels: the child passes through untouched, so the frame
+        // never adds label headroom where there are no labels.
         var cut = RenderComponent<PumbilityLevelTicks>(p => p
-            .Add(x => x.Floor, 0).Add(x => x.Ceiling, 10_000).Add(x => x.Pool, 4_000));
+            .Add(x => x.Floor, 0).Add(x => x.Ceiling, 10_000).Add(x => x.Pool, 4_000)
+            .AddChildContent("<div class='probe-bar'></div>"));
 
-        Assert.Empty(cut.Markup.Trim());
+        Assert.Single(cut.FindAll(".probe-bar"));
+        Assert.Empty(cut.FindAll(".pmb-lvl-frame"));
+        Assert.Empty(cut.FindAll(".pmb-lvl-tick"));
     }
 
     [Fact]
@@ -127,8 +139,11 @@ public sealed class PumbilityLevelMarkersTests : ComponentTestBase
             new SessionTitleBarModel("Singles", "[S] EXPERT LV.2", 0.03, 0.07, 17_507, 17_700)
         }));
 
-        var ticks = cut.FindAll(".sbd-track .pmb-lvl-tick");
+        var ticks = cut.FindAll(".pmb-lvl-tick");
         Assert.Equal(4, ticks.Count);
+        // The [P.B] bar itself sits framed; the [S] bar renders outside any frame.
+        Assert.Single(cut.FindAll(".pmb-lvl-frame .sbd-track"));
+        Assert.Equal(2, cut.FindAll(".sbd-track").Count);
         // 16,450 stands on PLATINUM LV.3 — the brightened tick inside the DIAMOND climb.
         Assert.Contains("cur", Assert.Single(ticks, t => (t.GetAttribute("title") ?? "").StartsWith("PLATINUM LV.3"))
             .GetAttribute("class"));

--- a/ScoreTracker/ScoreTracker.Tests.Components/TitleDetailDrawerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/TitleDetailDrawerTests.cs
@@ -225,7 +225,7 @@ public sealed class TitleDetailDrawerTests : ComponentTestBase
         // The DIAMOND bar spans 16,000 → 17,000 — PLATINUM's four interior levels tick it.
         var drawer = OpenWithHolders("[P.B] DIAMOND", new TitleHoldersRecord(Array.Empty<TitleHolder>(), 0));
 
-        Assert.Equal(4, drawer.FindAll(".title-bar .pmb-lvl-tick").Count);
+        Assert.Equal(4, drawer.FindAll(".pmb-lvl-tick").Count);
     }
 
     [Fact]
@@ -233,7 +233,7 @@ public sealed class TitleDetailDrawerTests : ComponentTestBase
     {
         var drawer = OpenWithHolders("[P.B] BRONZE", new TitleHoldersRecord(Array.Empty<TitleHolder>(), 0));
 
-        Assert.Empty(drawer.FindAll(".title-bar .pmb-lvl-tick"));
+        Assert.Empty(drawer.FindAll(".pmb-lvl-tick"));
     }
 
     [Fact]
@@ -241,7 +241,7 @@ public sealed class TitleDetailDrawerTests : ComponentTestBase
     {
         var drawer = OpenWithHolders("[S] ADVANCED LV.1", new TitleHoldersRecord(Array.Empty<TitleHolder>(), 0));
 
-        Assert.Empty(drawer.FindAll(".title-bar .pmb-lvl-tick"));
+        Assert.Empty(drawer.FindAll(".pmb-lvl-tick"));
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker/Components/Pumbility/PumbilityTitleRails.razor
+++ b/ScoreTracker/ScoreTracker/Components/Pumbility/PumbilityTitleRails.razor
@@ -41,17 +41,25 @@
                 else
                 {
                     <div class="pmb-rail-track">
-                        <div class="pmb-rail-bar">
-                            <span class="pmb-rail-fill" style="width:@Percent(rail.Progress)%"></span>
-                            @* The rail's span is one gem, so the total rail wears that gem's level
-                               rungs (docs/design/pumbility-levels.md §8). The per-type pools have
-                               no levels — their rails stay bare on the Pool gate. *@
-                            @if (rail.Pool == PumbilityPool.Total && rail.NextThreshold is { } nextThreshold)
-                            {
-                                <PumbilityLevelTicks Floor="rail.HeldThreshold" Ceiling="nextThreshold"
-                                                     Pool="rail.Value"></PumbilityLevelTicks>
-                            }
-                        </div>
+                        @* The rail's span is one gem, so the total rail wears that gem's level
+                           rungs — labelled, framed around the bar (docs/design/pumbility-levels.md
+                           §8). The per-type pools have no levels — their rails stay bare on the
+                           Pool gate. *@
+                        @if (rail.Pool == PumbilityPool.Total && rail.NextThreshold is { } nextThreshold)
+                        {
+                            <PumbilityLevelTicks Floor="rail.HeldThreshold" Ceiling="nextThreshold"
+                                                 Pool="rail.Value">
+                                <div class="pmb-rail-bar">
+                                    <span class="pmb-rail-fill" style="width:@Percent(rail.Progress)%"></span>
+                                </div>
+                            </PumbilityLevelTicks>
+                        }
+                        else
+                        {
+                            <div class="pmb-rail-bar">
+                                <span class="pmb-rail-fill" style="width:@Percent(rail.Progress)%"></span>
+                            </div>
+                        }
                         @* The remaining sits BETWEEN the two rungs, because that is what it is the
                            distance across. Said as a total at the foot of the rail it read as a
                            number with no unit, next to figures that were per-chart. *@

--- a/ScoreTracker/ScoreTracker/Components/PumbilityLevelTicks.razor
+++ b/ScoreTracker/ScoreTracker/Components/PumbilityLevelTicks.razor
@@ -3,15 +3,29 @@
 @using ScoreTracker.PlayerProgress.Contracts
 @using ScoreTracker.Web.Services
 
-@* The level rungs inside a one-gem PUMBILITY bar, as tick marks
-   (docs/design/pumbility-levels.md §8). Hosted inside any position:relative bar; the ticks sit
-   within the bar's own clip, full height, so every host keeps its rounded overflow. Renders
-   nothing when the span holds no rungs, which is what makes it safe on every bar. *@
+@* The level rungs on a one-gem PUMBILITY bar: big ticks with visible LV.n labels
+   (docs/design/pumbility-levels.md §8). Wraps the bar it decorates — every host bar clips its
+   fill with overflow:hidden, so the ticks live on a frame AROUND the bar instead: the frame
+   reserves label headroom above, the labels render into it, and the ticks overshoot the bar's
+   edges while the bar keeps its own rounded clip untouched. A span holding no rungs renders the
+   child bare, so the frame never adds layout where there is nothing to show. *@
 
-@foreach (var tick in Ticks)
+@if (Ticks.Count == 0)
 {
-    <span class="pmb-lvl-tick @(tick.Current ? "cur" : "")" style="left:@Left(tick)"
-          title="@TitleFor(tick)"></span>
+    @ChildContent
+}
+else
+{
+    <div class="pmb-lvl-frame">
+        @ChildContent
+        <div class="pmb-lvl-overlay">
+            @foreach (var tick in Ticks)
+            {
+                <span class="pmb-lvl-tick @(tick.Current ? "cur" : "")" style="left:@Left(tick)"
+                      title="@TitleFor(tick)"><b>@LabelText(tick)</b></span>
+            }
+        </div>
+    </div>
 }
 
 @code {
@@ -28,6 +42,10 @@
     [Parameter]
     public double Pool { get; set; }
 
+    /// <summary>The bar being decorated, rendered unchanged.</summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
     private IReadOnlyList<PumbilityLevelMarkers.Tick> Ticks =>
         PumbilityLevelMarkers.TicksFor(Floor, Ceiling, Pool);
 
@@ -36,7 +54,14 @@
         return (tick.Fraction * 100).ToString("0.##", CultureInfo.InvariantCulture) + "%";
     }
 
-    // "PLATINUM LV.2 · 16,200" — the game's own notation, so no localizer key.
+    // "LV.2" — the game's own notation, so no localizer key. The full-name fallback only fires
+    // if a span ever crosses a gem boundary, where a bare number would be ambiguous.
+    private static string LabelText(PumbilityLevelMarkers.Tick tick)
+    {
+        return tick.Level.Level is { } level ? $"LV.{level}" : PumbilityLevelChange.LabelFor(tick.Level);
+    }
+
+    // "PLATINUM LV.2 · 16,200" — the hover names the rung the label abbreviates.
     private static string TitleFor(PumbilityLevelMarkers.Tick tick)
     {
         return $"{PumbilityLevelChange.LabelFor(tick.Level)} · {tick.Level.Threshold:N0}";

--- a/ScoreTracker/ScoreTracker/Components/Sessions/SessionTitleBars.razor
+++ b/ScoreTracker/ScoreTracker/Components/Sessions/SessionTitleBars.razor
@@ -18,20 +18,28 @@
                         <span class="sbd-tbar-was">@Percent(bar.OldPercent) →</span> @Percent(bar.NewPercent)
                     </span>
                 </div>
-                <div class="sbd-track">
-                    <span class="sbd-track-held" style="@($"width:{Clamp(bar.OldPercent)}%")"></span>
-                    <span class="sbd-track-gain"
-                          style="@($"left:{Clamp(bar.OldPercent)}%;width:{Clamp(bar.NewPercent) - Clamp(bar.OldPercent)}%")"></span>
-                    @* A gem title's bar spans one gem (the percents are floor-aware), so it wears
-                       that gem's level rungs. The name lookup is the gate: [S]/[D] and Phoenix
-                       titles resolve to nothing and stay exactly as they are
-                       (docs/design/pumbility-levels.md §8). *@
-                    @if (PumbilityLevelMarkers.GemSpanFor(bar.Title) is { } span)
-                    {
-                        <PumbilityLevelTicks Floor="span.Floor" Ceiling="span.Required"
-                                             Pool="bar.Current"></PumbilityLevelTicks>
-                    }
-                </div>
+                @* A gem title's bar spans one gem (the percents are floor-aware), so it wears
+                   that gem's level rungs — labelled, framed around the bar. The name lookup is
+                   the gate: [S]/[D] and Phoenix titles resolve to nothing and stay exactly as
+                   they are (docs/design/pumbility-levels.md §8). *@
+                @if (PumbilityLevelMarkers.GemSpanFor(bar.Title) is { } span)
+                {
+                    <PumbilityLevelTicks Floor="span.Floor" Ceiling="span.Required" Pool="bar.Current">
+                        <div class="sbd-track">
+                            <span class="sbd-track-held" style="@($"width:{Clamp(bar.OldPercent)}%")"></span>
+                            <span class="sbd-track-gain"
+                                  style="@($"left:{Clamp(bar.OldPercent)}%;width:{Clamp(bar.NewPercent) - Clamp(bar.OldPercent)}%")"></span>
+                        </div>
+                    </PumbilityLevelTicks>
+                }
+                else
+                {
+                    <div class="sbd-track">
+                        <span class="sbd-track-held" style="@($"width:{Clamp(bar.OldPercent)}%")"></span>
+                        <span class="sbd-track-gain"
+                              style="@($"left:{Clamp(bar.OldPercent)}%;width:{Clamp(bar.NewPercent) - Clamp(bar.OldPercent)}%")"></span>
+                    </div>
+                }
                 @if (bar.Required > 0)
                 {
                     <div class="sbd-tbar-cap">@L["{0} of {1} rating", bar.Current.ToString("N0"), bar.Required.ToString("N0")]</div>

--- a/ScoreTracker/ScoreTracker/Components/TitleDetailDrawer.razor
+++ b/ScoreTracker/ScoreTracker/Components/TitleDetailDrawer.razor
@@ -39,18 +39,25 @@
                     else if (IsLoggedIn)
                     {
                         <p class="title-label">@L["Your progress"]</p>
-                        <div class="title-bar @(Rung.State == RungState.Earned ? "done" : "")">
-                            <i style="width:@Percent"></i>
-                            @* A gem title's bar spans one gem (LinkLadder floors it at the rung
-                               below), so it wears that gem's level rungs — the ones being climbed
-                               through on the way to the title (docs/design/pumbility-levels.md §8). *@
-                            @if (IsGemRung)
-                            {
-                                <PumbilityLevelTicks Floor="Rung.Title.CompletionFloor"
-                                                     Ceiling="Rung.Title.CompletionRequired"
-                                                     Pool="Rung.Progress.CompletionCount"></PumbilityLevelTicks>
-                            }
-                        </div>
+                        @* A gem title's bar spans one gem (LinkLadder floors it at the rung
+                           below), so it wears that gem's level rungs — labelled, framed around
+                           the bar (docs/design/pumbility-levels.md §8). *@
+                        @if (IsGemRung)
+                        {
+                            <PumbilityLevelTicks Floor="Rung.Title.CompletionFloor"
+                                                 Ceiling="Rung.Title.CompletionRequired"
+                                                 Pool="Rung.Progress.CompletionCount">
+                                <div class="title-bar @(Rung.State == RungState.Earned ? "done" : "")">
+                                    <i style="width:@Percent"></i>
+                                </div>
+                            </PumbilityLevelTicks>
+                        }
+                        else
+                        {
+                            <div class="title-bar @(Rung.State == RungState.Earned ? "done" : "")">
+                                <i style="width:@Percent"></i>
+                            </div>
+                        }
                         <div class="title-figures">
                             <span>@FloorText</span>
                             <span><b>@Have</b> / @Need</span>

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -9342,20 +9342,51 @@ button.chart-card-art {
     overflow: hidden;
 }
 
-/* PUMBILITY rung ticks inside a one-gem bar (docs/design/pumbility-levels.md §8). Full height
-   within the host's own clip; the current rung's tick is the bright one. Hover names the rung —
-   the labels are the game's own LV.n notation. */
+/* PUMBILITY rung ticks on a one-gem bar (docs/design/pumbility-levels.md §8). The frame wraps
+   the bar: 18px of reserved headroom carries the LV.n labels, the overlay aligns to the bar's
+   own box, and the ticks overshoot its edges — the bar underneath keeps its rounded clip. The
+   current rung's tick and label are the bright ones; hover names the rung in full. */
+.pmb-lvl-frame {
+    position: relative;
+    padding-top: 18px;
+}
+
+.pmb-lvl-overlay {
+    position: absolute;
+    inset: 18px 0 0 0;
+    pointer-events: none;
+}
+
 .pmb-lvl-tick {
     position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 2px;
-    margin-left: -1px;
-    background: color-mix(in srgb, var(--mix-ink) 35%, transparent);
+    top: -3px;
+    bottom: -3px;
+    width: 3px;
+    margin-left: -1.5px;
+    border-radius: 1px;
+    background: color-mix(in srgb, var(--mix-ink) 45%, transparent);
+    pointer-events: auto;
+}
+
+.pmb-lvl-tick b {
+    position: absolute;
+    bottom: calc(100% + 3px);
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: .03em;
+    color: var(--mix-ink-muted);
+    white-space: nowrap;
 }
 
 .pmb-lvl-tick.cur {
-    background: color-mix(in srgb, var(--mix-ink) 85%, transparent);
+    background: var(--mix-ink);
+}
+
+.pmb-lvl-tick.cur b {
+    color: var(--mix-ink);
 }
 
 .title-bar i {

--- a/docs/design/pumbility-levels.md
+++ b/docs/design/pumbility-levels.md
@@ -192,6 +192,14 @@ need no model change — the component resolves floor and threshold from the tit
 floor-linked `BuildList` output. No contract, no query, no storage, no localizer keys (the labels
 are the game's own `LV.n` notation).
 
+**The markers are big, and the labels are visible** (owner, field-testing the first cut: "I
+expected big ol' markers with visible labels"). The first version shrank the ticks to fit inside
+each bar's `overflow: hidden` clip and dropped the labels — wrong trade. `PumbilityLevelTicks`
+now *wraps* the bar it decorates: the frame reserves label headroom above, the `LV.n` labels
+render into it, and the ticks overshoot the bar's edges — while the bar itself keeps its own
+rounded clip untouched. A gem bar whose span holds no rungs (BRONZE's first) renders its child
+bare, so the frame never adds layout where there is nothing to show.
+
 ## 9. Explicitly out of scope
 
 - **Peers by pumbility level** (owner: "not yet") — needs a `GetPlayersByPumbilityLevel` beside


### PR DESCRIPTION
## What this is

Field-test feedback on the level markers that merged with #269: they rendered as 2px slivers inside each bar's clip — nothing like the mock, which promised big markers with visible `LV.n` labels. This makes them the mock.

**Why v1 was tiny:** all three host bars clip their contents (`overflow: hidden` for the rounded fills), and I shrank the ticks to fit inside rather than solving the clip. Wrong trade.

**The fix:** `PumbilityLevelTicks` now *wraps* the bar it decorates instead of hiding inside it. The frame reserves 18px of label headroom above, the `LV.n` labels render into it, and the 3px ticks overshoot the bar's edges — while the bar itself keeps its own rounded clip untouched. Current rung's tick and label are full-ink; hover still names the rung ("PLATINUM LV.3 · 16,400"). A gem bar whose span holds no rungs (BRONZE's first) passes its child through bare, so the frame never adds layout where there's nothing to show.

Same three surfaces as before — the `/Pumbility/Pool` Total rail, the Titles drawer's gem bar, the session title bars — same gates, same one formula. Presentation-only: no contracts, no queries, no storage, no localizer keys.

## Testing

Fast suites green: **3,521 / 910 / 162**. The fragment facts now pin the labels themselves (`LV.2`–`LV.5` in the markup), the frame-wraps-bar structure, and the bare-span passthrough; the drawer and session facts re-anchored to the new structure.

Worth an eyeball on `/Pumbility/Pool`, the drawer, and a session after deploy — the frame adds 18px above each gem bar, which is the room the labels live in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)