### PR TITLE
fix(discord): /piu calc takes calories as a decimal

### DIFF
--- a/ScoreTracker/ScoreTracker.Communities/Application/BotCommandSaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/BotCommandSaga.cs
@@ -655,8 +655,11 @@ namespace ScoreTracker.Communities.Application
             var bads = ReadInt(interaction, "bads");
             var misses = ReadInt(interaction, "misses");
             var combo = ReadInt(interaction, "combo");
+            // Option values arrive as invariant strings from the bot adapter, so a decimal
+            // parses the same way whatever culture the host process runs under.
             double? calories = interaction.Options.TryGetValue("calories", out var calorieString) &&
-                               double.TryParse(calorieString, out var parsed)
+                               double.TryParse(calorieString, NumberStyles.Float, CultureInfo.InvariantCulture,
+                                   out var parsed)
                 ? parsed
                 : null;
 

--- a/ScoreTracker/ScoreTracker.Communities/Contracts/PiuCommandCatalog.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Contracts/PiuCommandCatalog.cs
@@ -196,8 +196,9 @@ namespace ScoreTracker.Communities.Contracts
                     Count("bads", "Bad count"),
                     Count("misses", "Miss count"),
                     Count("combo", "Max combo"),
+                    // A decimal option: the result screen's kcal readout carries a fraction.
                     new BotCommandOption("calories", "Calories burned (optional — estimates step count)",
-                        BotCommandOptionType.Integer, MinValue: 0)
+                        BotCommandOptionType.Number, MinValue: 0)
                 });
 
         private static BotCommandOption Count(string name, string description) =>

--- a/ScoreTracker/ScoreTracker.Data/Clients/DiscordCommandTranslator.cs
+++ b/ScoreTracker/ScoreTracker.Data/Clients/DiscordCommandTranslator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Discord;
 using Discord.WebSocket;
 using ScoreTracker.Domain.Records;
@@ -101,7 +102,7 @@ public static class DiscordCommandTranslator
             else
             {
                 foreach (var leaf in current)
-                    options[leaf.Name] = leaf.Value?.ToString() ?? string.Empty;
+                    options[leaf.Name] = ValueText(leaf.Value);
                 break;
             }
         }
@@ -127,7 +128,7 @@ public static class DiscordCommandTranslator
                 or ApplicationCommandOptionType.SubCommandGroup)
                 path.Add(option.Name);
             else if (!option.Focused)
-                options[option.Name] = option.Value?.ToString() ?? string.Empty;
+                options[option.Name] = ValueText(option.Value);
 
         return (path, options);
     }
@@ -180,7 +181,16 @@ public static class DiscordCommandTranslator
     private static ApplicationCommandOptionType MapType(BotCommandOptionType type) => type switch
     {
         BotCommandOptionType.Integer => ApplicationCommandOptionType.Integer,
+        BotCommandOptionType.Number => ApplicationCommandOptionType.Number,
         BotCommandOptionType.Boolean => ApplicationCommandOptionType.Boolean,
         _ => ApplicationCommandOptionType.String
     };
+
+    /// <summary>
+    ///     An option value as the culture-invariant string the handlers parse back. Discord
+    ///     hands numeric options over as boxed numbers, and a decimal must not pick up the
+    ///     host's separator on the way to a parse that expects the invariant one.
+    /// </summary>
+    private static string ValueText(object? value) =>
+        Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
 }

--- a/ScoreTracker/ScoreTracker.Domain/Records/BotCommandDefinition.cs
+++ b/ScoreTracker/ScoreTracker.Domain/Records/BotCommandDefinition.cs
@@ -1,11 +1,15 @@
 namespace ScoreTracker.Domain.Records;
 
-/// <summary>The provider-agnostic option kinds a bot command exposes.</summary>
+/// <summary>
+///     The provider-agnostic option kinds a bot command exposes. <see cref="Number" /> is a
+///     decimal — the client accepts a fractional value where <see cref="Integer" /> rejects one.
+/// </summary>
 public enum BotCommandOptionType
 {
     String,
     Integer,
-    Boolean
+    Boolean,
+    Number
 }
 
 /// <summary>

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/BotCommandSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/BotCommandSagaTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
@@ -73,6 +74,32 @@ public sealed class BotCommandSagaTests
         Assert.Contains("#LETTERGRADE|", reply.Text);
         Assert.Contains("#PLATE|", reply.Text);
         Assert.Contains("Lost to Greats", reply.Text);
+    }
+
+    [Fact]
+    public async Task CalcAcceptsDecimalCaloriesAndEstimatesStepsFromThem()
+    {
+        // The kcal readout carries a fraction. The bot adapter hands the option over as an
+        // invariant string, so the estimate must hold under a host culture whose decimal
+        // separator is a comma — a culture-sensitive parse there reads "62.1" as 621.
+        var previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+        try
+        {
+            var reply = await Saga().Handle(Invoke(new[] { "calc" }, new Dictionary<string, string>
+            {
+                ["perfects"] = "950", ["greats"] = "40", ["goods"] = "5",
+                ["bads"] = "3", ["misses"] = "2", ["combo"] = "900", ["calories"] = "62.1"
+            }), CancellationToken.None);
+
+            // 1,000 notes burn .0621 kcal per press, so 62.1 kcal is exactly 1,000 presses; a
+            // parse that dropped the fraction (62 → 998) or mangled it lands somewhere else.
+            Assert.Contains($"{1000d.ToString("N0")} Estimated Arrow Presses", reply.Text);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/DiscordCommandTranslatorTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/DiscordCommandTranslatorTests.cs
@@ -27,6 +27,11 @@ public sealed class DiscordCommandTranslatorTests
                     {
                         new BotCommandOption("count", "How many", BotCommandOptionType.Integer, MinValue: 1, MaxValue: 10)
                     }),
+                new BotSubCommand("calc", "Score a result screen",
+                    new[]
+                    {
+                        new BotCommandOption("calories", "Calories burned", BotCommandOptionType.Number, MinValue: 0)
+                    }),
                 new BotSubCommand("suggest", "Personal picks", new BotCommandOption[0], Ephemeral: true)
             },
             new[]
@@ -67,6 +72,8 @@ public sealed class DiscordCommandTranslatorTests
         var name = chart.Options.Single(o => o.Name == "name");
         var random = props.Options.Value.Single(o => o.Name == "random");
         var count = random.Options.Single(o => o.Name == "count");
+        var calc = props.Options.Value.Single(o => o.Name == "calc");
+        var calories = calc.Options.Single(o => o.Name == "calories");
 
         Assert.Equal(ApplicationCommandOptionType.String, name.Type);
         Assert.True(name.IsRequired);
@@ -74,6 +81,11 @@ public sealed class DiscordCommandTranslatorTests
         Assert.Equal(ApplicationCommandOptionType.Integer, count.Type);
         Assert.Equal(1, count.MinValue);
         Assert.Equal(10, count.MaxValue);
+        // A decimal option registers as Discord's Number kind — Integer would make the
+        // client reject a fractional value before it ever reached the handler.
+        Assert.Equal(ApplicationCommandOptionType.Number, calories.Type);
+        Assert.Equal(0, calories.MinValue);
+        Assert.False(calories.IsRequired);
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PiuCommandCatalogTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/PiuCommandCatalogTests.cs
@@ -1,14 +1,16 @@
 using System.Linq;
 using ScoreTracker.Communities.Contracts;
+using ScoreTracker.Domain.Records;
 using Xunit;
 
 namespace ScoreTracker.Tests.ApplicationTests;
 
 /// <summary>
-///     Pins the /piu command tree's choice lists: static-initialization order can silently
-///     null a choice field captured by an eager initializer, which registers on Discord as
-///     an option with no dropdown. Every declared choice list must survive with its
-///     entries.
+///     Pins the /piu command tree's declared shape. Choice lists: static-initialization order
+///     can silently null a choice field captured by an eager initializer, which registers on
+///     Discord as an option with no dropdown, so every declared list must survive with its
+///     entries. Option kinds: the client enforces them before the handler runs, so a numeric
+///     option declared with the wrong kind rejects valid input at the prompt.
 /// </summary>
 public sealed class PiuCommandCatalogTests
 {
@@ -25,5 +27,20 @@ public sealed class PiuCommandCatalogTests
         Assert.Equal(3, random.Options.Single(o => o.Name == "type").Choices!.Count);
         Assert.Equal(2, weekly.Options.Single(o => o.Name == "mix").Choices!.Count);
         Assert.Equal(9, weekly.Options.Single(o => o.Name == "language").Choices!.Count);
+    }
+
+    [Fact]
+    public void CalcTakesCaloriesAsADecimalAndEveryJudgmentCountAsAnInteger()
+    {
+        // The result screen's kcal readout carries a fraction, so the option must be the
+        // decimal kind — declared Integer, the client refuses "12.5" outright.
+        var calc = PiuCommandCatalog.Commands.Single().SubCommands.Single(s => s.Name == "calc");
+
+        var calories = calc.Options.Single(o => o.Name == "calories");
+        Assert.Equal(BotCommandOptionType.Number, calories.Type);
+        Assert.False(calories.Required);
+        Assert.Equal(0, calories.MinValue);
+        Assert.All(calc.Options.Where(o => o.Name != "calories"),
+            o => Assert.Equal(BotCommandOptionType.Integer, o.Type));
     }
 }


### PR DESCRIPTION
## What

`/piu calc`'s `calories` option now accepts a decimal (e.g. `12.5`). It was declared `Integer` in the command catalog, so the Discord client rejected a fractional kcal readout at the prompt — before the handler, which already parsed the value as a `double`, ever saw it.

## Why the fix is more than one line

The provider-agnostic option enum (`BotCommandOptionType`) had no decimal kind at all — `String` / `Integer` / `Boolean` — so the translator could only ever register the option as an integer field. Changes:

- `BotCommandOptionType` gains `Number`; `DiscordCommandTranslator` maps it to Discord's `ApplicationCommandOptionType.Number` (min/max bounds carry through as before).
- `PiuCommandCatalog` declares `calories` as `Number, MinValue: 0`.
- Option values now cross the bot adapter as **culture-invariant** strings, and the saga parses `calories` with `NumberStyles.Float` + `InvariantCulture`. With integers there was never a decimal separator to disagree about; a `12.5` boxed by Discord.Net must not pick up the host process's separator on the way to the parse. Existing option kinds are unaffected (`long`, `bool`, `string` stringify identically either way).

## Tests (fast suite, no Docker)

- `PiuCommandCatalogTests.CalcTakesCaloriesAsADecimalAndEveryJudgmentCountAsAnInteger` — pins the declaration that was wrong.
- `DiscordCommandTranslatorTests.ToPropertiesMapsOptionKindsRequirednessAndBounds` — a `Number` option registers as Discord's `Number` with its bound.
- `BotCommandSagaTests.CalcAcceptsDecimalCaloriesAndEstimatesStepsFromThem` — `62.1` kcal on a 1,000-note screen yields exactly 1,000 estimated presses, run under `de-DE` so a culture-sensitive parse (which reads `"62.1"` as 621) cannot come back.

The three touched classes and the architecture ratchets pass on a fresh Debug build.

## Reviewer note

The command tree is bulk-overwritten at bot startup, so the option flips to a decimal field on the next deploy; Discord clients may hold the old global command definition briefly. No manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
