### PR TITLE
titles: the suggested-level bracket runs SSS+ / SS / AAA

### DIFF
--- a/ScoreTracker/ScoreTracker.Tests.Components/SuggestedTitleLevelTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/SuggestedTitleLevelTests.cs
@@ -43,7 +43,7 @@ public sealed class SuggestedTitleLevelTests
         return string.Join(" ", RungAt(title, grade).Folders);
     }
 
-    /// <summary>The AAA answer, which is the one this used to print on its own.</summary>
+    /// <summary>The AAA answer — the bottom of the block, and the one this used to print alone.</summary>
     private static string Folder(string title)
     {
         return Folder(title, PhoenixLetterGrade.AAA);
@@ -126,7 +126,7 @@ public sealed class SuggestedTitleLevelTests
     {
         var rungs = Suggestion("[S] ADVANCED LV.1").Rungs;
         Assert.Equal(
-            new[] { PhoenixLetterGrade.SSSPlus, PhoenixLetterGrade.AAA, PhoenixLetterGrade.A },
+            new[] { PhoenixLetterGrade.SSSPlus, PhoenixLetterGrade.SS, PhoenixLetterGrade.AAA },
             rungs.Select(r => r.Grade));
 
         var levels = rungs.Select(r => int.Parse(r.Folders[0][1..])).ToArray();
@@ -136,16 +136,20 @@ public sealed class SuggestedTitleLevelTests
     [Fact]
     public void PlayingBetterAsksForALowerFolder()
     {
-        // The whole point of three rungs: the same title is eight folders apart end to end.
+        // The point of three rungs, though a narrower one since the floor moved to AAA: the same
+        // title is three folders apart end to end where it used to be eight. Pinned literally on
+        // purpose — retuning a reference grade should have to name its new numbers.
         Assert.Equal("S13", Folder("[S] ADVANCED LV.1", PhoenixLetterGrade.SSSPlus));
+        Assert.Equal("S14", Folder("[S] ADVANCED LV.1", PhoenixLetterGrade.SS));
         Assert.Equal("S16", Folder("[S] ADVANCED LV.1", PhoenixLetterGrade.AAA));
-        Assert.Equal("S20", Folder("[S] ADVANCED LV.1", PhoenixLetterGrade.A));
     }
 
     [Fact]
-    public void TheMiddleRungIsWhatTheDrawerUsedToPrintAlone()
+    public void TheBottomRungIsWhatTheDrawerUsedToPrintAlone()
     {
-        // AAA on a TG plate was the single fixed reference before this became three rungs.
+        // AAA on a TG plate was the single fixed reference before this became three rungs. It was
+        // the middle of the block until 2026-09-06 and is its floor now; either way the number it
+        // answers with has never moved, which is what makes it the safe one to pin.
         Assert.Equal("D17", Folder("[D] ADVANCED LV.1", PhoenixLetterGrade.AAA));
         Assert.Equal("S16 D17", Folder("[P.B] GOLD", PhoenixLetterGrade.AAA));
     }
@@ -153,17 +157,17 @@ public sealed class SuggestedTitleLevelTests
     [Fact]
     public void GradesThatLandOnTheSameFolderMergeIntoOneRung()
     {
-        // The level-10 floor puts SSS+ and AAA both on S10 here; two identical rows would read
-        // as a rendering fault.
-        var rungs = Suggestion("[S] INTERMEDIATE LV.9").Rungs;
+        // SSS+ and SS are 2% apart and a level costs more than that here, so both answer S11;
+        // two identical rows would read as a rendering fault.
+        var rungs = Suggestion("[S] INTERMEDIATE LV.10").Rungs;
         Assert.Equal(2, rungs.Count);
 
         var merged = rungs[0];
-        Assert.Equal("S10", Assert.Single(merged.Folders));
-        Assert.Equal(PhoenixLetterGrade.AAA, merged.Grade);
+        Assert.Equal("S11", Assert.Single(merged.Folders));
+        Assert.Equal(PhoenixLetterGrade.SS, merged.Grade);
         Assert.True(merged.OrBetter);
 
-        Assert.Equal("S14", Assert.Single(rungs[1].Folders));
+        Assert.Equal("S13", Assert.Single(rungs[1].Folders));
         Assert.False(rungs[1].OrBetter);
     }
 
@@ -173,48 +177,23 @@ public sealed class SuggestedTitleLevelTests
         var rungs = Suggestion("[S] INTERMEDIATE LV.1").Rungs;
         var only = Assert.Single(rungs);
         Assert.Equal("S10", Assert.Single(only.Folders));
-        // Named for the lowest grade in the run, so the drawer can say "at A or better".
-        Assert.Equal(PhoenixLetterGrade.A, only.Grade);
+        // Named for the lowest grade in the run, so the drawer can say "at AAA or better".
+        Assert.Equal(PhoenixLetterGrade.AAA, only.Grade);
         Assert.True(only.OrBetter);
     }
 
     [Fact]
-    public void AGradeNoFolderReachesNamesTheCeilingItFallsShortOf()
+    public void NoRungFallsShortAtTheseReferenceGrades()
     {
-        // The 20,000 capstone is the only title fifty charts at a bare A cannot reach from the
-        // top folder on either side. DOUBLE MASTER used to be the example and no longer is: the
-        // Doubles A multiplier is interpolated rather than measured, and the value it currently
-        // holds lifts a D29 ceiling just past that title's 19,500 ask.
-        var rungs = Suggestion("ABYSS ABSOLUTE").Rungs;
-        var last = rungs[^1];
-        Assert.Equal(PhoenixLetterGrade.A, last.Grade);
-        Assert.False(last.Reachable);
-        Assert.Equal(new[] { "S29", "D29" }, last.Folders);
-
-        Assert.All(rungs.Take(rungs.Count - 1), r => Assert.True(r.Reachable));
-    }
-
-    [Fact]
-    public void AnUnreachableRungNeverMergesIntoTheOneAboveIt()
-    {
-        // Its folders name a ceiling rather than an answer, so folding it into a reachable run
-        // would claim that ceiling serves.
-        var rungs = Suggestion("ABYSS ABSOLUTE").Rungs;
-        Assert.Equal(3, rungs.Count);
-        Assert.All(rungs, r => Assert.False(r.OrBetter));
-        Assert.Equal(new[] { "S29", "D29" }, rungs[^1].Folders);
-        Assert.False(rungs[^1].Reachable);
-    }
-
-    [Fact]
-    public void EveryTitleIsReachableAtTheGradeAboveTheOneThatFailsIt()
-    {
-        // A rung is only allowed to fall short at the bottom of the block — an unreachable grade
-        // above a reachable one would mean the curve is not monotonic in grade.
+        // The block can render a rung no folder reaches: its folders name the ceiling that falls
+        // short — "D29 still isn't enough at A" — rather than an answer, and it never merges,
+        // since folding it into a reachable run would claim that ceiling serves.
+        //
+        // Nothing is in that shape while the floor is AAA. ABYSS ABSOLUTE's 20,000 was the last
+        // one, and only at a bare A. The branch stays as a guard against a threshold moving out
+        // from under the curve, so this is the tripwire that says when it has — a failure here
+        // means the block has started printing a ceiling, not that the guard is broken.
         foreach (var title in Phoenix2TitleList.BuildList().OfType<Phoenix2PumbilityTitle>())
-        {
-            var reachable = SuggestedTitleLevel.For(title)!.Rungs.Select(r => r.Reachable).ToArray();
-            Assert.Equal(reachable.OrderByDescending(r => r), reachable);
-        }
+            Assert.All(SuggestedTitleLevel.For(title)!.Rungs, r => Assert.True(r.Reachable));
     }
 }

--- a/ScoreTracker/ScoreTracker.Tests.Components/TitleDetailDrawerTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/TitleDetailDrawerTests.cs
@@ -67,7 +67,7 @@ public sealed class TitleDetailDrawerTests : ComponentTestBase
         // the low number is the hard one, and only the row can say so.
         var rows = Rows(Open("[S] ADVANCED LV.1"));
 
-        Assert.Equal(new[] { "S13 at SSS+", "S16 at AAA", "S20 at A" }, rows);
+        Assert.Equal(new[] { "S13 at SSS+", "S14 at SS", "S16 at AAA" }, rows);
     }
 
     [Fact]
@@ -75,15 +75,15 @@ public sealed class TitleDetailDrawerTests : ComponentTestBase
     {
         var rows = Rows(Open("[P.B] GOLD"));
 
-        Assert.Equal(new[] { "S13 · D14 at SSS+", "S16 · D17 at AAA", "S20 · D21 at A" }, rows);
+        Assert.Equal(new[] { "S13 · D14 at SSS+", "S14 · D15 at SS", "S16 · D17 at AAA" }, rows);
     }
 
     [Fact]
     public void GradesSharingAFolderRenderOnceRatherThanAsIdenticalRows()
     {
-        var rows = Rows(Open("[S] INTERMEDIATE LV.9"));
+        var rows = Rows(Open("[S] INTERMEDIATE LV.10"));
 
-        Assert.Equal(new[] { "S10 at AAA or better", "S14 at A" }, rows);
+        Assert.Equal(new[] { "S11 at SS or better", "S13 at AAA" }, rows);
     }
 
     [Fact]
@@ -91,20 +91,22 @@ public sealed class TitleDetailDrawerTests : ComponentTestBase
     {
         var rows = Rows(Open("[S] INTERMEDIATE LV.1"));
 
-        Assert.Equal("S10 at A or better", Assert.Single(rows));
+        Assert.Equal("S10 at AAA or better", Assert.Single(rows));
     }
 
     [Fact]
-    public void AGradeNoFolderReachesKeepsItsRowAndSaysWhy()
+    public void NoRowFallsShortAtTheseReferenceGrades()
     {
-        // The 20,000 capstone is the only title the top folder cannot reach at a bare A. Only
-        // the last row is pinned here — the rows above it are another test's subject, and this
-        // one is about the row that falls short still being shown, and saying so.
+        // A row the top folder cannot reach renders dimmed and says why — "still isn't enough
+        // at {grade}" — instead of naming a folder that would not serve. No title is in that
+        // shape while the block floors at AAA; ABYSS ABSOLUTE's 20,000 was the last one, and
+        // only at the bare A the block carried until 2026-09-06. Pinned on the capstone because
+        // it is the title that would fall short first if a threshold ever outran the curve.
         var drawer = Open("ABYSS ABSOLUTE");
 
-        Assert.Equal("S29 · D29 still isn't enough at A", Rows(drawer)[^1]);
-        // Dimmed, because that number is the ceiling it falls short of rather than an answer.
-        Assert.Single(drawer.FindAll(".title-suggest-row.short"));
+        Assert.Equal(new[] { "S25 · D26 at SSS+", "S26 · D27 at SS", "S27 · D28 at AAA" },
+            Rows(drawer));
+        Assert.Empty(drawer.FindAll(".title-suggest-row.short"));
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker/Services/SuggestedTitleLevel.cs
+++ b/ScoreTracker/ScoreTracker/Services/SuggestedTitleLevel.cs
@@ -38,26 +38,28 @@ public sealed record SuggestedLevel(IReadOnlyList<SuggestedRung> Rungs, PhoenixP
 ///         imported nothing.
 ///     </para>
 ///     <para>
-///         One folder is the wrong shape for that answer, because how well you play moves it by up
-///         to eight levels. So it answers at three grades instead, and the middle one is the AAA
-///         this used to print alone.
+///         One folder is the wrong shape for that answer, because how well you play moves it. So
+///         it answers at three grades instead — SSS+ down to the AAA this used to print alone,
+///         which is now the floor of the bracket rather than its middle.
 ///     </para>
 /// </summary>
 public static class SuggestedTitleLevel
 {
     /// <summary>
     ///     Best first, so the levels ascend down the block and the grades read in the order every
-    ///     other grade list on the site uses. A is the bottom rung because it is the lowest grade
-    ///     that reads as a real target rather than a near-miss — grinding a folder to a B is not
-    ///     an ask anyone acts on. It was also once the lowest multiplier verified against live
-    ///     data; that is no longer the reason, since a Double's A is itself interpolated while a
-    ///     Single's B, C and D are all measured.
+    ///     other grade list on the site uses. AAA is the bottom rung because it is the lowest grade
+    ///     a player might actually average across fifty charts — the block floored at A until
+    ///     2026-09-06, and a Phoenix 2 A is 800,000, so that row was naming a folder its own reader
+    ///     would have been scraping through rather than farming. The bracket pays for the honest
+    ///     floor in width: SSS+ / SS / AAA spans 6.4% where SSS+ / AAA / A spanned 17%, so the
+    ///     three rows sit within three levels of each other and merge more often. Widen it with a
+    ///     grade players average, never by reaching back down the ladder.
     /// </summary>
     private static readonly PhoenixLetterGrade[] ReferenceGrades =
     {
         PhoenixLetterGrade.SSSPlus,
-        PhoenixLetterGrade.AAA,
-        PhoenixLetterGrade.A
+        PhoenixLetterGrade.SS,
+        PhoenixLetterGrade.AAA
     };
 
     private const PhoenixPlate ReferencePlate = PhoenixPlate.TalentedGame;

--- a/docs/design/titles-overhaul.md
+++ b/docs/design/titles-overhaul.md
@@ -114,8 +114,8 @@ title, so `SuggestedTitleLevel` is deliberately **impersonal**:
 
 ```
 S13   at SSS+
+S14   at SS
 S16   at AAA
-S20   at A
 Fifty charts, TG plate.
 ```
 
@@ -124,21 +124,35 @@ grades** on a Talented Game plate, every multiplier read from the shipped `Scori
 Singles price one level up the base curve; nothing below level 10 counts (Phoenix 2 prices those at
 zero). A merged-pool rung names both types, since either side can fill it.
 
-One number was the wrong shape for this answer: how well you play moves it by **up to eight
-levels** ([S] ADVANCED LV.4 is S15 at SSS+ and S23 at A), so a single folder was right only for the
-player already performing at the reference. Three rungs bracket it instead, and AAA — what the
-drawer printed alone before — stays the middle one. **A is the floor on purpose**: it is the lowest
-grade whose multiplier is verified against live data, and below it the config is still extrapolating
-at −0.05 a step.
+One number was the wrong shape for this answer: how well you play moves it by **three levels**
+([S] ADVANCED LV.4 is S15 at SSS+ and S18 at AAA), so a single folder was right only for the player
+already performing at the reference. Three rungs bracket it instead, and AAA — what the drawer
+printed alone before — is now the floor of that bracket rather than its middle.
+
+**The floor is set by what the field averages, not by how wide a bracket it makes** (owner,
+2026-09-06). The block read SSS+ / AAA / A until then, which spanned eight levels — and the bottom
+row was the reason the whole thing looked wrong: an A on Phoenix 2 is 800,000, so *fifty S28s at an
+A* told a player they could earn `[S] EXPERT LV.8` on a folder they would be scraping through. A
+grade nobody averages names a folder nobody plays. Raising the floor to AAA costs the bracket most
+of its width — SSS+ / SS / AAA is 1.50 / 1.47 / 1.41, a 6.4% span against the old 17%, so the three
+rows now land within three levels of each other and 28 of 70 rungs merge at least two of them. That
+is the deliberate trade: three narrow rows that are all askable beat three wide ones whose bottom is
+fiction. Do not widen it again by reaching down the grade ladder — the way to widen it is a grade
+players actually average.
 
 Grades run best-first, so the levels ascend down the block and the column reads in the same order as
-every other grade list on the site. Two shapes fall out of the curve's ends and both are rendered
-rather than hidden:
+every other grade list on the site. One shape falls out of the curve's ends and is rendered rather
+than hidden:
 
 | Shape | Rungs | What the drawer does |
 |---|---|---|
-| Grades landing on the same folder | 19 of 70 | The run collapses to one row reading *at {lowest} or better* — the level-10 floor produces two identical rows for every easy title, and identical rows read as a rendering fault. 15 of those collapse all the way to a single row. |
-| No folder reaches it at that grade | 4 of 70 | [D] EXPERT LV.9/LV.10, DOUBLE MASTER, ABYSS ABSOLUTE. Fifty D29s at a bare A come to 19,260. The row keeps its place naming the ceiling that falls short — *D29 still isn't enough at A* — and never merges, since its folders are not an answer. |
+| Grades landing on the same folder | 28 of 70 | The run collapses to one row reading *at {lowest} or better* — the level-10 floor produces identical rows for every easy title, the narrow grade span produces them again wherever a level costs more than 6.4%, and identical rows read as a rendering fault. 19 of those collapse all the way to a single row. |
+
+A rung no folder reaches keeps its place naming the ceiling that falls short (*D29 still isn't
+enough at A*) and never merges, since its folders are not an answer. **No title is in that shape at
+the current reference grades** — at AAA the top folder reaches every threshold, and ABYSS ABSOLUTE,
+the last one that fell short, does so only at a bare A. The branch stays as a guard against a
+threshold moving out from under the curve.
 
 Owner call, field-test round 3: a personalised version was built first and rejected as too wordy —
 *"don't mix in personalization here."* Three impersonal rungs are the answer to the same problem


### PR DESCRIPTION
The Titles drawer's **Suggested level** block floored at A, and an A on Phoenix 2 is **800,000**. So the bottom row was telling a player they could earn `[S] EXPERT LV.8` with fifty S28s at a grade they would be scraping through — a folder nobody plays, named by a grade nobody averages. That is what made the block look wrong; the folder read as nonsense because the grade did.

The bracket is now **SSS+ / SS / AAA**. Owner's reason for the floor: there are not a lot of people averaging AAs right now.

| Title | Before | After |
|---|---|---|
| `[S] ADVANCED LV.1` | S13 · S16 · **S20** | S13 · S14 · **S16** |
| `[S] EXPERT LV.8` | S23 · S25 · **S28** | S23 · S24 · **S25** |
| `[P.B] GOLD` | S13/D14 · S16/D17 · **S20/D21** | S13/D14 · S14/D15 · **S16/D17** |
| `[S] INTERMEDIATE LV.1` | S10 at A or better | S10 at AAA or better |

### What it costs, deliberately

The three multipliers are 1.50 / 1.47 / 1.41 — a **6.4% span against the old 17%** — while a level on the base curve costs 2–3%. So the block narrows from a max of eight levels to three (median 5 → 2), and **28 of 70 rungs now merge at least two rows** where 19 did, 19 of them collapsing to a single row.

That trade is written into `docs/design/titles-overhaul.md` along with the rule it implies: widen the bracket with a grade players actually average, never by reaching further down the ladder.

One shape disappears — at AAA the top folder clears every threshold, so nothing renders *"D29 still isn't enough at A"* any more. `ABYSS ABSOLUTE` was the last title in that shape and only at a bare A. The `Reachable == false` branch stays as a guard against a threshold outrunning the curve, and both suites replace their now-subjectless tests with a tripwire that fails if anything ever falls short again.

### Commits

1. **docs** — the section rewritten, plus two counts it had already outgrown (the unreachable row said 4 of 70; today's code has 1, because the doubles A multiplier was re-measured 1.28 → 1.30 after that table was written)
2. **feat** — the `ReferenceGrades` array in `SuggestedTitleLevel.cs`, and the two doc-comments that argued for A
3. **test** — new literals in `SuggestedTitleLevelTests` + `TitleDetailDrawerTests`; the merge case moves from `[S] INTERMEDIATE LV.9` (now one row) to `LV.10`, which merges because a level costs more than the 2% between SSS+ and SS rather than because the level-10 floor flattened it

Presentation only — `Phoenix2PumbilityScoring` is read, never edited, so a later multiplier correction still moves this page on its own. **No localization**: the grade is a `{0}` parameter and its name comes off the enum, so there are no new resx keys.

### Testing

All five suites green locally on this tree: **4,322** unit/arch · **218** API · **1,347** component · **381** integration · **88** E2E. Up to date with `main` and merge-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
