### PR TITLE
fix(highlights): a folder debut needs the folder to be at your level

### DIFF
--- a/ScoreTracker/ScoreTracker.PlayerProgress/Application/HighlightCaptureSaga.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Application/HighlightCaptureSaga.cs
@@ -6,6 +6,7 @@ using ScoreTracker.Catalog.Contracts.Queries;
 using ScoreTracker.ChartIntelligence.Contracts.Queries;
 using ScoreTracker.Domain.Events;
 using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
 using ScoreTracker.Domain.SecondaryPorts;
 using ScoreTracker.PlayerProgress.Contracts;
 using ScoreTracker.PlayerProgress.Contracts.Events;
@@ -199,8 +200,7 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
         IDictionary<Guid, double> ScoringLevels,
         Dictionary<(ChartType Type, DifficultyLevel Level), int> FolderSizes,
         Dictionary<(ChartType Type, DifficultyLevel Level), int> FolderClears,
-        double SinglesCompetitive,
-        double DoublesCompetitive);
+        PlayerStatsRecord Stats);
 
     private async Task<List<ScoreHighlightWrite>> ComputeFlags(PlayerScoresUpdatedEvent e,
         Dictionary<Guid, HighlightFlags> flags, Dictionary<Guid, HighlightDetail> details,
@@ -337,9 +337,9 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
             .ToDictionary(x => x.ChartId, x => x.Rank);
         var scoringLevels = await _mediator.Send(new GetChartScoringLevelsQuery(e.Mix), cancellationToken);
 
-        // Competitive levels gate Score Quality (and are cheap to carry): a back-filled chart
-        // more than 5 levels under the player's competitive level for its type is noise, not a
-        // peer flag — the cohort is never even built for it.
+        // Competitive levels gate two flags: a chart more than 5 levels under the player's
+        // competitive level for its type never gets a peer cohort built at all, and a folder
+        // below that level debuts nothing.
         var stats = await _playerStats.GetStats(e.Mix, e.UserId, cancellationToken);
 
         // Folder totals and clears come from data already in hand — no extra queries.
@@ -349,8 +349,7 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
             .Where(b => !b.IsBroken && b.Score != null && charts.ContainsKey(b.ChartId))
             .GroupBy(b => (charts[b.ChartId].Type, charts[b.ChartId].Level))
             .ToDictionary(g => g.Key, g => g.Count());
-        return new CaptureData(charts, bests, top50, scoringLevels, folderSizes, folderClears,
-            stats.SinglesCompetitiveLevel, stats.DoublesCompetitiveLevel);
+        return new CaptureData(charts, bests, top50, scoringLevels, folderSizes, folderClears, stats);
     }
 
     private const int PerfectGameScore = 1_000_000;
@@ -388,7 +387,9 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
 
         // Owner call: below (competitive − 5) for the chart's type, peer comparison is noise
         // (a 23-competitive player back-filling S5s). Skip the whole folder — no cohort, no flag.
-        var competitive = folder.Type == ChartType.Single ? data.SinglesCompetitive : data.DoublesCompetitive;
+        var competitive = folder.Type == ChartType.Single
+            ? data.Stats.SinglesCompetitiveLevel
+            : data.Stats.DoublesCompetitiveLevel;
         if ((int)folder.Level < competitive - 5) return;
 
         var cohort = await GetCohortScores(e.Mix, e.UserId, folder.Type, folder.Level, competitive,
@@ -438,8 +439,15 @@ internal sealed class HighlightCaptureSaga : IConsumer<PlayerScoresUpdatedEvent>
                 flags[chartId] = flags.GetValueOrDefault(chartId) | HighlightFlags.FolderCompletion90;
 
         // Folder debut: the first 3 passes ever in this folder (S and D counted
-        // separately). A batch landing several at once debuts its top ones by noteworthy
-        // ordering; the ordinal (First/Second/Third) is the prior clear count plus place.
+        // separately), at or above the player's floored competitive level for the folder's
+        // discipline. Below that line a first pass is a back-fill of ground already held, not a
+        // debut — and it is the case that fires hardest, because the folders a player has never
+        // touched are the easy ones. Same bar the community and rival feeds apply to the same
+        // event, so a row cannot be marked here and withheld there.
+        //
+        // A batch landing several at once debuts its top ones by noteworthy ordering; the ordinal
+        // (First/Second/Third) is the prior clear count plus place.
+        if ((int)folder.Level < CompetitiveLevels.Floor(folder.Type, data.Stats)) return;
         var priorClears = clears - newPasses.Length;
         var debutSlots = 3 - priorClears;
         if (debutSlots <= 0) return;

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/HighlightFlags.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Contracts/HighlightFlags.cs
@@ -24,7 +24,10 @@ public enum HighlightFlags
     /// <summary>The batch raised Singles or Doubles competitive level and this score drove it.</summary>
     CompetitiveImprover = 16,
 
-    /// <summary>One of the first 3 passes ever in this (type, level) folder.</summary>
+    /// <summary>
+    ///     One of the first 3 passes ever in this (type, level) folder, the folder being at or
+    ///     above the player's floored competitive level for its discipline.
+    /// </summary>
     FolderDebut = 32,
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Domain/CompetitiveLevels.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Domain/CompetitiveLevels.cs
@@ -1,0 +1,28 @@
+using ScoreTracker.Domain.Records;
+using ScoreTracker.SharedKernel.Enums;
+
+namespace ScoreTracker.PlayerProgress.Domain;
+
+/// <summary>
+///     The competitive-level bar a (type, level) folder clears before a first pass in it counts
+///     as a debut rather than a back-fill.
+///     <para>
+///         One definition for both surfaces that ask — the 🆕 flag capture writes onto a session
+///         row, and the significant-win policy behind the community and rival feeds — so a debut
+///         cannot be marked on one and withheld by the other.
+///     </para>
+/// </summary>
+internal static class CompetitiveLevels
+{
+    /// <summary>
+    ///     The player's competitive level for a chart type, floored to a whole difficulty level.
+    ///     Co-Op has no competitive discipline of its own, so it reads the overall level.
+    /// </summary>
+    public static int Floor(ChartType type, PlayerStatsRecord stats) =>
+        (int)Math.Floor(type switch
+        {
+            ChartType.Single => stats.SinglesCompetitiveLevel,
+            ChartType.Double => stats.DoublesCompetitiveLevel,
+            _ => stats.CompetitiveLevel
+        });
+}

--- a/ScoreTracker/ScoreTracker.PlayerProgress/Domain/PlayerHighlightPolicy.cs
+++ b/ScoreTracker/ScoreTracker.PlayerProgress/Domain/PlayerHighlightPolicy.cs
@@ -214,21 +214,11 @@ internal static class PlayerHighlightPolicy
         // discipline — an early pass in a folder well below your skill isn't a community big win.
         if (change.Flags.HasFlag(HighlightFlags.FolderDebut)
             && change.Detail?.FolderDebutOrdinal is { } ordinal && ordinal <= FolderFirstMaxOrdinal
-            && (int)chart.Level >= FlooredCompetitiveLevel(chart.Type, stats))
+            && (int)chart.Level >= CompetitiveLevels.Floor(chart.Type, stats))
             return (PriorityFolderFirst, Win(WinKind.FolderFirst, chart, change.NewScore, rank: ordinal));
 
         return null;
     }
-
-    // A (type, level) folder is gated by the competitive level for its own discipline, falling back
-    // to the overall level for non-Singles/Doubles folders.
-    private static int FlooredCompetitiveLevel(ChartType type, PlayerStatsRecord stats) =>
-        (int)Math.Floor(type switch
-        {
-            ChartType.Single => stats.SinglesCompetitiveLevel,
-            ChartType.Double => stats.DoublesCompetitiveLevel,
-            _ => stats.CompetitiveLevel
-        });
 
     private static SignificantWin Win(WinKind kind, Chart chart, int? score, double? rarityShare = null,
         int? rank = null) =>

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/HighlightCaptureSagaTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/HighlightCaptureSagaTests.cs
@@ -142,8 +142,13 @@ public sealed class HighlightCaptureSagaTests
         // against. The row still exists — folder flags are type-agnostic and this one is a
         // folder debut — but it carries no percentile, and the page renders it in plain ink
         // rather than inventing a band for it.
+        //
+        // The overall competitive level is what a co-op folder's debut floor reads, so it is
+        // set at the chart's level here: below it there would be no debut, hence no row, and
+        // the test would pass for the wrong reason.
         var chart = new ChartBuilder().WithType(ChartType.CoOp).WithLevel(18).Build();
         var ctx = new HandlerContext();
+        ctx.GivenCompetitive(singles: 20, doubles: 20, overall: 18);
         ctx.GivenCharts(chart);
         ctx.GivenBest(chart, 910000);
 
@@ -380,6 +385,93 @@ public sealed class HighlightCaptureSagaTests
             It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
                 x.Flags.HasFlag(HighlightFlags.FolderDebut))),
             It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task FolderDebutIsSuppressedBelowFlooredCompetitiveLevel()
+    {
+        // Doubles competitive 24.5 floors to 24, so a first-ever pass in the D20 folder is a
+        // back-fill of ground already held rather than a debut.
+        var chart = new ChartBuilder().WithType(ChartType.Double).WithLevel(20).Build();
+        var others = Enumerable.Range(0, 9)
+            .Select(_ => new ChartBuilder().WithType(ChartType.Double).WithLevel(20).Build()).ToArray();
+        var ctx = new HandlerContext();
+        ctx.GivenCompetitive(singles: 24.5, doubles: 24.5);
+        ctx.GivenCharts(others.Append(chart).ToArray());
+        ctx.GivenBest(chart, 910000);
+
+        await ctx.Saga.Consume(ctx.Context(NewPassEvent(chart)));
+
+        ctx.Highlights.Verify(h => h.UpsertFlags(It.IsAny<MixEnum>(), It.IsAny<Guid>(),
+            It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
+                x.Flags.HasFlag(HighlightFlags.FolderDebut))),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task FolderDebutStillFlagsAtTheFlooredCompetitiveLevel()
+    {
+        // The cutoff is inclusive, and it floors: 24.5 competitive still debuts the D24 folder.
+        var chart = new ChartBuilder().WithType(ChartType.Double).WithLevel(24).Build();
+        var others = Enumerable.Range(0, 9)
+            .Select(_ => new ChartBuilder().WithType(ChartType.Double).WithLevel(24).Build()).ToArray();
+        var ctx = new HandlerContext();
+        ctx.GivenCompetitive(singles: 24.5, doubles: 24.5);
+        ctx.GivenCharts(others.Append(chart).ToArray());
+        ctx.GivenBest(chart, 910000);
+
+        await ctx.Saga.Consume(ctx.Context(NewPassEvent(chart)));
+
+        ctx.Highlights.Verify(h => h.UpsertFlags(MixEnum.Phoenix, UserId,
+            It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
+                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.FolderDebut)
+                && x.Detail != null && x.Detail.FolderDebutOrdinal == 1)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task FolderDebutIsGatedByTheCompetitiveLevelForItsOwnType()
+    {
+        // A Singles folder gates on Singles competitive level, not the higher Doubles one —
+        // matching PlayerHighlightPolicy, which reads the same helper.
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build();
+        var others = Enumerable.Range(0, 9)
+            .Select(_ => new ChartBuilder().WithType(ChartType.Single).WithLevel(20).Build()).ToArray();
+        var ctx = new HandlerContext();
+        ctx.GivenCompetitive(singles: 18, doubles: 26);
+        ctx.GivenCharts(others.Append(chart).ToArray());
+        ctx.GivenBest(chart, 910000);
+
+        await ctx.Saga.Consume(ctx.Context(NewPassEvent(chart)));
+
+        ctx.Highlights.Verify(h => h.UpsertFlags(MixEnum.Phoenix, UserId,
+            It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
+                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.FolderDebut))),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task FolderCompletionIsNotGatedByCompetitiveLevel()
+    {
+        // Only the debut carries the floor (owner call): finishing an easy folder is the
+        // achievement, so the pass that completes it stays marked however far below you play.
+        // Two-chart S15 folder, one already passed — completion AND a free debut slot, so the
+        // debut's absence here is the floor and nothing else.
+        var chart = new ChartBuilder().WithType(ChartType.Single).WithLevel(15).Build();
+        var other = new ChartBuilder().WithType(ChartType.Single).WithLevel(15).Build();
+        var ctx = new HandlerContext();
+        ctx.GivenCompetitive(singles: 24.5, doubles: 24.5);
+        ctx.GivenCharts(other, chart);
+        ctx.GivenBest(other, 920000);
+        ctx.GivenBest(chart, 910000);
+
+        await ctx.Saga.Consume(ctx.Context(NewPassEvent(chart)));
+
+        ctx.Highlights.Verify(h => h.UpsertFlags(MixEnum.Phoenix, UserId,
+            It.Is<IEnumerable<ScoreHighlightWrite>>(w => w.Any(x =>
+                x.ChartId == chart.Id && x.Flags.HasFlag(HighlightFlags.FolderCompletion90)
+                && !x.Flags.HasFlag(HighlightFlags.FolderDebut))),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -685,6 +777,17 @@ public sealed class HighlightCaptureSagaTests
                 new MemoryCache(new MemoryCacheOptions()), FakeDateTime.At(Now).Object,
                 Attempts.Object, OfficialPlacements.Object,
                 NullLogger<HighlightCaptureSaga>.Instance);
+        }
+
+        /// <summary>
+        ///     Overrides the default 20/20/20 competitive levels. Singles and Doubles are set
+        ///     separately because the folder gates read the one for the folder's own discipline.
+        /// </summary>
+        public void GivenCompetitive(double singles, double doubles, double overall = 20)
+        {
+            PlayerStats.Setup(p => p.GetStats(It.IsAny<MixEnum>(), UserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PlayerStatsRecord(UserId, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1,
+                    overall, singles, doubles));
         }
 
         public void GivenCharts(params Chart[] charts)

--- a/docs/design/discord-rich-score-notifications.md
+++ b/docs/design/discord-rich-score-notifications.md
@@ -598,8 +598,17 @@ card's CTA before it gets linked from other UI surfaces.
    heuristic: flag the improved side's rows whose score rating meets the old level; tune at
    implementation.
 6. 🆕 **Folder debut** — one of the **first 3 passes ever in a (type, level) folder**,
-   S23 and D23 counted separately (owner-added 2026-07-05). When one batch lands more than
-   3 passes in a brand-new folder, the top 3 by noteworthy ordering get the flag.
+   S23 and D23 counted separately (owner-added 2026-07-05), the folder sitting **at or above
+   the player's floored competitive level** for that discipline — the overall level for co-op,
+   which has no discipline of its own (owner, 2026-08-20). Below that line a first pass is a
+   back-fill of ground already held rather than a debut, and it was the loudest false positive
+   on the Sessions page: the folders a player has never touched are the easy ones, so the flag
+   fired *hardest* the further below their level they played. The community and rival feeds
+   already applied this bar to the same event; both sides now read one helper
+   (`CompetitiveLevels.Floor`) so a debut cannot be marked on one surface and withheld by the
+   other. The 📁 nearly-complete-folder flag is deliberately **not** floored — finishing an easy
+   folder is the achievement, not the pass. When one batch lands more than 3 passes in a
+   brand-new folder, the top 3 by noteworthy ordering get the flag.
 
 **Write-time capture, not read-time derivation** (supersedes the earlier read-time-badges
 design). PlayerProgress already consumes `PlayerScoresUpdatedEvent` to compute ratings,


### PR DESCRIPTION
Session rows were showing 🆕 folder debuts on charts well below the player's level. Asked to check what the highlight system gates on level-wise, the answer was: almost nothing.

## What the audit found

There were only **three** level gates in the whole highlight system:

| Gate | Where | What it covers |
|---|---|---|
| `level >= competitive − 5` | `HighlightCaptureSaga` | Score Quality / peer percentile only |
| `level >= 20` | `PlayerHighlightPolicy` | the community feed's Notable PG only |
| `level >= floor(competitive)` | `PlayerHighlightPolicy` | the community feed's Folder First only |

Everything else on a session row — 👑 top 50, 📁 nearly-complete, 🆕 debut, 🌐 official board, 🎯 attempts — was ungated. 🆕 is the loudest of those, because it fires *hardest* the further below your level you play: the folders you have never touched are the easy ones.

Note the asymmetry it created — folder debut **was** floored for the community and rival feeds, but not for the Sessions page the same player looks at.

## The change

`FlooredCompetitiveLevel` moves out of `PlayerHighlightPolicy` into a shared `CompetitiveLevels.Floor(ChartType, PlayerStatsRecord)`. Capture and the significant-win policy both read it, so a debut cannot be marked on one surface and withheld by the other.

Capture then floors the debut half of `FlagFolderCompletionAndDebut`:

```csharp
if ((int)folder.Level < CompetitiveLevels.Floor(folder.Type, data.Stats)) return;
```

Singles and Doubles gate on their own competitive level; co-op falls back to the overall one, which is why `CaptureData` now carries the whole `PlayerStatsRecord` instead of two projected doubles.

**📁 nearly-complete is deliberately left ungated** — finishing an easy folder is the achievement, not the pass.

The feed keeps its own gate rather than leaning on capture: `PlayerHighlightBackfillConsumer` re-classifies stored events, and rows captured before this deploy still carry the ungated flag.

## Tests

Four new capture-side tests: suppressed below the floor, still fires at it (inclusive, and it floors — 24.5 competitive debuts D24), gated by the folder's own discipline, and 📁 explicitly *not* floored. That last one uses a 2-chart folder with a free debut slot, so the debut's absence is the floor rather than the ordinal running out.

One existing test failed, correctly: `ACoOpChartCarriesNoPeerStanding` used a Co-Op 18 chart against the default competitive 20 and relied on an ungated debut to get a row written at all. Its context now sets the overall competitive to 18 so the debut still fires and the test keeps asserting its real point.

- `ScoreTracker.Tests` — **3809 passed**, 0 failed
- `ScoreTracker.Tests.Components` — **1014 passed**, 0 failed
- Integration and E2E not run locally (Docker); CI covers them.

## Not in this PR

Existing `ScoreHighlight` rows keep their ungated flag, so sessions from before the deploy still show 🆕 on low folders — consistent with write-time capture staying historically true, but it is most of what is visible today. Cleaning the back catalogue is a single `UPDATE` clearing bit 32 where `Level` is below the holder's floored competitive level for the type; happy to write it as a dry-run-default script if you want the history to read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
