### PR TITLE
fix(discord-roles): ManageDiscord was a permission nobody could grant

### DIFF
--- a/ScoreTracker/ScoreTracker.Communities/Application/BotCommandSaga.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Application/BotCommandSaga.cs
@@ -211,9 +211,13 @@ namespace ScoreTracker.Communities.Application
                 return new BotReply(Text: _localizer.Get(invokerCulture, "That community wasn't found."));
 
             var community = await _communities.GetCommunityByName(communityName, cancellationToken);
-            if (community == null || !community.HasPermission(user.Id, CommunityPermission.ManageDiscord))
-                return new BotReply(Text: _localizer.Get(invokerCulture,
-                    "You don't have permission to manage Discord for that community."));
+            // A second read of the same name, so it answers separately from the id lookup above —
+            // and it must answer the same way, because "no such community" folded into the
+            // permission refusal is how a typo came back as an authority problem.
+            if (community == null)
+                return new BotReply(Text: _localizer.Get(invokerCulture, "That community wasn't found."));
+            if (!community.HasPermission(user.Id, CommunityPermission.ManageDiscord))
+                return new BotReply(Text: RefusalReason(community, user, invokerCulture));
 
             var existing = await _roleConfiguration.GetServer(id, cancellationToken);
             if (existing != null && existing.GuildId != guildId)
@@ -230,8 +234,39 @@ namespace ScoreTracker.Communities.Application
         }
 
         /// <summary>
+        ///     Why the site side said no. The three causes are fixed by three different people, so
+        ///     one sentence for all of them sent everybody to the wrong one — and the commonest is
+        ///     not a permission problem at all: a Discord account linked to a second PIU Scores
+        ///     login refuses exactly like a missing flag does. Naming the account the invocation
+        ///     resolved to is the whole diagnosis in that case, and it is the invoker's own name in
+        ///     an ephemeral reply, so it tells them nothing they do not own.
+        /// </summary>
+        private string RefusalReason(Community community, User user, string? culture)
+        {
+            var name = (string)community.Name;
+            var account = (string)user.Name;
+
+            return community.RoleOf(user.Id) is null or CommunityRole.Banned
+                ? _localizer.Get(culture,
+                    "Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. " +
+                    "If you manage {1} from another account, link Discord to that account instead.",
+                    account, name)
+                : _localizer.Get(culture,
+                    "Your Discord is linked to {0} on PIU Scores, which is in {1} without the " +
+                    "Manage Discord roles permission. The community's creator can grant it on the Members page.",
+                    account, name);
+        }
+
+        /// <summary>
         ///     The invoker's own communities that they may configure Discord for — never a public
         ///     directory search, since this option hands a server to whatever it names.
+        ///     <para>
+        ///         One predicate, and it is the command's own: the creator's standing already
+        ///         carries <see cref="CommunityPermission.All" /> by the time it reaches here, so a
+        ///         second Creator clause would only re-answer a question the flag has answered, and
+        ///         re-answering it off a different column is what let this list offer a community
+        ///         the command then refused.
+        ///     </para>
         /// </summary>
         private async Task<IReadOnlyList<BotOptionChoice>> ManageableCommunityChoices(
             BotAutocompleteRequest request, CancellationToken cancellationToken)
@@ -242,8 +277,8 @@ namespace ScoreTracker.Communities.Application
             var partial = request.PartialValue?.Trim() ?? string.Empty;
             var roles = await _communities.GetUserRoles(user.Id, cancellationToken);
             return roles
-                .Where(r => r.Role == CommunityRole.Creator ||
-                            (r.Permissions & CommunityPermission.ManageDiscord) == CommunityPermission.ManageDiscord)
+                .Where(r => (r.Permissions & CommunityPermission.ManageDiscord) ==
+                            CommunityPermission.ManageDiscord)
                 .Select(r => (string)r.CommunityName)
                 .Where(name => name.Contains(partial, StringComparison.OrdinalIgnoreCase))
                 .OrderBy(name => name)

--- a/ScoreTracker/ScoreTracker.Communities/Infrastructure/EFCommunitiesRepository.cs
+++ b/ScoreTracker/ScoreTracker.Communities/Infrastructure/EFCommunitiesRepository.cs
@@ -504,6 +504,22 @@ namespace ScoreTracker.Communities.Infrastructure
                 }))!;
         }
 
+        /// <summary>
+        ///     Standing in each of the caller's communities, resolved the same way the aggregate
+        ///     resolves it: the ban row wins, then the community's own owning row, then whatever
+        ///     the membership row says.
+        ///     <para>
+        ///         Reading the membership row alone made this a SECOND authority on who the creator
+        ///         is, and the two can disagree — <see cref="Community" /> derives Creator (and its
+        ///         implicit <see cref="CommunityPermission.All" />) from <c>OwningUserId</c>, which
+        ///         is what every server-side gate then checks. A row saying Creator over a
+        ///         community owned by somebody else offered <c>/piu link-server</c> a community it
+        ///         would refuse; a hand-named owner over an ordinary Member row hid one it would
+        ///         accept. Neither is reachable through a save — both are reachable by naming an
+        ///         owner on a system community's row, which is how the official Discord gets its
+        ///         title roles (D20).
+        ///     </para>
+        /// </summary>
         public async Task<IEnumerable<MyCommunityRoleRecord>> GetUserRoles(Guid userId,
             CancellationToken cancellationToken)
         {
@@ -511,12 +527,37 @@ namespace ScoreTracker.Communities.Infrastructure
             var rows = await (from cm in database.Set<CommunityMembershipEntity>()
                     where cm.UserId == userId
                     join c in database.Set<CommunityEntity>() on cm.CommunityId equals c.Id
-                    select new { c.Id, c.Name, cm.Role, cm.Permissions })
+                    select new { c.Id, c.Name, c.OwningUserId, cm.Role, cm.Permissions })
                 .ToArrayAsync(cancellationToken);
 
-            return rows.Select(r => new MyCommunityRoleRecord(r.Id, r.Name,
-                Enum.TryParse<CommunityRole>(r.Role, out var role) ? role : CommunityRole.Member,
-                (CommunityPermission)r.Permissions)).ToArray();
+            return rows.Select(r =>
+            {
+                var stored = Enum.TryParse<CommunityRole>(r.Role, out var parsed)
+                    ? parsed
+                    : CommunityRole.Member;
+                var (role, permissions) = Standing(userId, r.OwningUserId, stored,
+                    (CommunityPermission)r.Permissions);
+                return new MyCommunityRoleRecord(r.Id, r.Name, role, permissions);
+            }).ToArray();
+        }
+
+        /// <summary>
+        ///     <see cref="Community.RoleOf" /> and <see cref="Community.PermissionsOf" />, in the
+        ///     same order and off the same two columns the aggregate hydrates from: a ban outranks
+        ///     everything, the owning row is the only source of Creator, permissions are only
+        ///     meaningful on an admin row. A Creator row over somebody else's community is a plain
+        ///     member here for the same reason it is one there — the flag bits on it were never
+        ///     honored by any gate.
+        /// </summary>
+        private static (CommunityRole Role, CommunityPermission Permissions) Standing(Guid userId,
+            Guid owningUserId, CommunityRole stored, CommunityPermission storedPermissions)
+        {
+            if (stored == CommunityRole.Banned) return (CommunityRole.Banned, CommunityPermission.None);
+            if (userId != Guid.Empty && userId == owningUserId)
+                return (CommunityRole.Creator, CommunityPermission.All);
+            return stored == CommunityRole.Admin
+                ? (CommunityRole.Admin, storedPermissions)
+                : (CommunityRole.Member, CommunityPermission.None);
         }
 
         public async Task<IEnumerable<CommunityMemberRoleRecord>> GetMemberRoles(Guid communityId,

--- a/ScoreTracker/ScoreTracker.Tests.Components/CommunityMembersPageTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Components/CommunityMembersPageTests.cs
@@ -2,11 +2,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
+using AngleSharp.Dom;
 using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using ScoreTracker.Communities.Contracts;
+using ScoreTracker.Communities.Contracts.Commands;
 using ScoreTracker.Communities.Contracts.Queries;
 using ScoreTracker.Domain.Models;
 using ScoreTracker.SharedKernel.Enums;
@@ -128,4 +133,59 @@ public sealed class CommunityMembersPageTests : ComponentTestBase
         Assert.Contains("Edit Permissions", cut.Markup);
         Assert.DoesNotContain("Make Creator", cut.Markup);
     }
+
+    /// <summary>
+    ///     A permission the creator cannot tick is a permission no admin can ever hold, and this
+    ///     page is the only place any of them are handed out. ManageDiscord shipped missing from
+    ///     the list, so every admin sent to /piu link-server was refused by a flag their creator
+    ///     had no way to grant.
+    /// </summary>
+    [Fact]
+    public void EveryDelegablePermissionIsOfferedToTheCreator()
+    {
+        GivenMyRole(CommunityRole.Creator, CommunityPermission.All);
+        var cut = Render();
+
+        foreach (var permission in Enum.GetValues<CommunityPermission>()
+                     .Where(p => p is not (CommunityPermission.None or CommunityPermission.All)))
+            Assert.Contains(PermissionLabels[permission], cut.Markup);
+    }
+
+    /// <summary>
+    ///     Offered is not the same as grantable — the switch has to reach the command carrying the
+    ///     flag. Driven through the promotion defaults rather than the per-admin dialog because a
+    ///     MudDialog's body needs a provider this tree has none of; both read the same array, so
+    ///     the array is what is under test either way.
+    /// </summary>
+    [Fact]
+    public async Task TickingManageDiscordSendsTheFlagToTheCommand()
+    {
+        GivenMyRole(CommunityRole.Creator, CommunityPermission.All);
+        var cut = Render();
+
+        await cut.FindAll("input[type=checkbox]")
+            .Single(input => Label(input)?.Contains("Manage Discord roles") == true)
+            .ChangeAsync(new ChangeEventArgs { Value = true });
+
+        // The page dispatches through a shared Dispatch(IRequest ...) helper, so the mock records
+        // the call at IRequest — matching on the concrete type here would never bind.
+        _mediator.Verify(m => m.Send(
+            It.Is<IRequest>(c => c is SetDefaultAdminPermissionsCommand &&
+                                 ((SetDefaultAdminPermissionsCommand)c).Permissions
+                                 .HasFlag(CommunityPermission.ManageDiscord)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>MudSwitch renders its caption on the wrapping label, not on the input.</summary>
+    private static string? Label(IElement input) => input.Closest("label")?.TextContent;
+
+    private static readonly Dictionary<CommunityPermission, string> PermissionLabels = new()
+    {
+        [CommunityPermission.ManageInviteLinks] = "Manage invite links",
+        [CommunityPermission.PromoteAdmins] = "Promote other admins",
+        [CommunityPermission.ManageUsers] = "Manage users (ban/unban)",
+        [CommunityPermission.ManageChannelSubscriptions] = "Manage channel subscriptions",
+        [CommunityPermission.ModerateComments] = "Moderate comments (remove/mute)",
+        [CommunityPermission.ManageDiscord] = "Manage Discord roles"
+    };
 }

--- a/ScoreTracker/ScoreTracker.Tests.Integration/EFCommunitiesRepositoryTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests.Integration/EFCommunitiesRepositoryTests.cs
@@ -1,8 +1,10 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Moq;
 using ScoreTracker.Domain.SecondaryPorts;
 using ScoreTracker.Communities.Domain;
 using ScoreTracker.Communities.Infrastructure;
+using ScoreTracker.Communities.Infrastructure.Entities;
 using ScoreTracker.SharedKernel.Enums;
 using ScoreTracker.Domain.Models;
 using ScoreTracker.SharedKernel.Models;
@@ -194,6 +196,52 @@ public sealed class EFCommunitiesRepositoryTests : IAsyncLifetime
         Assert.DoesNotContain(belongs, c => (string)c.CommunityName == "Clubhouse");
         var row = Assert.Single(holds, r => (string)r.CommunityName == "Clubhouse");
         Assert.Equal(CommunityRole.Banned, row.Role);
+    }
+
+    /// <summary>
+    ///     Two columns can say who the creator is — the community's own owning row and the seat's
+    ///     Role string — and only the first is the one every server-side gate reads, because it is
+    ///     what <see cref="Community" /> hydrates from. A save writes them together, so they agree
+    ///     until somebody names an owner on a system community's row by hand (D20, and how the
+    ///     official Discord gets its title roles). This read has to answer like the aggregate does
+    ///     in both directions: a stale Creator seat is a plain member, and a named owner is the
+    ///     creator whatever their seat says. Offering /piu link-server a community the command
+    ///     then refuses — or hiding one it would accept — is the difference otherwise.
+    /// </summary>
+    [Theory]
+    [InlineData("Creator", false, CommunityRole.Member, CommunityPermission.None)]
+    [InlineData("Member", true, CommunityRole.Creator, CommunityPermission.All)]
+    public async Task StandingFollowsTheOwningRowRatherThanTheSeatsRoleString(string seatRole, bool ownsIt,
+        CommunityRole expectedRole, CommunityPermission expectedPermissions)
+    {
+        var owner = Guid.NewGuid();
+        var subject = Guid.NewGuid();
+        await BuildRepository().SaveCommunity(new Community("Divergent", owner, CommunityPrivacyType.Public,
+                new[] { owner, subject }, Array.Empty<Community.ChannelConfiguration>(),
+                new Dictionary<Guid, DateOnly?>(), false), CancellationToken.None);
+
+        // Straight to the rows: this is a state SaveCommunity cannot produce, which is the point.
+        await using (var database = await _fixture.DbContextFactory.CreateDbContextAsync())
+        {
+            var community = await database.Set<CommunityEntity>()
+                .SingleAsync(c => c.Name == "Divergent");
+            if (ownsIt) community.OwningUserId = subject;
+
+            var seat = await database.Set<CommunityMembershipEntity>()
+                .SingleAsync(m => m.CommunityId == community.Id && m.UserId == subject);
+            seat.Role = seatRole;
+            seat.Permissions = (int)CommunityPermission.All;
+            await database.SaveChangesAsync();
+        }
+
+        var rows = await BuildRepository().GetUserRoles(subject, CancellationToken.None);
+        var aggregate = await BuildRepository().GetCommunityByName("Divergent", CancellationToken.None);
+
+        var row = Assert.Single(rows, r => (string)r.CommunityName == "Divergent");
+        Assert.Equal(expectedRole, row.Role);
+        Assert.Equal(expectedPermissions, row.Permissions);
+        Assert.Equal(aggregate!.RoleOf(subject), row.Role);
+        Assert.Equal(aggregate.PermissionsOf(subject), row.Permissions);
     }
 
     [Fact]

--- a/ScoreTracker/ScoreTracker.Tests/ApplicationTests/LinkServerCommandTests.cs
+++ b/ScoreTracker/ScoreTracker.Tests/ApplicationTests/LinkServerCommandTests.cs
@@ -62,12 +62,11 @@ public sealed class LinkServerCommandTests
             .ReturnsAsync(new BotGuild(Guild, "Arrow Eclipse", true));
     }
 
-    private void GivenPermission(CommunityPermission permissions)
+    private void GivenPermission(CommunityPermission permissions) =>
+        GivenCommunity(new CommunityMember(UserId, CommunityRole.Admin, permissions, null, null));
+
+    private void GivenCommunity(params CommunityMember[] members)
     {
-        var members = new[]
-        {
-            new CommunityMember(UserId, CommunityRole.Admin, permissions, null, null)
-        };
         _communities.Setup(c => c.GetCommunityByName(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Community(Name.From("Arrow Eclipse"), Guid.NewGuid(),
                 CommunityPrivacyType.Public, members, Array.Empty<Community.ChannelConfiguration>(),
@@ -138,6 +137,50 @@ public sealed class LinkServerCommandTests
         Assert.Contains("Link your Discord account", reply.Text);
         _roleConfiguration.Verify(r => r.SaveServer(It.IsAny<Guid>(), It.IsAny<ulong>(), It.IsAny<string>(),
             It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    ///     The commonest refusal is not a permission problem: a Discord linked to a second PIU
+    ///     Scores login refuses exactly like a missing flag does, and one sentence for both sent
+    ///     people to /Account when the answer was on the Members page and the other way round.
+    ///     Each names the account the invocation resolved to, which is the whole diagnosis.
+    /// </summary>
+    [Fact]
+    public async Task AnAccountWithNoStandingIsToldWhichAccountItLandedOn()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<GetUserByExternalLoginQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserBuilder().WithId(UserId).WithName("Stranger").Build());
+        GivenCommunity(new CommunityMember(Guid.NewGuid(), CommunityRole.Creator, CommunityPermission.All,
+            null, null));
+
+        var reply = await Saga().Handle(Invoke(), CancellationToken.None);
+
+        Assert.Contains("Stranger", reply.Text);
+        Assert.Contains("isn't in Arrow Eclipse", reply.Text);
+        _roleConfiguration.Verify(r => r.SaveServer(It.IsAny<Guid>(), It.IsAny<ulong>(), It.IsAny<string>(),
+            It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AnAdminWithoutTheFlagIsPointedAtTheCreatorRatherThanAtLinking()
+    {
+        GivenPermission(CommunityPermission.ManageUsers);
+
+        var reply = await Saga().Handle(Invoke(), CancellationToken.None);
+
+        Assert.Contains("Manage Discord roles permission", reply.Text);
+        Assert.Contains("creator", reply.Text);
+    }
+
+    [Fact]
+    public async Task AnUnknownCommunityIsNotReportedAsAPermissionProblem()
+    {
+        _communities.Setup(c => c.GetCommunityId(It.IsAny<Name>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+
+        var reply = await Saga().Handle(Invoke(), CancellationToken.None);
+
+        Assert.Contains("wasn't found", reply.Text);
     }
 
     /// <summary>

--- a/ScoreTracker/ScoreTracker/Pages/Communities/CommunityMembers.razor
+++ b/ScoreTracker/ScoreTracker/Pages/Communities/CommunityMembers.razor
@@ -312,11 +312,15 @@ else
     private CommunityMemberRecord? _muteTarget;
     private string? _muteReason;
 
+    // Every delegable flag, in enum order. A permission missing HERE is a permission no admin
+    // can ever hold: this array drives both the per-admin dialog and the promotion defaults, and
+    // there is no other way to grant one. ManageDiscord shipped absent from it, which left
+    // /piu link-server refusing every admin the community's creator thought they had authorized.
     private static readonly CommunityPermission[] ManageablePermissions =
     {
         CommunityPermission.ManageInviteLinks, CommunityPermission.PromoteAdmins,
         CommunityPermission.ManageUsers, CommunityPermission.ManageChannelSubscriptions,
-        CommunityPermission.ModerateComments
+        CommunityPermission.ModerateComments, CommunityPermission.ManageDiscord
     };
 
     private bool CanPromote => _myRole != null && _myRole.Permissions.HasFlag(CommunityPermission.PromoteAdmins);
@@ -574,6 +578,7 @@ else
         CommunityPermission.ManageUsers => L["Manage users (ban/unban)"].Value,
         CommunityPermission.ManageChannelSubscriptions => L["Manage channel subscriptions"].Value,
         CommunityPermission.ModerateComments => L["Moderate comments (remove/mute)"].Value,
+        CommunityPermission.ManageDiscord => L["Manage Discord roles"].Value,
         _ => permission.ToString()
     };
 

--- a/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-US.resx
@@ -10686,6 +10686,12 @@
   <data name="Your Discord handle" xml:space="preserve">
     <value>Your Discord handle</value>
   </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. If you manage {1} from another account, link Discord to that account instead." xml:space="preserve">
+    <value>Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. If you manage {1} from another account, link Discord to that account instead.</value>
+  </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, which is in {1} without the Manage Discord roles permission. The community's creator can grant it on the Members page." xml:space="preserve">
+    <value>Your Discord is linked to {0} on PIU Scores, which is in {1} without the Manage Discord roles permission. The community's creator can grant it on the Members page.</value>
+  </data>
   <data name="your doubles pool is {0}" xml:space="preserve">
     <value>your doubles pool is {0}</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.en-ZW.resx
@@ -10686,6 +10686,12 @@
   <data name="Your Discord handle" xml:space="preserve">
     <value>Murgm Discord mrg</value>
   </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. If you manage {1} from another account, link Discord to that account instead." xml:space="preserve">
+    <value>Blu Discord murmargl ur {0} ur PIU Mgrlgmrg, ol {0} bo rgllurg ur {1}. Ub murm {1} mrp glorg grgl, murmargl Discord ur blu grgl.</value>
+  </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, which is in {1} without the Manage Discord roles permission. The community's creator can grant it on the Members page." xml:space="preserve">
+    <value>Blu Discord murmargl ur {0} ur PIU Mgrlgmrg, molu ur {1} bo Murmargl Discord roglubrgl urgmurpmrp. Plglmurgblub murmarglmurm morp grabmurp brgl ur Mrglmurmro mrpglargl.</value>
+  </data>
   <data name="your doubles pool is {0}" xml:space="preserve">
     <value>morp groggl blubgro arg {0}</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-ES.resx
@@ -10618,6 +10618,12 @@
   <data name="Your Discord handle" xml:space="preserve">
     <value>Tu usuario de Discord</value>
   </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. If you manage {1} from another account, link Discord to that account instead." xml:space="preserve">
+    <value>Tu Discord está vinculado a {0} en PIU Scores, y {0} no está en {1}. Si gestionas {1} desde otra cuenta, vincula Discord a esa cuenta.</value>
+  </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, which is in {1} without the Manage Discord roles permission. The community's creator can grant it on the Members page." xml:space="preserve">
+    <value>Tu Discord está vinculado a {0} en PIU Scores, que está en {1} sin el permiso Gestionar los roles de Discord. Quien creó la comunidad puede concederlo en la página Miembros.</value>
+  </data>
   <data name="your doubles pool is {0}" xml:space="preserve">
     <value>tu conjunto de doubles es {0}</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.es-MX.resx
@@ -10618,6 +10618,12 @@
   <data name="Your Discord handle" xml:space="preserve">
     <value>Tu usuario de Discord</value>
   </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. If you manage {1} from another account, link Discord to that account instead." xml:space="preserve">
+    <value>Tu Discord está vinculado a {0} en PIU Scores, y {0} no está en {1}. Si administras {1} desde otra cuenta, vincula Discord a esa cuenta.</value>
+  </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, which is in {1} without the Manage Discord roles permission. The community's creator can grant it on the Members page." xml:space="preserve">
+    <value>Tu Discord está vinculado a {0} en PIU Scores, que está en {1} sin el permiso Administrar los roles de Discord. Quien creó la comunidad puede otorgarlo en la página Miembros.</value>
+  </data>
   <data name="your doubles pool is {0}" xml:space="preserve">
     <value>tu conjunto de dobles es {0}</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.fr-FR.resx
@@ -10685,6 +10685,12 @@
   <data name="Your Discord handle" xml:space="preserve">
     <value>Votre pseudo Discord</value>
   </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. If you manage {1} from another account, link Discord to that account instead." xml:space="preserve">
+    <value>Votre Discord est lié à {0} sur PIU Scores, et {0} n'est pas dans {1}. Si vous gérez {1} depuis un autre compte, liez Discord à ce compte.</value>
+  </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, which is in {1} without the Manage Discord roles permission. The community's creator can grant it on the Members page." xml:space="preserve">
+    <value>Votre Discord est lié à {0} sur PIU Scores, qui est dans {1} sans la permission Gérer les rôles Discord. Le créateur de la communauté peut l'accorder sur la page Membres.</value>
+  </data>
   <data name="your doubles pool is {0}" xml:space="preserve">
     <value>votre ensemble doubles est de {0}</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.it-IT.resx
@@ -10686,6 +10686,12 @@
   <data name="Your Discord handle" xml:space="preserve">
     <value>Il tuo nome su Discord</value>
   </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. If you manage {1} from another account, link Discord to that account instead." xml:space="preserve">
+    <value>Il tuo Discord è collegato a {0} su PIU Scores, e {0} non è in {1}. Se gestisci {1} da un altro account, collega Discord a quell'account.</value>
+  </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, which is in {1} without the Manage Discord roles permission. The community's creator can grant it on the Members page." xml:space="preserve">
+    <value>Il tuo Discord è collegato a {0} su PIU Scores, che è in {1} senza l'autorizzazione Gestisci i ruoli Discord. Il creatore della community può concederla nella pagina Membri.</value>
+  </data>
   <data name="your doubles pool is {0}" xml:space="preserve">
     <value>il tuo insieme doubles è {0}</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ja-JP.resx
@@ -10686,6 +10686,12 @@
   <data name="Your Discord handle" xml:space="preserve">
     <value>あなたの Discord ハンドル</value>
   </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. If you manage {1} from another account, link Discord to that account instead." xml:space="preserve">
+    <value>この Discord は PIU Scores の {0} に連携されていますが、{0} は {1} のメンバーではありません。{1} を別のアカウントで管理している場合は、そのアカウントに Discord を連携してください。</value>
+  </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, which is in {1} without the Manage Discord roles permission. The community's creator can grant it on the Members page." xml:space="preserve">
+    <value>この Discord は PIU Scores の {0} に連携されていますが、{0} には {1} の Discord ロールを管理する権限がありません。コミュニティの作成者がメンバーページで付与できます。</value>
+  </data>
   <data name="your doubles pool is {0}" xml:space="preserve">
     <value>あなたの Doubles プールは {0}</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.ko-KR.resx
@@ -10618,6 +10618,12 @@
   <data name="Your Discord handle" xml:space="preserve">
     <value>여러분의 Discord 핸들</value>
   </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. If you manage {1} from another account, link Discord to that account instead." xml:space="preserve">
+    <value>이 Discord는 PIU Scores의 {0} 계정에 연결되어 있고, {0}은(는) {1}의 멤버가 아닙니다. {1}을(를) 다른 계정으로 관리한다면 그 계정에 Discord를 연결하세요.</value>
+  </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, which is in {1} without the Manage Discord roles permission. The community's creator can grant it on the Members page." xml:space="preserve">
+    <value>이 Discord는 PIU Scores의 {0} 계정에 연결되어 있는데, {0}에게는 {1}의 Discord 역할 관리 권한이 없습니다. 커뮤니티 개설자가 멤버 페이지에서 부여할 수 있습니다.</value>
+  </data>
   <data name="your doubles pool is {0}" xml:space="preserve">
     <value>내 더블 풀은 {0}</value>
   </data>

--- a/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
+++ b/ScoreTracker/ScoreTracker/Resources/App.pt-BR.resx
@@ -10618,6 +10618,12 @@
   <data name="Your Discord handle" xml:space="preserve">
     <value>Seu usuário no Discord</value>
   </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, and {0} isn't in {1}. If you manage {1} from another account, link Discord to that account instead." xml:space="preserve">
+    <value>Seu Discord está vinculado a {0} no PIU Scores, e {0} não está em {1}. Se você gerencia {1} por outra conta, vincule o Discord a essa conta.</value>
+  </data>
+  <data name="Your Discord is linked to {0} on PIU Scores, which is in {1} without the Manage Discord roles permission. The community's creator can grant it on the Members page." xml:space="preserve">
+    <value>Seu Discord está vinculado a {0} no PIU Scores, que está em {1} sem a permissão Gerenciar cargos do Discord. O criador da comunidade pode concedê-la na página Membros.</value>
+  </data>
   <data name="your doubles pool is {0}" xml:space="preserve">
     <value>seu conjunto de doubles é {0}</value>
   </data>

--- a/docs/design/discord-role-management.md
+++ b/docs/design/discord-role-management.md
@@ -38,9 +38,10 @@ Owner calls from the 2026-09-09 workshop.
 
 | # | Decision |
 |---|---|
-| D8 | **New `CommunityPermission.ManageDiscord`**, delegable by the Creator under the existing rules. It does not subsume `ManageChannelSubscriptions`; feeds and roles are configured by different people in practice. |
+| D8 | **New `CommunityPermission.ManageDiscord`**, delegable by the Creator under the existing rules. It does not subsume `ManageChannelSubscriptions`; feeds and roles are configured by different people in practice. **Delegable means a switch on `/Community/Members`** — the flag shipped absent from that page's `ManageablePermissions`, which is the only array that hands any permission out, so no creator could grant it and every admin sent to `/piu link-server` was refused (fixed 2026-09-09). A permission missing from that list is a permission nobody but the creator can ever hold. |
 | D9 | **Designating a server requires Discord authority too** — `Manage Server` in the target guild, read off the interaction that links it. Site permission alone cannot point a community at a server the admin does not run. |
 | D10 | **The admin needs their own Discord account linked**, because designation happens by running a command as themselves. The page checks up front and sends them to `/Account` rather than letting them discover it mid-command. |
+| D21 | **The refusal says which of the three things is wrong** (2026-09-09). One sentence covered the community not existing, the invoker's Discord resolving to a *different* PIU Scores login, and an admin missing the flag — three causes fixed by three different people. The second is the commonest and reads exactly like a permission problem, so each refusal now names the account the invocation resolved to. |
 
 ### Mechanics
 
@@ -239,6 +240,12 @@ Run in the target server, community chosen by autocomplete. The interaction prov
 is (`GuildId`) and that the invoker holds `Manage Server` there (`InvokerCanManageGuild`, new); the
 handler checks `ManageDiscord` on the site side. Both authorities, one step, and no need to
 enumerate servers we are not permitted to list.
+
+The autocomplete asks the command's own question — `ManageDiscord` on the standing
+`GetUserRoles` returns — rather than a second one off the membership row's `Role` string. Two
+authorities on who the creator is can disagree (the aggregate derives it from `OwningUserId`, which
+is what every gate reads), and D20 made that reachable: naming an owner on a system community's row
+left the list offering a community the command refused, or hiding one it would accept.
 
 ### 5.3 The bot invite URL
 


### PR DESCRIPTION
The flag landed everywhere it is CHECKED and nowhere it is HANDED OUT.
/Community/Members drives both the per-admin dialog and the promotion
defaults off one array, ManageablePermissions, and that array is the only
route any community permission takes to an admin -- ManageDiscord shipped
absent from it. So the creator held it implicitly through All and nobody
else could ever hold it, which is the refusal in the field report: an
admin, freshly Discord-linked because the page told them to be, running
/piu link-server and being turned away by a flag their creator had no
switch for. D8 said "delegable by the Creator"; it was not.

The refusal also could not be diagnosed. One sentence covered three
causes fixed by three different people -- no such community, an admin
without the flag, and the commonest: the invoker's Discord resolving to a
DIFFERENT PIU Scores login than the one that manages the club, which
reads exactly like a permission problem and is not one. Each now says
which, and names the account the invocation landed on, in the invoker's
own ephemeral reply.

And the autocomplete asked its own question. It read Creator off the
membership row's Role string while every gate derives it from
OwningUserId, so the two could disagree -- offering a community the
command refuses, or hiding one it accepts. Reachable since D20 made
naming an owner on a system community's row a supported thing. GetUserRoles
now resolves standing the way the aggregate does, off the same columns in
the same order, and the option list asks the command's own predicate.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UdodtcACiAyYXMjni5VJ41