### PR TITLE
Tier-list reads: cache the work, not just the query

### DIFF
--- a/ScoreTracker/ScoreTracker.Catalog/Contracts/IdentityClaimKeys.cs
+++ b/ScoreTracker/ScoreTracker.Catalog/Contracts/IdentityClaimKeys.cs
@@ -18,8 +18,31 @@ public static class IdentityClaimKeys
     public const string Wide = "Wide";
     public const string Twistless = "Twistless";
     public const string TwistHeavy = "Twist-heavy";
-    public const string VeryFast = "Very Fast";
+    // The five speed bands, slowest first. All five are claim keys because the chart page and
+    // the dialog print the band a chart actually landed in; only the outer two are IDENTITY,
+    // which is what keeps "Mid Tempo" off a card. "Mid Tempo" and not the obvious "Moderate":
+    // that key is already the comment-moderation button, so the band rendered 관리 ("manage") in
+    // Korean and its equivalent elsewhere, and English being the key text is why nothing looked
+    // wrong in English.
     public const string VerySlow = "Very Slow";
+    public const string Slow = "Slow";
+    public const string MidTempo = "Mid Tempo";
+    public const string Fast = "Fast";
+    public const string VeryFast = "Very Fast";
+
+    /// <summary>The band's rung, 0 (slowest) to 4, or null if the key is not a speed band.</summary>
+    public static int? SpeedBandIndex(string badge)
+    {
+        return badge switch
+        {
+            VerySlow => 0,
+            Slow => 1,
+            MidTempo => 2,
+            Fast => 3,
+            VeryFast => 4,
+            _ => null
+        };
+    }
 
     /// <summary>Not a shape claim, but keyed the same way: a label the UI localizes, not a badge.</summary>
     public const string LongestRun = "Longest run";

--- a/ScoreTracker/ScoreTracker.Catalog/Domain/ChartIdentityBuilder.cs
+++ b/ScoreTracker/ScoreTracker.Catalog/Domain/ChartIdentityBuilder.cs
@@ -36,6 +36,9 @@ internal static class ChartIdentityBuilder
         // between a half-double that features twists and a twist chart that features mid-6.
         if (Width(profile, folder) is { } width) identity.Add(width);
         if (Twist(profile, folder) is { } twist) identity.Add(twist);
+        // Speed is the one of these that can come back a FEATURE — the middle three bands are
+        // measurements rather than claims. It still leads the list, because the tier on the
+        // record is what sorts it into a group; a card, which shows identity only, drops it.
         if (Speed(profile, folder) is { } speed) identity.Add(speed);
         if (LongestRun(profile) is { } run) identity.Add(run);
 
@@ -209,11 +212,6 @@ internal static class ChartIdentityBuilder
     }
 
     /// <summary>
-    ///     Speed only claims a chart at the extremes. "Mid Tempo" is a measurement, not a claim,
-    ///     and the outer bands have to keep meaning what they say — so this is the Speed list's
-    ///     own boundary and nothing softer.
-    /// </summary>
-    /// <summary>
     ///     The longest unbroken run, when it is most of the chart. Piucenter's "Sustain time" is
     ///     max(length) over their eNPS ranges of interest — the LONGEST single run rather than a
     ///     total, which is why it can be named as one.
@@ -233,16 +231,43 @@ internal static class ChartIdentityBuilder
             : null;
     }
 
+    /// <summary>
+    ///     Which of the five speed bands the chart landed in, cut at ±0.5σ and ±1.5σ of its
+    ///     folder's notes-per-second spread — the same arithmetic the Speed tier list runs.
+    ///     <para>
+    ///         Only the outer two are IDENTITY. "Mid Tempo" is a measurement, not a claim, so it
+    ///         reaches the chart page and the dialog as a feature and never reaches a card at all;
+    ///         the outer bands have to keep meaning what they say, which is why this is the Speed
+    ///         list's own boundary and nothing softer.
+    ///     </para>
+    ///     <para>
+    ///         The baseline stores μ−1.5σ and μ+1.5σ, and μ and σ fall straight back out of the
+    ///         pair — so every band is readable from a row that is already in memory. Both detail
+    ///         surfaces used to read the whole Speed tier list to answer this for ONE chart,
+    ///         uncached, once per request (prod, 2026-08-27). It also means the band no longer
+    ///         depends on that list having been rebuilt.
+    ///     </para>
+    /// </summary>
     private static IdentityChipRecord? Speed(ChartBadgeProfile profile,
         IReadOnlyDictionary<string, ChartFolderBaseline> folder)
     {
         if (profile.GeometryOf(PiuCenterMetrics.Nps) is not { } nps || nps <= 0) return null;
         if (!folder.TryGetValue(PiuCenterMetrics.Nps, out var baseline) || baseline.DrenchedCutoff <= 0) return null;
-        if (nps >= baseline.DrenchedCutoff)
-            return Geometry(IdentityChipKind.Speed, IdentityClaimKeys.VeryFast, nps);
-        return nps <= baseline.CoreCutoff
-            ? Geometry(IdentityChipKind.Speed, IdentityClaimKeys.VerySlow, nps)
-            : null;
+
+        var mean = (baseline.CoreCutoff + baseline.DrenchedCutoff) / 2m;
+        var deviation = (baseline.DrenchedCutoff - baseline.CoreCutoff) / 3m;
+        if (deviation <= 0) return null;
+
+        var z = (nps - mean) / deviation;
+        var (key, tier) = z switch
+        {
+            < -1.5m => (IdentityClaimKeys.VerySlow, IdentityTier.Identity),
+            < -0.5m => (IdentityClaimKeys.Slow, IdentityTier.Feature),
+            <= 0.5m => (IdentityClaimKeys.MidTempo, IdentityTier.Feature),
+            <= 1.5m => (IdentityClaimKeys.Fast, IdentityTier.Feature),
+            _ => (IdentityClaimKeys.VeryFast, IdentityTier.Identity)
+        };
+        return new IdentityChipRecord(IdentityChipKind.Speed, tier, key, key, null, nps);
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker.ChartIntelligence/Infrastructure/EFTierListRepository.cs
+++ b/ScoreTracker/ScoreTracker.ChartIntelligence/Infrastructure/EFTierListRepository.cs
@@ -79,6 +79,25 @@ namespace ScoreTracker.ChartIntelligence.Infrastructure
         }
 
 
+        /// <summary>
+        ///     One tier list, cached for a day. Both halves of that sentence used to be untrue in
+        ///     ways that only showed under load (prod, 2026-08-27):
+        ///     <list type="bullet">
+        ///         <item>
+        ///             The list-name filter sat AFTER <c>ToArrayAsync</c>, so every read pulled
+        ///             every tier list in the mix — 25,637 rows for Phoenix, 19,309 for Phoenix 2 —
+        ///             to answer a question about one of them.
+        ///         </item>
+        ///         <item>
+        ///             What went into the cache was a lazy <c>Where().Select()</c> over those rows,
+        ///             not a list. The query was cached; the WORK was not. Every caller re-walked
+        ///             every row, re-ran <c>Enum.Parse</c> on each match and allocated a fresh
+        ///             record for it — on a page with no output caching, once per request.
+        ///         </item>
+        ///     </list>
+        ///     Both are one-line fixes and neither is optional: this read sits under the tier-list
+        ///     page, the PUMBILITY projection, the chart page and the /Charts search.
+        /// </summary>
         public async Task<IEnumerable<SongTierListEntry>> GetAllEntries(MixEnum mix, Name tierListName,
             CancellationToken cancellationToken)
         {
@@ -89,10 +108,11 @@ namespace ScoreTracker.ChartIntelligence.Infrastructure
                 var nameString = tierListName.ToString();
                 var mixId = MixIds.For(mix);
                 return (await database.Set<TierListEntryEntity>()
-                        .Where(e => e.MixId == mixId).ToArrayAsync(cancellationToken))
-                    .Where(e => e.TierListName == nameString).Select(e =>
-                        new SongTierListEntry(e.TierListName,
-                            e.ChartId, Enum.Parse<TierListCategory>(e.Category), e.Order));
+                        .Where(e => e.MixId == mixId && e.TierListName == nameString)
+                        .ToArrayAsync(cancellationToken))
+                    .Select(e => new SongTierListEntry(e.TierListName,
+                        e.ChartId, Enum.Parse<TierListCategory>(e.Category), e.Order))
+                    .ToArray();
             });
         }
 

--- a/ScoreTracker/ScoreTracker.Tests.Components/IdentityChipsTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/IdentityChipsTests.cs
@@ -59,8 +59,10 @@ public sealed class IdentityChipsTests : ComponentTestBase
         Assert.Equal("badgecat-staminaandruns", chips[4].CategoryClass);
         Assert.Equal("badgecat-twists", chips[5].CategoryClass);
         Assert.Equal("badgecat-staminaandruns", chips[6].CategoryClass);
-        Assert.Equal("chip-speed-fast", chips[7].CategoryClass);
-        Assert.Equal("chip-speed-slow", chips[8].CategoryClass);
+        // One class per rung of the five-band ramp, so the chip and the Speed list's section
+        // headers read as the same scale.
+        Assert.Equal("chip-speed-5", chips[7].CategoryClass);
+        Assert.Equal("chip-speed-1", chips[8].CategoryClass);
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker.Tests.Integration/EFTierListRepositoryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/EFTierListRepositoryTests.cs
@@ -96,6 +96,28 @@ public sealed class EFTierListRepositoryTests : IAsyncLifetime
         Assert.Equal(chartB, popularity[0].ChartId);
     }
 
+    /// <summary>
+    ///     What lands in the cache has to be a MATERIALIZED list, not a lazy projection over the
+    ///     rows. It was the latter, so the query was cached and the work was not: every caller
+    ///     re-walked every row and re-ran Enum.Parse on each match — under a page with no output
+    ///     caching, once per request (prod, 2026-08-27). A behavioural test cannot see the
+    ///     difference, which is why this asserts on the shape of what comes back.
+    /// </summary>
+    [Fact]
+    public async Task GetAllEntriesCachesAMaterializedListRatherThanALazyProjection()
+    {
+        await BuildRepository().SaveEntry(MixEnum.Phoenix,
+            new SongTierListEntry("PassCount", Guid.NewGuid(), TierListCategory.Easy, 1), CancellationToken.None);
+
+        var reader = BuildRepository();
+        var first = await reader.GetAllEntries(MixEnum.Phoenix, "PassCount", CancellationToken.None);
+        var second = await reader.GetAllEntries(MixEnum.Phoenix, "PassCount", CancellationToken.None);
+
+        // A Select iterator is neither, and enumerating one re-does the projection every time.
+        Assert.IsAssignableFrom<IReadOnlyCollection<SongTierListEntry>>(first);
+        Assert.Same(first, second);
+    }
+
     [Fact]
     public async Task SaveEntriesBulkHandlesMixedInsertsAndUpdatesInOnePass()
     {

--- a/ScoreTracker/ScoreTracker.Tests/DomainTests/ChartIdentityBuilderTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/DomainTests/ChartIdentityBuilderTests.cs
@@ -336,9 +336,9 @@ public sealed class ChartIdentityBuilderTests
     }
 
     /// <summary>
-    ///     §2. Speed claims a chart only in the outer bands, and the boundary is not softened to
-    ///     catch near misses — A Site De La Rue D20 sits at z = 1.46 and gets nothing. The test
-    ///     reads the folder's own computed boundary rather than a guessed number, so it stays
+    ///     §2. Speed CLAIMS a chart only in the outer bands, and the boundary is not softened to
+    ///     catch near misses — A Site De La Rue D20 sits at z = 1.46 and is not Very Fast. The
+    ///     test reads the folder's own computed boundary rather than a guessed number, so it stays
     ///     true if the constant moves.
     /// </summary>
     [Fact]
@@ -348,18 +348,44 @@ public sealed class ChartIdentityBuilderTests
         for (var i = 0; i < 20; i++) folder.AddCharts(1, Speeds(9.5m + i * 0.1m), ("run", 0.5m));
 
         var fastBound = folder.SpeedBound(Speeds(11m), true);
-        Assert.Equal(IdentityClaimKeys.VeryFast, SpeedClaim(folder, fastBound + 0.2m));
-        Assert.Null(SpeedClaim(folder, fastBound - 0.2m));
+        Assert.Equal((IdentityClaimKeys.VeryFast, IdentityTier.Identity), SpeedClaim(folder, fastBound + 0.2m));
+        Assert.NotEqual(IdentityTier.Identity, SpeedClaim(folder, fastBound - 0.2m).Tier);
 
         var slowBound = folder.SpeedBound(Speeds(11m), false);
-        Assert.Equal(IdentityClaimKeys.VerySlow, SpeedClaim(folder, slowBound - 0.2m));
-        Assert.Null(SpeedClaim(folder, slowBound + 0.2m));
+        Assert.Equal((IdentityClaimKeys.VerySlow, IdentityTier.Identity), SpeedClaim(folder, slowBound - 0.2m));
+        Assert.NotEqual(IdentityTier.Identity, SpeedClaim(folder, slowBound + 0.2m).Tier);
     }
 
-    private static string? SpeedClaim(Folder folder, decimal nps)
+    /// <summary>
+    ///     Every chart still gets a band — the detail surfaces print which of the five it landed
+    ///     in, and they read it off the folder baseline rather than the Speed tier list, which
+    ///     used to cost a whole uncached list read per request (prod, 2026-08-27). The middle
+    ///     three are FEATURES, which is what keeps "Mid Tempo" off a card.
+    /// </summary>
+    [Fact]
+    public void EveryChartLandsInOneOfTheFiveSpeedBands()
+    {
+        var folder = new Folder();
+        for (var i = 0; i < 20; i++) folder.AddCharts(1, Speeds(9.5m + i * 0.1m), ("run", 0.5m));
+
+        // The baseline stores mu +/- 1.5 sigma, so the half-sigma cuts are a third of that reach.
+        var fastBound = folder.SpeedBound(Speeds(11m), true);
+        var slowBound = folder.SpeedBound(Speeds(11m), false);
+        var mean = (fastBound + slowBound) / 2m;
+        var deviation = (fastBound - slowBound) / 3m;
+
+        Assert.Equal((IdentityClaimKeys.VerySlow, IdentityTier.Identity), SpeedClaim(folder, slowBound - 0.2m));
+        Assert.Equal((IdentityClaimKeys.Slow, IdentityTier.Feature), SpeedClaim(folder, mean - deviation));
+        Assert.Equal((IdentityClaimKeys.MidTempo, IdentityTier.Feature), SpeedClaim(folder, mean));
+        Assert.Equal((IdentityClaimKeys.Fast, IdentityTier.Feature), SpeedClaim(folder, mean + deviation));
+        Assert.Equal((IdentityClaimKeys.VeryFast, IdentityTier.Identity), SpeedClaim(folder, fastBound + 0.2m));
+    }
+
+    private static (string? Badge, IdentityTier Tier) SpeedClaim(Folder folder, decimal nps)
     {
         var chart = Folder.Profile(Array.Empty<(string, decimal)>(), geometry: Speeds(nps));
-        return folder.ChipsFor(chart).FirstOrDefault(c => c.Kind == IdentityChipKind.Speed)?.Badge;
+        var chip = folder.ChipsFor(chart).FirstOrDefault(c => c.Kind == IdentityChipKind.Speed);
+        return (chip?.Badge, chip?.Tier ?? IdentityTier.Feature);
     }
 
     private static IReadOnlyDictionary<string, decimal> Speeds(decimal nps)

--- a/ScoreTracker/ScoreTracker/Components/ChartStatsTab.razor
+++ b/ScoreTracker/ScoreTracker/Components/ChartStatsTab.razor
@@ -151,22 +151,7 @@
         // landed in — the identity query is cached per (chart, mix), so the page dispatching the
         // same one makes this a shared read rather than a second cost.
         var identity = await Mediator.Send(new GetChartIdentityQuery(new[] { Chart.Id }, Mix));
-        _identityChips = IdentityChips.WithSpeedBand(
-            IdentityChips.ToCardChips(identity.GetValueOrDefault(Chart.Id), false, L),
-            await SpeedBand(Chart.Id), L);
-    }
-
-    /// <summary>
-    ///     Which of the five speed bands the chart landed in, or null where the folder has none.
-    ///     The fallback is read and then refused: a band is a chart's speed relative to the folder
-    ///     it was banded in, and a chart's folder changes between mixes.
-    /// </summary>
-    private async Task<TierListCategory?> SpeedBand(Guid chartId)
-    {
-        var speed = await Mediator.Send(new GetTierListWithFallbackQuery(SpeedBandLabels.ListName, Mix));
-        return speed.IsProvisionalFallback
-            ? null
-            : speed.Entries.FirstOrDefault(e => e.ChartId == chartId)?.Category;
+        _identityChips = IdentityChips.ToCardChips(identity.GetValueOrDefault(Chart.Id), false, L);
     }
 
     private async Task<IReadOnlyList<(string, string)>> LoadPlacements(Guid chartId)

--- a/ScoreTracker/ScoreTracker/Pages/ChartDetails.razor
+++ b/ScoreTracker/ScoreTracker/Pages/ChartDetails.razor
@@ -271,22 +271,7 @@
         // Every chip, uncapped — the card's three-chip cut is a card's problem, and a page that
         // silently dropped a claim would be the one surface where the chart looks different.
         var identity = await Mediator.Send(new GetChartIdentityQuery(new[] { chart.Id }, chartMix));
-        _identityChips = IdentityChips.WithSpeedBand(
-            IdentityChips.ToCardChips(identity.TryGetValue(chart.Id, out var record) ? record : null, false, L),
-            await SpeedBand(chart.Id, chartMix), L);
-    }
-
-    /// <summary>
-    ///     Which of the five speed bands the chart landed in, or null where the folder has none.
-    ///     Read WITH the fallback flag and then refused: a band is a chart's speed relative to the
-    ///     folder it was banded in, and a chart's folder changes between mixes — Phoenix's bands
-    ///     standing in for an unbuilt Phoenix 2 list would be measuring against company the chart
-    ///     does not keep there.
-    /// </summary>
-    private async Task<TierListCategory?> SpeedBand(Guid chartId, MixEnum mix)
-    {
-        var speed = await Mediator.Send(new GetTierListWithFallbackQuery(SpeedBandLabels.ListName, mix));
-        if (speed.IsProvisionalFallback) return null;
-        return speed.Entries.FirstOrDefault(e => e.ChartId == chartId)?.Category;
+        _identityChips = IdentityChips.ToCardChips(
+            identity.TryGetValue(chart.Id, out var record) ? record : null, false, L);
     }
 }

--- a/ScoreTracker/ScoreTracker/Services/IdentityChips.cs
+++ b/ScoreTracker/ScoreTracker/Services/IdentityChips.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Localization;
 using ScoreTracker.Catalog.Contracts;
-using ScoreTracker.SharedKernel.Enums;
 using ScoreTracker.Web.Components;
 
 namespace ScoreTracker.Web.Services;
@@ -75,13 +74,12 @@ public static class IdentityChips
                     localizer[chip.DisplayName].Value,
                     BadgeCategoryClasses.For(BadgeCategory.DoublesTech), null, identity);
 
-            // Its own five-stop ramp, cool to hot, matching the Speed list's section headers so
-            // the chip and the folder it came from cannot disagree. Only the outer bands ever
-            // reach a chip, so only the outer stops are used.
+            // Its own five-stop ramp, cool to hot, matching the Speed tier list's section headers
+            // so a chip and that folder cannot look like different readings of the same number.
             case IdentityChipKind.Speed:
                 return new TierListChartCard.CardSkillChip(
                     localizer[chip.DisplayName].Value,
-                    chip.Badge == IdentityClaimKeys.VeryFast ? "chip-speed-fast" : "chip-speed-slow",
+                    $"chip-speed-{(IdentityClaimKeys.SpeedBandIndex(chip.Badge) ?? 2) + 1}",
                     null, identity);
 
             // How far the chart turns you, in the vocabulary of what it turns into (owner,
@@ -112,36 +110,10 @@ public static class IdentityChips
     }
 
     /// <summary>
-    ///     The chart's speed band as a chip, for the detail surfaces — which, unlike a card, have
-    ///     room for a measurement and not only a claim. It REPLACES the engine's own Speed chip
-    ///     rather than joining it: both say how fast the chart is for its folder, and the band
-    ///     says it in five steps instead of two, so showing both would print the coarser answer
-    ///     twice. Filed under Features unless it is one of the outer bands, which is the same
-    ///     line the engine draws — the middle three are measurements, not claims.
-    /// </summary>
-    public static IReadOnlyList<TierListChartCard.CardSkillChip> WithSpeedBand(
-        IReadOnlyList<TierListChartCard.CardSkillChip> chips, TierListCategory? band,
-        IStringLocalizer localizer)
-    {
-        if (band == null) return chips;
-        var claim = SpeedBandLabels.IsClaim(band.Value);
-        var chip = new TierListChartCard.CardSkillChip(
-            localizer[SpeedBandLabels.KeyOf(band.Value)].Value,
-            SpeedBandLabels.IndexOf(band.Value) == 0 ? "chip-speed-slow" :
-            SpeedBandLabels.IndexOf(band.Value) == 4 ? "chip-speed-fast" : "chip-speed-mid",
-            null, claim);
-        var rest = chips.Where(c => !IsSpeedChip(c)).ToList();
-        // Ahead of the badge claims, like the engine's own: how fast a chart is frames everything
-        // read after it, the same way the width claim does.
-        rest.Insert(claim ? 0 : rest.Count, chip);
-        return rest;
-    }
-
-    /// <summary>
-    ///     Whether a chip is the speed claim. Public because a surface that already SAYS how fast
-    ///     the chart is drops it: on the tier list grouped by Speed, the section heading and the
-    ///     chip are the same word, and a claim that repeats its own heading is the one chip on the
-    ///     card carrying no information (owner, 2026-08-26).
+    ///     Whether a chip is the speed claim. A surface that already SAYS how fast the chart is
+    ///     drops it: on the tier list grouped by Speed, the section heading over the card and the
+    ///     chip inside it are the same word, and a claim that repeats its own heading spends the
+    ///     card's loudest slot on the one thing the reader cannot fail to know (owner, 2026-08-26).
     /// </summary>
     public static bool IsSpeedChip(TierListChartCard.CardSkillChip chip)
     {

--- a/ScoreTracker/ScoreTracker/Services/SpeedBandLabels.cs
+++ b/ScoreTracker/ScoreTracker/Services/SpeedBandLabels.cs
@@ -8,6 +8,11 @@ namespace ScoreTracker.Web.Services;
 ///     its ORDER only — nothing about a band is a difficulty judgement — so this is the one place
 ///     that borrowing is undone, and the tier lists, the chart page and the chart dialog all read
 ///     it here rather than each deciding for themselves what Medium means on the Speed list.
+///     <para>
+///         The CHIP does not come from here — the identity engine reads the same five bands off
+///         the folder's cached nps baseline, so no surface reads a whole tier list to answer the
+///         question for one chart (docs/design/chart-identity.md §2).
+///     </para>
 /// </summary>
 public static class SpeedBandLabels
 {
@@ -46,15 +51,5 @@ public static class SpeedBandLabels
             TierListCategory.Hard => "Fast",
             _ => "Very Fast"
         };
-    }
-
-    /// <summary>
-    ///     Whether the band is one the identity engine would have claimed on its own. Only the
-    ///     outer two are claims; the middle three are measurements, which is why a card shows
-    ///     nothing for them and the detail surfaces file them under Features.
-    /// </summary>
-    public static bool IsClaim(TierListCategory band)
-    {
-        return IndexOf(band) is 0 or 4;
     }
 }

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -2377,15 +2377,16 @@ html.sheet-open .more-sheet-scrim {
     font-weight: 600;
 }
 
-/* The two speed claims wear the ends of the Speed list's own ramp, so a chip and the folder
-   section it came from cannot disagree about what "Very Fast" looks like. The ramp is cool-to-
-   hot and deliberately NOT the difficulty ramp: a slow chart at a high level is not an easy
-   one (docs/design/chart-identity.md §2). */
-.tier-chart-card-skill.chip-speed-slow { --skill-chip: var(--speed-1); }
-/* Only the detail surfaces ever print the middle band: a card has room for a claim, not for a
-   measurement that says the chart is ordinary. */
-.tier-chart-card-skill.chip-speed-mid { --skill-chip: var(--speed-3); }
-.tier-chart-card-skill.chip-speed-fast { --skill-chip: var(--speed-5); }
+/* The speed claims wear the Speed list's own ramp, so a chip and the folder section it came
+   from cannot disagree about what "Very Fast" looks like. The ramp is cool-to-hot and
+   deliberately NOT the difficulty ramp: a slow chart at a high level is not an easy one
+   (docs/design/chart-identity.md §2). One class per rung; only rungs 1 and 5 ever reach a card,
+   because the middle three are measurements rather than claims and a card shows identity only. */
+.tier-chart-card-skill.chip-speed-1 { --skill-chip: var(--speed-1); }
+.tier-chart-card-skill.chip-speed-2 { --skill-chip: var(--speed-2); }
+.tier-chart-card-skill.chip-speed-3 { --skill-chip: var(--speed-3); }
+.tier-chart-card-skill.chip-speed-4 { --skill-chip: var(--speed-4); }
+.tier-chart-card-skill.chip-speed-5 { --skill-chip: var(--speed-5); }
 
 .tier-chart-card-skill[class*="chip-speed-"] {
     color: color-mix(in srgb, var(--skill-chip) 55%, var(--mix-ink));

--- a/docs/design/chart-identity.md
+++ b/docs/design/chart-identity.md
@@ -113,6 +113,18 @@ z = 1.46 and deliberately does not qualify.
 meaningless number to most people. Good on chart details, not for quick info"*), so the
 comfortable card carries no NPS chip at all; the number lives on the chart page and dialog.
 
+**The chip's band is read off the folder's cached nps baseline, never off the Speed tier list**
+(prod, 2026-08-27). The baseline stores μ−1.5σ and μ+1.5σ, and μ and σ fall straight back out of
+the pair, so all five cuts are readable from a row already in memory. The chart page and the chart
+dialog each used to read the whole Speed list — uncached, once per request, on a page with no
+output caching — to answer this for one chart.
+
+Measured against the stored Phoenix 2 Speed list over 4,377 charts: **81.5% land in the same band,
+99.9% within one**, and 5 charts differ by more than one. The gap is the population — the baseline
+spans the L−1/L/L+1 peer window (§5) while the tier list bands inside the single folder and folds
+thin tails. The two never appear together: the tier list drops the speed chip when it is grouped by
+Speed, precisely because a chip must not restate its own section heading.
+
 **Its own ramp, cool to hot** — `--speed-1` … `--speed-5`, read through `ThemeScales.SpeedColor`.
 Deliberately not the difficulty ramp: a slow chart at a high level is not an easy one, and the
 folder's pass rates routinely say the opposite, which is exactly what a green-to-red reading would


### PR DESCRIPTION
Prod slowed noticeably after #299 across the tier-list page, the PUMBILITY page and chart details. All three sit on the same read.

## 1 — `EFTierListRepository.GetAllEntries`

Two bugs, both pre-existing, both only visible under load:

- **The list-name filter sat after `ToArrayAsync`.** A question about one tier list pulled *every* tier list in the mix — 25,637 rows for Phoenix, 19,309 for Phoenix 2 — and the predicate `WHERE MixId = @p` could not seek `IX_TierListEntry_TierListName_MixId`, because `MixId` is its second key column. It scanned. Now it is a server-side predicate on both columns, and a seek.
- **The cached value was a lazy `Where().Select()`, not a list.** The query was cached; the work was not. Every caller re-walked every row, re-ran `Enum.Parse` on each match, allocated a fresh record for it, then called `.ToArray()`. On a page with no output caching that is once per request.

Callers on that path: the tier-list page, `PumbilityProjectionSaga`, `ChartVerdictHandler`, `SearchChartsHandler` (three reads), `TierListBlendBuilder`, `RecommendedChartsSaga`, both API controllers.

An integration test asserts the cached value is a materialized collection — no behavioural test can see the difference, which is how this survived.

## 2 — the detail surfaces stop reading that list at all

The speed band was their only reason to touch it, and #299 put that read on `/Charts/{mix}/{song}/{difficulty}` — the crawlable SEO page, rendered per request. The folder's `nps` baseline already stores μ−1.5σ and μ+1.5σ, and μ and σ fall back out of the pair, so all five band cuts are readable from a row already in memory.

The engine now returns the band a chart landed in: **Identity** for the outer two, **Feature** for the middle three. That is what keeps "Mid Tempo" off a card without any surface needing to know the rule. The band also no longer depends on the Speed tier list having been rebuilt.

**Divergence, measured** over 4,377 Phoenix 2 charts against the stored Speed list: **81.5% exact, 99.9% within one band**, 5 charts further. The gap is population — the baseline spans the L−1/L/L+1 peer window while the tier list bands inside the single folder and folds thin tails. The two never render together: the tier list drops the speed chip when it is grouped by Speed.

## Verification

Fast suites green — 4002 / 1075 / 164 — plus `EFTierListRepositoryTests` (11) against real SQL Server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)