### PR TITLE
Homepage fixes: feeds go short-form, Title Hunt learns Phoenix 2, Account Stats wears the gem

### DIFF
--- a/ScoreTracker/ScoreTracker.Domain/Models/Titles/TitleLists.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Models/Titles/TitleLists.cs
@@ -1,0 +1,37 @@
+using ScoreTracker.Domain.Models.Titles.Phoenix;
+using ScoreTracker.Domain.Models.Titles.Phoenix2;
+using ScoreTracker.SharedKernel.Enums;
+
+namespace ScoreTracker.Domain.Models.Titles;
+
+/// <summary>
+///     Mix-level facts about the shipped title taxonomy, derived from the lists themselves so
+///     they can never drift from what actually ships.
+/// </summary>
+public static class TitleLists
+{
+    // The TYPE is the test, matching the recommendation engine's own emptiness condition —
+    // Phoenix 2's "Difficulty" CATEGORY names its pumbility titles, so a category check would
+    // wrongly say P2 has a level ladder to hunt.
+    private static readonly bool PhoenixHasDifficulty =
+        PhoenixTitleList.BuildList().Any(t => t is PhoenixDifficultyTitle);
+
+    private static readonly bool Phoenix2HasDifficulty =
+        Phoenix2TitleList.BuildList().Any(t => t is PhoenixDifficultyTitle);
+
+    /// <summary>
+    ///     Whether the mix has chart-level difficulty titles to push toward. Phoenix does;
+    ///     Phoenix 2 does not — its 272 titles are pumbility ladders, grade badges and play
+    ///     counts. If Andamiro ships P2 difficulty titles and the list gains them, this flips
+    ///     on its own.
+    /// </summary>
+    public static bool HasDifficultyTitles(MixEnum mix)
+    {
+        return mix switch
+        {
+            MixEnum.Phoenix => PhoenixHasDifficulty,
+            MixEnum.Phoenix2 => Phoenix2HasDifficulty,
+            _ => false
+        };
+    }
+}

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/PlayerHighlightCapturer.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/PlayerHighlightCapturer.cs
@@ -32,14 +32,12 @@ internal sealed class PlayerHighlightCapturer : IPlayerHighlightCapturer
     private readonly IPlayerHighlightRepository _highlights;
     private readonly IPlayerStatsReader _playerStats;
     private readonly IScoreReader _scores;
-    private readonly ITitleRepository _titles;
 
-    public PlayerHighlightCapturer(IChartRepository charts, IScoreReader scores, ITitleRepository titles,
+    public PlayerHighlightCapturer(IChartRepository charts, IScoreReader scores,
         IPlayerHighlightRepository highlights, IPlayerStatsReader playerStats, IMemoryCache cache, IBus bus)
     {
         _charts = charts;
         _scores = scores;
-        _titles = titles;
         _highlights = highlights;
         _playerStats = playerStats;
         _cache = cache;
@@ -78,11 +76,7 @@ internal sealed class PlayerHighlightCapturer : IPlayerHighlightCapturer
             var pgHolders = (await _scores.GetChartScoreAggregates(mix, cancellationToken))
                 .ToDictionary(a => a.ChartId, a => a.PgCount);
             var activePlayers = (await _scores.GetActiveUserIds(mix, DateTimeOffset.MinValue, cancellationToken)).Count;
-            var titleHolders = (await _titles.GetTitleAggregations(mix, cancellationToken))
-                .GroupBy(t => t.Title.ToString())
-                .ToDictionary(g => g.Key, g => g.First().Count);
-            var titledUsers = await _titles.CountTitledUsers(cancellationToken);
-            return new RaritySnapshot(pgHolders, activePlayers, titleHolders, titledUsers);
+            return new RaritySnapshot(pgHolders, activePlayers);
         }))!;
     }
 }

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/RecommendedChartsSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/RecommendedChartsSaga.cs
@@ -471,8 +471,11 @@ namespace ScoreTracker.PlayerProgress.Application
                 .Where(kv => window == null || window(charts[kv.Key]))
                 .OrderByDescending(kv => kv.Value)
                 .Take(12)
+                // Truncated, never rounded up — a gain is never overstated (the PUMBILITY
+                // precision rule): 36.7 stamps as +36.
                 .Select(kv => new ChartRecommendation(RecommendationCategories.PushPumbility, kv.Key,
-                    "The biggest Pumbility gains available to you right now", "+" + kv.Value.ToString("N0")));
+                    "The biggest Pumbility gains available to you right now",
+                    "+" + Math.Floor(kv.Value).ToString("N0")));
         }
 
         private async Task<IEnumerable<ChartRecommendation>> GetSkillTitleCharts(MixEnum mix,

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/RecommendedChartsSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/RecommendedChartsSaga.cs
@@ -448,11 +448,17 @@ namespace ScoreTracker.PlayerProgress.Application
                     "These are randomly pulled from your best 100 charts based on competitive score. Push that score!"));
         }
 
+        /// <summary>The ranked pool a Pumbility Push hand draws from.</summary>
+        private const int PumbilityPushDrawPool = 50;
+
+        /// <summary>How many drawn picks one load shows.</summary>
+        private const int PumbilityPushShown = 12;
+
         /// <summary>
         ///     The projected-Pumbility targets that used to live in the Pumbility widget: each
-        ///     chart's expected gain to your overall rating, biggest first. Unlike
-        ///     <see cref="GetRandomFromTop50Charts" />, which shuffles the top 50, these are
-        ///     ranked by gain and stamp the "+N" onto the recommendation.
+        ///     chart's expected gain to your overall rating. Unlike
+        ///     <see cref="GetRandomFromTop50Charts" />, which shuffles the top 50, these stay
+        ///     gain-ranked and stamp the "+N" onto the recommendation.
         /// </summary>
         private async Task<IEnumerable<ChartRecommendation>> GetPumbilityPushes(MixEnum mix,
             IDictionary<string, ISet<Guid>> ignoredChartIds, ChartType? chartType,
@@ -465,12 +471,23 @@ namespace ScoreTracker.PlayerProgress.Application
             var projection =
                 await _mediator.Send(new ProjectPumbilityGainsQuery(_currentUser.User.Id, mix), cancellationToken);
 
-            return projection.ProjectedGains
+            // A fresh hand each load (owner, field test): the shown dozen samples from the top
+            // pool instead of pinning the same twelve forever, then ranks the hand by gain so
+            // the list still reads best-first — which is also what makes the header shuffle an
+            // honest control on this goal. The /Pumbility page reads the projection directly
+            // and stays fully ranked.
+            var pool = projection.ProjectedGains
                 .Where(kv => kv.Value > 0 && charts.ContainsKey(kv.Key) && !skipped.Contains(kv.Key))
                 .Where(kv => chartType == null || charts[kv.Key].Type == chartType)
                 .Where(kv => window == null || window(charts[kv.Key]))
                 .OrderByDescending(kv => kv.Value)
-                .Take(12)
+                .Take(PumbilityPushDrawPool)
+                .ToArray();
+            var random = _random;
+            return pool
+                .OrderBy(_ => random.Next(int.MaxValue))
+                .Take(PumbilityPushShown)
+                .OrderByDescending(kv => kv.Value)
                 // Truncated, never rounded up — a gain is never overstated (the PUMBILITY
                 // precision rule): 36.7 stamps as +36.
                 .Select(kv => new ChartRecommendation(RecommendationCategories.PushPumbility, kv.Key,

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/SignificantWin.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/SignificantWin.cs
@@ -15,8 +15,9 @@ namespace ScoreTracker.PlayerProgress.Contracts;
 ///     </para>
 ///     Field usage per <see cref="WinKind" />:
 ///     <list type="bullet">
-///         <item>BigTitle — TitleName</item>
-///         <item>RareTitle — TitleName + RarityShare (holder fraction, e.g. 0.004)</item>
+///         <item>BigTitle — TitleName (since 2026-08-14: ANY earned title — the big/rare split retired)</item>
+///         <item>PumbilityTitleSpan — TitleName (the rung reached) + Detail (the first rung crossed)</item>
+///         <item>RareTitle — TitleName + RarityShare; no longer produced, survives on stored rows</item>
 ///         <item>FolderComplete — Difficulty (the folder, e.g. "D23") — every chart in it passed</item>
 ///         <item>FolderFirst — Chart* + Score + Rank (folder ordinal 1/2/3)</item>
 ///         <item>TopPumbility — Chart* + Score + Rank (pumbility rank, e.g. 2 for #2)</item>
@@ -60,7 +61,16 @@ public enum WinKind
     ///     (docs/design/pumbility-levels.md §5). Suppressed at classification when the same batch
     ///     completed the gem title itself, so this row only speaks when the title didn't.
     /// </summary>
-    PumbilityLevelUp
+    PumbilityLevelUp,
+
+    /// <summary>
+    ///     One batch climbed several rungs of a single Phoenix 2 PUMBILITY pool ladder, and the
+    ///     rungs roll into one row ("[S] ADVANCED LV.6 → LV.9") instead of one per rung — in the
+    ///     feeds only; the Discord card renders from the milestones themselves and stays
+    ///     uncollapsed (owner, 2026-08-14). TitleName is the rung reached, Detail the first rung
+    ///     crossed. Only the pumbility ladders roll up; every other title family prints per rung.
+    /// </summary>
+    PumbilityTitleSpan
 }
 
 /// <summary>
@@ -80,6 +90,12 @@ public enum WinKind
 ///         v3 added <see cref="WinKind.PumbilityLevelUp" /> and <see cref="SignificantWin.PoolValue" />
 ///         — same reasoning as v2: a summary written before level crossings existed is incomplete
 ///         rather than wrong, and rows regenerate on their next import.
+///     </para>
+///     <para>
+///         2026-08-14: <see cref="WinKind.PumbilityTitleSpan" /> and the all-titles inclusion landed
+///         WITHOUT a bump — deliberately. A pre-change row is a complete summary under the rules of
+///         its day (nothing it should have carried is missing), so it keeps rendering; the 30-day
+///         window ages the old shapes out on its own.
 ///     </para>
 /// </summary>
 [ExcludeFromCodeCoverage]

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Domain/PlayerHighlightPolicy.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Domain/PlayerHighlightPolicy.cs
@@ -32,9 +32,6 @@ internal static class PlayerHighlightPolicy
     /// <summary>PG rarity self-selects hard charts, but a new easy chart reads "rare" too — floor it.</summary>
     public const int PgMinLevel = 20;
 
-    /// <summary>A title held by fewer than this fraction of titled players is a rare title.</summary>
-    public const double TitleRarityThreshold = 0.01;
-
     /// <summary>A pumbility rank at or above this (i.e. ≤ N) is a huge pumbility win.</summary>
     public const int PumbilityTopRank = 10;
 
@@ -60,12 +57,25 @@ internal static class PlayerHighlightPolicy
     public const int MaxWinsPerEvent = 4;
 
     private const string PerfectGamePlate = "Perfect Game";
-    private const string DifficultyCategory = "Difficulty";
+    private const string DefaultTitleDescription = "Default title";
 
-    // Difficulty titles (Phoenix) and PUMBILITY titles (Phoenix 2) both carry Category "Difficulty" —
-    // exactly the owner's "big title" set. Names come from the shipped title taxonomy.
-    private static readonly IReadOnlySet<string> PhoenixDifficultyTitles = DifficultyTitleNames(PhoenixTitleList.BuildList());
-    private static readonly IReadOnlySet<string> Phoenix2DifficultyTitles = DifficultyTitleNames(Phoenix2TitleList.BuildList());
+    // Name → rung for the three Phoenix 2 PUMBILITY pool ladders ([S], [D], [P.B] total) — the
+    // only titles that roll up (owner, 2026-08-14: "specifically only the pumbility titles").
+    // Phoenix 1 has no pool ladders; its difficulty titles print one row per rung like every
+    // other family.
+    private static readonly IReadOnlyDictionary<string, Phoenix2PumbilityTitle> Phoenix2PumbilityRungs =
+        Phoenix2TitleList.BuildList().OfType<Phoenix2PumbilityTitle>()
+            .ToDictionary(t => t.Name.ToString(), t => t, StringComparer.OrdinalIgnoreCase);
+
+    private static readonly IReadOnlyDictionary<string, Phoenix2PumbilityTitle> NoPumbilityRungs =
+        new Dictionary<string, Phoenix2PumbilityTitle>(StringComparer.OrdinalIgnoreCase);
+
+    // The default title every account starts with — a first import "earning" it is noise.
+    private static readonly IReadOnlySet<string> DefaultTitleNames = PhoenixTitleList.BuildList()
+        .Concat(Phoenix2TitleList.BuildList())
+        .Where(t => string.Equals(t.Description, DefaultTitleDescription, StringComparison.OrdinalIgnoreCase))
+        .Select(t => t.Name.ToString())
+        .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     public static IReadOnlyList<SignificantWin> Classify(ScoreHighlightsCapturedEvent e,
         IReadOnlyDictionary<Guid, Chart> charts, RaritySnapshot snapshot, PlayerStatsRecord stats)
@@ -74,9 +84,11 @@ internal static class PlayerHighlightPolicy
 
         foreach (var milestone in e.Milestones)
         {
-            var win = ClassifyMilestone(milestone, e.Mix, snapshot);
+            var win = ClassifyMilestone(milestone);
             if (win is not null) wins.Add(win.Value);
         }
+
+        wins.AddRange(ClassifyTitles(e.Mix, e.Milestones));
 
         // The level crossing is a batch-level fact, not a per-milestone one: whether it speaks
         // depends on which titles completed beside it, so it derives from the whole set.
@@ -100,23 +112,49 @@ internal static class PlayerHighlightPolicy
             .ToArray();
     }
 
-    // A title completion or full-folder clear → its win. FolderPassLamp Detail is the folder ("D23");
-    // titles split into difficulty/pumbility "big" titles and sub-1%-held "rare" ones.
-    private static (int Priority, SignificantWin Win)? ClassifyMilestone(PlayerMilestoneRecord milestone,
-        MixEnum mix, RaritySnapshot snapshot)
+    // A full-folder clear or folder movement → its win. FolderPassLamp Detail is the folder ("D23").
+    private static (int Priority, SignificantWin Win)? ClassifyMilestone(PlayerMilestoneRecord milestone)
     {
         if (milestone.Kind == MilestoneKind.FolderPassLamp && milestone.Detail is { Length: > 0 } folder)
             return (PriorityFolderComplete, new SignificantWin(WinKind.FolderComplete, Difficulty: folder));
 
         if (milestone.Kind == MilestoneKind.FolderProgress) return ClassifyFolderProgress(milestone);
 
-        if (milestone.Kind != MilestoneKind.TitleCompleted || milestone.Title is null) return null;
-        var title = milestone.Title;
-        if (IsBigTitle(mix, title))
-            return (PriorityBigTitle, new SignificantWin(WinKind.BigTitle, TitleName: title));
-        if (TitleShare(title, snapshot) is { } share && share < TitleRarityThreshold)
-            return (PriorityRareTitle, new SignificantWin(WinKind.RareTitle, TitleName: title, RarityShare: share));
         return null;
+    }
+
+    /// <summary>
+    ///     Every earned title is feed-worthy (owner, 2026-08-14: "all titles are big titles") — the
+    ///     old big/rare gate is gone, and with it the policy's only use of title-rarity data. The one
+    ///     grouping: a batch that climbs several rungs of one Phoenix 2 PUMBILITY pool ladder reads
+    ///     as a single span ("[S] ADVANCED LV.6 → LV.9") rather than one row per rung — in the feeds
+    ///     only, since the Discord card renders from the milestones themselves and stays loud.
+    /// </summary>
+    private static IEnumerable<(int Priority, SignificantWin Win)> ClassifyTitles(MixEnum mix,
+        IReadOnlyList<PlayerMilestoneRecord> milestones)
+    {
+        var completed = milestones
+            .Where(m => m.Kind == MilestoneKind.TitleCompleted && m.Title is { Length: > 0 })
+            .Select(m => m.Title!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(t => !DefaultTitleNames.Contains(t))
+            .ToArray();
+
+        var rungs = mix == MixEnum.Phoenix2 ? Phoenix2PumbilityRungs : NoPumbilityRungs;
+
+        // The ladder story leads: one span per pool whose rungs order by threshold, a lone rung
+        // staying a plain title row.
+        foreach (var pool in completed.Where(rungs.ContainsKey).GroupBy(t => rungs[t].Pool))
+        {
+            var climbed = pool.OrderBy(t => rungs[t].CompletionRequired).ToArray();
+            yield return climbed.Length == 1
+                ? (PriorityTitle, new SignificantWin(WinKind.BigTitle, TitleName: climbed[0]))
+                : (PriorityTitle, new SignificantWin(WinKind.PumbilityTitleSpan,
+                    TitleName: climbed[^1], Detail: climbed[0]));
+        }
+
+        foreach (var title in completed.Where(t => !rungs.ContainsKey(t)))
+            yield return (PriorityTitle, new SignificantWin(WinKind.BigTitle, TitleName: title));
     }
 
     /// <summary>
@@ -205,40 +243,25 @@ internal static class PlayerHighlightPolicy
             ? 0
             : snapshot.PgHoldersByChart.GetValueOrDefault(chartId) / (double)snapshot.ActivePlayerCount;
 
-    private static double? TitleShare(string title, RaritySnapshot snapshot) =>
-        snapshot.TitledUserCount > 0 && snapshot.TitleHoldersByName.TryGetValue(title, out var holders)
-            ? holders / (double)snapshot.TitledUserCount
-            : null;
-
-    private static bool IsBigTitle(MixEnum mix, string titleName) => mix == MixEnum.Phoenix2
-        ? Phoenix2DifficultyTitles.Contains(titleName)
-        : PhoenixDifficultyTitles.Contains(titleName);
-
-    private static IReadOnlySet<string> DifficultyTitleNames(IEnumerable<PhoenixTitle> titles) =>
-        titles.Where(t => string.Equals(t.Category.ToString(), DifficultyCategory, StringComparison.OrdinalIgnoreCase))
-            .Select(t => t.Name.ToString())
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
     // Priority: lower renders first (owner order 2026-07-13): titles, then folder wins, then the
-    // number wins. Within titles, rare above big. The level crossing sits with the titles — it is
-    // a gem sub-step, and it only ever speaks when the gem title itself stayed quiet.
-    private const int PriorityRareTitle = 0;
-    private const int PriorityBigTitle = 1;
-    private const int PriorityPumbilityLevelUp = 2;
-    private const int PriorityFolderComplete = 3;
-    private const int PriorityFolderProgress = 4;
-    private const int PriorityFolderFirst = 5;
-    private const int PriorityTopPumbility = 6;
-    private const int PriorityNotablePg = 7;
-    private const int PriorityPeerElite = 8;
+    // number wins. The level crossing sits with the titles — it is a gem sub-step, and it only
+    // ever speaks when the gem title itself stayed quiet.
+    private const int PriorityTitle = 0;
+    private const int PriorityPumbilityLevelUp = 1;
+    private const int PriorityFolderComplete = 2;
+    private const int PriorityFolderProgress = 3;
+    private const int PriorityFolderFirst = 4;
+    private const int PriorityTopPumbility = 5;
+    private const int PriorityNotablePg = 6;
+    private const int PriorityPeerElite = 7;
 }
 
 /// <summary>
 ///     The slow-moving population aggregates the policy needs, snapshotted so the busy import path
 ///     doesn't recompute them per event. Loaded by the capturer behind a per-mix memory cache.
+///     Title-holder aggregates left 2026-08-14 with the rare-title gate — PG rarity is the one
+///     population read left.
 /// </summary>
 internal sealed record RaritySnapshot(
     IReadOnlyDictionary<Guid, int> PgHoldersByChart,
-    int ActivePlayerCount,
-    IReadOnlyDictionary<string, int> TitleHoldersByName,
-    int TitledUserCount);
+    int ActivePlayerCount);

--- a/ScoreTracker/ScoreTracker.Tests.Components/AccountStatsWidgetTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/AccountStatsWidgetTests.cs
@@ -47,8 +47,6 @@ public sealed class AccountStatsWidgetTests : ComponentTestBase
                 SinglesRating: 852, SinglesScore: 900000, SinglesLevel: 21.3,
                 DoublesRating: 774, DoublesScore: 880000, DoublesLevel: 19.9,
                 CompetitiveLevel: 20.61, SinglesCompetitiveLevel: 21.34, DoublesCompetitiveLevel: 19.87));
-        _mediator.Setup(m => m.Send(It.IsAny<GetPlayerHistoryQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<PlayerRatingRecord>());
         Services.AddSingleton(_mediator.Object);
         Services.AddSingleton(_users.Object);
         Services.AddScoped<CommunityGlowReader>();
@@ -57,14 +55,15 @@ public sealed class AccountStatsWidgetTests : ComponentTestBase
         this.RenderInteractive();
     }
 
-    private IRenderedComponent<PumbilityWidget> Render(string size, string configJson = "{}")
+    private IRenderedComponent<PumbilityWidget> Render(string size, string configJson = "{}",
+        MixEnum mix = MixEnum.Phoenix)
     {
         var widget = new HomePageWidgetRecord(Guid.NewGuid(), "pumbility", null, 0, size, configJson, 1);
         return base.Render(builder =>
         {
             builder.OpenComponent<PumbilityWidget>(0);
             builder.AddAttribute(1, nameof(PumbilityWidget.Widget), widget);
-            builder.AddAttribute(2, nameof(PumbilityWidget.EffectiveMix), MixEnum.Phoenix);
+            builder.AddAttribute(2, nameof(PumbilityWidget.EffectiveMix), mix);
             builder.CloseComponent();
         }).FindComponent<PumbilityWidget>();
     }
@@ -105,6 +104,29 @@ public sealed class AccountStatsWidgetTests : ComponentTestBase
         Assert.Contains("19.87", cut.Markup);         // doubles competitive level
         // 1x1 is stats only — no match list.
         Assert.Empty(cut.FindAll(".dash-acct-matches"));
+        // The weekly delta left for the Sessions page (owner, 2026-08-14), and the
+        // history query that existed only to compute it left with it.
+        Assert.Empty(cut.FindAll(".dash-stat-delta"));
+        _mediator.Verify(m => m.Send(It.IsAny<GetPlayerHistoryQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void Phoenix2WearsTheLevelGemBesideTheTotal()
+    {
+        // 868 total sits below the 10,000 BRONZE floor → the UNRANKED rung, index 0.
+        var cut = Render("1x1", mix: MixEnum.Phoenix2);
+
+        var badge = Assert.Single(cut.FindAll(".pumbility-level-badge"));
+        Assert.Contains("pumbility/p2/pumbility_00.png", badge.GetAttribute("src"));
+    }
+
+    [Fact]
+    public void PhoenixHasNoLadderAndWearsNoGem()
+    {
+        var cut = Render("1x1");
+
+        Assert.Empty(cut.FindAll(".pumbility-level-badge"));
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests.Components/CompetitiveLevelConfigPanelTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/CompetitiveLevelConfigPanelTests.cs
@@ -1,0 +1,73 @@
+using System;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using ScoreTracker.HomePage.Contracts;
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.Web.Components.HomeWidgets;
+using Xunit;
+
+namespace ScoreTracker.Tests.Components;
+
+/// <summary>
+///     A null Mixes config means "follow the current mix", and the panel's checkboxes must show
+///     what that resolves to — the owner's field report was a fresh widget drawing Phoenix 2 data
+///     while the panel displayed Phoenix checked.
+/// </summary>
+public sealed class CompetitiveLevelConfigPanelTests : ComponentTestBase
+{
+    private IRenderedComponent<CompetitiveLevelConfigPanel> RenderPanel(string configJson, MixEnum? effective)
+    {
+        var widget = new HomePageWidgetRecord(Guid.NewGuid(), "competitive-level", null, 0, "2x2", configJson, 1);
+        RenderFragment panel = b =>
+        {
+            b.OpenComponent<CompetitiveLevelConfigPanel>(0);
+            b.AddAttribute(1, nameof(CompetitiveLevelConfigPanel.Widget), widget);
+            b.CloseComponent();
+        };
+        return base.Render(builder =>
+        {
+            builder.OpenComponent<CascadingValue<MixEnum?>>(0);
+            builder.AddAttribute(1, "Name", "EffectiveMix");
+            builder.AddAttribute(2, "Value", effective);
+            builder.AddAttribute(3, "ChildContent", panel);
+            builder.CloseComponent();
+        }).FindComponent<CompetitiveLevelConfigPanel>();
+    }
+
+    private static (bool Phoenix, bool Phoenix2) Checked(IRenderedComponent<CompetitiveLevelConfigPanel> cut)
+    {
+        var boxes = cut.FindComponents<MudCheckBox<bool>>();
+        return (boxes[0].Instance.Value, boxes[1].Instance.Value);
+    }
+
+    [Fact]
+    public void AFollowCurrentConfigShowsTheMixTheWidgetIsActuallyDrawing()
+    {
+        var cut = RenderPanel("{}", MixEnum.Phoenix2);
+
+        var (phoenix, phoenix2) = Checked(cut);
+        Assert.False(phoenix);
+        Assert.True(phoenix2);
+    }
+
+    [Fact]
+    public void AFollowCurrentConfigOnALegacyMixFallsToPhoenixLikeTheWidgetDoes()
+    {
+        var cut = RenderPanel("{}", MixEnum.XX);
+
+        var (phoenix, phoenix2) = Checked(cut);
+        Assert.True(phoenix);
+        Assert.False(phoenix2);
+    }
+
+    [Fact]
+    public void AnExplicitMixListStillWinsOverTheCascade()
+    {
+        var cut = RenderPanel("{\"mixes\":[\"Phoenix\"]}", MixEnum.Phoenix2);
+
+        var (phoenix, phoenix2) = Checked(cut);
+        Assert.True(phoenix);
+        Assert.False(phoenix2);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests.Components/CompetitiveLevelWidgetTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/CompetitiveLevelWidgetTests.cs
@@ -39,10 +39,15 @@ public sealed class CompetitiveLevelWidgetTests : ComponentTestBase
 
     private void SetUpHistory(params (double Singles, double Doubles)[] points)
     {
+        SetUpHistoryWithPasses(points.Select(p => (p, 100)).ToArray());
+    }
+
+    private void SetUpHistoryWithPasses(params ((double Singles, double Doubles) Levels, int Passes)[] points)
+    {
         // Recent dates so every point sits inside any range window.
         var rows = points.Select((p, i) => new PlayerRatingRecord(_me,
-            DateTimeOffset.Now.AddDays(-points.Length + i), (p.Singles + p.Doubles) / 2,
-            p.Singles, p.Doubles, 0, 100)).ToArray();
+            DateTimeOffset.Now.AddDays(-points.Length + i), (p.Levels.Singles + p.Levels.Doubles) / 2,
+            p.Levels.Singles, p.Levels.Doubles, 0, p.Passes)).ToArray();
         _mediator.Setup(m => m.Send(It.IsAny<GetPlayerHistoryQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(rows);
     }
@@ -84,6 +89,23 @@ public sealed class CompetitiveLevelWidgetTests : ComponentTestBase
         Assert.Equal(2, series.Count);
         var doubles = Assert.Single(series, s => s.Instance.Name!.Contains("Doubles"));
         Assert.Equal(2, doubles.Instance.Items!.Count());
+    }
+
+    [Fact]
+    public void ReadingsBeforeTwentyPassesAreEstimatorChaosAndDoNotPlot()
+    {
+        // The first-session estimate swings wildly on a tiny pool (owner field test: a dip
+        // from 19.5 to 17.2 and back inside days). The pass-count gate is per-date — the
+        // early rows drop, the seasoned ones plot.
+        SetUpHistoryWithPasses(
+            ((19.5, 18.0), 4), ((17.2, 15.5), 11),
+            ((17.8, 16.0), 25), ((17.9, 16.2), 40), ((18.1, 16.5), 60));
+
+        var cut = Render();
+
+        var series = cut.FindComponents<ApexCharts.ApexPointSeries<PlayerRatingRecord>>();
+        Assert.Equal(2, series.Count);
+        Assert.All(series, s => Assert.Equal(3, s.Instance.Items!.Count()));
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests.Components/CompetitiveLevelWidgetTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/CompetitiveLevelWidgetTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Bunit;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.HomePage.Contracts;
+using ScoreTracker.PlayerProgress.Contracts.Queries;
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.Web.Components.HomeWidgets;
+using ScoreTracker.Web.Services.HomeDashboard;
+using Xunit;
+
+namespace ScoreTracker.Tests.Components;
+
+/// <summary>
+///     The Competitive Level graph's validity floor: a competitive level at or below 5 is the
+///     calculator's no-data territory, and a pool with nothing above it must draw nothing at
+///     all — the field report was a never-played doubles flatline pinning the y-axis to ~0 so
+///     a real singles climb rendered as "no change".
+/// </summary>
+public sealed class CompetitiveLevelWidgetTests : ComponentTestBase
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Guid _me = Guid.NewGuid();
+
+    public CompetitiveLevelWidgetTests()
+    {
+        CurrentUser.SetupGet(c => c.IsLoggedIn).Returns(true);
+        CurrentUser.SetupGet(c => c.User)
+            .Returns(new User(_me, "Me", true, null, new Uri("https://piu.test/me.png"), null));
+        _mediator.Setup(m => m.Send(It.IsAny<GetPlayerHistoryQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerRatingRecord>());
+        Services.AddSingleton(_mediator.Object);
+    }
+
+    private void SetUpHistory(params (double Singles, double Doubles)[] points)
+    {
+        // Recent dates so every point sits inside any range window.
+        var rows = points.Select((p, i) => new PlayerRatingRecord(_me,
+            DateTimeOffset.Now.AddDays(-points.Length + i), (p.Singles + p.Doubles) / 2,
+            p.Singles, p.Doubles, 0, 100)).ToArray();
+        _mediator.Setup(m => m.Send(It.IsAny<GetPlayerHistoryQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rows);
+    }
+
+    private IRenderedComponent<CompetitiveLevelWidget> Render()
+    {
+        var widget = new HomePageWidgetRecord(Guid.NewGuid(), "competitive-level", null, 0, "2x2", "{}", 1);
+        return base.Render(builder =>
+        {
+            builder.OpenComponent<CompetitiveLevelWidget>(0);
+            builder.AddAttribute(1, nameof(CompetitiveLevelWidget.Widget), widget);
+            builder.AddAttribute(2, nameof(CompetitiveLevelWidget.EffectiveMix), MixEnum.Phoenix);
+            builder.CloseComponent();
+        }).FindComponent<CompetitiveLevelWidget>();
+    }
+
+    [Fact]
+    public void ANeverPlayedPoolDrawsNoSeriesInsteadOfAFloorFlatline()
+    {
+        SetUpHistory((17.4, 1.0), (17.6, 1.0), (17.9, 1.0));
+
+        var cut = Render();
+
+        var series = cut.FindComponents<ApexCharts.ApexPointSeries<PlayerRatingRecord>>();
+        var one = Assert.Single(series);
+        Assert.Contains("Singles", one.Instance.Name);
+    }
+
+    [Fact]
+    public void FloorPointsDropOutOfASeriesThatLaterComesAlive()
+    {
+        // The doubles pool starts existing on the third row — the first two are the no-data
+        // floor and never plot, so the series begins where the data does.
+        SetUpHistory((17.4, 1.0), (17.6, 1.0), (17.8, 12.3), (17.9, 12.6));
+
+        var cut = Render();
+
+        var series = cut.FindComponents<ApexCharts.ApexPointSeries<PlayerRatingRecord>>();
+        Assert.Equal(2, series.Count);
+        var doubles = Assert.Single(series, s => s.Instance.Name!.Contains("Doubles"));
+        Assert.Equal(2, doubles.Instance.Items!.Count());
+    }
+
+    [Fact]
+    public void HistoryEntirelyAtTheFloorShowsTheEmptyState()
+    {
+        SetUpHistory((1.0, 1.0), (1.0, 1.0), (1.0, 1.0));
+
+        var cut = Render();
+
+        Assert.Contains("Your level history starts tracking with your next import.", cut.Markup);
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests.Components/RivalHighlightsFeedTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/RivalHighlightsFeedTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.PlayerProgress.Contracts;
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.SharedKernel.Models;
+using ScoreTracker.Web.Components.Rivals;
+using Xunit;
+
+namespace ScoreTracker.Tests.Components;
+
+/// <summary>
+///     The feed rows speak in chips (the feeds' short-form rule): a title stands on its name with
+///     no rarity claim, a pumbility ladder span compacts to one label, and the sentence the chip
+///     dropped survives on the row's hover title.
+/// </summary>
+public sealed class RivalHighlightsFeedTests : ComponentTestBase
+{
+    public RivalHighlightsFeedTests()
+    {
+        var clock = new Mock<IDateTimeOffsetAccessor>();
+        clock.SetupGet(c => c.Now).Returns(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+        Services.AddSingleton(clock.Object);
+    }
+
+    private IRenderedComponent<RivalHighlightsFeed> Render(params SignificantWin[] wins)
+    {
+        var record = new PlayerHighlightRecord(Guid.NewGuid(), Guid.NewGuid(), "KYLOREN",
+            new Uri("https://example.test/avatar.png"), IsPublic: true, MixEnum.Phoenix2,
+            new DateTimeOffset(2026, 8, 14, 10, 0, 0, TimeSpan.Zero), SessionId: null, wins);
+        return RenderComponent<RivalHighlightsFeed>(p => p
+            .Add(x => x.Records, new[] { record })
+            .Add(x => x.Charts, new Dictionary<Guid, Chart>()));
+    }
+
+    [Fact]
+    public void ATitleRowIsTheNameAloneWithNoRarityClaim()
+    {
+        var cut = Render(new SignificantWin(WinKind.BigTitle, TitleName: "SCROOGE"));
+
+        var row = cut.Find(".dash-ch-why");
+        Assert.Equal("🏅 [SCROOGE]", row.TextContent.Trim());
+    }
+
+    [Fact]
+    public void AStoredRareTitleRowRendersLikeAnyOtherTitle()
+    {
+        // Pre-change rows still carry the retired kind; they read as plain titles now.
+        var cut = Render(new SignificantWin(WinKind.RareTitle, TitleName: "SCROOGE", RarityShare: 0.004));
+
+        Assert.Equal("🏅 [SCROOGE]", cut.Find(".dash-ch-why").TextContent.Trim());
+    }
+
+    [Fact]
+    public void APumbilityLadderSpanCompactsToOneLabel()
+    {
+        var cut = Render(new SignificantWin(WinKind.PumbilityTitleSpan,
+            TitleName: "[S] ADVANCED LV.9", Detail: "[S] ADVANCED LV.6"));
+
+        Assert.Equal("🏅 [S] ADVANCED LV.6 → 9", cut.Find(".dash-ch-why").TextContent.Trim());
+    }
+
+    [Fact]
+    public void AScoredChipKeepsItsSentenceOnTheHover()
+    {
+        var cut = Render(new SignificantWin(WinKind.PeerElite, ChartName: "Bee", Difficulty: "D24",
+            RarityShare: 0.04, Rank: 4, Score: 987_654));
+
+        var row = cut.Find(".dash-ch-why");
+        Assert.Equal("📊 Top 4%", row.TextContent.Trim());
+        Assert.Equal("📊 top 4% of peers", row.GetAttribute("title"));
+    }
+
+    [Fact]
+    public void ALevelUpRowIsTheRungNameWithThePoolOnTheHover()
+    {
+        // Index 24 = DIAMOND LV.4 (docs/design/pumbility-levels.md).
+        var cut = Render(new SignificantWin(WinKind.PumbilityLevelUp, Rank: 24, PoolValue: 17_641));
+
+        var row = cut.Find(".dash-ch-why");
+        Assert.Equal("🆙 DIAMOND LV.4", row.TextContent.Trim());
+        Assert.Equal("🆙 Reached DIAMOND LV.4 · 17,641", row.GetAttribute("title"));
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests.Components/RivalHighlightsFeedTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/RivalHighlightsFeedTests.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Bunit;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using ScoreTracker.Domain.SecondaryPorts;
 using ScoreTracker.PlayerProgress.Contracts;
 using ScoreTracker.SharedKernel.Enums;
 using ScoreTracker.SharedKernel.Models;
+using ScoreTracker.SharedKernel.ValueTypes;
 using ScoreTracker.Web.Components.Rivals;
 using Xunit;
 
@@ -24,16 +27,33 @@ public sealed class RivalHighlightsFeedTests : ComponentTestBase
         var clock = new Mock<IDateTimeOffsetAccessor>();
         clock.SetupGet(c => c.Now).Returns(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
         Services.AddSingleton(clock.Object);
+        // DifficultyBubble gates its tooltip on RendererInfo; declare the render world.
+        this.RenderInteractive();
     }
 
-    private IRenderedComponent<RivalHighlightsFeed> Render(params SignificantWin[] wins)
+    private IRenderedComponent<RivalHighlightsFeed> Render(SignificantWin[] wins,
+        IReadOnlyDictionary<Guid, Chart>? charts = null, Action<Chart>? onChartClick = null)
     {
         var record = new PlayerHighlightRecord(Guid.NewGuid(), Guid.NewGuid(), "KYLOREN",
             new Uri("https://example.test/avatar.png"), IsPublic: true, MixEnum.Phoenix2,
             new DateTimeOffset(2026, 8, 14, 10, 0, 0, TimeSpan.Zero), SessionId: null, wins);
-        return RenderComponent<RivalHighlightsFeed>(p => p
-            .Add(x => x.Records, new[] { record })
-            .Add(x => x.Charts, new Dictionary<Guid, Chart>()));
+        return RenderComponent<RivalHighlightsFeed>(p =>
+        {
+            p.Add(x => x.Records, new[] { record })
+                .Add(x => x.Charts, charts ?? new Dictionary<Guid, Chart>());
+            if (onChartClick != null) p.Add(x => x.OnChartClick, onChartClick);
+        });
+    }
+
+    private IRenderedComponent<RivalHighlightsFeed> Render(params SignificantWin[] wins) =>
+        Render(wins, charts: null);
+
+    private static Chart MakeChart(string name)
+    {
+        return new Chart(Guid.NewGuid(), MixEnum.Phoenix2,
+            new Song(name, SongType.Arcade, new Uri("https://piu.test/art.png"),
+                TimeSpan.FromMinutes(2), "Artist", Bpm.From(140, 140)),
+            ChartType.Double, 24, MixEnum.Phoenix2, null, 1200, new HashSet<Skill>());
     }
 
     [Fact]
@@ -72,6 +92,33 @@ public sealed class RivalHighlightsFeedTests : ComponentTestBase
         var row = cut.Find(".dash-ch-why");
         Assert.Equal("📊 Top 4%", row.TextContent.Trim());
         Assert.Equal("📊 top 4% of peers", row.GetAttribute("title"));
+    }
+
+    [Fact]
+    public async Task AChartRowOpensTheDialogWhenThePageWiresIt()
+    {
+        var chart = MakeChart("Bee");
+        Chart? opened = null;
+        var cut = Render(
+            new[] { new SignificantWin(WinKind.PeerElite, ChartId: chart.Id, RarityShare: 0.04, Rank: 4) },
+            new Dictionary<Guid, Chart> { [chart.Id] = chart },
+            onChartClick: c => opened = c);
+
+        var row = cut.Find(".dash-ch-chart");
+        Assert.Contains("dash-clickable", row.ClassName);
+        await row.ClickAsync(new MouseEventArgs());
+        Assert.Equal(chart.Id, opened!.Id);
+    }
+
+    [Fact]
+    public void ChartRowsAreInertWhenNoPageWiresTheClick()
+    {
+        var chart = MakeChart("Bee");
+        var cut = Render(
+            new[] { new SignificantWin(WinKind.PeerElite, ChartId: chart.Id, RarityShare: 0.04, Rank: 4) },
+            new Dictionary<Guid, Chart> { [chart.Id] = chart });
+
+        Assert.DoesNotContain("dash-clickable", cut.Find(".dash-ch-chart").ClassName);
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests.Components/SuggestedChartsWidgetTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/SuggestedChartsWidgetTests.cs
@@ -94,7 +94,7 @@ public sealed class SuggestedChartsWidgetTests : ComponentTestBase
     }
 
     private IRenderedComponent<SuggestedChartsWidget> Render(SuggestedChartsConfig? config = null,
-        WidgetHeaderSlot? headerSlot = null)
+        WidgetHeaderSlot? headerSlot = null, MixEnum mix = MixEnum.Phoenix)
     {
         config ??= new SuggestedChartsConfig { Goal = SuggestedGoal.HotStreak };
         var widget = new HomePageWidgetRecord(Guid.NewGuid(), "suggested-charts", null, 0, "1x2",
@@ -105,7 +105,7 @@ public sealed class SuggestedChartsWidgetTests : ComponentTestBase
             builder.CloseComponent();
             builder.OpenComponent<SuggestedChartsWidget>(1);
             builder.AddAttribute(2, nameof(SuggestedChartsWidget.Widget), widget);
-            builder.AddAttribute(3, nameof(SuggestedChartsWidget.EffectiveMix), MixEnum.Phoenix);
+            builder.AddAttribute(3, nameof(SuggestedChartsWidget.EffectiveMix), mix);
             builder.CloseComponent();
         };
         return base.Render(builder =>
@@ -127,6 +127,31 @@ public sealed class SuggestedChartsWidgetTests : ComponentTestBase
     private ChartRecommendation HotStreakRec(Guid chartId, double? ranking = 0.94, bool fallback = false) =>
         new(RecommendationCategories.HotStreak, chartId, "More charts like your recent standout plays",
             SeedChartId: _seed.Id, SeedPeerRanking: ranking, SeedIsFallback: fallback);
+
+    [Fact]
+    public void TitleHuntFallsBackToPumbilityPushOnPhoenix2()
+    {
+        // P2 has no difficulty or skill titles, so the goal's own categories are structurally
+        // empty there — the widget asks for the Pumbility Push bundle instead, silently
+        // (owner, 2026-08-14: no explainer glyph; a P2 "next title" IS a pumbility threshold).
+        Render(new SuggestedChartsConfig { Goal = SuggestedGoal.TitleHunt }, mix: MixEnum.Phoenix2);
+
+        _mediator.Verify(m => m.Send(It.Is<GetRecommendedChartsQuery>(q =>
+                q.Mix == MixEnum.Phoenix2 && q.Categories != null && q.Categories.Count == 1
+                && q.Categories.Contains(RecommendationCategory.PushPumbility)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void TitleHuntKeepsItsTitleCategoriesOnPhoenix()
+    {
+        Render(new SuggestedChartsConfig { Goal = SuggestedGoal.TitleHunt });
+
+        _mediator.Verify(m => m.Send(It.Is<GetRecommendedChartsQuery>(q =>
+                q.Categories != null && q.Categories.Contains(RecommendationCategory.PushLevel)
+                && q.Categories.Contains(RecommendationCategory.SkillTitles)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
 
     [Fact]
     public void GroupedModeCaptionsTheSeedEvenForASingleSectionWithThePeersBarInTheTooltip()

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerHighlightSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PlayerHighlightSagaTests.cs
@@ -29,7 +29,6 @@ public sealed class PlayerHighlightSagaTests
     private readonly Mock<IPlayerHighlightRepository> _highlights = new();
     private readonly Mock<IPlayerStatsReader> _playerStats = new();
     private readonly Mock<IScoreReader> _scores = new();
-    private readonly Mock<ITitleRepository> _titles = new();
     private readonly Mock<IBus> _bus = new();
 
     // The capture logic lives in the capturer now; the saga just delegates + isolates failures.
@@ -41,7 +40,7 @@ public sealed class PlayerHighlightSagaTests
                 It.IsAny<DateTimeOffset>(), It.IsAny<Guid?>(), It.IsAny<IReadOnlyList<SignificantWin>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        return new(_charts.Object, _scores.Object, _titles.Object, _highlights.Object, _playerStats.Object,
+        return new(_charts.Object, _scores.Object, _highlights.Object, _playerStats.Object,
             new MemoryCache(new MemoryCacheOptions()), _bus.Object);
     }
 
@@ -54,9 +53,6 @@ public sealed class PlayerHighlightSagaTests
             .ReturnsAsync(new[] { new ChartScoreAggregate(chart.Id, activePlayers, activePlayers, pgHolders) });
         _scores.Setup(s => s.GetActiveUserIds(It.IsAny<MixEnum>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Range(0, activePlayers).Select(_ => Guid.NewGuid()).ToHashSet());
-        _titles.Setup(t => t.GetTitleAggregations(It.IsAny<MixEnum>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<TitleAggregationRecord>());
-        _titles.Setup(t => t.CountTitledUsers(It.IsAny<CancellationToken>())).ReturnsAsync(1000);
     }
 
     private static ScoreHighlightsCapturedEvent PgEvent(Guid userId, Guid chartId, string? plate = "Perfect Game") =>

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs
@@ -321,6 +321,22 @@ public sealed class RecommendedChartsSagaTests
     }
 
     [Fact]
+    public async Task PumbilityPushTruncatesTheStampedGainSoItIsNeverOverstated()
+    {
+        // The PUMBILITY precision rule: a gain truncates — 36.7 stamps +36, never +37.
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(21).Build();
+        var ctx = new RecommendedChartsContext()
+            .WithCharts(chart)
+            .WithPumbilityGains((chart.Id, 36.7));
+
+        var result = (await ctx.Saga.Handle(new GetRecommendedChartsQuery(ChartType: null, LevelOffset: 0,
+                Categories: new HashSet<RecommendationCategory> { RecommendationCategory.PushPumbility }),
+            CancellationToken.None)).ToArray();
+
+        Assert.Equal("+36", Assert.Single(result).ChartDetails);
+    }
+
+    [Fact]
     public async Task PumbilityPushExcludesHiddenChartsAndNonPositiveGains()
     {
         var gainer = new ChartBuilder().WithType(ChartType.Single).WithLevel(21).Build();

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/RecommendedChartsSagaTests.cs
@@ -321,6 +321,33 @@ public sealed class RecommendedChartsSagaTests
     }
 
     [Fact]
+    public async Task PumbilityPushDealsAFreshHandFromTheTopPoolNotAlwaysTheSameTwelve()
+    {
+        // Thirteen candidates; the mocked RNG hands out descending keys, so the ascending
+        // sample enumerates the pool back-to-front — the top gainer is left out of the hand.
+        // Only possible if the shown dozen samples from a wider pool (owner, field test).
+        var charts = Enumerable.Range(1, 13)
+            .Select(i => (Chart: new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build(),
+                Gain: (double)i))
+            .ToArray();
+        var ctx = new RecommendedChartsContext()
+            .WithCharts(charts.Select(c => c.Chart).ToArray())
+            .WithPumbilityGains(charts.Select(c => (c.Chart.Id, c.Gain)).ToArray());
+        var key = 1000;
+        ctx.Random.Setup(r => r.Next(It.IsAny<int>())).Returns(() => key--);
+
+        var result = (await ctx.Saga.Handle(new GetRecommendedChartsQuery(ChartType: null, LevelOffset: 0,
+                Categories: new HashSet<RecommendationCategory> { RecommendationCategory.PushPumbility }),
+            CancellationToken.None)).ToArray();
+
+        var topGainer = charts.Single(c => c.Gain == 13).Chart.Id;
+        Assert.Equal(12, result.Length);
+        Assert.DoesNotContain(result, r => r.ChartId == topGainer);
+        // The hand still reads best-first.
+        Assert.Equal("+12", result[0].ChartDetails);
+    }
+
+    [Fact]
     public async Task PumbilityPushTruncatesTheStampedGainSoItIsNeverOverstated()
     {
         // The PUMBILITY precision rule: a gain truncates — 36.7 stamps +36, never +37.

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/PlayerHighlightPolicyTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/PlayerHighlightPolicyTests.cs
@@ -52,12 +52,10 @@ public sealed class PlayerHighlightPolicyTests
     private static Dictionary<Guid, Chart> Charts(params Chart[] charts) => charts.ToDictionary(c => c.Id);
 
     private static RaritySnapshot Snapshot(
-        (Guid ChartId, int PgHolders)? pg = null, int activePlayers = 1463,
-        (string Title, int Holders)? title = null, int titledUsers = 1000)
+        (Guid ChartId, int PgHolders)? pg = null, int activePlayers = 1463)
     {
         var pgs = pg is { } p ? new Dictionary<Guid, int> { [p.ChartId] = p.PgHolders } : new Dictionary<Guid, int>();
-        var titles = title is { } t ? new Dictionary<string, int> { [t.Title] = t.Holders } : new Dictionary<string, int>();
-        return new RaritySnapshot(pgs, activePlayers, titles, titledUsers);
+        return new RaritySnapshot(pgs, activePlayers);
     }
 
     // Default player: zero competitive level, so the folder-debut gate never blocks unless a test
@@ -141,27 +139,35 @@ public sealed class PlayerHighlightPolicyTests
     }
 
     [Fact]
-    public void ATitleHeldByUnderOnePercentOfTitledPlayersIsARareTitle()
+    public void AnyEarnedTitleIsAWinWithNoRarityClaim()
     {
+        // "All titles are big titles" (owner, 2026-08-14) — no rarity gate, no population read.
         var wins = Classify(
             Event(MixEnum.Phoenix, Array.Empty<ScoreHighlightsCapturedEvent.HighlightedChange>(),
                 TitleCompleted("SCROOGE")),
-            new Dictionary<Guid, Chart>(), Snapshot(title: ("SCROOGE", 5), titledUsers: 1000));
+            new Dictionary<Guid, Chart>(), Snapshot());
 
         var win = Assert.Single(wins);
-        Assert.Equal(WinKind.RareTitle, win.Kind);
-        Assert.Equal(0.005, win.RarityShare);
+        Assert.Equal(WinKind.BigTitle, win.Kind);
+        Assert.Equal("SCROOGE", win.TitleName);
+        Assert.Null(win.RarityShare);
     }
 
     [Fact]
-    public void ACommonTitleIsNotAWin()
+    public void TheDefaultTitleNeverAnnounces()
     {
-        var wins = Classify(
+        // A first import "earns" the account's default title; that is noise, not news.
+        var phoenix = Classify(
             Event(MixEnum.Phoenix, Array.Empty<ScoreHighlightsCapturedEvent.HighlightedChange>(),
-                TitleCompleted("SCROOGE")),
-            new Dictionary<Guid, Chart>(), Snapshot(title: ("SCROOGE", 500), titledUsers: 1000));
+                TitleCompleted("Beginner")),
+            new Dictionary<Guid, Chart>(), Snapshot());
+        var phoenix2 = Classify(
+            Event(MixEnum.Phoenix2, Array.Empty<ScoreHighlightsCapturedEvent.HighlightedChange>(),
+                TitleCompleted("BEGINNER")),
+            new Dictionary<Guid, Chart>(), Snapshot());
 
-        Assert.Empty(wins);
+        Assert.Empty(phoenix);
+        Assert.Empty(phoenix2);
     }
 
     [Fact]
@@ -416,6 +422,65 @@ public sealed class PlayerHighlightPolicyTests
 
         var win = Assert.Single(wins);
         Assert.Equal(WinKind.FolderFirst, win.Kind);
+    }
+
+    // ---- pumbility ladder roll-up (owner, 2026-08-14; feeds only, the card stays loud) ----
+
+    [Fact]
+    public void SeveralRungsOfOnePumbilityLadderRollIntoOneSpan()
+    {
+        var wins = Classify(
+            Event(MixEnum.Phoenix2, Array.Empty<ScoreHighlightsCapturedEvent.HighlightedChange>(),
+                TitleCompleted("[S] ADVANCED LV.7"), TitleCompleted("[S] ADVANCED LV.6"),
+                TitleCompleted("[S] ADVANCED LV.9"), TitleCompleted("[S] ADVANCED LV.8")),
+            Charts(), Snapshot());
+
+        var win = Assert.Single(wins);
+        Assert.Equal(WinKind.PumbilityTitleSpan, win.Kind);
+        Assert.Equal("[S] ADVANCED LV.9", win.TitleName); // the rung reached
+        Assert.Equal("[S] ADVANCED LV.6", win.Detail);    // the first rung crossed
+    }
+
+    [Fact]
+    public void EachPumbilityPoolRollsUpSeparately()
+    {
+        var wins = Classify(
+            Event(MixEnum.Phoenix2, Array.Empty<ScoreHighlightsCapturedEvent.HighlightedChange>(),
+                TitleCompleted("[S] ADVANCED LV.6"), TitleCompleted("[S] ADVANCED LV.7"),
+                TitleCompleted("[D] INTERMEDIATE LV.3"), TitleCompleted("[D] INTERMEDIATE LV.4")),
+            Charts(), Snapshot());
+
+        Assert.Equal(2, wins.Count);
+        Assert.All(wins, w => Assert.Equal(WinKind.PumbilityTitleSpan, w.Kind));
+        Assert.Contains(wins, w => w.TitleName == "[S] ADVANCED LV.7" && w.Detail == "[S] ADVANCED LV.6");
+        Assert.Contains(wins, w => w.TitleName == "[D] INTERMEDIATE LV.4" && w.Detail == "[D] INTERMEDIATE LV.3");
+    }
+
+    [Fact]
+    public void ALonePumbilityRungStaysAPlainTitleRow()
+    {
+        var wins = Classify(
+            Event(MixEnum.Phoenix2, Array.Empty<ScoreHighlightsCapturedEvent.HighlightedChange>(),
+                TitleCompleted("[S] ADVANCED LV.6")),
+            Charts(), Snapshot());
+
+        var win = Assert.Single(wins);
+        Assert.Equal(WinKind.BigTitle, win.Kind);
+        Assert.Equal("[S] ADVANCED LV.6", win.TitleName);
+    }
+
+    [Fact]
+    public void PhoenixDifficultyChainsDoNotRollUp()
+    {
+        // Only the pumbility pool ladders roll (owner: "specifically only the pumbility titles") —
+        // a Phoenix difficulty chain prints one row per rung.
+        var wins = Classify(
+            Event(MixEnum.Phoenix, Array.Empty<ScoreHighlightsCapturedEvent.HighlightedChange>(),
+                TitleCompleted("Expert Lv. 1"), TitleCompleted("Expert Lv. 2")),
+            new Dictionary<Guid, Chart>(), Snapshot());
+
+        Assert.Equal(2, wins.Count);
+        Assert.All(wins, w => Assert.Equal(WinKind.BigTitle, w.Kind));
     }
 
     // ---- the PUMBILITY level crossing (docs/design/pumbility-levels.md §5) ----

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/TitleListsTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/TitleListsTests.cs
@@ -1,0 +1,34 @@
+using ScoreTracker.Domain.Models.Titles;
+using ScoreTracker.SharedKernel.Enums;
+using Xunit;
+
+namespace ScoreTracker.Tests.DomainTests;
+
+/// <summary>
+///     The difficulty-titles fact drives Title Hunt's Phoenix 2 fallback, and it must track the
+///     shipped lists rather than a hardcoded mix check: if Phoenix 2 ever gains difficulty
+///     titles, the fallback has to lift on its own — and this pin has to fail so the fallback's
+///     consumers get looked at.
+/// </summary>
+public sealed class TitleListsTests
+{
+    [Fact]
+    public void PhoenixHasDifficultyTitlesToHunt()
+    {
+        Assert.True(TitleLists.HasDifficultyTitles(MixEnum.Phoenix));
+    }
+
+    [Fact]
+    public void Phoenix2HasNoneWhichIsWhatTriggersTheTitleHuntFallback()
+    {
+        // P2's 272 titles are pumbility ladders, grade badges and play counts — none are
+        // difficulty-typed. When this fails, the list gained one: revisit the fallback.
+        Assert.False(TitleLists.HasDifficultyTitles(MixEnum.Phoenix2));
+    }
+
+    [Fact]
+    public void LegacyMixesHaveNoTitleTaxonomyAtAll()
+    {
+        Assert.False(TitleLists.HasDifficultyTitles(MixEnum.XX));
+    }
+}

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CommunityHighlightsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CommunityHighlightsWidget.razor
@@ -190,6 +190,7 @@ else
     private IReadOnlySet<Guid> _rivalUserIds = new HashSet<Guid>();
     private IReadOnlyDictionary<Guid, Chart> _charts = new Dictionary<Guid, Chart>();
     private MixEnum _mix = MixEnum.Phoenix;
+    private bool _mixedAudience;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -201,6 +202,7 @@ else
         var config = WidgetConfigJson.Read<CommunityHighlightsConfig>(Widget.ConfigJson);
         _mix = config.Mix != null && Supported.Contains(config.Mix.Value) ? config.Mix.Value
             : Supported.Contains(EffectiveMix) ? EffectiveMix : MixEnum.Phoenix;
+        _mixedAudience = config.IncludeCommunities && config.IncludeRivals;
 
         // Empty config follows your non-regional crews (CH1) — World/country are opt-in.
         var communities = !config.IncludeCommunities
@@ -306,10 +308,12 @@ else
     private bool IsMe(PlayerHighlightRecord record) =>
         CurrentUser.IsLoggedIn && CurrentUser.User.Id == record.UserId;
 
-    // The only surface where all three states are meaningful, because it is the only one whose
-    // population is genuinely mixed (docs/design/rivals.md D36).
+    // Row states only when the board is genuinely mixed (owner, 2026-08-14): on a
+    // single-audience feed every row shares the one audience, and a marker everyone wears
+    // says nothing. Both halves on is where green/red/both disambiguate.
     private string RowClass(PlayerHighlightRecord record)
     {
+        if (!_mixedAudience) return "dash-ch-entry";
         return ("dash-ch-entry " + CommunityGlowReader.RowClass(false,
             _rivalUserIds.Contains(record.UserId), _communityUserIds.Contains(record.UserId),
             youClass: string.Empty)).TrimEnd();

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CommunityHighlightsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CommunityHighlightsWidget.razor
@@ -135,7 +135,7 @@ else
                             else if (win.Kind == WinKind.PumbilityLevelUp)
                             {
                                 <div class="dash-ch-win">
-                                    <span class="dash-ch-why" title="@($"{L["Reached {0}", LevelName(win)]}{PoolSuffix(win)}")">
+                                    <span class="dash-ch-why dash-ch-lvlup" title="@($"{L["Reached {0}", LevelName(win)]}{PoolSuffix(win)}")">
                                         <PumbilityLevelBadge Level="LevelOf(win)" Height="18"></PumbilityLevelBadge>
                                         <b>@LevelName(win)</b>
                                     </span>

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CommunityHighlightsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CommunityHighlightsWidget.razor
@@ -12,6 +12,7 @@
 @using ChartType = ScoreTracker.SharedKernel.Enums.ChartType
 @using ScoreTracker.SharedKernel.ValueTypes
 @using ScoreTracker.Web.Components
+@using ScoreTracker.Web.Services
 @using ScoreTracker.Web.Services.HomeDashboard
 
 @* Highlights feed (docs/design/home-page-widgets.md §7, docs/design/rivals.md D35): recent big
@@ -99,7 +100,9 @@ else
                                         <DifficultyBubble Chart="chart" Small="true"></DifficultyBubble>
                                         <span class="dash-ch-song">@chart.Song.Name</span>
                                     </span>
-                                    <span class="dash-ch-why">@Caption(win)</span>
+                                    @* The chip states the fact; the sentence rides the hover (owner: lean
+                                       hard on tooltips — the strips' rule, extended to the feed rows). *@
+                                    <span class="dash-ch-why" title="@Caption(win)">@ShortCaption(win)</span>
                                     @if (win.Score is { } score)
                                     {
                                         <span class="dash-ch-score-right">
@@ -120,7 +123,7 @@ else
                             else if (win.Kind == WinKind.FolderComplete)
                             {
                                 <div class="dash-ch-win">
-                                    <span class="dash-ch-why">🎉 @L["Cleared all of {0}", win.Difficulty ?? ""]</span>
+                                    <span class="dash-ch-why">🎉 @L["Cleared {0}", win.Difficulty ?? ""]</span>
                                 </div>
                             }
                             else if (win.Kind == WinKind.FolderProgress)
@@ -132,16 +135,18 @@ else
                             else if (win.Kind == WinKind.PumbilityLevelUp)
                             {
                                 <div class="dash-ch-win">
-                                    <span class="dash-ch-why">
+                                    <span class="dash-ch-why" title="@($"{L["Reached {0}", LevelName(win)]}{PoolSuffix(win)}")">
                                         <PumbilityLevelBadge Level="LevelOf(win)" Height="18"></PumbilityLevelBadge>
-                                        <b>@L["Reached {0}", LevelName(win)]</b>@PoolSuffix(win)
+                                        <b>@LevelName(win)</b>
                                     </span>
                                 </div>
                             }
                             else if (win.TitleName != null)
                             {
+                                @* Every title stands on its name — no "Completed", no rarity claim
+                                   ("all titles are big titles"); a ladder span compacts to one row. *@
                                 <div class="dash-ch-win">
-                                    <span class="dash-ch-why">🏅 <b>@Bracket(win.TitleName)</b> @TitleSuffix(win)</span>
+                                    <span class="dash-ch-why">🏅 <b>@TitleLabel(win)</b></span>
                                 </div>
                             }
                             else if (win.ChartName != null)
@@ -271,9 +276,12 @@ else
 
     private static int PeerPct(SignificantWin win) => Math.Max(1, (int)Math.Ceiling((win.RarityShare ?? 0) * 100));
 
-    private string TitleSuffix(SignificantWin win) => win.Kind == WinKind.RareTitle && win.RarityShare != null
-        ? $"· {L["only {0} hold it", Pct(win.RarityShare)]}"
-        : L["Completed"];
+    // Spans compact to "[S] ADVANCED LV.6 → 9"; everything else is the bracketed name alone —
+    // no "Completed", no rarity claim ("all titles are big titles", owner 2026-08-14).
+    private static string TitleLabel(SignificantWin win) =>
+        win.Kind == WinKind.PumbilityTitleSpan && win.Detail is { Length: > 0 }
+            ? TitleSpans.Compact(Bracket(win.Detail), Bracket(win.TitleName ?? ""))
+            : Bracket(win.TitleName ?? "");
 
     private static string Pct(double? share) =>
         share == null ? "" : (share.Value * 100).ToString("0.#", CultureInfo.InvariantCulture) + "%";
@@ -314,22 +322,19 @@ else
         : L["{0} now {1}", win.Difficulty ?? "", win.Detail].Value;
 
     private string NonChartTip(SignificantWin win) => win.Kind == WinKind.FolderComplete
-        ? $"🎉 {L["Cleared all of {0}", win.Difficulty ?? ""].Value}"
-        : $"🏅 {Bracket(win.TitleName ?? "")} {TitleSuffix(win)}";
+        ? $"🎉 {L["Cleared {0}", win.Difficulty ?? ""].Value}"
+        : $"🏅 {TitleLabel(win)}";
 
-    // Cards get the *shortest* form — the full sentence lives in the tooltip (owner: lean hard on tooltips).
+    // The shortest form — cards and feed rows alike; the full sentence lives in the tooltip
+    // (owner: lean hard on tooltips).
     private string ShortCaption(SignificantWin win) => win.Kind switch
     {
         WinKind.NotablePg => $"💎 {L["Rare PG"]}",
         WinKind.TopPumbility => $"👑 #{win.Rank ?? 0} PUMB",
-        WinKind.PeerElite => $"📊 {L["Top {0}%", PeerPct(win)]}",
-        WinKind.FolderFirst => $"🆕 {Ordinal(win.Rank ?? 0)} {win.Difficulty}",
+        WinKind.PeerElite => win.Rank == 1 ? "📊 #1" : $"📊 {L["Top {0}%", PeerPct(win)]}",
+        WinKind.FolderFirst => $"🆕 {Ordinal(win.Rank ?? 0)} · {win.Difficulty}",
         _ => string.Empty
     };
-
-    // Rare titles get a "Rare Title" tag; big titles get nothing (no "completed").
-    private string ShortTitleSub(SignificantWin win) =>
-        win.Kind == WinKind.RareTitle ? L["Rare Title"].Value : string.Empty;
 
     // A win as a strip card. Chart wins = art + grade/plate + score + the short caption; titles + folder
     // clears are text cards. The full detail + song name ride a MudTooltip on hover (owner).
@@ -403,15 +408,11 @@ else
             }
             else
             {
-                @* Big + rare titles: name, plus "Rare Title" for a rare-title win only (no "completed"). *@
+                @* Titles: the name alone (a ladder span compacts) — no tags, no "completed". *@
                 <MudTooltip Text="@NonChartTip(win)" Arrow="true">
                     <div class="dash-chart-card dash-card-text">
                         <div class="dash-card-emoji">🏅</div>
-                        <div class="dash-card-name">@Bracket(win.TitleName ?? "")</div>
-                        @if (ShortTitleSub(win) is { Length: > 0 } sub)
-                        {
-                            <div class="dash-card-detail dash-muted">@sub</div>
-                        }
+                        <div class="dash-card-name">@TitleLabel(win)</div>
                     </div>
                 </MudTooltip>
             }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelConfigPanel.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelConfigPanel.razor
@@ -25,6 +25,12 @@
     [Parameter] public EventCallback<(string ConfigJson, int ConfigVersion)> OnSave { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
 
+    /// <summary>What "no mixes configured" resolves to, from the dialog's cascade — so the
+    /// checkboxes show the mix whose data the widget is actually drawing (owner field test:
+    /// a fresh widget showed Phoenix checked while rendering Phoenix 2).</summary>
+    [CascadingParameter(Name = "EffectiveMix")]
+    public MixEnum? EffectiveMix { get; set; }
+
     private bool _phoenix;
     private bool _phoenix2;
     private int _rangeMonths;
@@ -35,8 +41,12 @@
     {
         var config = WidgetConfigJson.Read<CompetitiveLevelConfig>(Widget.ConfigJson);
         var mixes = config.Mixes ?? new List<MixEnum>();
-        _phoenix = !mixes.Any() || mixes.Contains(MixEnum.Phoenix);
-        _phoenix2 = mixes.Contains(MixEnum.Phoenix2);
+        // Null mixes = follow the current mix — mirror the widget's own resolution (Phoenix 2
+        // when that's current, Phoenix for anything else) instead of defaulting the display
+        // to Phoenix while the graph draws something else.
+        var effective = EffectiveMix == MixEnum.Phoenix2 ? MixEnum.Phoenix2 : MixEnum.Phoenix;
+        _phoenix = mixes.Contains(MixEnum.Phoenix) || (!mixes.Any() && effective == MixEnum.Phoenix);
+        _phoenix2 = mixes.Contains(MixEnum.Phoenix2) || (!mixes.Any() && effective == MixEnum.Phoenix2);
         _rangeMonths = config.RangeMonths;
         _showSingles = config.ShowSingles;
         _showDoubles = config.ShowDoubles;

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelWidget.razor
@@ -65,6 +65,14 @@ else
 
     private static readonly MixEnum[] Supported = { MixEnum.Phoenix, MixEnum.Phoenix2 };
 
+    /// <summary>
+    ///     A competitive level at or below this is not a real reading: ≤1 is the calculator's
+    ///     no-data floor, and a never-played pool otherwise plots a flatline that pins the
+    ///     y-axis near 0 and flattens every real series (owner, 2026-08-14 — a no-doubles
+    ///     player's graph read as "no change", and its zero-slope dashed lines read as dots).
+    /// </summary>
+    private const double ValidityFloor = 5.0;
+
     private sealed record LevelSeries(string Label, string Color, bool Dashed,
         IReadOnlyList<PlayerRatingRecord> Points, Func<PlayerRatingRecord, double> YSelector);
 
@@ -105,43 +113,38 @@ else
         {
             var history = (await Mediator.Send(new GetPlayerHistoryQuery(CurrentUser.User.Id, mix)))
                 .OrderBy(h => h.Date).ToArray();
-            var inRange = history.Where(h => h.Date >= cutoff).ToArray();
             var dashed = mix != EffectiveMix && mixes.Length > 1;
 
-            if (inRange.Length >= 2)
+            // Per pool, because the floor makes the halves genuinely diverge: a player with a
+            // live singles line and a never-played doubles pool draws one series, not a series
+            // plus a flatline at the floor.
+            void AddType(bool show, string typeLabel, string color, Func<PlayerRatingRecord, double> level)
             {
-                if (config.ShowSingles)
+                if (!show) return;
+                var valid = history.Where(h => level(h) > ValidityFloor).ToArray();
+                var inRange = valid.Where(h => h.Date >= cutoff).ToArray();
+                if (inRange.Length >= 2)
                 {
-                    _series.Add(new LevelSeries($"{L["Singles"]} · {mix}", palette.ChartSingles, dashed,
-                        inRange, h => h.SinglesLevel));
+                    _series.Add(new LevelSeries($"{typeLabel} · {mix}", color, dashed, inRange, level));
                     dashes.Add(dashed ? 5 : 0);
                 }
+                else if (valid.Any())
+                {
+                    // "Where you left off": the pool's valid data sits entirely left of the
+                    // range — a ghost line at its final level, the reference the re-grind
+                    // chases. A pool with nothing valid draws nothing at all: no series, no
+                    // ghost at the no-data floor.
+                    var last = valid.Last();
+                    annotations.Add(new AnnotationsYAxis
+                    {
+                        Y = level(last), BorderColor = color, StrokeDashArray = 4,
+                        Label = new Label { Text = $"{mix} {typeLabel} {level(last):0.0}" }
+                    });
+                }
+            }
 
-                if (config.ShowDoubles)
-                {
-                    _series.Add(new LevelSeries($"{L["Doubles"]} · {mix}", palette.ChartDoubles, dashed,
-                        inRange, h => h.DoublesLevel));
-                    dashes.Add(dashed ? 5 : 0);
-                }
-            }
-            else if (history.Any())
-            {
-                // "Where you left off": the mix's data sits entirely left of the range —
-                // ghost lines at its final levels, the reference the re-grind chases.
-                var last = history.Last();
-                if (config.ShowSingles)
-                    annotations.Add(new AnnotationsYAxis
-                    {
-                        Y = last.SinglesLevel, BorderColor = palette.ChartSingles, StrokeDashArray = 4,
-                        Label = new Label { Text = $"{mix} {L["Singles"]} {last.SinglesLevel:0.0}" }
-                    });
-                if (config.ShowDoubles)
-                    annotations.Add(new AnnotationsYAxis
-                    {
-                        Y = last.DoublesLevel, BorderColor = palette.ChartDoubles, StrokeDashArray = 4,
-                        Label = new Label { Text = $"{mix} {L["Doubles"]} {last.DoublesLevel:0.0}" }
-                    });
-            }
+            AddType(config.ShowSingles, L["Singles"], palette.ChartSingles, h => h.SinglesLevel);
+            AddType(config.ShowDoubles, L["Doubles"], palette.ChartDoubles, h => h.DoublesLevel);
         }
 
         // Single-era boards get the gradient-area treatment (the "PIU Scores" look);

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelWidget.razor
@@ -73,6 +73,14 @@ else
     /// </summary>
     private const double ValidityFloor = 5.0;
 
+    /// <summary>
+    ///     A reading taken before the mix had ~20 passes is estimator chaos, not a level — the
+    ///     first-session points swing wildly on a tiny pool (owner, field test). PassCount rides
+    ///     every history row, so the gate is per-date and fully retroactive; it is the mix total
+    ///     rather than per-type, which the validity floor above backstops.
+    /// </summary>
+    private const int MinPassCount = 20;
+
     private sealed record LevelSeries(string Label, string Color, bool Dashed,
         IReadOnlyList<PlayerRatingRecord> Points, Func<PlayerRatingRecord, double> YSelector);
 
@@ -121,7 +129,9 @@ else
             void AddType(bool show, string typeLabel, string color, Func<PlayerRatingRecord, double> level)
             {
                 if (!show) return;
-                var valid = history.Where(h => level(h) > ValidityFloor).ToArray();
+                var valid = history
+                    .Where(h => h.PassCount >= MinPassCount && level(h) > ValidityFloor)
+                    .ToArray();
                 var inRange = valid.Where(h => h.Date >= cutoff).ToArray();
                 if (inRange.Length >= 2)
                 {

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelWidget.razor
@@ -172,7 +172,9 @@ else
             }
             : null;
         _options.Yaxis = new List<YAxis> { new() { DecimalsInFloat = 2 } };
-        _options.Annotations = annotations.Any() ? new Annotations { Yaxis = annotations } : null;
+        // Unconditional: an empty yaxis list draws nothing, same as null — and the list is
+        // filled inside AddType, which static flow analysis can't see through the closure.
+        _options.Annotations = new Annotations { Yaxis = annotations };
         _renderKey = signature;
         _loaded = true;
     }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
@@ -43,7 +43,7 @@ else
                        it self-hides on 404 until the art is mirrored, and the hover names
                        the rung. The weekly delta left for the Sessions page (owner,
                        2026-08-14) — this is the space it freed. *@
-                    <PumbilityLevelBadge Level="Phoenix2PumbilityLevel.From(_stats.SkillRating)" Height="34"/>
+                    <PumbilityLevelBadge Level="Phoenix2PumbilityLevel.From(_stats.SkillRating)" Height="44"/>
                 }
                 <span class="dash-acct-total">
                     <span class="dash-stat-num rarity-glow-1">@_stats.SkillRating.ToString("N0")</span>

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
@@ -1,5 +1,6 @@
 ﻿@using MediatR
 @using ScoreTracker.Domain.Models
+@using ScoreTracker.Domain.Models.Titles.Phoenix2
 @using ScoreTracker.Domain.Records
 @using ScoreTracker.Domain.SecondaryPorts
 @using ScoreTracker.HomePage.Contracts
@@ -36,12 +37,16 @@ else
         <div class="dash-acct-stats">
             <div class="dash-acct-eyebrow">@L["PUMBILITY"]</div>
             <div class="dash-acct-hero">
+                @if (_mix == MixEnum.Phoenix2)
+                {
+                    @* The P2 total-pool level gem (the ladder belongs to Phoenix 2 alone);
+                       it self-hides on 404 until the art is mirrored, and the hover names
+                       the rung. The weekly delta left for the Sessions page (owner,
+                       2026-08-14) — this is the space it freed. *@
+                    <PumbilityLevelBadge Level="Phoenix2PumbilityLevel.From(_stats.SkillRating)" Height="34"/>
+                }
                 <span class="dash-acct-total">
                     <span class="dash-stat-num rarity-glow-1">@_stats.SkillRating.ToString("N0")</span>
-                    @if (_weeklyDelta is > 0)
-                    {
-                        <PumbilityDelta Value="_weeklyDelta.Value" Marker="▲ " Class="dash-stat-delta"></PumbilityDelta>
-                    }
                 </span>
                 <div class="dash-acct-pools">
                     <div class="dash-acct-poolrow">
@@ -137,7 +142,6 @@ else
     private MixEnum _mix;
     private ChartType? _dimension;
     private PlayerStatsRecord? _stats;
-    private double? _weeklyDelta;
     private double _myLevel;
     private List<MatchRow> _matches = new();
     private string? _headerSlotKey;
@@ -168,15 +172,6 @@ else
 
             var userId = CurrentUser.User.Id;
             _stats = await Mediator.Send(new GetPlayerStatsQuery(userId, _mix));
-
-            var history = (await Mediator.Send(new GetPlayerHistoryQuery(userId, _mix)))
-                .Where(h => h.SkillRating != null)
-                .OrderBy(h => h.Date)
-                .ToArray();
-            var weekAgo = history.LastOrDefault(h => h.Date <= DateTimeOffset.Now.AddDays(-7));
-            _weeklyDelta = weekAgo?.SkillRating is { } baseline && _stats != null
-                ? _stats.SkillRating - baseline
-                : null;
 
             _matches = new List<MatchRow>();
             if (_showMatches && _stats != null) await LoadMatches(userId);

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsConfig.cs
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsConfig.cs
@@ -1,3 +1,4 @@
+using ScoreTracker.Domain.Models.Titles;
 using ScoreTracker.PlayerProgress.Contracts;
 using ScoreTracker.SharedKernel.Enums;
 using ScoreTracker.SharedKernel.ValueTypes;
@@ -128,12 +129,26 @@ public static class SuggestedGoals
     }
 
     /// <summary>
+    ///     The bundle a render actually runs: on a mix whose title list has no difficulty titles
+    ///     (Phoenix 2 today) Title Hunt silently falls back to Pumbility Push — a P2 "next title"
+    ///     IS a PUMBILITY threshold, so the biggest gains are the title path (owner, 2026-08-14).
+    ///     The config panel keeps showing the goal's own bundle via the mix-free overload.
+    /// </summary>
+    public static IReadOnlyList<RecommendationCategory> CategoriesFor(SuggestedGoal goal, MixEnum mix)
+    {
+        return goal == SuggestedGoal.TitleHunt && !TitleLists.HasDifficultyTitles(mix)
+            ? CategoriesFor(SuggestedGoal.PumbilityPush)
+            : CategoriesFor(goal);
+    }
+
+    /// <summary>
     ///     The goal's categories minus the player's disables; falls back to the full
     ///     bundle if config managed to disable everything (imports are tolerant, D19).
     /// </summary>
-    public static IReadOnlyList<RecommendationCategory> EffectiveCategories(SuggestedChartsConfig config)
+    public static IReadOnlyList<RecommendationCategory> EffectiveCategories(SuggestedChartsConfig config,
+        MixEnum mix)
     {
-        var categories = CategoriesFor(config.Goal);
+        var categories = CategoriesFor(config.Goal, mix);
         var enabled = categories.Where(c => !config.DisabledCategories.Contains(c)).ToArray();
         return enabled.Any() ? enabled : categories;
     }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsWidget.razor
@@ -233,7 +233,7 @@ else
         _mix = config.Mix != null && Supported.Contains(config.Mix.Value) ? config.Mix.Value
             : Supported.Contains(EffectiveMix) ? EffectiveMix : MixEnum.Phoenix;
 
-        var categories = SuggestedGoals.EffectiveCategories(config);
+        var categories = SuggestedGoals.EffectiveCategories(config, _mix);
         var recommendations = (await Mediator.Send(new GetRecommendedChartsQuery(
                 config.ChartType, LevelOffset: 0, _mix,
                 Categories: categories.ToHashSet(),

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/WidgetHost.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/WidgetHost.razor
@@ -29,7 +29,7 @@
                edit controls keep the bar to themselves. *@
             <span class="dash-head-slot">@_headerSlot.Content</span>
         }
-        @if (_descriptor?.RefreshIcon != null)
+        @if (_descriptor?.RefreshIcon != null && (_descriptor.ShowRefresh?.Invoke(Widget.ConfigJson) ?? true))
         {
             @* Header refresh (owner, round 5): bumps RefreshToken so the widget reloads
                without spending body space on a meta row. *@

--- a/ScoreTracker/ScoreTracker/Components/Rivals/RivalHighlightsFeed.razor
+++ b/ScoreTracker/ScoreTracker/Components/Rivals/RivalHighlightsFeed.razor
@@ -59,9 +59,11 @@ else
                             <div class="dash-ch-win">
                                 @if (win.ChartId is { } chartId && Charts.TryGetValue(chartId, out var chart))
                                 {
-                                    <span class="dash-ch-chart">
-                                        <DifficultyBubble Chart="chart" Small="true"></DifficultyBubble>
-                                        <span class="dash-ch-song">@chart.Song.Name</span>
+                                    var c = chart;
+                                    <span class="dash-ch-chart @(OnChartClick.HasDelegate ? "dash-clickable" : "")"
+                                          @onclick="() => Open(c)">
+                                        <DifficultyBubble Chart="c" Small="true"></DifficultyBubble>
+                                        <span class="dash-ch-song">@c.Song.Name</span>
                                     </span>
                                 }
                                 @* The chip states the fact; the sentence rides the hover (the feeds'
@@ -99,6 +101,13 @@ else
     [Parameter] public IReadOnlyList<PlayerHighlightRecord> Records { get; set; } = Array.Empty<PlayerHighlightRecord>();
     [Parameter] public IReadOnlyDictionary<Guid, Chart> Charts { get; set; } = new Dictionary<Guid, Chart>();
     [Parameter] public IReadOnlySet<Guid> Clubmates { get; set; } = new HashSet<Guid>();
+
+    /// <summary>Charts open the host page's details dialog when this is wired (the /Rivals
+    /// page passes its own OpenChart). Unwired, rows render inert — no dead cursor.</summary>
+    [Parameter] public EventCallback<Chart> OnChartClick { get; set; }
+
+    private Task Open(Chart chart) =>
+        OnChartClick.HasDelegate ? OnChartClick.InvokeAsync(chart) : Task.CompletedTask;
 
     private string RowClass(PlayerHighlightRecord record) =>
         Clubmates.Contains(record.UserId) ? "dash-ch-entry is-community" : "dash-ch-entry";

--- a/ScoreTracker/ScoreTracker/Components/Rivals/RivalHighlightsFeed.razor
+++ b/ScoreTracker/ScoreTracker/Components/Rivals/RivalHighlightsFeed.razor
@@ -1,6 +1,7 @@
 @using System.Globalization
 @using ScoreTracker.PlayerProgress.Contracts
 @using ScoreTracker.SharedKernel.Models
+@using ScoreTracker.Web.Services
 @namespace ScoreTracker.Web.Components.Rivals
 @using Microsoft.JSInterop
 @inject IJSRuntime JSRuntime
@@ -63,7 +64,9 @@ else
                                         <span class="dash-ch-song">@chart.Song.Name</span>
                                     </span>
                                 }
-                                <span class="dash-ch-why">@Caption(win)</span>
+                                @* The chip states the fact; the sentence rides the hover (the feeds'
+                                   short-form rule — same vocabulary as the home widget). *@
+                                <span class="dash-ch-why" title="@Caption(win)">@Short(win)</span>
                             </div>
                         }
                     </div>
@@ -113,6 +116,25 @@ else
         return $"{(int)(span.TotalDays / 7)}w";
     }
 
+    // The row text — the shortest true form; a ladder span compacts to one label. Titles carry
+    // no rarity claim ("all titles are big titles", owner 2026-08-14).
+    private string Short(SignificantWin win) => win.Kind switch
+    {
+        WinKind.NotablePg => $"💎 {L["Rare PG"]}",
+        WinKind.TopPumbility => $"👑 #{win.Rank ?? 0} PUMB",
+        WinKind.PeerElite => win.Rank == 1
+            ? "📊 #1"
+            : $"📊 {L["Top {0}%", Math.Max(1, (int)Math.Ceiling((win.RarityShare ?? 0) * 100))]}",
+        WinKind.FolderFirst => $"🆕 {Ordinal(win.Rank ?? 0)} · {win.Difficulty}",
+        WinKind.FolderComplete => $"🎉 {L["Cleared {0}", win.Difficulty ?? ""]}",
+        WinKind.FolderProgress => $"📈 {L["{0}% of {1}", win.Rank ?? 0, win.Difficulty ?? ""]}",
+        WinKind.PumbilityLevelUp => $"🆙 {LevelName(win)}",
+        WinKind.PumbilityTitleSpan when win.Detail is { Length: > 0 } =>
+            $"🏅 {TitleSpans.Compact(Bracket(win.Detail), Bracket(win.TitleName))}",
+        _ => $"🏅 {Bracket(win.TitleName)}"
+    };
+
+    // The hover keeps what the chip dropped — the sentence, the percent, the pool.
     private string Caption(SignificantWin win) => win.Kind switch
     {
         WinKind.NotablePg => $"💎 {L["only {0} have PG", Pct(win.RarityShare)]}",
@@ -121,12 +143,12 @@ else
             ? $"📊 {L["#1 of all peers"]}"
             : $"📊 {L["top {0}% of peers", Math.Max(1, (int)Math.Ceiling((win.RarityShare ?? 0) * 100))]}",
         WinKind.FolderFirst => $"🆕 {L["{0} pass in this folder", Ordinal(win.Rank ?? 0)]}",
-        WinKind.FolderComplete => $"🎉 {L["Cleared all of {0}", win.Difficulty ?? ""]}",
-        WinKind.FolderProgress => $"📈 {L["{0}% of {1}", win.Rank ?? 0, win.Difficulty ?? ""]}",
         WinKind.PumbilityLevelUp => $"🆙 {L["Reached {0}", LevelName(win)]}{PoolSuffix(win)}",
-        WinKind.RareTitle => $"🏅 [{win.TitleName}] · {L["only {0} hold it", Pct(win.RarityShare)]}",
-        _ => $"🏅 [{win.TitleName}]"
+        _ => Short(win)
     };
+
+    private static string Bracket(string? title) =>
+        string.IsNullOrEmpty(title) ? "" : title.StartsWith('[') ? title : $"[{title}]";
 
     // The gem is the game's own proper noun and never localizes.
     private string LevelName(SignificantWin win) =>

--- a/ScoreTracker/ScoreTracker/Pages/Compete/Rivals.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Compete/Rivals.razor
@@ -41,7 +41,7 @@ else
                 <span class="sbd-eyebrow">@L["What your rivals are up to"]</span>
             </div>
             <RivalHighlightsFeed Records="_feed" Charts="_charts" Clubmates="_clubmateIds"
-                                 Rail="true"></RivalHighlightsFeed>
+                                 Rail="true" OnChartClick="OpenChart"></RivalHighlightsFeed>
         </div>
     }
 

--- a/ScoreTracker/ScoreTracker/Pages/HomeDashboard.razor
+++ b/ScoreTracker/ScoreTracker/Pages/HomeDashboard.razor
@@ -307,7 +307,13 @@ else if (_loaded)
         <DialogContent>
             @if (_configureWidget != null && _configureComponent != null)
             {
-                <DynamicComponent Type="_configureComponent" Parameters="_configureParameters"/>
+                @* A named cascade rather than a dictionary entry: DynamicComponent throws on a
+                   parameter a panel didn't declare, so panels opt in — the ones whose display
+                   depends on what "follow current mix" resolves to right now. *@
+                <CascadingValue Name="EffectiveMix"
+                                Value="(MixEnum?)(_selectedPage == null ? _currentMix : EffectiveMixFor(_selectedPage))">
+                    <DynamicComponent Type="_configureComponent" Parameters="_configureParameters"/>
+                </CascadingValue>
             }
         </DialogContent>
     </MudDialog>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -1298,11 +1298,11 @@
   <data name="Clear Progress" xml:space="preserve">
     <value>Clear Progress</value>
   </data>
-  <data name="Cleared all of {0}" xml:space="preserve">
-    <value>Cleared all of {0}</value>
-  </data>
   <data name="Cleared on attempt {0}" xml:space="preserve">
     <value>Cleared on attempt {0}</value>
+  </data>
+  <data name="Cleared {0}" xml:space="preserve">
+    <value>Cleared {0}</value>
   </data>
   <data name="Clearly Has Friends" xml:space="preserve">
     <value>Clearly Has Friends</value>
@@ -4444,11 +4444,7 @@
   </data>
   <data name="only {0} have PG" xml:space="preserve">
     <value>only {0} have PG</value>
-  </data>
-  <data name="only {0} hold it" xml:space="preserve">
-    <value>only {0} hold it</value>
-  </data>
-  <data name="only {0} pass it" xml:space="preserve">
+  </data>  <data name="only {0} pass it" xml:space="preserve">
     <value>only {0} pass it</value>
   </data>
   <data name="Open" xml:space="preserve">
@@ -5287,11 +5283,7 @@
   </data>
   <data name="Rare PGs, big titles, and top scores from your communities show up here." xml:space="preserve">
     <value>Rare PGs, big titles, and top scores from your communities show up here.</value>
-  </data>
-  <data name="Rare Title" xml:space="preserve">
-    <value>Rare Title</value>
-  </data>
-  <data name="Rarest passes" xml:space="preserve">
+  </data>  <data name="Rarest passes" xml:space="preserve">
     <value>Rarest passes</value>
   </data>
   <data name="Rarest titles" xml:space="preserve">

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -1298,11 +1298,11 @@
   <data name="Clear Progress" xml:space="preserve">
     <value>Mrpmurg Mrglrlgl</value>
   </data>
-  <data name="Cleared all of {0}" xml:space="preserve">
-    <value>Blarggrrglglorg rgl mrgl {0}</value>
-  </data>
   <data name="Cleared on attempt {0}" xml:space="preserve">
     <value>Palo blub {0}</value>
+  </data>
+  <data name="Cleared {0}" xml:space="preserve">
+    <value>Blarggrrglglorg {0}</value>
   </data>
   <data name="Clearly Has Friends" xml:space="preserve">
     <value>Grorprglgrorp Rgl Murggrorpurg</value>
@@ -4444,11 +4444,7 @@
   </data>
   <data name="only {0} have PG" xml:space="preserve">
     <value>mrpmurg {0} mrglro PG</value>
-  </data>
-  <data name="only {0} hold it" xml:space="preserve">
-    <value>mrpmurg {0} rglmr gl</value>
-  </data>
-  <data name="only {0} pass it" xml:space="preserve">
+  </data>  <data name="only {0} pass it" xml:space="preserve">
     <value>mrpmurg {0} maglplgl gl</value>
   </data>
   <data name="Open" xml:space="preserve">
@@ -5287,11 +5283,7 @@
   </data>
   <data name="Rare PGs, big titles, and top scores from your communities show up here." xml:space="preserve">
     <value>Maglmurg Gl, grgl mrgl, ro blarg mgrlgmrg romurg gromurp grglrglplglblub romorg morg blubmorg.</value>
-  </data>
-  <data name="Rare Title" xml:space="preserve">
-    <value>Maglmurg Mrgl</value>
-  </data>
-  <data name="Rarest passes" xml:space="preserve">
+  </data>  <data name="Rarest passes" xml:space="preserve">
     <value>Urgblgrl grgllurg</value>
   </data>
   <data name="Rarest titles" xml:space="preserve">

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -1288,11 +1288,11 @@
   <data name="Clear Progress" xml:space="preserve">
     <value>Progreso de pases</value>
   </data>
-  <data name="Cleared all of {0}" xml:space="preserve">
-    <value>Completó todo {0}</value>
-  </data>
   <data name="Cleared on attempt {0}" xml:space="preserve">
     <value>Superado en el intento {0}</value>
+  </data>
+  <data name="Cleared {0}" xml:space="preserve">
+    <value>Completó {0}</value>
   </data>
   <data name="Clearly Has Friends" xml:space="preserve">
     <value>Está claro que tiene amigos</value>
@@ -4413,11 +4413,7 @@
   </data>
   <data name="only {0} have PG" xml:space="preserve">
     <value>solo {0} tienen PG</value>
-  </data>
-  <data name="only {0} hold it" xml:space="preserve">
-    <value>solo {0} lo poseen</value>
-  </data>
-  <data name="only {0} pass it" xml:space="preserve">
+  </data>  <data name="only {0} pass it" xml:space="preserve">
     <value>solo lo pasa un {0}</value>
   </data>
   <data name="Open" xml:space="preserve">
@@ -5247,11 +5243,7 @@
   </data>
   <data name="Rare PGs, big titles, and top scores from your communities show up here." xml:space="preserve">
     <value>Aquí aparecen PG raros, grandes títulos y mejores puntuaciones de tus comunidades.</value>
-  </data>
-  <data name="Rare Title" xml:space="preserve">
-    <value>Título raro</value>
-  </data>
-  <data name="Rarest passes" xml:space="preserve">
+  </data>  <data name="Rarest passes" xml:space="preserve">
     <value>Passes más raros</value>
   </data>
   <data name="Rarest titles" xml:space="preserve">

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -1288,11 +1288,11 @@
   <data name="Clear Progress" xml:space="preserve">
     <value>Progreso de pases</value>
   </data>
-  <data name="Cleared all of {0}" xml:space="preserve">
-    <value>Completó todo {0}</value>
-  </data>
   <data name="Cleared on attempt {0}" xml:space="preserve">
     <value>Superado en el intento {0}</value>
+  </data>
+  <data name="Cleared {0}" xml:space="preserve">
+    <value>Completó {0}</value>
   </data>
   <data name="Clearly Has Friends" xml:space="preserve">
     <value>Clearly Has Friends</value>
@@ -4413,11 +4413,7 @@
   </data>
   <data name="only {0} have PG" xml:space="preserve">
     <value>solo {0} tienen PG</value>
-  </data>
-  <data name="only {0} hold it" xml:space="preserve">
-    <value>solo {0} lo poseen</value>
-  </data>
-  <data name="only {0} pass it" xml:space="preserve">
+  </data>  <data name="only {0} pass it" xml:space="preserve">
     <value>solo el {0} lo pasa</value>
   </data>
   <data name="Open" xml:space="preserve">
@@ -5249,11 +5245,7 @@
   </data>
   <data name="Rare PGs, big titles, and top scores from your communities show up here." xml:space="preserve">
     <value>Aquí aparecen PG raros, grandes títulos y mejores puntajes de tus comunidades.</value>
-  </data>
-  <data name="Rare Title" xml:space="preserve">
-    <value>Título raro</value>
-  </data>
-  <data name="Rarest passes" xml:space="preserve">
+  </data>  <data name="Rarest passes" xml:space="preserve">
     <value>Passes más raros</value>
   </data>
   <data name="Rarest titles" xml:space="preserve">

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -1298,11 +1298,11 @@
   <data name="Clear Progress" xml:space="preserve">
     <value>Progression des pass</value>
   </data>
-  <data name="Cleared all of {0}" xml:space="preserve">
-    <value>Tout {0} réussi</value>
-  </data>
   <data name="Cleared on attempt {0}" xml:space="preserve">
     <value>Réussi à l'essai {0}</value>
+  </data>
+  <data name="Cleared {0}" xml:space="preserve">
+    <value>{0} réussi</value>
   </data>
   <data name="Clearly Has Friends" xml:space="preserve">
     <value>Clearly Has Friends</value>
@@ -4443,11 +4443,7 @@
   </data>
   <data name="only {0} have PG" xml:space="preserve">
     <value>seuls {0} ont le PG</value>
-  </data>
-  <data name="only {0} hold it" xml:space="preserve">
-    <value>seuls {0} le détiennent</value>
-  </data>
-  <data name="only {0} pass it" xml:space="preserve">
+  </data>  <data name="only {0} pass it" xml:space="preserve">
     <value>seuls {0} le passent</value>
   </data>
   <data name="Open" xml:space="preserve">
@@ -5286,11 +5282,7 @@
   </data>
   <data name="Rare PGs, big titles, and top scores from your communities show up here." xml:space="preserve">
     <value>Les PG rares, grands titres et meilleurs scores de vos communautés apparaissent ici.</value>
-  </data>
-  <data name="Rare Title" xml:space="preserve">
-    <value>Titre rare</value>
-  </data>
-  <data name="Rarest passes" xml:space="preserve">
+  </data>  <data name="Rarest passes" xml:space="preserve">
     <value>Passes les plus rares</value>
   </data>
   <data name="Rarest titles" xml:space="preserve">

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -1298,11 +1298,11 @@
   <data name="Clear Progress" xml:space="preserve">
     <value>Progresso clear</value>
   </data>
-  <data name="Cleared all of {0}" xml:space="preserve">
-    <value>Tutto {0} superato</value>
-  </data>
   <data name="Cleared on attempt {0}" xml:space="preserve">
     <value>Superato al tentativo {0}</value>
+  </data>
+  <data name="Cleared {0}" xml:space="preserve">
+    <value>{0} superato</value>
   </data>
   <data name="Clearly Has Friends" xml:space="preserve">
     <value>Clearly Has Friends</value>
@@ -4444,11 +4444,7 @@
   </data>
   <data name="only {0} have PG" xml:space="preserve">
     <value>solo {0} hanno il PG</value>
-  </data>
-  <data name="only {0} hold it" xml:space="preserve">
-    <value>solo {0} lo possiedono</value>
-  </data>
-  <data name="only {0} pass it" xml:space="preserve">
+  </data>  <data name="only {0} pass it" xml:space="preserve">
     <value>solo il {0} la passa</value>
   </data>
   <data name="Open" xml:space="preserve">
@@ -5287,11 +5283,7 @@
   </data>
   <data name="Rare PGs, big titles, and top scores from your communities show up here." xml:space="preserve">
     <value>Qui compaiono PG rari, grandi titoli e migliori punteggi dalle tue comunità.</value>
-  </data>
-  <data name="Rare Title" xml:space="preserve">
-    <value>Titolo raro</value>
-  </data>
-  <data name="Rarest passes" xml:space="preserve">
+  </data>  <data name="Rarest passes" xml:space="preserve">
     <value>Pass più rari</value>
   </data>
   <data name="Rarest titles" xml:space="preserve">

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -1298,11 +1298,11 @@
   <data name="Clear Progress" xml:space="preserve">
     <value>クリア進捗</value>
   </data>
-  <data name="Cleared all of {0}" xml:space="preserve">
-    <value>{0} 全曲クリア</value>
-  </data>
   <data name="Cleared on attempt {0}" xml:space="preserve">
     <value>{0} 回目でクリア</value>
+  </data>
+  <data name="Cleared {0}" xml:space="preserve">
+    <value>{0} クリア</value>
   </data>
   <data name="Clearly Has Friends" xml:space="preserve">
     <value>Clearly Has Friends</value>
@@ -4444,11 +4444,7 @@
   </data>
   <data name="only {0} have PG" xml:space="preserve">
     <value>PG保持者 {0} のみ</value>
-  </data>
-  <data name="only {0} hold it" xml:space="preserve">
-    <value>{0} のみ保持</value>
-  </data>
-  <data name="only {0} pass it" xml:space="preserve">
+  </data>  <data name="only {0} pass it" xml:space="preserve">
     <value>クリア率{0}</value>
   </data>
   <data name="Open" xml:space="preserve">
@@ -5287,11 +5283,7 @@
   </data>
   <data name="Rare PGs, big titles, and top scores from your communities show up here." xml:space="preserve">
     <value>コミュニティの珍しいPG、大きな称号、トップスコアがここに表示されます。</value>
-  </data>
-  <data name="Rare Title" xml:space="preserve">
-    <value>珍しい称号</value>
-  </data>
-  <data name="Rarest passes" xml:space="preserve">
+  </data>  <data name="Rarest passes" xml:space="preserve">
     <value>最もレアなクリア</value>
   </data>
   <data name="Rarest titles" xml:space="preserve">

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -1288,11 +1288,11 @@
   <data name="Clear Progress" xml:space="preserve">
     <value>클리어 진행도</value>
   </data>
-  <data name="Cleared all of {0}" xml:space="preserve">
-    <value>{0} 전부 클리어</value>
-  </data>
   <data name="Cleared on attempt {0}" xml:space="preserve">
     <value>{0}번째 시도에 클리어</value>
+  </data>
+  <data name="Cleared {0}" xml:space="preserve">
+    <value>{0} 클리어</value>
   </data>
   <data name="Clearly Has Friends" xml:space="preserve">
     <value>Clearly Has Friends</value>
@@ -4413,11 +4413,7 @@
   </data>
   <data name="only {0} have PG" xml:space="preserve">
     <value>{0}만 PG 보유</value>
-  </data>
-  <data name="only {0} hold it" xml:space="preserve">
-    <value>{0}만 보유</value>
-  </data>
-  <data name="only {0} pass it" xml:space="preserve">
+  </data>  <data name="only {0} pass it" xml:space="preserve">
     <value>클리어율 {0}</value>
   </data>
   <data name="Open" xml:space="preserve">
@@ -5249,11 +5245,7 @@
   </data>
   <data name="Rare PGs, big titles, and top scores from your communities show up here." xml:space="preserve">
     <value>커뮤니티의 희귀한 PG, 큰 칭호, 최고 점수가 여기에 표시됩니다.</value>
-  </data>
-  <data name="Rare Title" xml:space="preserve">
-    <value>희귀 칭호</value>
-  </data>
-  <data name="Rarest passes" xml:space="preserve">
+  </data>  <data name="Rarest passes" xml:space="preserve">
     <value>가장 희귀한 클리어</value>
   </data>
   <data name="Rarest titles" xml:space="preserve">

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -1288,11 +1288,11 @@
   <data name="Clear Progress" xml:space="preserve">
     <value>Progresso de passes</value>
   </data>
-  <data name="Cleared all of {0}" xml:space="preserve">
-    <value>Completou tudo {0}</value>
-  </data>
   <data name="Cleared on attempt {0}" xml:space="preserve">
     <value>Passou na tentativa {0}</value>
+  </data>
+  <data name="Cleared {0}" xml:space="preserve">
+    <value>Completou {0}</value>
   </data>
   <data name="Clearly Has Friends" xml:space="preserve">
     <value>Clearly Has Friends</value>
@@ -4413,11 +4413,7 @@
   </data>
   <data name="only {0} have PG" xml:space="preserve">
     <value>só {0} têm PG</value>
-  </data>
-  <data name="only {0} hold it" xml:space="preserve">
-    <value>só {0} possuem</value>
-  </data>
-  <data name="only {0} pass it" xml:space="preserve">
+  </data>  <data name="only {0} pass it" xml:space="preserve">
     <value>só {0} passam</value>
   </data>
   <data name="Open" xml:space="preserve">
@@ -5249,11 +5245,7 @@
   </data>
   <data name="Rare PGs, big titles, and top scores from your communities show up here." xml:space="preserve">
     <value>PGs raros, grandes títulos e melhores pontuações das suas comunidades aparecem aqui.</value>
-  </data>
-  <data name="Rare Title" xml:space="preserve">
-    <value>Título raro</value>
-  </data>
-  <data name="Rarest passes" xml:space="preserve">
+  </data>  <data name="Rarest passes" xml:space="preserve">
     <value>Passes mais raros</value>
   </data>
   <data name="Rarest titles" xml:space="preserve">

--- a/ScoreTracker/ScoreTracker/Services/HomeDashboard/WidgetDescriptor.cs
+++ b/ScoreTracker/ScoreTracker/Services/HomeDashboard/WidgetDescriptor.cs
@@ -85,4 +85,8 @@ public sealed record WidgetDescriptor(
     string? RefreshTitleKey = null,
     // When true, the host auto-bumps RefreshToken after the viewer's score import lands, so
     // personal-score widgets reflect the new scores/rating without a manual refresh.
-    bool RefreshOnScoreImport = false);
+    bool RefreshOnScoreImport = false,
+    // Optional config-aware visibility for the refresh action: some goals of a type are
+    // deterministic, and a shuffle that re-rolls into the identical list is a lie. Null =
+    // always shown when RefreshIcon is set.
+    Func<string?, bool>? ShowRefresh = null);

--- a/ScoreTracker/ScoreTracker/Services/HomeDashboard/WidgetRegistry.cs
+++ b/ScoreTracker/ScoreTracker/Services/HomeDashboard/WidgetRegistry.cs
@@ -183,6 +183,12 @@ public static class WidgetRegistry
                 },
             RefreshIcon: Icons.Material.Filled.Shuffle,
             RefreshTitleKey: "Shuffle suggestions",
+            // Shuffle only where a re-roll changes the hand: Hot Streak is deterministic
+            // (seeds newest-first, targets by similarity), so the button would lie there.
+            // Pumbility Push samples its pool, so it keeps it — and the Title Hunt fallback
+            // inherits that sampling on Phoenix 2.
+            ShowRefresh: json =>
+                WidgetConfigJson.Read<SuggestedChartsConfig>(json).Goal != SuggestedGoal.HotStreak,
             RefreshOnScoreImport: true),
         new("by-level-breakdown",
             "By-Level Breakdown",

--- a/ScoreTracker/ScoreTracker/Services/TitleSpans.cs
+++ b/ScoreTracker/ScoreTracker/Services/TitleSpans.cs
@@ -1,0 +1,25 @@
+namespace ScoreTracker.Web.Services;
+
+/// <summary>
+///     The compact label for a rolled-up PUMBILITY ladder span ("[S] ADVANCED LV.6 → 9"): the
+///     reached rung keeps only what differs from the first, so a same-band climb reads as its
+///     numbers and a band-crossing climb keeps the second band's name ("[S] ADVANCED LV.9 →
+///     EXPERT LV.2"). The trim backs up to a word boundary so "LV.1 → LV.12" can never mangle
+///     into "1 → 2".
+/// </summary>
+public static class TitleSpans
+{
+    public static string Compact(string from, string to)
+    {
+        if (string.IsNullOrEmpty(from)) return to;
+        if (string.IsNullOrEmpty(to) || from == to) return from;
+
+        var common = 0;
+        var max = Math.Min(from.Length, to.Length);
+        while (common < max && from[common] == to[common]) common++;
+        while (common > 0 && from[common - 1] != ' ' && from[common - 1] != '.') common--;
+
+        var suffix = to[common..];
+        return suffix.Length == 0 ? $"{from} → {to}" : $"{from} → {suffix}";
+    }
+}

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -3759,6 +3759,12 @@ html.sheet-open .more-sheet-scrim {
     gap: 16px;
 }
 
+/* The P2 level gem beside the total — a fixed square so a slow image load
+   never reflows the hero. */
+.dash-acct-hero .pumbility-level-badge {
+    flex: none;
+}
+
 .dash-acct-total {
     display: inline-flex;
     align-items: baseline;

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -3759,10 +3759,12 @@ html.sheet-open .more-sheet-scrim {
     gap: 16px;
 }
 
-/* The P2 level gem beside the total — a fixed square so a slow image load
-   never reflows the hero. */
+/* The P2 level gem beside the total — a fixed square so a slow image load never
+   reflows the hero. The negative margin eats the hero gap plus the art's own
+   transparent frame, so gem and number read as one unit (owner, field test). */
 .dash-acct-hero .pumbility-level-badge {
     flex: none;
+    margin-right: -8px;
 }
 
 .dash-acct-total {

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -3066,6 +3066,8 @@ html.sheet-open .more-sheet-scrim {
        too-long line would otherwise mint a horizontal scrollbar for the whole feed. */
     overflow-x: hidden;
     height: 100%;
+    /* Air between the right-aligned scores and the edge the scroll thumb overlays. */
+    padding-right: .4rem;
     /* So win rows can respond to the widget's own width, not just the viewport. */
     container-type: inline-size;
 }
@@ -3264,6 +3266,13 @@ html.sheet-open .more-sheet-scrim {
 
 .dash-ch-win-scored .dash-ch-why {
     white-space: nowrap;
+}
+
+/* The level-up row is a badge image plus text — centered as a unit, not baseline-hung. */
+.dash-ch-lvlup {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
 }
 
 .dash-ch-win-scored .dash-ch-chart {

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -3062,6 +3062,9 @@ html.sheet-open .more-sheet-scrim {
     display: flex;
     flex-direction: column;
     overflow-y: auto;
+    /* Never pans: overflow-y:auto forces this axis from visible to auto, so any
+       too-long line would otherwise mint a horizontal scrollbar for the whole feed. */
+    overflow-x: hidden;
     height: 100%;
     /* So win rows can respond to the widget's own width, not just the viewport. */
     container-type: inline-size;
@@ -3243,9 +3246,12 @@ html.sheet-open .more-sheet-scrim {
     max-width: 12rem;
 }
 
+/* Prose rows (titles, folders, level-ups) wrap; only the scored one-liner below
+   pins its caption to a single line, and the narrow reflows release even that. */
 .dash-ch-why {
     color: var(--mix-ink-muted);
-    white-space: nowrap;
+    overflow-wrap: break-word;
+    min-width: 0;
 }
 
 /* Scored win = one line on wide: chart (the song name truncates) + highlight, then a right-aligned
@@ -3254,6 +3260,10 @@ html.sheet-open .more-sheet-scrim {
     flex-wrap: nowrap;
     align-items: center;
     gap: .35rem;
+}
+
+.dash-ch-win-scored .dash-ch-why {
+    white-space: nowrap;
 }
 
 .dash-ch-win-scored .dash-ch-chart {
@@ -3276,18 +3286,18 @@ html.sheet-open .more-sheet-scrim {
 
 /* Narrow — a 1-wide widget (container query on the feed) or mobile, where the dashboard is one
    column (media query): hide the song name and drop the highlight onto its own subtitle line. */
-@container (max-width: 300px) {
+@container (max-width: 340px) {
     .dash-ch-song { display: none; }
     .dash-ch-win-scored { flex-wrap: wrap; }
     .dash-ch-win-scored .dash-ch-score-right { order: 2; }
-    .dash-ch-win-scored .dash-ch-why { order: 3; flex-basis: 100%; font-size: .72rem; }
+    .dash-ch-win-scored .dash-ch-why { order: 3; flex-basis: 100%; font-size: .72rem; white-space: normal; }
 }
 
 @media (max-width: 600px) {
     .dash-ch-song { display: none; }
     .dash-ch-win-scored { flex-wrap: wrap; }
     .dash-ch-win-scored .dash-ch-score-right { order: 2; }
-    .dash-ch-win-scored .dash-ch-why { order: 3; flex-basis: 100%; font-size: .72rem; }
+    .dash-ch-win-scored .dash-ch-why { order: 3; flex-basis: 100%; font-size: .72rem; white-space: normal; }
 }
 
 /* Card-strip person divider (avatar + vertical name) — the community analog of the

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -3066,8 +3066,6 @@ html.sheet-open .more-sheet-scrim {
        too-long line would otherwise mint a horizontal scrollbar for the whole feed. */
     overflow-x: hidden;
     height: 100%;
-    /* Air between the right-aligned scores and the edge the scroll thumb overlays. */
-    padding-right: .4rem;
     /* So win rows can respond to the widget's own width, not just the viewport. */
     container-type: inline-size;
 }
@@ -3187,7 +3185,9 @@ html.sheet-open .more-sheet-scrim {
 .dash-ch-entry {
     display: flex;
     gap: .6rem;
-    padding: .55rem .25rem;
+    /* Right side breathes: on a marked row the audience band paints the entry, and a
+       score flush against the band's edge read as clipped (owner, field test). */
+    padding: .55rem .5rem .55rem .25rem;
     border-bottom: 1px solid color-mix(in srgb, var(--mix-ink-muted) 15%, transparent);
 }
 

--- a/docs/UX-GUIDELINES.md
+++ b/docs/UX-GUIDELINES.md
@@ -300,11 +300,15 @@ The widget home page ([design doc](design/HomePageWidgets/README.md)) adds a voc
 - **Graphs start from `ApexChartTheming.BaseOptions` + its `WrapperClass`** on the container: frozen
   canvas, display face, palette fore color, whisper-grid, dark theme, themed tooltips. Charts layer
   their specifics (strokes, fills, axes) on top — never rebuild the base by hand.
-- **Community-scoped feeds reuse the shipped vocabulary**: the Community Highlights widget renders each
-  big win with the Discord card's own caption emoji (👑 pumbility, 📊 peers, 🆕 folder, 🏅 title, 💎 rare
-  PG) and colors the "% have it" rarity through the rarity ramp — the on-site feed and the Discord cards
-  read as one system. Persisted win data is structured, never pre-rendered text: the row localizes every
-  caption (a UI string never rides the DB payload).
+- **Community-scoped feeds reuse the shipped vocabulary, at feed density**: the Highlights feed renders
+  each big win with the Discord card's own caption emoji (👑 pumbility, 📊 peers, 🆕 folder, 🏅 title,
+  💎 rare PG) in **short form** — the chip states the fact ("Top 3%", "Rare PG"), the full sentence rides
+  the tooltip (owner: lean hard on tooltips; extended from the strip cards to the vertical feed rows
+  2026-08-14). Titles carry **no rarity claim** — every earned title is feed-worthy ("all titles are big
+  titles"), and pumbility-ladder crossings roll up into one span row per pool ("[S] ADVANCED LV.6 →
+  LV.9") **in the feeds only**; the Discord session card stays un-collapsed ("many titles should feel
+  like many titles", 2026-07-26). Persisted win data is structured, never pre-rendered text: the row
+  localizes every caption (a UI string never rides the DB payload).
 
 ## 5. Challenge boards (Weekly Charts + Daily Step)
 

--- a/docs/design/HomePageWidgets/README.md
+++ b/docs/design/HomePageWidgets/README.md
@@ -87,6 +87,15 @@ public sealed record WidgetDescriptor(
 Verticals contribute *data* (contract queries, precompute jobs); Web contributes the descriptor +
 components. A future vertical (Rivals) adds descriptors without touching shell code (D9).
 
+The descriptor has since grown optional config-aware hooks beyond this sketch: `DynamicNameKey`
+(instance titles follow config), `DrawerPresets`, the refresh action (`RefreshIcon`/`RefreshTitleKey`/
+`RefreshOnScoreImport`), and `ShowRefresh` (2026-08-14) — a predicate the host consults so a goal
+whose content is deterministic doesn't render a shuffle that re-rolls into the identical list.
+The **config dialog** also cascades the page's effective mix as a named `CascadingValue`
+(`Name="EffectiveMix"`, `MixEnum?`) — panels whose display depends on what "follow current mix"
+resolves to opt in via `[CascadingParameter]`; a dictionary parameter can't do this, because
+`DynamicComponent` throws on a parameter a panel didn't declare.
+
 ### 2.3 Widget lifecycle contract (D14)
 
 Every render component must provide:

--- a/docs/design/HomePageWidgets/competitive-level.md
+++ b/docs/design/HomePageWidgets/competitive-level.md
@@ -18,6 +18,13 @@ starter trio).**
   range (typical post-P2-switch), render left-edge ghost ticks at Phoenix's final Singles/Doubles values
   with a small "Phoenix: S 20.4 · D 21.1" label — the regrind's reference line. Values are just the last
   records of the Phoenix history call; no new query.
+- **Validity floor (owner, 2026-08-14)**: a competitive level at or below **5** is not a real reading —
+  ≤1 is the calculator's no-data floor, and a never-played pool otherwise plots a flatline that pins the
+  y-axis near 0 and flattens every real series (field report: a no-doubles player's graph read as "no
+  change", and the zero-slope dashed era lines read as dots). Each series drops points ≤5 before
+  rendering; a series with **no surviving points is omitted entirely**, including its "where you left
+  off" ghost marker. A literal ≥20-charts-played series gate was considered and deferred; per-date
+  historical gating was rejected (needs a journal-reconstruction backfill, not worth it).
 - **Config v1**: mixes (multi-select: Phoenix / Phoenix 2; default = current mix); range
   (3/6/12 months/all — default 6); series toggles (Singles / Doubles, both on).
 - **Sizes**: 2×1 (default), 2×2. No 1×1 — line charts need width; per-widget `SupportedSizes` exists

--- a/docs/design/HomePageWidgets/competitive-level.md
+++ b/docs/design/HomePageWidgets/competitive-level.md
@@ -23,8 +23,14 @@ starter trio).**
   y-axis near 0 and flattens every real series (field report: a no-doubles player's graph read as "no
   change", and the zero-slope dashed era lines read as dots). Each series drops points ≤5 before
   rendering; a series with **no surviving points is omitted entirely**, including its "where you left
-  off" ghost marker. A literal ≥20-charts-played series gate was considered and deferred; per-date
-  historical gating was rejected (needs a journal-reconstruction backfill, not worth it).
+  off" ghost marker.
+- **Pass-count gate (owner, 2026-08-14 — "try that")**: alongside the floor, points from rows whose
+  `PassCount` is under **20** don't plot — the first-session estimate swings wildly on a tiny pool
+  (field report: a two-level dip and recovery inside days). History rows carry the mix's pass count
+  at write time, so the per-date gating once thought to need a journal backfill turned out to be
+  already persisted: retroactive, zero queries, one constant. Caveat stated honestly: it is the mix
+  **total**, not per-type — the validity floor backstops never-played pools, but a lopsided
+  account's early weak-side readings can pass the count gate.
 - **Config v1**: mixes (multi-select: Phoenix / Phoenix 2; default = current mix); range
   (3/6/12 months/all — default 6); series toggles (Singles / Doubles, both on).
 - **Sizes**: 2×1 (default), 2×2. No 1×1 — line charts need width; per-widget `SupportedSizes` exists

--- a/docs/design/HomePageWidgets/pumbility.md
+++ b/docs/design/HomePageWidgets/pumbility.md
@@ -18,6 +18,14 @@ starter trio); refactored Pumbility → Account Stats in PR #149.** Consumes the
 > Sizes are now **1×1 / 1×2 / 1×3**. TypeId stays `pumbility` (export vocabulary). The historical spec
 > below describes the original Pumbility widget.
 
+> **2026-08-14: the weekly ▲ delta left the widget** (owner: the Sessions page is where that delta
+> matters) — and with it the `GetPlayerHistoryQuery` fetch that existed only to compute it. In the
+> space it frees, on **Phoenix 2** the **PUMBILITY level gem** renders beside the glowy total:
+> `PumbilityLevelBadge` with the rung from `Phoenix2PumbilityLevel.From(SkillRating)` (the total-pool
+> ladder — [pumbility-levels.md](../pumbility-levels.md)). The badge self-hides on 404 until the art
+> is mirrored, so ship order vs. the blob upload doesn't matter. Phoenix 1 has no ladder and renders
+> no gem.
+
 ---
 
 - **Data**: `GetPlayerStatsQuery` → `SkillRating` (the merged top-50; + `SinglesRating`/`DoublesRating`

--- a/docs/design/HomePageWidgets/suggested-charts.md
+++ b/docs/design/HomePageWidgets/suggested-charts.md
@@ -21,10 +21,13 @@ re-roll in the body meta row. The page's vestigial `LevelOffset` UI is supersede
   the same emptiness condition the engine's PushLevel checks — not the "Difficulty" *category*, which
   in P2 names its pumbility titles), so it self-heals if P2 ever ships difficulty titles ·
   *Score Push* = PushPGs + ImproveTop50 + RevisitOldScores · *Fill Gaps* = FillScores · *Pumbility
-  Push* = PushPumbility (PR #149: the gain-ranked projected targets that moved off the Account Stats
-  widget — `ProjectPumbilityGainsQuery`, biggest overall-rating gain first, stamps "+N", **truncated,
-  never rounded up** — a 36.7 gain prints +36 (owner, 2026-08-14; gains never overstate, the
-  PUMBILITY-precision rule); distinct from the random ImproveTop50, and has its own drawer preset) · *Hot Streak* = HotStreak (the
+  Push* = PushPumbility (PR #149: the projected targets that moved off the Account Stats widget —
+  `ProjectPumbilityGainsQuery`; since 2026-08-14 the shown dozen **samples from the top-50 gains**
+  and re-ranks the hand best-first (owner: a fresh hand each load, which is also what makes the
+  header shuffle honest on this goal; the /Pumbility page reads the projection directly and stays
+  fully ranked), stamps "+N" **truncated, never rounded up** — a 36.7 gain prints +36 (gains never
+  overstate, the PUMBILITY-precision rule); distinct from the random ImproveTop50, and has its own
+  drawer preset) · *Hot Streak* = HotStreak (the
   seed-and-expand goal, spec in §Hot Streak below — the one category that never runs for
   null-Categories callers, and the one whose sections group by seed rather than by category). The
   Weekly category is dropped from the widget — the Weekly widget owns that board. Defaults per
@@ -55,8 +58,12 @@ re-roll in the body meta row. The page's vestigial `LevelOffset` UI is supersede
   a phone). The veto path above is untouched. `ChartClickContext` still carries the category —
   it is part of the render contract — but nothing reads it now.
 - **Shell extensions this widget introduced**: `WidgetDescriptor.DrawerPresets` (one add-drawer card
-  per pre-filled config, D10) and `ChartClickContext` (the OnChartClick payload — chart + optional
-  suggestion category; all widgets raise it).
+  per pre-filled config, D10), `ChartClickContext` (the OnChartClick payload — chart + optional
+  suggestion category; all widgets raise it), and `WidgetDescriptor.ShowRefresh` (2026-08-14): a
+  config-aware predicate the host consults before rendering the refresh action — **Hot Streak hides
+  its shuffle** because its content is deterministic (seeds newest-first, targets by similarity), and
+  a re-roll into the identical list is a lie. Pumbility Push keeps it, honestly, via the sampling
+  above.
 - **Phoenix 2**: supported; the old page-level P2 gate stays dead (D14). Field-tested 2026-08-14:
   the 272 P2 titles do **not** light Title Hunt up — none are difficulty- or skill-typed, so both of
   the goal's categories are structurally empty there (worse, the generic empty state told P2 players

--- a/docs/design/HomePageWidgets/suggested-charts.md
+++ b/docs/design/HomePageWidgets/suggested-charts.md
@@ -13,11 +13,18 @@ edit-mode only** (declutters browse — revisit if people complain); level confi
 scoring-level basis** toggle (`GetChartScoringLevelsQuery`, printed-level fallback); **shuffle**
 re-roll in the body meta row. The page's vestigial `LevelOffset` UI is superseded by the level modes.
 
-- **Goal bundles** (`SuggestedGoal` → engine categories): *Title Hunt* = PushLevel + SkillTitles ·
+- **Goal bundles** (`SuggestedGoal` → engine categories): *Title Hunt* = PushLevel + SkillTitles —
+  and on a mix whose title list holds **no difficulty titles** (Phoenix 2 today) the goal **silently
+  falls back to the PumbilityPush bundle** (owner, 2026-08-14: no explainer glyph). The fallback is
+  on-theme, not a shrug: a P2 "next title" *is* a PUMBILITY threshold, so the biggest gains are the
+  title path. The trigger derives from the title list itself (the `PhoenixDifficultyTitle` **type**,
+  the same emptiness condition the engine's PushLevel checks — not the "Difficulty" *category*, which
+  in P2 names its pumbility titles), so it self-heals if P2 ever ships difficulty titles ·
   *Score Push* = PushPGs + ImproveTop50 + RevisitOldScores · *Fill Gaps* = FillScores · *Pumbility
   Push* = PushPumbility (PR #149: the gain-ranked projected targets that moved off the Account Stats
-  widget — `ProjectPumbilityGainsQuery`, biggest overall-rating gain first, stamps "+N"; distinct from
-  the random ImproveTop50, and has its own drawer preset) · *Hot Streak* = HotStreak (the
+  widget — `ProjectPumbilityGainsQuery`, biggest overall-rating gain first, stamps "+N", **truncated,
+  never rounded up** — a 36.7 gain prints +36 (owner, 2026-08-14; gains never overstate, the
+  PUMBILITY-precision rule); distinct from the random ImproveTop50, and has its own drawer preset) · *Hot Streak* = HotStreak (the
   seed-and-expand goal, spec in §Hot Streak below — the one category that never runs for
   null-Categories callers, and the one whose sections group by seed rather than by category). The
   Weekly category is dropped from the widget — the Weekly widget owns that board. Defaults per
@@ -50,8 +57,10 @@ re-roll in the body meta row. The page's vestigial `LevelOffset` UI is supersede
 - **Shell extensions this widget introduced**: `WidgetDescriptor.DrawerPresets` (one add-drawer card
   per pre-filled config, D10) and `ChartClickContext` (the OnChartClick payload — chart + optional
   suggestion category; all widgets raise it).
-- **Phoenix 2**: supported; the 272 P2 titles (PR #128) should light Title Hunt up — verify at field
-  test, the old page-level P2 gate stays dead (D14).
+- **Phoenix 2**: supported; the old page-level P2 gate stays dead (D14). Field-tested 2026-08-14:
+  the 272 P2 titles do **not** light Title Hunt up — none are difficulty- or skill-typed, so both of
+  the goal's categories are structurally empty there (worse, the generic empty state told P2 players
+  to import scores they'd already imported). Hence the PumbilityPush fallback above.
 
 ---
 

--- a/docs/design/pumbility-levels.md
+++ b/docs/design/pumbility-levels.md
@@ -125,7 +125,8 @@ Three render surfaces consume the one rule:
    (`SignificantWin.Rank` carries the badge index, a new `PoolValue` the pool), rendered by
    `CommunityHighlightsWidget` and `RivalHighlightsFeed`. `PlayerHighlightSchema` bumps to v3 so
    pre-level summaries read as stale and regenerate on their next import (v2 did the same for
-   folder standings).
+   folder standings). Feed rows shortened 2026-08-14 (the feeds' short-form pass): the row is the
+   badge + rung name; "Reached …" and the pool value ride the tooltip.
 
 ## 6. Storage and mirroring (Slice 4)
 

--- a/docs/design/rivals.md
+++ b/docs/design/rivals.md
@@ -280,8 +280,10 @@ stayed unreachable in a component that had supported it all along.
 ### 3.7 Feeds
 
 Rivals page = rivals only, green marks clubmates. Community page = communities only, red marks
-rivals. Home widget = checkable, all three states live (D35–D36). Ghosts never appear (D30), and
-the empty state names what would fill it.
+rivals. Home widget = checkable — and its row states light **only when both audiences are on**
+(owner, 2026-08-14): on a single-audience board every row shares the one audience, so a marker
+everyone wears says nothing; the mixed board is where green/red/both disambiguate (D35–D36).
+Ghosts never appear (D30), and the empty state names what would fill it.
 
 ---
 


### PR DESCRIPTION
The six workshopped homepage fixes plus a same-day field-test round (workshop doc + decisions: https://claude.ai/code/artifact/8c0a34ae-8ac3-4893-9da4-98d7651e5f9e). Seventeen commits, docs first, i18n at the end of the original pass, per-item throughout.

## The original six

1. **Docs** — the design docs these changes invalidate, updated first.
2. **Highlights feed never pans sideways** — `overflow-y:auto` was forcing `overflow-x` to auto, so any nowrap caption longer than a 1-wide cell minted a horizontal scrollbar. The feed clips, prose wraps, narrow threshold 300→340px.
3. **Every earned title is feed-worthy** ("all titles are big titles") — the big/rare gate leaves `PlayerHighlightPolicy`, the capturer stops loading title-holder aggregations entirely, and Phoenix 2 pumbility ladders ([S]/[D]/[P.B]) roll up into one `PumbilityTitleSpan` win per pool — **feeds only**; the Discord card renders from the milestones and stays uncollapsed per the 2026-07-26 ruling. Default titles never announce. No schema bump: old rows stay renderable and age out inside the 30-day window.
4. **The feeds speak in chips** — both renderers take the strip cards' short-form rule (chip states the fact, sentence rides the hover); titles stand on their name with no rarity claim; spans compact ("[S] ADVANCED LV.6 → 9") via the boundary-safe `TitleSpans` helper.
5. **Title Hunt silently falls back to Pumbility Push on Phoenix 2** — both of its categories filter title types P2's list doesn't contain, so the goal was structurally empty (and its empty state told P2 players to import scores they'd already imported). The trigger derives from the title list, drift-pinned.
6. **The +N stamp truncates** — 36.7 stamped "+37"; now "+36". The sort was already gain-descending end to end — verified, untouched.
7. **Account Stats: weekly delta out, P2 level gem in** — the delta belongs to the Sessions page, and its history query leaves with it; the gem renders beside the glowy total (self-hides on 404 until the art is mirrored).
8. **Competitive Level graph drops no-data floor readings** — a never-played pool's ≤1 floor flatline was pinning the y-axis to ~0. Points ≤5 drop per pool; a pool with nothing valid draws no series and no ghost.
9. **i18n** — three retired keys leave all nine locales; "Cleared {0}" arrives in its ordinal slot per locale.

## Field-test round 1 (same day, owner screenshots)

- **Gem sits tight and bigger** — 34→44px, −8px into the hero gap (the art's transparent frame was adding to the hole).
- **Config panel shows the truth** — a follow-current (null-Mixes) Competitive Level widget displayed Phoenix checked while drawing Phoenix 2. The config dialog cascades the page's effective mix (named `CascadingValue` — `DynamicComponent` throws on undeclared dictionary params) and the panel mirrors the widget's own resolution.
- **Pumbility Push deals a fresh hand** — samples its dozen from the top-50 gains, re-ranked best-first; every load and shuffle is a different set of genuinely good picks. New `WidgetDescriptor.ShowRefresh` predicate hides the shuffle for Hot Streak, whose content is deterministic.
- **The graph waits out the first twenty passes** — history rows carry the mix's `PassCount`, so the per-date early-chaos gate needed no backfill: readings before 20 passes don't plot.
- **Rival feed charts open the details dialog** — the component never had a click contract; the /Rivals page now passes its existing `OpenChart`.
- **Feed polish** — level-up rows center badge + rung name as one unit; entries carry right padding so scores clear the audience band's edge; and **row markers light only on a mixed board** (both audiences on) — a marker every row wears says nothing.

## Verified

- Fast suites on the final tip: **3,530 / 162 / 928**, all green; Docker suites green in CI (Integration 3m38s, E2E 5m41s on build 1694).
- New coverage: policy roll-up/all-titles/default-title suppression, sampling + truncation pins, Title Hunt fallback, gem, graph floor + pass gate, feed chips + span label + click wiring, config-panel cascade; `TitleLists` drift pin fails the day P2 gains difficulty titles.

## Known adjacent gap (deliberately untouched)

The Discord bot's own goal→category map (`BotCommandSaga.CategoriesForGoal`) still points its titles goal at the title categories, so a P2-mix bot request returns empty — pre-existing; mirroring the fallback there is its own small decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)