### PR TITLE
Mobile dashboard: widget reloads stop eating scroll gestures

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/SuggestedChartsWidgetTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/SuggestedChartsWidgetTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Bunit;
 using MediatR;
 using Microsoft.AspNetCore.Components;
@@ -283,5 +284,60 @@ public sealed class SuggestedChartsWidgetTests : ComponentTestBase
         Assert.Contains("Treat very old scores as unplayed", cut.Markup);
         Assert.Contains("Group by seed chart", cut.Markup);
         Assert.DoesNotContain("Around my level", cut.Markup);
+    }
+
+    [Fact]
+    public void FirstLoadShowsTheSpinnerBecauseThereIsNothingToKeep()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<GetRecommendedChartsQuery>(), It.IsAny<CancellationToken>()))
+            .Returns(new TaskCompletionSource<IEnumerable<ChartRecommendation>>().Task);
+
+        var cut = RenderComponent<SuggestedChartsWidget>(p => p
+            .Add(w => w.Widget, WidgetRecord())
+            .Add(w => w.EffectiveMix, MixEnum.Phoenix));
+
+        Assert.NotEmpty(cut.FindAll(".mud-progress-circular"));
+        Assert.Empty(cut.FindAll(".dash-refreshable"));
+    }
+
+    [Fact]
+    public void RefreshKeepsTheCurrentListDimmedInsteadOfTheSpinner()
+    {
+        // The stale-while-revalidate contract (§2.3): a reload renders what is already on
+        // screen, dimmed, and swaps in place — the spinner never returns after first load.
+        // On the auto-height mobile column the old spinner swap collapsed the page under a
+        // mid-scroll finger, which is the bug this pins shut.
+        SetUpRecommendations(HotStreakRec(_easyMatch.Id));
+        var cut = RenderComponent<SuggestedChartsWidget>(p => p
+            .Add(w => w.Widget, WidgetRecord())
+            .Add(w => w.EffectiveMix, MixEnum.Phoenix));
+        cut.WaitForAssertion(() => Assert.Contains("Achluoias", cut.Markup));
+
+        var pending = new TaskCompletionSource<IEnumerable<ChartRecommendation>>();
+        _mediator.Setup(m => m.Send(It.IsAny<GetRecommendedChartsQuery>(), It.IsAny<CancellationToken>()))
+            .Returns(pending.Task);
+        cut.SetParametersAndRender(p => p.Add(w => w.RefreshToken, 1));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotEmpty(cut.FindAll(".dash-stale"));
+            Assert.Contains("Achluoias", cut.Markup);
+            Assert.Empty(cut.FindAll(".mud-progress-circular"));
+        });
+
+        pending.SetResult(new[] { HotStreakRec(_hardMatch.Id) });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Uh-Heung", cut.Markup);
+            Assert.DoesNotContain("Achluoias", cut.Markup);
+            Assert.Empty(cut.FindAll(".dash-stale"));
+        });
+    }
+
+    private static HomePageWidgetRecord WidgetRecord()
+    {
+        return new HomePageWidgetRecord(Guid.NewGuid(), "suggested-charts", null, 0, "1x2",
+            WidgetConfigJson.Write(new SuggestedChartsConfig { Goal = SuggestedGoal.HotStreak }), 1);
     }
 }

--- a/ScoreTracker/ScoreTracker.Tests.Components/WidgetHostRefreshTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/WidgetHostRefreshTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using ScoreTracker.Catalog.Contracts.Queries;
+using ScoreTracker.Communities.Contracts;
+using ScoreTracker.Communities.Contracts.Queries;
+using ScoreTracker.Domain.Events;
+using ScoreTracker.Domain.Models;
+using ScoreTracker.Domain.Records;
+using ScoreTracker.Domain.SecondaryPorts;
+using ScoreTracker.HomePage.Contracts;
+using ScoreTracker.PlayerProgress.Contracts.Queries;
+using ScoreTracker.Rivals.Contracts;
+using ScoreTracker.Rivals.Contracts.Queries;
+using ScoreTracker.SharedKernel.Enums;
+using ScoreTracker.SharedKernel.Models;
+using ScoreTracker.WeeklyChallenge.Contracts;
+using ScoreTracker.WeeklyChallenge.Contracts.Queries;
+using ScoreTracker.Web.Components.HomeWidgets;
+using ScoreTracker.Web.Services.HomeDashboard;
+using ScoreTracker.Web.Services.UiNotifications;
+using Xunit;
+
+namespace ScoreTracker.Tests.Components;
+
+/// <summary>
+///     WidgetHost's auto-refresh machinery (owner, 2026-08-30): each widget subscribes only to
+///     the signal its data follows — import-terminal for score readers, recalculated stats for
+///     analysis readers — a burst of events coalesces into one reload, and a reload that lands
+///     mid-edit waits for Done. The reload itself is observable as the child re-sending its
+///     load query.
+/// </summary>
+public sealed class WidgetHostRefreshTests : ComponentTestBase
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly FakeUiHub _hub = new();
+    private readonly Guid _me = Guid.NewGuid();
+
+    public WidgetHostRefreshTests()
+    {
+        // Only this class publishes hub events, so the shortened window leaks nowhere; the
+        // real 2s would just slow these facts down.
+        WidgetHost.RefreshDebounce = TimeSpan.FromMilliseconds(40);
+
+        CurrentUser.SetupGet(c => c.IsLoggedIn).Returns(true);
+        CurrentUser.SetupGet(c => c.User)
+            .Returns(new User(_me, "Me", true, null, new Uri("https://piu.test/me.png"), null));
+
+        // Enough for the hosted widgets (Account Stats 1x1, Weekly 1x1) to render quietly —
+        // these facts assert on queries sent, not on widget markup.
+        _mediator.Setup(m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Stats());
+        _mediator.Setup(m => m.Send(It.IsAny<GetMyCommunitiesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CommunityOverviewRecord>());
+        _mediator.Setup(m => m.Send(It.IsAny<GetMyRivalsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RivalSubject>());
+        _mediator.Setup(m => m.Send(It.IsAny<GetWeeklyChartsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WeeklyTournamentChart>());
+        _mediator.Setup(m => m.Send(It.IsAny<GetWeeklyChartEntriesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WeeklyTournamentEntry>());
+        _mediator.Setup(m => m.Send(It.IsAny<GetChartsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Chart>());
+        Services.AddSingleton(_mediator.Object);
+        Services.AddSingleton<IUiNotificationHub>(_hub);
+        Services.AddSingleton(Mock.Of<IUserRepository>());
+        Services.AddScoped<CommunityGlowReader>();
+        Services.AddScoped<ChartCatalogCache>();
+        this.RenderInteractive();
+    }
+
+    private IRenderedComponent<WidgetHost> RenderHost(string typeId, bool editMode = false)
+    {
+        var widget = new HomePageWidgetRecord(Guid.NewGuid(), typeId, null, 0, "1x1", "{}", 1);
+        return RenderComponent<WidgetHost>(p => p
+            .Add(h => h.Widget, widget)
+            .Add(h => h.EffectiveMix, MixEnum.Phoenix)
+            .Add(h => h.EditMode, editMode));
+    }
+
+    private Task PublishStats()
+    {
+        return _hub.PublishAsync(UiTopics.User(_me),
+            new PlayerStatsUpdatedEvent(_me, Stats(), MixEnum.Phoenix));
+    }
+
+    private Task PublishImportStatus(string status)
+    {
+        return _hub.PublishAsync(UiTopics.User(_me),
+            new ImportStatusUpdatedEvent(_me, status, Array.Empty<RecordedPhoenixScore>(),
+                MixEnum.Phoenix));
+    }
+
+    private PlayerStatsRecord Stats()
+    {
+        return new PlayerStatsRecord(_me, 5000, 26, 100, 0, 0,
+            SkillRating: 868, SkillScore: 900000, SkillLevel: 21.5,
+            SinglesRating: 852, SinglesScore: 900000, SinglesLevel: 21.3,
+            DoublesRating: 774, DoublesScore: 880000, DoublesLevel: 19.9,
+            CompetitiveLevel: 20.61, SinglesCompetitiveLevel: 21.34, DoublesCompetitiveLevel: 19.87);
+    }
+
+    [Fact]
+    public void AnalysisWidgetsSubscribeToTheStatsSignalOnly()
+    {
+        RenderHost("pumbility");
+
+        var subscription = Assert.Single(_hub.Subscriptions);
+        Assert.Equal(UiTopics.User(_me), subscription.Topic);
+        Assert.Equal(typeof(PlayerStatsUpdatedEvent), subscription.MessageType);
+    }
+
+    [Fact]
+    public void ScoreWidgetsSubscribeToTheImportSignalOnly()
+    {
+        RenderHost("weekly-challenge");
+
+        var subscription = Assert.Single(_hub.Subscriptions);
+        Assert.Equal(UiTopics.User(_me), subscription.Topic);
+        Assert.Equal(typeof(ImportStatusUpdatedEvent), subscription.MessageType);
+    }
+
+    [Fact]
+    public async Task ABurstOfStatsEventsCoalescesIntoOneReload()
+    {
+        var cut = RenderHost("pumbility");
+        cut.WaitForAssertion(() => _mediator.Verify(
+            m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()), Times.Once));
+
+        await PublishStats();
+        await PublishStats();
+        await PublishStats();
+
+        cut.WaitForAssertion(() => _mediator.Verify(
+                m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(2)),
+            TimeSpan.FromSeconds(2));
+        // Nothing further trickles in after the window closes.
+        await Task.Delay(200);
+        _mediator.Verify(m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task ProgressTicksDoNotReloadOnlyTheTerminalStatusDoes()
+    {
+        var cut = RenderHost("weekly-challenge");
+        cut.WaitForAssertion(() => _mediator.Verify(
+            m => m.Send(It.IsAny<GetWeeklyChartsQuery>(), It.IsAny<CancellationToken>()), Times.Once));
+
+        await PublishImportStatus("Saving 12 of 300");
+        await Task.Delay(200);
+        _mediator.Verify(m => m.Send(It.IsAny<GetWeeklyChartsQuery>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        await PublishImportStatus("Charts finished saving");
+        cut.WaitForAssertion(() => _mediator.Verify(
+                m => m.Send(It.IsAny<GetWeeklyChartsQuery>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(2)),
+            TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task ARefreshLandingMidEditWaitsForDone()
+    {
+        var cut = RenderHost("pumbility", editMode: true);
+        cut.WaitForAssertion(() => _mediator.Verify(
+            m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()), Times.Once));
+
+        await PublishStats();
+        await Task.Delay(200);
+        // §2.3: nothing reloads the grid while it is being rearranged.
+        _mediator.Verify(m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        cut.SetParametersAndRender(p => p.Add(h => h.EditMode, false));
+
+        cut.WaitForAssertion(() => _mediator.Verify(
+                m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(2)),
+            TimeSpan.FromSeconds(2));
+    }
+
+    /// <summary>Records subscriptions and hands published messages straight to them.</summary>
+    private sealed class FakeUiHub : IUiNotificationHub
+    {
+        private readonly List<Entry> _subscriptions = new();
+
+        public IReadOnlyList<Entry> Subscriptions => _subscriptions;
+
+        public IDisposable Subscribe<T>(string topic, Func<T, Task> handler)
+        {
+            var entry = new Entry(topic, typeof(T), handler);
+            _subscriptions.Add(entry);
+            return new Unsubscriber(() => _subscriptions.Remove(entry));
+        }
+
+        public async Task PublishAsync<T>(string topic, T message)
+        {
+            foreach (var entry in _subscriptions.ToArray())
+                if (entry.Topic == topic && entry.MessageType == typeof(T))
+                    await ((Func<T, Task>)entry.Handler)(message);
+        }
+
+        internal sealed record Entry(string Topic, Type MessageType, object Handler);
+
+        private sealed class Unsubscriber : IDisposable
+        {
+            private readonly Action _dispose;
+
+            public Unsubscriber(Action dispose)
+            {
+                _dispose = dispose;
+            }
+
+            public void Dispose()
+            {
+                _dispose();
+            }
+        }
+    }
+}

--- a/ScoreTracker/ScoreTracker.Tests.Components/WidgetHostRefreshTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/WidgetHostRefreshTests.cs
@@ -1,13 +1,16 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Bunit;
 using MediatR;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using ScoreTracker.Catalog.Contracts.Queries;
+using ScoreTracker.PlayerProgress.Contracts;
+using ScoreTracker.ScoreLedger.Contracts.Queries;
 using ScoreTracker.Communities.Contracts;
 using ScoreTracker.Communities.Contracts.Queries;
 using ScoreTracker.Domain.Events;
@@ -38,40 +41,50 @@ namespace ScoreTracker.Tests.Components;
 /// </summary>
 public sealed class WidgetHostRefreshTests : ComponentTestBase
 {
-    private readonly Mock<IMediator> _mediator = new();
     private readonly FakeUiHub _hub = new();
     private readonly Guid _me = Guid.NewGuid();
+    private readonly TimeSpan _realDebounce = WidgetHost.RefreshDebounce;
 
     public WidgetHostRefreshTests()
     {
-        // Only this class publishes hub events, so the shortened window leaks nowhere; the
-        // real 2s would just slow these facts down.
+        // Shortened so these facts don't each wait two seconds; restored in Dispose because
+        // it is assembly-wide state and xUnit runs other classes in parallel with this one.
         WidgetHost.RefreshDebounce = TimeSpan.FromMilliseconds(40);
 
         CurrentUser.SetupGet(c => c.IsLoggedIn).Returns(true);
         CurrentUser.SetupGet(c => c.User)
             .Returns(new User(_me, "Me", true, null, new Uri("https://piu.test/me.png"), null));
 
+        // Setups go on the base's mediator, never a replacement registration: re-registering
+        // would shadow the base's own stubs (the scoring-level cache DifficultyBubble reads).
         // Enough for the hosted widgets (Account Stats 1x1, Weekly 1x1) to render quietly —
         // these facts assert on queries sent, not on widget markup.
-        _mediator.Setup(m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()))
+        Mediator.Setup(m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Stats());
-        _mediator.Setup(m => m.Send(It.IsAny<GetMyCommunitiesQuery>(), It.IsAny<CancellationToken>()))
+        Mediator.Setup(m => m.Send(It.IsAny<GetMyCommunitiesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CommunityOverviewRecord>());
-        _mediator.Setup(m => m.Send(It.IsAny<GetMyRivalsQuery>(), It.IsAny<CancellationToken>()))
+        Mediator.Setup(m => m.Send(It.IsAny<GetMyRivalsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<RivalSubject>());
-        _mediator.Setup(m => m.Send(It.IsAny<GetWeeklyChartsQuery>(), It.IsAny<CancellationToken>()))
+        Mediator.Setup(m => m.Send(It.IsAny<GetWeeklyChartsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<WeeklyTournamentChart>());
-        _mediator.Setup(m => m.Send(It.IsAny<GetWeeklyChartEntriesQuery>(), It.IsAny<CancellationToken>()))
+        Mediator.Setup(m => m.Send(It.IsAny<GetWeeklyChartEntriesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<WeeklyTournamentEntry>());
-        _mediator.Setup(m => m.Send(It.IsAny<GetChartsQuery>(), It.IsAny<CancellationToken>()))
+        Mediator.Setup(m => m.Send(It.IsAny<GetChartsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<Chart>());
-        Services.AddSingleton(_mediator.Object);
         Services.AddSingleton<IUiNotificationHub>(_hub);
         Services.AddSingleton(Mock.Of<IUserRepository>());
+        // Suggested Charts dates its rows; every registration has to land here, because the
+        // first render freezes the provider.
+        Services.AddSingleton(Mock.Of<IDateTimeOffsetAccessor>());
         Services.AddScoped<CommunityGlowReader>();
         Services.AddScoped<ChartCatalogCache>();
         this.RenderInteractive();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        WidgetHost.RefreshDebounce = _realDebounce;
+        base.Dispose(disposing);
     }
 
     private IRenderedComponent<WidgetHost> RenderHost(string typeId, bool editMode = false)
@@ -129,20 +142,20 @@ public sealed class WidgetHostRefreshTests : ComponentTestBase
     public async Task ABurstOfStatsEventsCoalescesIntoOneReload()
     {
         var cut = RenderHost("pumbility");
-        cut.WaitForAssertion(() => _mediator.Verify(
+        cut.WaitForAssertion(() => Mediator.Verify(
             m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()), Times.Once));
 
         await PublishStats();
         await PublishStats();
         await PublishStats();
 
-        cut.WaitForAssertion(() => _mediator.Verify(
+        cut.WaitForAssertion(() => Mediator.Verify(
                 m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()),
                 Times.Exactly(2)),
             TimeSpan.FromSeconds(2));
         // Nothing further trickles in after the window closes.
         await Task.Delay(200);
-        _mediator.Verify(m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()),
+        Mediator.Verify(m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()),
             Times.Exactly(2));
     }
 
@@ -150,16 +163,16 @@ public sealed class WidgetHostRefreshTests : ComponentTestBase
     public async Task ProgressTicksDoNotReloadOnlyTheTerminalStatusDoes()
     {
         var cut = RenderHost("weekly-challenge");
-        cut.WaitForAssertion(() => _mediator.Verify(
+        cut.WaitForAssertion(() => Mediator.Verify(
             m => m.Send(It.IsAny<GetWeeklyChartsQuery>(), It.IsAny<CancellationToken>()), Times.Once));
 
         await PublishImportStatus("Saving 12 of 300");
         await Task.Delay(200);
-        _mediator.Verify(m => m.Send(It.IsAny<GetWeeklyChartsQuery>(), It.IsAny<CancellationToken>()),
+        Mediator.Verify(m => m.Send(It.IsAny<GetWeeklyChartsQuery>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         await PublishImportStatus("Charts finished saving");
-        cut.WaitForAssertion(() => _mediator.Verify(
+        cut.WaitForAssertion(() => Mediator.Verify(
                 m => m.Send(It.IsAny<GetWeeklyChartsQuery>(), It.IsAny<CancellationToken>()),
                 Times.Exactly(2)),
             TimeSpan.FromSeconds(2));
@@ -169,24 +182,59 @@ public sealed class WidgetHostRefreshTests : ComponentTestBase
     public async Task ARefreshLandingMidEditWaitsForDone()
     {
         var cut = RenderHost("pumbility", editMode: true);
-        cut.WaitForAssertion(() => _mediator.Verify(
+        cut.WaitForAssertion(() => Mediator.Verify(
             m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()), Times.Once));
 
         await PublishStats();
         await Task.Delay(200);
-        // §2.3: nothing reloads the grid while it is being rearranged.
-        _mediator.Verify(m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()),
+        // Â§2.3: nothing reloads the grid while it is being rearranged.
+        Mediator.Verify(m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         cut.SetParametersAndRender(p => p.Add(h => h.EditMode, false));
 
-        cut.WaitForAssertion(() => _mediator.Verify(
+        cut.WaitForAssertion(() => Mediator.Verify(
                 m => m.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()),
                 Times.Exactly(2)),
             TimeSpan.FromSeconds(2));
     }
 
-    /// <summary>Records subscriptions and hands published messages straight to them.</summary>
+    [Fact]
+    public async Task AManualRefreshStandsDownAQueuedOneInsteadOfBeingReRolledByIt()
+    {
+        // Shuffle inside the debounce window used to be thrown away seconds later: the queued
+        // reload still fired and re-rolled the picks the player had just asked for. A wide
+        // window here so the click lands mid-flight rather than racing the timer.
+        WidgetHost.RefreshDebounce = TimeSpan.FromSeconds(1);
+        Mediator.Setup(m => m.Send(It.IsAny<GetRecommendedChartsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ChartRecommendation>());
+        Mediator.Setup(m => m.Send(It.IsAny<GetPhoenixRecordsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RecordedPhoenixScore>());
+        var cut = RenderHost("suggested-charts");
+        cut.WaitForAssertion(() => Mediator.Verify(
+            m => m.Send(It.IsAny<GetRecommendedChartsQuery>(), It.IsAny<CancellationToken>()), Times.Once));
+
+        var shuffle = cut.Find(".dash-head-action button");
+        await PublishStats();
+        await shuffle.ClickAsync(new MouseEventArgs());
+
+        // The shuffle reloaded once. Past the window, the auto-refresh it superseded must not
+        // add a second and throw the fresh picks away.
+        cut.WaitForAssertion(() => Mediator.Verify(
+                m => m.Send(It.IsAny<GetRecommendedChartsQuery>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(2)),
+            TimeSpan.FromSeconds(2));
+        await Task.Delay(1400);
+        Mediator.Verify(m => m.Send(It.IsAny<GetRecommendedChartsQuery>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    /// <summary>
+    ///     Records subscriptions and hands published messages straight to them. The real hub is
+    ///     not used here because these facts assert on WHICH signal a widget subscribed to,
+    ///     which only a recording double can answer — but delivery matches it, exceptions
+    ///     swallowed included, so nothing here passes on semantics production lacks.
+    /// </summary>
     private sealed class FakeUiHub : IUiNotificationHub
     {
         private readonly List<Entry> _subscriptions = new();
@@ -204,7 +252,15 @@ public sealed class WidgetHostRefreshTests : ComponentTestBase
         {
             foreach (var entry in _subscriptions.ToArray())
                 if (entry.Topic == topic && entry.MessageType == typeof(T))
-                    await ((Func<T, Task>)entry.Handler)(message);
+                    try
+                    {
+                        await ((Func<T, Task>)entry.Handler)(message);
+                    }
+                    catch
+                    {
+                        // Same best-effort delivery as UiNotificationHub: a torn-down circuit
+                        // must not sink the publish.
+                    }
         }
 
         internal sealed record Entry(string Topic, Type MessageType, object Handler);

--- a/ScoreTracker/ScoreTracker.Tests.Components/WidgetRefreshOnImportTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/WidgetRefreshOnImportTests.cs
@@ -3,28 +3,61 @@ using Xunit;
 
 namespace ScoreTracker.Tests.Components;
 
-// Pins which widgets the dashboard auto-refreshes after a score import — personal-score widgets in,
-// the recorder / importer / community feed out.
+// Pins which refresh signal each widget subscribes to (owner, 2026-08-30): a widget that reads
+// the scores themselves reloads the moment the import finishes saving, the few whose data IS the
+// post-batch analysis reload when the recalculated stats land, and the recorder / importer /
+// community feed subscribe to neither.
 public sealed class WidgetRefreshOnImportTests
 {
     [Theory]
-    [InlineData("competitive-level")]
-    [InlineData("pumbility")]
     [InlineData("weekly-challenge")]
     [InlineData("daily-step")]
+    [InlineData("folder-levels")]
     [InlineData("suggested-charts")]
     [InlineData("by-level-breakdown")]
-    public void PersonalScoreWidgetsRefreshOnImport(string typeId)
+    public void ScoreReadingWidgetsRefreshWhenTheImportFinishesSaving(string typeId)
     {
         Assert.True(WidgetRegistry.TryGet(typeId)!.RefreshOnScoreImport);
+    }
+
+    [Theory]
+    [InlineData("competitive-level")]
+    [InlineData("pumbility")]
+    // The straddler: most goals read scores, but Pumbility Push gains ride the projections.
+    [InlineData("suggested-charts")]
+    public void AnalysisReadingWidgetsRefreshWhenRecalculatedStatsLand(string typeId)
+    {
+        Assert.True(WidgetRegistry.TryGet(typeId)!.RefreshOnStatsUpdate);
+    }
+
+    [Theory]
+    [InlineData("competitive-level")]
+    [InlineData("pumbility")]
+    public void AnalysisOnlyWidgetsDoNotReloadAtImportTime(string typeId)
+    {
+        // Their data (level history, stored ratings) doesn't exist until the analysis runs —
+        // an import-time reload would refetch the old numbers and read as "nothing changed".
+        Assert.False(WidgetRegistry.TryGet(typeId)!.RefreshOnScoreImport);
+    }
+
+    [Theory]
+    [InlineData("weekly-challenge")]
+    [InlineData("daily-step")]
+    [InlineData("folder-levels")]
+    [InlineData("by-level-breakdown")]
+    public void ScoreOnlyWidgetsDoNotAlsoReloadWhenStatsLand(string typeId)
+    {
+        Assert.False(WidgetRegistry.TryGet(typeId)!.RefreshOnStatsUpdate);
     }
 
     [Theory]
     [InlineData("import-scores")]
     [InlineData("quick-record")]
     [InlineData("community-highlights")]
-    public void OtherWidgetsDoNotRefreshOnImport(string typeId)
+    public void OtherWidgetsSubscribeToNeitherSignal(string typeId)
     {
-        Assert.False(WidgetRegistry.TryGet(typeId)!.RefreshOnScoreImport);
+        var descriptor = WidgetRegistry.TryGet(typeId)!;
+        Assert.False(descriptor.RefreshOnScoreImport);
+        Assert.False(descriptor.RefreshOnStatsUpdate);
     }
 }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/ByLevelBreakdownWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/ByLevelBreakdownWidget.razor
@@ -13,14 +13,17 @@
    resolve through MixThemes (literals for ApexCharts); the pure math lives in
    ByLevelAggregator. *@
 
-@if (!_loaded)
+@if (!_hasContent)
 {
     <div class="dash-widget-message">
         <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary"/>
     </div>
 }
-else if (_kind == BreakdownChartKind.Empty)
+else
 {
+    <div class="dash-refreshable @(_loaded ? "" : "dash-stale")">
+    @if (_kind == BreakdownChartKind.Empty)
+    {
     <div class="dash-widget-message">
         <div>
             <MudText Typo="Typo.body2">@L["No scores in this range yet — record or import to see your breakdown."]</MudText>
@@ -54,6 +57,8 @@ else
                                  YValue="@(p => p.Y)"/>
             }
         </ApexChart>
+    </div>
+    }
     </div>
 }
 
@@ -90,6 +95,7 @@ else
     private sealed record RenderSeries(string Name, string Color, bool Dashed, string? Group, IReadOnlyList<Pt> Points);
 
     private bool _loaded;
+    private bool _hasContent;
     private string? _loadedFor;
     private string _renderKey = string.Empty;
     private BreakdownChartKind _kind = BreakdownChartKind.Empty;
@@ -110,6 +116,7 @@ else
             _series = new List<RenderSeries>();
             _bands = new();
             _loaded = true;
+            _hasContent = true;
             return;
         }
 
@@ -117,7 +124,9 @@ else
         var dataMix = config.Mix ?? EffectiveMix;
         var (records, scales) = await DataSource.Load(CurrentUser.User.Id, dataMix);
         var result = ByLevelAggregator.Aggregate(config, records, scales);
-        _kind = result.Kind;
+        // Local until the load completes — assigning it here would flip the empty/chart
+        // branch across the settings awaits while a reload is showing the current graph.
+        var kind = result.Kind;
 
         var themeMix = MixThemes.ResolveThemeMix(
             await UiSettings.GetSetting(MixThemes.OverrideSettingKey), await UiSettings.GetSelectedMix());
@@ -125,7 +134,7 @@ else
 
         _series = new List<RenderSeries>();
         _bands = new();
-        var isBars = _kind == BreakdownChartKind.StackedBars;
+        var isBars = kind == BreakdownChartKind.StackedBars;
         if (result.Kind != BreakdownChartKind.Empty)
         {
             foreach (var series in result.Series)
@@ -216,8 +225,10 @@ else
         _options.Yaxis = new List<YAxis> { yAxis };
         // Distribution (lines) leans on the hover tooltip; stacked bars keep the category legend.
         _options.Legend = new Legend { Show = isBars };
+        _kind = kind;
         _renderKey = signature;
         _loaded = true;
+        _hasContent = true;
     }
 
     private string TypeLabel(ChartType type) =>

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CommunityHighlightsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CommunityHighlightsWidget.razor
@@ -22,14 +22,17 @@
    other's overlap. Membership is the consent boundary on the community half; a row's chart opens
    the shared ChartDetailsDialog; "See more" deep-links a public player's Sessions page. *@
 
-@if (!_loaded)
+@if (!_hasContent)
 {
     <div class="dash-widget-message">
         <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary"/>
     </div>
 }
-else if (!_records.Any())
+else
 {
+    <div class="dash-refreshable @(_loaded ? "" : "dash-stale")">
+    @if (!_records.Any())
+    {
     <div class="dash-widget-message dash-ch-empty">
         <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Large"/>
         <MudText Typo="Typo.body2">@L["No big wins yet"]</MudText>
@@ -161,6 +164,8 @@ else
             </div>
         }
     </div>
+    }
+    </div>
 }
 
 @inject IMediator Mediator
@@ -184,6 +189,7 @@ else
     private bool UseStrips => SizePreset.TryParse(Widget.SizePreset) is { Columns: > 1, Rows: 1 };
 
     private bool _loaded;
+    private bool _hasContent;
     private string? _loadedFor;
     private IReadOnlyList<PlayerHighlightRecord> _records = Array.Empty<PlayerHighlightRecord>();
     private IReadOnlySet<Guid> _communityUserIds = new HashSet<Guid>();
@@ -219,6 +225,7 @@ else
             _records = Array.Empty<PlayerHighlightRecord>();
             _charts = new Dictionary<Guid, Chart>();
             _loaded = true;
+            _hasContent = true;
             return;
         }
 
@@ -248,6 +255,7 @@ else
         }
         _charts = await ChartCatalog.GetCharts(_mix);
         _loaded = true;
+        _hasContent = true;
     }
 
     private static string SessionsLink(PlayerHighlightRecord r) =>

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/CompetitiveLevelWidget.razor
@@ -14,14 +14,19 @@
    mixes dashed and dimmed (CVD-independent channel). Phoenix 2 lines start from the
    floor on purpose; the re-grind is the story. No Combined series (owner). *@
 
-@if (!_loaded)
+@if (!_hasContent)
 {
     <div class="dash-widget-message">
         <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary"/>
     </div>
 }
-else if (!_series.Any())
+else
 {
+    @* Reloads keep the current graph mounted (the @key only changes when a load
+       completes) and dim it until the new one swaps in — no spinner round trip. *@
+    <div class="dash-refreshable @(_loaded ? "" : "dash-stale")">
+    @if (!_series.Any())
+    {
     <div class="dash-widget-message">
         <div>
             <MudText Typo="Typo.body2">@L["Your level history starts tracking with your next import."]</MudText>
@@ -46,6 +51,8 @@ else
                                  OrderBy="e => e.X"/>
             }
         </ApexChart>
+    </div>
+    }
     </div>
 }
 
@@ -85,6 +92,7 @@ else
         IReadOnlyList<PlayerRatingRecord> Points, Func<PlayerRatingRecord, double> YSelector);
 
     private bool _loaded;
+    private bool _hasContent;
     private bool _useArea;
     private string _renderKey = string.Empty;
     private string? _loadedFor;
@@ -114,7 +122,9 @@ else
             ? DateTimeOffset.Now.AddMonths(-config.RangeMonths)
             : DateTimeOffset.MinValue;
 
-        _series = new List<LevelSeries>();
+        // Locals until the load completes: renders can interleave with the per-mix awaits,
+        // and a reload keeps showing the CURRENT graph (dimmed) until the swap is whole.
+        var series = new List<LevelSeries>();
         var dashes = new List<double>();
         var annotations = new List<AnnotationsYAxis>();
         foreach (var mix in mixes)
@@ -135,7 +145,7 @@ else
                 var inRange = valid.Where(h => h.Date >= cutoff).ToArray();
                 if (inRange.Length >= 2)
                 {
-                    _series.Add(new LevelSeries($"{typeLabel} · {mix}", color, dashed, inRange, level));
+                    series.Add(new LevelSeries($"{typeLabel} · {mix}", color, dashed, inRange, level));
                     dashes.Add(dashed ? 5 : 0);
                 }
                 else if (valid.Any())
@@ -159,24 +169,29 @@ else
 
         // Single-era boards get the gradient-area treatment (the "PIU Scores" look);
         // mixed-era keeps clean lines so the dashed history stays legible.
-        _useArea = _series.All(s => !s.Dashed);
+        var useArea = series.All(s => !s.Dashed);
 
         // Shared canvas (ApexChartTheming) + this chart's specifics on top.
-        _options = ApexChartTheming.BaseOptions<PlayerRatingRecord>(palette);
-        _options.Stroke = new Stroke { Curve = Curve.Smooth, DashArray = dashes, Width = 3 };
-        _options.Fill = _useArea
+        var options = ApexChartTheming.BaseOptions<PlayerRatingRecord>(palette);
+        options.Stroke = new Stroke { Curve = Curve.Smooth, DashArray = dashes, Width = 3 };
+        options.Fill = useArea
             ? new Fill
             {
                 Type = new List<FillType> { FillType.Gradient },
                 Gradient = new FillGradient { ShadeIntensity = 0, OpacityFrom = 0.20, OpacityTo = 0.0 }
             }
             : null;
-        _options.Yaxis = new List<YAxis> { new() { DecimalsInFloat = 2 } };
+        options.Yaxis = new List<YAxis> { new() { DecimalsInFloat = 2 } };
         // Unconditional: an empty yaxis list draws nothing, same as null — and the list is
         // filled inside AddType, which static flow analysis can't see through the closure.
-        _options.Annotations = new Annotations { Yaxis = annotations };
+        options.Annotations = new Annotations { Yaxis = annotations };
+
+        _series = series;
+        _useArea = useArea;
+        _options = options;
         _renderKey = signature;
         _loaded = true;
+        _hasContent = true;
     }
 
 }

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/DailyStepWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/DailyStepWidget.razor
@@ -107,7 +107,15 @@ else
     {
         <div class="dash-daily-controls">@HeaderControls</div>
     }
+    }
+    </div>
 
+    @* Both dialogs live outside the dash-refreshable wrapper: its dim is an opacity, which
+       fades a dialog and its scrim with the body and traps their z-index in this cell's
+       stacking context. They keep their own null guard — the record dialog's title reads the
+       chart, which is exactly what the wrapper's branch used to guarantee. *@
+    @if (_chart != null)
+    {
     <MudDialog @bind-Visible="_recordOpen" Options="RecordDialogOptions">
         <TitleContent>
             <MudText Typo="Typo.h6">@L["Record"] — @_chart.Song.Name</MudText>
@@ -133,7 +141,6 @@ else
                        Ascending="_isLimbo" OfficialUserIds="_officialUserIds"
                        CommunityUserIds="_communityIds" RivalUserIds="_rivalIds"/>
     }
-    </div>
 }
 
 @inject IMediator Mediator
@@ -262,13 +269,13 @@ else
                 chart = charts.GetValueOrDefault(board.ChartId);
             }
 
-            _chart = chart;
             if (chart != null)
             {
-                await ReloadBoardData();
+                await ReloadBoardData(chart);
             }
             else
             {
+                _chart = null;
                 _rows = new List<Row>();
                 _myRow = null;
                 _dialogEntries = Array.Empty<WeeklyTournamentEntry>();
@@ -282,12 +289,14 @@ else
         UpdateHeaderSlot();
     }
 
-    private async Task ReloadBoardData()
+    // Takes the chart rather than reading the field, and publishes it with the board it
+    // belongs to: assigning _chart up front would leave today's chart sitting above
+    // yesterday's rows for the length of these two queries (§2.3).
+    private async Task ReloadBoardData(Chart chart)
     {
-        if (_chart == null) return;
         var me = CurrentUser.User.Id;
         var entries = (await Mediator.Send(new GetDailyStepEntriesQuery(_mix)))
-            .Where(e => e.ChartId == _chart.Id).ToArray();
+            .Where(e => e.ChartId == chart.Id).ToArray();
         var users = (await Users.GetUsers(entries.Select(e => e.UserId).Distinct().ToArray()))
             .ToDictionary(u => u.Id);
 
@@ -296,10 +305,12 @@ else
                 ? entries.Where(e => !e.IsBroken).OrderBy(e => (int)e.Score)
                 : entries.OrderBy(e => e.IsBroken).ThenByDescending(e => (int)e.Score))
             .ToArray();
-        _rows = ordered.Select((e, i) => new Row(i + 1, e, users.GetValueOrDefault(e.UserId),
+        var rows = ordered.Select((e, i) => new Row(i + 1, e, users.GetValueOrDefault(e.UserId),
             e.UserId == me, _communityIds.Contains(e.UserId), _rivalIds.Contains(e.UserId))).ToList();
-        _myRow = _rows.FirstOrDefault(r => r.IsYou);
 
+        _chart = chart;
+        _rows = rows;
+        _myRow = rows.FirstOrDefault(r => r.IsYou);
         _dialogEntries = ordered.Select(e => new WeeklyTournamentEntry(e.UserId, e.ChartId, e.Score, e.Plate,
             e.IsBroken, null, e.CompetitiveLevel)).ToArray();
         _officialUserIds = entries.Where(e => e.Source == ChallengeEntrySource.Official).Select(e => e.UserId).ToHashSet();
@@ -317,13 +328,13 @@ else
 
     private async Task SubmitRecord()
     {
-        if (_recordScore == null) return;
+        if (_recordScore == null || _chart == null) return;
         _submitting = true;
         try
         {
             await Mediator.Send(new RecordDailyStepScoreCommand(_recordScore.Value, _recordPlate, _mix));
             _recordOpen = false;
-            await ReloadBoardData();
+            await ReloadBoardData(_chart);
         }
         finally
         {

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/DailyStepWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/DailyStepWidget.razor
@@ -18,14 +18,17 @@
    you sit past it. Your row glows blue, anyone from your communities glows green. Record and the full
    dialog ride the host's title-bar slot to keep the body all leaderboard. *@
 
-@if (!_loaded)
+@if (!_hasContent)
 {
     <div class="dash-widget-message">
         <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary"/>
     </div>
 }
-else if (_chart == null)
+else
 {
+    <div class="dash-refreshable @(_loaded ? "" : "dash-stale")">
+    @if (_chart == null)
+    {
     <div class="dash-widget-message">
         <MudText Typo="Typo.body2">@L["Today's Step posts at midnight."]</MudText>
     </div>
@@ -129,6 +132,8 @@ else
     <LeaderboardDialog @bind-Visible="_showLeaderboard" Chart="_chart" Entries="_dialogEntries"
                        Ascending="_isLimbo" OfficialUserIds="_officialUserIds"
                        CommunityUserIds="_communityIds" RivalUserIds="_rivalIds"/>
+    }
+    </div>
 }
 
 @inject IMediator Mediator
@@ -164,6 +169,7 @@ else
             "dash-lb-you", "dash-lb-community");
 
     private bool _loaded;
+    private bool _hasContent;
     private bool _tall;
     private string? _loadedFor;
     private Chart? _chart;
@@ -246,19 +252,30 @@ else
             _rivalIds = await CommunityGlow.GetMyRivalIds(_mix);
 
             var board = await Mediator.Send(new GetDailyStepQuery(_mix));
-            _chart = null;
-            _rows = new List<Row>();
-            _myRow = null;
-            _dialogEntries = Array.Empty<WeeklyTournamentEntry>();
+            // Resolve into a local first: clearing the fields up front would blank the current
+            // board across the awaits below, and a reload renders the current content (dimmed).
+            Chart? chart = null;
             if (board != null)
             {
                 _isLimbo = board.IsLimbo;
                 var charts = await ChartCatalog.GetCharts(_mix);
-                _chart = charts.TryGetValue(board.ChartId, out var chart) ? chart : null;
-                if (_chart != null) await ReloadBoardData();
+                chart = charts.GetValueOrDefault(board.ChartId);
+            }
+
+            _chart = chart;
+            if (chart != null)
+            {
+                await ReloadBoardData();
+            }
+            else
+            {
+                _rows = new List<Row>();
+                _myRow = null;
+                _dialogEntries = Array.Empty<WeeklyTournamentEntry>();
             }
 
             _loaded = true;
+            _hasContent = true;
         }
 
         // Every param set (not only on reload) so an EditMode toggle re-evaluates the header slot.

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/FolderLevelsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/FolderLevelsWidget.razor
@@ -15,14 +15,17 @@
    completion percent and a folder grade. Detail drops by size rather than re-laying out — 1x1 is
    one folder large, wider sizes stack rows, and the tier ticks appear once there is room for them. *@
 
-@if (!_loaded)
+@if (!_hasContent)
 {
     <div class="dash-widget-message">
         <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary"/>
     </div>
 }
-else if (_rows.Length == 0)
+else
 {
+    <div class="dash-refreshable @(_loaded ? "" : "dash-stale")">
+    @if (_rows.Length == 0)
+    {
     <div class="dash-widget-message">
         <MudText Typo="Typo.body2">@L["Pick the folders you're working on."]</MudText>
     </div>
@@ -71,6 +74,8 @@ else
             </div>
         }
     </div>
+    }
+    </div>
 }
 
 @code {
@@ -91,6 +96,7 @@ else
     private sealed record Row(FolderLevelRecord Level, IReadOnlyList<PhoenixLetterGrade> Grades);
 
     private bool _loaded;
+    private bool _hasContent;
     private bool _showTicks;
     private bool _showCounts;
     private string? _loadedFor;
@@ -123,6 +129,7 @@ else
         _hero = size is { Columns: 1, Rows: 1 } ? _rows.FirstOrDefault() : null;
         if (_hero != null) _rows = new[] { _hero };
         _loaded = true;
+        _hasContent = true;
     }
 
     // Live from the player's scores rather than the stored projection: the spectrum needs per-chart

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
@@ -16,14 +16,17 @@
    Pumbility Push goal. 1x2 and taller add your closest competitive matches; a pinned mix
    that differs from the current one shows as a pill in the title (via the header slot). *@
 
-@if (!_loaded)
+@if (!_hasContent)
 {
     <div class="dash-widget-message">
         <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary"/>
     </div>
 }
-else if (_stats == null || (_stats.SkillRating <= 0 && _stats.ClearCount == 0))
+else
 {
+    <div class="dash-refreshable @(_loaded ? "" : "dash-stale")">
+    @if (_stats == null || (_stats.SkillRating <= 0 && _stats.ClearCount == 0))
+    {
     <div class="dash-widget-message">
         <div>
             <MudText Typo="Typo.body2">@L["No scores yet — Pumbility starts with your first import."]</MudText>
@@ -105,6 +108,8 @@ else
             </div>
         }
     </div>
+    }
+    </div>
 }
 
 @inject IMediator Mediator
@@ -137,6 +142,7 @@ else
     private sealed record MatchRow(User User, double Level, bool IsCommunity);
 
     private bool _loaded;
+    private bool _hasContent;
     private bool _showMatches;
     private string? _loadedFor;
     private MixEnum _mix;
@@ -173,10 +179,13 @@ else
             var userId = CurrentUser.User.Id;
             _stats = await Mediator.Send(new GetPlayerStatsQuery(userId, _mix));
 
-            _matches = new List<MatchRow>();
+            // LoadMatches assigns _matches once, at its end — no pre-clear, so a reload
+            // keeps the current list on screen (dimmed) instead of flashing it empty.
             if (_showMatches && _stats != null) await LoadMatches(userId);
+            else _matches = new List<MatchRow>();
 
             _loaded = true;
+            _hasContent = true;
         }
 
         UpdateHeaderSlot(WidgetConfigJson.Read<PumbilityConfig>(Widget.ConfigJson).Mix);
@@ -190,7 +199,11 @@ else
             ChartType.Double => _stats!.DoublesCompetitiveLevel,
             _ => _stats!.CompetitiveLevel
         };
-        if (_myLevel <= 0) return;
+        if (_myLevel <= 0)
+        {
+            _matches = new List<MatchRow>();
+            return;
+        }
 
         // The cohort (in-range, nearest first) comes ranked from SQL; eligibility is applied
         // here where the community set and privacy flags live: public players, plus anyone

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/PumbilityWidget.razor
@@ -177,13 +177,17 @@ else
             _dimension = config.MatchDimension;
 
             var userId = CurrentUser.User.Id;
-            _stats = await Mediator.Send(new GetPlayerStatsQuery(userId, _mix));
+            var stats = await Mediator.Send(new GetPlayerStatsQuery(userId, _mix));
 
-            // LoadMatches assigns _matches once, at its end — no pre-clear, so a reload
-            // keeps the current list on screen (dimmed) instead of flashing it empty.
-            if (_showMatches && _stats != null) await LoadMatches(userId);
-            else _matches = new List<MatchRow>();
+            var myLevel = 0d;
+            var matches = new List<MatchRow>();
+            if (_showMatches && stats != null) (myLevel, matches) = await LoadMatches(userId, stats);
 
+            // All three land together, after the last await (§2.3): a new total above the
+            // previous mix's neighbours is a worse read than a moment of dimmed old numbers.
+            _stats = stats;
+            _myLevel = myLevel;
+            _matches = matches;
             _loaded = true;
             _hasContent = true;
         }
@@ -191,35 +195,32 @@ else
         UpdateHeaderSlot(WidgetConfigJson.Read<PumbilityConfig>(Widget.ConfigJson).Mix);
     }
 
-    private async Task LoadMatches(Guid userId)
+    private async Task<(double MyLevel, List<MatchRow> Matches)> LoadMatches(Guid userId,
+        PlayerStatsRecord stats)
     {
-        _myLevel = _dimension switch
+        var myLevel = _dimension switch
         {
-            ChartType.Single => _stats!.SinglesCompetitiveLevel,
-            ChartType.Double => _stats!.DoublesCompetitiveLevel,
-            _ => _stats!.CompetitiveLevel
+            ChartType.Single => stats.SinglesCompetitiveLevel,
+            ChartType.Double => stats.DoublesCompetitiveLevel,
+            _ => stats.CompetitiveLevel
         };
-        if (_myLevel <= 0)
-        {
-            _matches = new List<MatchRow>();
-            return;
-        }
+        if (myLevel <= 0) return (myLevel, new List<MatchRow>());
 
         // The cohort (in-range, nearest first) comes ranked from SQL; eligibility is applied
         // here where the community set and privacy flags live: public players, plus anyone
         // from your non-region communities (who also get the green glow), closest 25.
         var neighbors = await Mediator.Send(
-            new GetCompetitiveNeighborsQuery(_mix, _dimension, _myLevel, Range, CandidateFetch));
+            new GetCompetitiveNeighborsQuery(_mix, _dimension, myLevel, Range, CandidateFetch));
         var community = await CommunityGlow.GetMyCommunityMemberIds();
         var users = (await Users.GetUsers(neighbors.Select(n => n.UserId).Where(id => id != userId)))
             .ToDictionary(u => u.Id);
 
-        _matches = neighbors
+        return (myLevel, neighbors
             .Where(n => n.UserId != userId && users.ContainsKey(n.UserId))
             .Where(n => users[n.UserId].IsPublic || community.Contains(n.UserId))
             .Take(MatchCount)
             .Select(n => new MatchRow(users[n.UserId], n.CompetitiveLevel, community.Contains(n.UserId)))
-            .ToList();
+            .ToList());
     }
 
     private void UpdateHeaderSlot(MixEnum? pinned)

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsWidget.razor
@@ -142,9 +142,14 @@ else
             </div>
         }
     </div>
+    }
+    </div>
 
     @* The WSIP veto flow, widget-shaped: reason + notes + hide, straight into the same
-       per-category feedback store the engine already honors. *@
+       per-category feedback store the engine already honors. Deliberately OUTSIDE the
+       dash-refreshable wrapper: opacity applies to a whole subtree as a group, so a dialog
+       inside it fades with the reload — scrim and all — and the wrapper's stacking context
+       would scope the dialog's z-index to this cell, letting later grid cells paint over it. *@
     <MudDialog @bind-Visible="_showVeto">
         <TitleContent>
             <MudText Typo="Typo.h6">@L["Not a good suggestion?"]</MudText>
@@ -177,8 +182,6 @@ else
                        OnClick="SubmitVeto">@L["Submit"]</MudButton>
         </DialogActions>
     </MudDialog>
-    }
-    </div>
 }
 
 @inject IMediator Mediator
@@ -269,14 +272,17 @@ else
         // it — so the personalized reading of the Pass lens asks for that list (how many
         // players at your level hold each chart); Score personalizes through the projection as
         // before. One query per (type, level) folder in the results.
-        _lensTiers.Clear();
+        // Collected locally and published after the last folder query (§2.3) — clearing up
+        // front blanks every visible row's tier for the length of one query per folder.
+        var lensTiers = new Dictionary<Guid, TierListCategory>();
+        var tiersArePumbility = false;
         if (config.DifficultyLens != SuggestedDifficultyLens.None
             && categories.Contains(RecommendationCategory.FillScores))
         {
             var lens = config.DifficultyLens == SuggestedDifficultyLens.PassDifficulty
                 ? config.PersonalizedLens ? "PUMBILITY" : "Pass"
                 : "Score";
-            _tiersArePumbility = lens == "PUMBILITY";
+            tiersArePumbility = lens == "PUMBILITY";
             var fillCharts = recommendations
                 .Where(r => (string)r.Category == RecommendationCategories.FillScores
                             && charts.ContainsKey(r.ChartId))
@@ -286,9 +292,11 @@ else
                 var tierList = await Mediator.Send(new GetBlendedTierListQuery(folder.Key.Type,
                     folder.Key.Level, lens, config.PersonalizedLens, Mix: _mix));
                 foreach (var entry in tierList.Entries.Where(e => e.Category != TierListCategory.Unrecorded))
-                    _lensTiers[entry.ChartId] = entry.Category;
+                    lensTiers[entry.ChartId] = entry.Category;
             }
         }
+
+        PublishTiers(lensTiers, tiersArePumbility);
 
         // Category → section, in the goal's bundle order. The pushing-title category has
         // no fixed name (it's the title's own name), so it matches "everything else".
@@ -338,15 +346,17 @@ else
         // All of one load's recommendations share a seed source; any row tells us.
         UpdateFallbackPill(known.Any(r => r.SeedIsFallback));
 
-        _lensTiers.Clear();
-        _tiersArePumbility = true;
+        var lensTiers = new Dictionary<Guid, TierListCategory>();
         foreach (var folder in known.Select(r => charts[r.ChartId]).GroupBy(c => (c.Type, c.Level)))
         {
             var tierList = await Mediator.Send(new GetBlendedTierListQuery(folder.Key.Type,
                 folder.Key.Level, "PUMBILITY", Personalized: true, Mix: _mix));
             foreach (var entry in tierList.Entries.Where(e => e.Category != TierListCategory.Unrecorded))
-                _lensTiers[entry.ChartId] = entry.Category;
+                lensTiers[entry.ChartId] = entry.Category;
         }
+
+        // Before the rows are built — BuildHotStreakRow reads these — but after every query.
+        PublishTiers(lensTiers, true);
 
         _sections = new List<SuggestionSection>();
         if (groupBySeed)
@@ -507,6 +517,18 @@ else
     }
 
     private readonly Dictionary<Guid, TierListCategory> _lensTiers = new();
+
+    /// <summary>
+    ///     Swaps in a completed tier set. Both loads collect into a local across their
+    ///     per-folder queries and publish here, so the rows on screen never lose their tier
+    ///     column mid-reload (§2.3).
+    /// </summary>
+    private void PublishTiers(Dictionary<Guid, TierListCategory> tiers, bool arePumbility)
+    {
+        _lensTiers.Clear();
+        foreach (var (chartId, category) in tiers) _lensTiers[chartId] = category;
+        _tiersArePumbility = arePumbility;
+    }
 
     private SuggestionRow BuildRow(RecommendationCategory category, Chart chart, RecordedPhoenixScore? score,
         string stampedDetail)

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/SuggestedChartsWidget.razor
@@ -20,14 +20,19 @@
    Rows are the dash-targets vocabulary; multi-category goals get section captions
    inside the scroll. Shuffle re-runs the query so the engine re-rolls its picks. *@
 
-@if (!_loaded)
+@if (!_hasContent)
 {
     <div class="dash-widget-message">
         <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary"/>
     </div>
 }
-else if (!_sections.Any(s => s.Rows.Any()))
+else
 {
+    @* Reloads (shuffle, auto-refresh, config/mix changes) keep the current list on
+       screen, dimmed, and swap in place — never back through the spinner (§2.3). *@
+    <div class="dash-refreshable @(_loaded ? "" : "dash-stale")">
+    @if (!_sections.Any(s => s.Rows.Any()))
+    {
     <div class="dash-widget-message">
         <div>
             @if (_isHotStreak)
@@ -172,6 +177,8 @@ else
                        OnClick="SubmitVeto">@L["Submit"]</MudButton>
         </DialogActions>
     </MudDialog>
+    }
+    </div>
 }
 
 @inject IMediator Mediator
@@ -209,6 +216,7 @@ else
         string? CaptionDetail = null);
 
     private bool _loaded;
+    private bool _hasContent;
     private string? _loadedFor;
     private MixEnum _mix = MixEnum.Phoenix;
     private bool _useStrips;
@@ -220,6 +228,7 @@ else
         if (signature == _loadedFor) return;
         _loadedFor = signature;
         await LoadAsync();
+        _hasContent = true;
     }
 
     private async Task LoadAsync()

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/WeeklyWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/WeeklyWidget.razor
@@ -19,14 +19,17 @@
    hand-rolled bands. Unplayed charts are content, not emptiness; the row trophy opens
    the per-chart leaderboard dialog. *@
 
-@if (!_loaded)
+@if (!_hasContent)
 {
     <div class="dash-widget-message">
         <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary"/>
     </div>
 }
-else if (!_rows.Any())
+else
 {
+    <div class="dash-refreshable @(_loaded ? "" : "dash-stale")">
+    @if (!_rows.Any())
+    {
     <div class="dash-widget-message">
         <MudText Typo="Typo.body2">@L["New board soon."]</MudText>
     </div>
@@ -80,6 +83,8 @@ else
 
     <LeaderboardDialog @bind-Visible="_showLeaderboard" Chart="_leaderboardChart" Entries="_entries"
                        CommunityUserIds="_communityIds" RivalUserIds="_rivalIds"/>
+    }
+    </div>
 }
 
 @inject IMediator Mediator
@@ -100,6 +105,7 @@ else
     private sealed record BoardRow(Chart Chart, int? Place, int Total);
 
     private bool _loaded;
+    private bool _hasContent;
     private bool _wide;
     private string? _loadedFor;
     private List<BoardRow> _rows = new();
@@ -155,6 +161,7 @@ else
             .OrderBy(r => WeeklyBoardOrder.SortKey(r.Chart))
             .ToList();
         _loaded = true;
+        _hasContent = true;
     }
 
     private async Task<IReadOnlyList<Chart>> Filter(IReadOnlyDictionary<Guid, Chart> charts,

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/WeeklyWidget.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/WeeklyWidget.razor
@@ -81,10 +81,13 @@ else
         </div>
     </div>
 
-    <LeaderboardDialog @bind-Visible="_showLeaderboard" Chart="_leaderboardChart" Entries="_entries"
-                       CommunityUserIds="_communityIds" RivalUserIds="_rivalIds"/>
     }
     </div>
+
+    @* Outside the dash-refreshable wrapper: its dim is an opacity, which fades a dialog and
+       its scrim along with the body and traps their z-index in this cell's stacking context. *@
+    <LeaderboardDialog @bind-Visible="_showLeaderboard" Chart="_leaderboardChart" Entries="_entries"
+                       CommunityUserIds="_communityIds" RivalUserIds="_rivalIds"/>
 }
 
 @inject IMediator Mediator
@@ -144,7 +147,6 @@ else
         var filtered = await Filter(charts, known, config, _mix);
 
         var entries = (await Mediator.Send(new GetWeeklyChartEntriesQuery(Mix: _mix))).ToArray();
-        _entries = entries;
         var totals = entries.GroupBy(e => e.ChartId).ToDictionary(g => g.Key, g => g.Count());
         var mine = entries.Where(e => e.UserId == userId).Select(e => e.ChartId).ToHashSet();
         var placements = mine.Any()
@@ -154,6 +156,9 @@ else
 
         // Canonical Phoenix 1 board order, shared with the weekly page via WeeklyBoardOrder:
         // level descending, singles before doubles within a level, co-ops last (2-player last).
+        // Fields land together, after the last await (§2.3), so no render can catch this
+        // board's entries beside the previous board's rows.
+        _entries = entries;
         _rows = filtered
             .Select(c => new BoardRow(c,
                 placements.TryGetValue(c.Id, out var place) ? place : null,

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/WidgetHost.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/WidgetHost.razor
@@ -140,8 +140,16 @@
     private IDisposable? _importSubscription;
     private IDisposable? _statsSubscription;
     private bool _subscribed;
-    private CancellationTokenSource? _pendingRefresh;
     private bool _refreshDeferred;
+    private bool _disposed;
+
+    /// <summary>
+    ///     Which queued reload is still the current one. A pending debounce carries the
+    ///     generation it was queued at and stands down if anything has superseded it — another
+    ///     event, a manual refresh, or disposal. Every read and write happens on the renderer's
+    ///     dispatcher, so a plain int is sufficient and there is nothing to dispose.
+    /// </summary>
+    private int _refreshGeneration;
 
     /// <summary>
     ///     Refresh events arrive in clusters (per-mix recalcs; import-terminal then stats), and
@@ -189,6 +197,10 @@
 
     private void Refresh()
     {
+        // Any queued auto-reload is now moot: this IS the reload. Without standing them down,
+        // a shuffle pressed inside the debounce window is silently re-rolled seconds later and
+        // the picks the player just asked for are thrown away.
+        _refreshGeneration++;
         _refreshToken++;
         // Self-triggered change: OnParametersSet won't re-run, rebuild by hand.
         _parameters = BuildParameters();
@@ -211,45 +223,39 @@
             _statsSubscription = UiHub.Subscribe<PlayerStatsUpdatedEvent>(topic, OnPlayerStats);
     }
 
+    // The hub invokes handlers on the publisher's thread, so both of these hop to the
+    // dispatcher before touching anything: the queue is a check-then-assign, and two events
+    // arriving together off two threads could otherwise each install a live timer — defeating
+    // the coalescing in exactly the burst case it exists for. The hub swallows handler
+    // exceptions, so a torn-down circuit here is already harmless.
     private Task OnImportStatus(ImportStatusUpdatedEvent e)
     {
         // Only the terminal status — the per-chart progress ticks would thrash the reload.
         if (e.Status != "Charts finished saving") return Task.CompletedTask;
-        QueueRefresh();
-        return Task.CompletedTask;
+        return InvokeAsync(QueueRefresh);
     }
 
     private Task OnPlayerStats(PlayerStatsUpdatedEvent e)
     {
-        QueueRefresh();
-        return Task.CompletedTask;
+        return InvokeAsync(QueueRefresh);
     }
 
-    // Coalesce: restarting the delay folds every event inside the window into one reload.
+    // Coalesce: each event supersedes the last, so a burst folds into one reload.
     private void QueueRefresh()
     {
-        _pendingRefresh?.Cancel();
-        var cts = new CancellationTokenSource();
-        _pendingRefresh = cts;
-        _ = DebouncedRefresh(cts);
+        if (_disposed) return;
+        _ = DebouncedRefresh(++_refreshGeneration);
     }
 
-    private async Task DebouncedRefresh(CancellationTokenSource cts)
+    private async Task DebouncedRefresh(int generation)
     {
-        try
-        {
-            await Task.Delay(RefreshDebounce, cts.Token);
-        }
-        catch (TaskCanceledException)
-        {
-            return; // Superseded by a newer event, or the host was disposed.
-        }
-
+        await Task.Delay(RefreshDebounce);
         try
         {
             await InvokeAsync(() =>
             {
-                if (cts.IsCancellationRequested) return;
+                // Superseded while we waited — by a newer event, a manual refresh, or disposal.
+                if (_disposed || generation != _refreshGeneration) return;
                 if (EditMode)
                 {
                     _refreshDeferred = true;
@@ -273,9 +279,13 @@
 
     public void Dispose()
     {
-        _pendingRefresh?.Cancel();
+        // Unsubscribe BEFORE standing the queue down: the other order leaves a window where a
+        // late event queues a reload that nothing will ever supersede, which then wakes up
+        // pointing at a torn-down renderer.
         _importSubscription?.Dispose();
         _statsSubscription?.Dispose();
+        _disposed = true;
+        _refreshGeneration++;
     }
 
     private IDictionary<string, object> BuildParameters()

--- a/ScoreTracker/ScoreTracker/Components/HomeWidgets/WidgetHost.razor
+++ b/ScoreTracker/ScoreTracker/Components/HomeWidgets/WidgetHost.razor
@@ -139,7 +139,17 @@
     // Auto-refresh subscriptions (opt-in per descriptor); held for the host's lifetime.
     private IDisposable? _importSubscription;
     private IDisposable? _statsSubscription;
-    private bool _subscribedForImport;
+    private bool _subscribed;
+    private CancellationTokenSource? _pendingRefresh;
+    private bool _refreshDeferred;
+
+    /// <summary>
+    ///     Refresh events arrive in clusters (per-mix recalcs; import-terminal then stats), and
+    ///     every bump tears through a reload — one reload per cluster is enough. Two seconds is
+    ///     a judgment call, not a tuned constant: long enough to swallow a cluster, short enough
+    ///     that the refresh still reads as immediate. Settable for tests only.
+    /// </summary>
+    internal static TimeSpan RefreshDebounce { get; set; } = TimeSpan.FromSeconds(2);
 
     // Header slot (§2.3): opt-in title-bar real estate a widget can push a fragment into.
     private WidgetHeaderSlot _headerSlot = null!;
@@ -165,8 +175,16 @@
     protected override void OnParametersSet()
     {
         _descriptor = WidgetRegistry.TryGet(Widget.WidgetType);
+        // A refresh that landed mid-arrange waited (§2.3: nothing reloads the grid while it
+        // is being rearranged); leaving edit mode is when it cashes in.
+        if (!EditMode && _refreshDeferred)
+        {
+            _refreshDeferred = false;
+            _refreshToken++;
+        }
+
         _parameters = BuildParameters();
-        EnsureImportRefreshSubscription();
+        EnsureRefreshSubscriptions();
     }
 
     private void Refresh()
@@ -176,29 +194,75 @@
         _parameters = BuildParameters();
     }
 
-    // Owner "fire on both": a personal-score widget reloads after the viewer's import lands —
-    // once when the scores finish saving, and again when the derived rating settles — so
-    // score-based and rating-based widgets are each current. Routed by user topic, so only this
-    // viewer's import triggers it.
-    private void EnsureImportRefreshSubscription()
+    // Two auto-refresh signals, each opt-in per descriptor (owner, 2026-08-30): a widget that
+    // reads the scores themselves reloads the moment the import finishes saving; the few whose
+    // data IS the post-batch analysis (stored ratings, level history, projection-fed gains)
+    // reload when that lands instead. Routed by user topic, so only this viewer's import
+    // triggers it.
+    private void EnsureRefreshSubscriptions()
     {
-        if (_subscribedForImport || _descriptor?.RefreshOnScoreImport != true || !CurrentUser.IsLoggedIn) return;
-        _subscribedForImport = true;
+        if (_subscribed || _descriptor == null || !CurrentUser.IsLoggedIn) return;
+        if (!_descriptor.RefreshOnScoreImport && !_descriptor.RefreshOnStatsUpdate) return;
+        _subscribed = true;
         var topic = UiTopics.User(CurrentUser.User.Id);
-        _importSubscription = UiHub.Subscribe<ImportStatusUpdatedEvent>(topic, OnImportStatus);
-        _statsSubscription = UiHub.Subscribe<PlayerStatsUpdatedEvent>(topic, OnPlayerStats);
+        if (_descriptor.RefreshOnScoreImport)
+            _importSubscription = UiHub.Subscribe<ImportStatusUpdatedEvent>(topic, OnImportStatus);
+        if (_descriptor.RefreshOnStatsUpdate)
+            _statsSubscription = UiHub.Subscribe<PlayerStatsUpdatedEvent>(topic, OnPlayerStats);
     }
 
     private Task OnImportStatus(ImportStatusUpdatedEvent e)
     {
         // Only the terminal status — the per-chart progress ticks would thrash the reload.
         if (e.Status != "Charts finished saving") return Task.CompletedTask;
-        return InvokeAsync(BumpRefresh);
+        QueueRefresh();
+        return Task.CompletedTask;
     }
 
     private Task OnPlayerStats(PlayerStatsUpdatedEvent e)
     {
-        return InvokeAsync(BumpRefresh);
+        QueueRefresh();
+        return Task.CompletedTask;
+    }
+
+    // Coalesce: restarting the delay folds every event inside the window into one reload.
+    private void QueueRefresh()
+    {
+        _pendingRefresh?.Cancel();
+        var cts = new CancellationTokenSource();
+        _pendingRefresh = cts;
+        _ = DebouncedRefresh(cts);
+    }
+
+    private async Task DebouncedRefresh(CancellationTokenSource cts)
+    {
+        try
+        {
+            await Task.Delay(RefreshDebounce, cts.Token);
+        }
+        catch (TaskCanceledException)
+        {
+            return; // Superseded by a newer event, or the host was disposed.
+        }
+
+        try
+        {
+            await InvokeAsync(() =>
+            {
+                if (cts.IsCancellationRequested) return;
+                if (EditMode)
+                {
+                    _refreshDeferred = true;
+                    return;
+                }
+
+                BumpRefresh();
+            });
+        }
+        catch (ObjectDisposedException)
+        {
+            // Raced the circuit's teardown — nothing left to refresh.
+        }
     }
 
     private void BumpRefresh()
@@ -209,6 +273,7 @@
 
     public void Dispose()
     {
+        _pendingRefresh?.Cancel();
         _importSubscription?.Dispose();
         _statsSubscription?.Dispose();
     }

--- a/ScoreTracker/ScoreTracker/Services/HomeDashboard/WidgetDescriptor.cs
+++ b/ScoreTracker/ScoreTracker/Services/HomeDashboard/WidgetDescriptor.cs
@@ -83,9 +83,14 @@ public sealed record WidgetDescriptor(
     // stays with the content. TitleKey is the button's localized tooltip.
     string? RefreshIcon = null,
     string? RefreshTitleKey = null,
-    // When true, the host auto-bumps RefreshToken after the viewer's score import lands, so
-    // personal-score widgets reflect the new scores/rating without a manual refresh.
+    // When true, the host auto-bumps RefreshToken the moment the viewer's score import
+    // finishes saving — for widgets that read the scores themselves (owner, 2026-08-30:
+    // refresh rides the IMPORT; the post-batch analysis is a separate, later signal).
     bool RefreshOnScoreImport = false,
+    // When true, the host auto-bumps RefreshToken when the viewer's recalculated stats
+    // land (~2 minutes after the batch settles) — only for the few widgets whose data IS
+    // that analysis: stored ratings, competitive-level history, projection-fed gains.
+    bool RefreshOnStatsUpdate = false,
     // Optional config-aware visibility for the refresh action: some goals of a type are
     // deterministic, and a shuffle that re-rolls into the identical list is a lie. Null =
     // always shown when RefreshIcon is set.

--- a/ScoreTracker/ScoreTracker/Services/HomeDashboard/WidgetRegistry.cs
+++ b/ScoreTracker/ScoreTracker/Services/HomeDashboard/WidgetRegistry.cs
@@ -27,7 +27,9 @@ public static class WidgetRegistry
             typeof(CompetitiveLevelWidget),
             typeof(CompetitiveLevelConfigPanel),
             typeof(CompetitiveLevelConfig),
-            RefreshOnScoreImport: true),
+            // History rows are written by the post-batch analysis, not the import itself —
+            // an import-time reload would refetch before the new point exists.
+            RefreshOnStatsUpdate: true),
         // TypeId stays "pumbility" (public export vocabulary, never renamed) though the
         // widget is now Account Stats. 1x2+ adds the closest-competitive-matches list.
         new("pumbility",
@@ -41,7 +43,9 @@ public static class WidgetRegistry
             typeof(PumbilityWidget),
             typeof(PumbilityConfigPanel),
             typeof(PumbilityConfig),
-            RefreshOnScoreImport: true),
+            // Everything here is the stored PlayerStats record — it only changes when the
+            // post-batch analysis lands, so that is the refresh signal.
+            RefreshOnStatsUpdate: true),
         new("weekly-challenge",
             "Weekly Charts",
             "This week's board and your placements.",
@@ -189,7 +193,10 @@ public static class WidgetRegistry
             // inherits that sampling on Phoenix 2.
             ShowRefresh: json =>
                 WidgetConfigJson.Read<SuggestedChartsConfig>(json).Goal != SuggestedGoal.HotStreak,
-            RefreshOnScoreImport: true),
+            // The straddler: most goals read the scores (import-time), but Pumbility Push
+            // gains ride the projections the post-batch analysis feeds — so both signals.
+            RefreshOnScoreImport: true,
+            RefreshOnStatsUpdate: true),
         new("by-level-breakdown",
             "By-Level Breakdown",
             "One configurable graph of your scores, grades, plates, or clears by level.",

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -2773,6 +2773,22 @@ html.sheet-open .more-sheet-scrim {
     color: var(--mix-ink-muted);
 }
 
+/* Stale-while-revalidate: once a widget has rendered, a reload dims the current content
+   in place instead of collapsing to a spinner — on the auto-height mobile column a
+   spinner swap shrinks the page under a mid-scroll finger and kills the gesture. The
+   wrapper mirrors .dash-widget-body's flex chain so widget roots keep stretching. */
+.dash-refreshable {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    transition: opacity .2s ease;
+}
+
+.dash-stale {
+    opacity: .6;
+}
+
 /* Import Scores widget (§4): a credential form has to live in a 1x1 body, so the fields and
    button pack into a tight flex column that scrolls rather than clipping the action off. */
 .import-widget-body {
@@ -3108,6 +3124,15 @@ html.sheet-open .more-sheet-scrim {
     .dash-cols-2, .dash-cols-3, .dash-cols-4 { grid-column: span 1; }
 
     .dash-rows-2, .dash-rows-3 { grid-row: span 1; }
+
+    /* Cells grow to content here, so no dash-scroll list can ever overflow — the scroll
+       fade would only ever lie, permanently ghosting each list's last row into a
+       "scroll me" that scrolls nothing (the scroll(self) timeline that clears it needs
+       overflow to activate). The drawer keeps its fade: it genuinely scrolls. */
+    .dash-scroll {
+        mask-image: none;
+        animation: none;
+    }
 }
 
 /* Edit mode: toolbar, edit chrome, add-drawer. */

--- a/ScoreTracker/ScoreTracker/wwwroot/css/site.css
+++ b/ScoreTracker/ScoreTracker/wwwroot/css/site.css
@@ -3124,15 +3124,6 @@ html.sheet-open .more-sheet-scrim {
     .dash-cols-2, .dash-cols-3, .dash-cols-4 { grid-column: span 1; }
 
     .dash-rows-2, .dash-rows-3 { grid-row: span 1; }
-
-    /* Cells grow to content here, so no dash-scroll list can ever overflow — the scroll
-       fade would only ever lie, permanently ghosting each list's last row into a
-       "scroll me" that scrolls nothing (the scroll(self) timeline that clears it needs
-       overflow to activate). The drawer keeps its fade: it genuinely scrolls. */
-    .dash-scroll {
-        mask-image: none;
-        animation: none;
-    }
 }
 
 /* Edit mode: toolbar, edit chrome, add-drawer. */
@@ -4305,15 +4296,6 @@ html.sheet-open .more-sheet-scrim {
     height: 26px;
 }
 
-@media (max-width: 599.98px) {
-    /* Mobile cells auto-grow — let the page scroll instead of clipping rows. */
-    .dash-targets {
-        overflow-y: visible;
-        mask-image: none;
-        animation: none;
-    }
-}
-
 .dash-endzone {
     box-shadow: inset 0 -3px 0 0 var(--mix-primary);
     border-radius: 10px;
@@ -4910,6 +4892,23 @@ html.sheet-open .more-sheet-scrim {
             --dash-fade-top: 24px;
             --dash-fade-bottom: 0px;
         }
+    }
+}
+
+/* Phone column: cells auto-grow to their content, so no widget list overflows — which is
+   also why the scroll(self) timeline above never advances there. Left alone, the mask
+   would park at its initial value and permanently ghost every list's last row into a
+   "scroll me" that scrolls nothing.
+
+   This block sits AFTER the two rules it overrides on purpose. Every selector involved is
+   (0,1,0), and neither a media query nor @supports adds specificity, so source order is
+   the only thing that can decide — the same suppression written above them is inert. That
+   is not hypothetical: it shipped that way twice, once here and once as a .dash-targets
+   rule that spent its whole life dead. If this ever moves, it stops working silently. */
+@media (max-width: 599.98px) {
+    .dash-scroll {
+        mask-image: none;
+        animation: none;
     }
 }
 

--- a/docs/UX-GUIDELINES.md
+++ b/docs/UX-GUIDELINES.md
@@ -305,7 +305,15 @@ The widget home page ([design doc](design/HomePageWidgets/README.md)) adds a voc
   described by the capability schema, pinned by `Tests.Api` goldens. Changing a config record's shape
   or a `TypeId` is breaking-change review.
 - **Widgets reload only when their identity inputs change** (instance id, config, effective mix) —
-  edit-mode mutations elsewhere on the board must not refetch every widget.
+  edit-mode mutations elsewhere on the board must not refetch every widget. Auto-refresh is two
+  opt-in signals per descriptor (owner, 2026-08-30): score-reading widgets bump when the viewer's
+  **import finishes saving**, the few whose data is the post-batch analysis bump when the
+  **recalculated stats land** (`RefreshOnScoreImport` / `RefreshOnStatsUpdate`); the host coalesces
+  event bursts and holds any bump that arrives mid-edit until Done.
+- **A reload never collapses a rendered widget.** The spinner is for the first load only; after
+  that, refreshes keep the current content on screen dimmed (`dash-refreshable`/`dash-stale`) and
+  swap in place. On the auto-height mobile column a spinner swap shrinks the page under a
+  mid-scroll finger and kills the gesture — the "can't scroll the widgets" bug.
 - Chart series colors resolve through literal-hex accessors on `MixThemes` (ApexCharts can't read CSS
   vars), all mirroring `DifficultyHex`: **chart type** = `ChartTypeHex` (red Single / green Double / gold
   Co-Op, the ball vocabulary — the By-Level Breakdown distribution lines encode S/D by this color, the
@@ -326,6 +334,9 @@ The widget home page ([design doc](design/HomePageWidgets/README.md)) adds a voc
 - **Quiet scrolling**: widget inner scrollers use `dash-scroll` — no scrollbar at rest, a thin themed
   thumb on hover, and edge fades as the "there's more" affordance (scroll-aware where the browser
   supports scroll-driven animations, static bottom fade elsewhere). Touch keeps native overlays.
+  **On the phone column the fade is off entirely**: cells grow to content there, so no list can
+  overflow and the fade could only lie — a permanently ghosted last row that invites swipes nothing
+  answers.
 - **Graphs start from `ApexChartTheming.BaseOptions` + its `WrapperClass`** on the container: frozen
   canvas, display face, palette fore color, whisper-grid, dark theme, themed tooltips. Charts layer
   their specifics (strokes, fills, axes) on top — never rebuild the base by hand.

--- a/docs/UX-GUIDELINES.md
+++ b/docs/UX-GUIDELINES.md
@@ -336,7 +336,10 @@ The widget home page ([design doc](design/HomePageWidgets/README.md)) adds a voc
   supports scroll-driven animations, static bottom fade elsewhere). Touch keeps native overlays.
   **On the phone column the fade is off entirely**: cells grow to content there, so no list can
   overflow and the fade could only lie — a permanently ghosted last row that invites swipes nothing
-  answers.
+  answers. That suppression must sit **after** the base `.dash-scroll` rule in `site.css`: every
+  selector involved is a single class, and neither a media query nor `@supports` adds specificity,
+  so source order is the only tiebreak. Written above them it is inert, which is how the fade
+  survived two separate attempts to remove it.
 - **Graphs start from `ApexChartTheming.BaseOptions` + its `WrapperClass`** on the container: frozen
   canvas, display face, palette fore color, whisper-grid, dark theme, themed tooltips. Charts layer
   their specifics (strokes, fills, axes) on top — never rebuild the base by hand.

--- a/docs/design/HomePageWidgets/README.md
+++ b/docs/design/HomePageWidgets/README.md
@@ -88,9 +88,16 @@ Verticals contribute *data* (contract queries, precompute jobs); Web contributes
 components. A future vertical (Rivals) adds descriptors without touching shell code (D9).
 
 The descriptor has since grown optional config-aware hooks beyond this sketch: `DynamicNameKey`
-(instance titles follow config), `DrawerPresets`, the refresh action (`RefreshIcon`/`RefreshTitleKey`/
-`RefreshOnScoreImport`), and `ShowRefresh` (2026-08-14) — a predicate the host consults so a goal
+(instance titles follow config), `DrawerPresets`, the refresh action (`RefreshIcon`/`RefreshTitleKey`),
+and `ShowRefresh` (2026-08-14) — a predicate the host consults so a goal
 whose content is deterministic doesn't render a shuffle that re-rolls into the identical list.
+Auto-refresh is **two opt-in signals** (owner, 2026-08-30, replacing the earlier fire-on-both):
+`RefreshOnScoreImport` bumps the widget the moment the viewer's import finishes saving — for
+widgets that read the scores themselves — and `RefreshOnStatsUpdate` bumps when the recalculated
+stats land (~2 minutes after the batch settles) — only for the few whose data IS that analysis
+(Account Stats, the Competitive Level graph; Suggested Charts declares both because Pumbility Push
+gains ride the projections). The host coalesces event bursts into one reload (2s debounce) and
+holds a bump that arrives mid-edit until Done.
 The **config dialog** also cascades the page's effective mix as a named `CascadingValue`
 (`Name="EffectiveMix"`, `MixEnum?`) — panels whose display depends on what "follow current mix"
 resolves to opt in via `[CascadingParameter]`; a dictionary parameter can't do this, because
@@ -100,7 +107,13 @@ resolves to opt in via `[CascadingParameter]`; a dictionary parameter can't do t
 
 Every render component must provide:
 
-1. **Skeleton** at fixed footprint for its size preset (no layout shift on load).
+1. **Skeleton** at fixed footprint for its size preset (no layout shift on load) — **first load
+   only**. A reload (shuffle, auto-refresh, config/mix change) keeps the current content rendered,
+   dimmed via the shared `dash-refreshable`/`dash-stale` wrapper, and swaps in place when the new
+   data lands: on the auto-height mobile column, a spinner swap collapses the page under a
+   mid-scroll finger and kills the gesture (the 2026-08-30 "can't scroll the widgets" bug). Loads
+   therefore build into locals and assign fields after their last await, so an interleaved render
+   never shows a half-built or flashed-empty state.
 2. **Empty state** with a setup CTA (no scores → import link; no data yet → what will make it appear).
    A widget with no data is an onboarding surface, not a blank box.
 3. **Isolated errors** — each grid cell wraps its widget in `<ErrorBoundary>`; one vertical throwing


### PR DESCRIPTION
## The bug

A user filmed the mobile dashboard refusing to scroll. Frame-by-frame, two mechanisms:

1. **The post-import refresh storm.** Every `RefreshOnScoreImport` widget subscribed to BOTH the import-terminal event and `PlayerStatsUpdatedEvent` (which lands ~2 minutes after the batch settles — exactly while the player is browsing). Each bump swapped every widget body for a spinner. On the phone column (auto-height cells) that collapses the page by hundreds of px under the finger: in-flight scroll gestures die, scrollTop clamps, flicks degrade into taps that pop the chart dialog. On camera: the Score Push list visibly re-rolled with no touch on screen.
2. **The lying fade.** `dash-scroll`'s mask ghosts the last row as a "scroll me" affordance, cleared by a `scroll(self)` timeline — which never activates on mobile because cells grow to content and nothing overflows. Every list widget's last row rendered permanently half-faded, inviting swipes nothing answered.

## The fix (three legs)

- **Stale-while-revalidate**: after first render, a reload keeps the current body mounted inside a `dash-refreshable` wrapper, dims it (`dash-stale`, 60% opacity), and swaps in place. Spinner is first-load only. Loads build into locals and assign fields after their last await so interleaved renders never flash empty states; the two Apex widgets re-key only on load completion so the old graph stays mounted through a reload.
- **Split refresh signals** (owner ruling 2026-08-30, replacing fire-on-both): `RefreshOnScoreImport` = import finished saving (weekly, daily-step, folder-levels, suggested-charts, by-level-breakdown); new `RefreshOnStatsUpdate` = recalculated stats landed (competitive-level, pumbility; suggested-charts declares both — Pumbility Push gains ride the projections). The host coalesces event bursts into one reload (2s debounce) and holds a bump that arrives mid-edit until Done, which §2.3 always promised.
- **No fade on the phone column**: `mask-image: none` under the 600px breakpoint; the add-drawer keeps its fade (it genuinely scrolls).

## Tests

- `WidgetHostRefreshTests` (new): per-flag subscriptions, burst coalescing, progress-ticks-don't-reload, mid-edit deferral.
- `SuggestedChartsWidgetTests`: first-load spinner + refresh-keeps-content-dimmed (pending-TCS swap).
- `WidgetRefreshOnImportTests`: re-pinned to the split model.

Suites: fast trio 4040 + 164 + 1102, Integration 357, E2E 84 — all green locally.

Nothing to press post-deploy. No schema, API, or localization changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
